### PR TITLE
docs: 📝 pypi,license badges are added and installation section corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 [![colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/roboflow-ai/notebooks/blob/main/notebooks/how-to-finetune-rf-detr-on-detection-dataset.ipynb)
 [![roboflow](https://raw.githubusercontent.com/roboflow-ai/notebooks/main/assets/badges/roboflow-blogpost.svg)](https://blog.roboflow.com/rf-detr)
 [![discord](https://img.shields.io/discord/1159501506232451173?logo=discord&label=discord&labelColor=fff&color=5865f2&link=https%3A%2F%2Fdiscord.gg%2FGbfgXGJ8Bk)](https://discord.gg/GbfgXGJ8Bk)
+[![version](https://badge.fury.io/py/rfdetr.svg)](https://badge.fury.io/py/rfdetr)
+[![license](https://img.shields.io/pypi/l/rfdetr)](https://github.com/roboflow/rfdetr/blob/main/LICENSE.md)
+[![python-version](https://img.shields.io/pypi/pyversions/rfdetr)](https://badge.fury.io/py/rfdetr)
 
 RF-DETR is a real-time, transformer-based object detection model architecture developed by Roboflow and released under the Apache 2.0 license.
 
@@ -43,8 +46,6 @@ D-FINE’s fine-tuning capability is currently unavailable, making its domain ad
 ```bash
 pip install rfdetr
 ```
-
-The `rfdetr` package will be distributed soon via PyPI.
 
 ## Prediction
 


### PR DESCRIPTION
# Description

* Added new badges for version, license, and Python version to the top of the file.
* Removed outdated information about the `rfdetr` package distribution via PyPI.

## Docs

-   [X ] Docs updated? What were the changes:


