### PR TITLE
Fix weights download if weights are not properly downloaded

### DIFF
--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -1,11 +1,8 @@
 import os
 import json
-import requests
-from tqdm import tqdm
 
 from rfdetr.config import RFDETRBaseConfig, RFDETRLargeConfig, TrainConfig, ModelConfig
-from rfdetr.main import Model
-from rfdetr.util.files import download_file
+from rfdetr.main import Model, download_pretrain_weights
 from functools import partial
 from logging import getLogger
 import torch
@@ -17,13 +14,6 @@ from collections import defaultdict
 import supervision as sv
 
 logger = getLogger(__name__)
-HOSTED_MODELS = {
-    "rf-detr-base.pth": "https://storage.googleapis.com/rfdetr/rf-detr-base-coco.pth",
-    # below is a less converged model that may be better for finetuning but worse for inference
-    "rf-detr-base-2.pth": "https://storage.googleapis.com/rfdetr/rf-detr-base-2.pth",
-    "rf-detr-large.pth": "https://storage.googleapis.com/rfdetr/rf-detr-large.pth"
-}
-
 class RFDETR:
     means = [0.485, 0.456, 0.406]
     stds = [0.229, 0.224, 0.225]
@@ -35,15 +25,7 @@ class RFDETR:
         self.callbacks = defaultdict(list)
 
     def maybe_download_pretrain_weights(self):
-        if self.model_config.pretrain_weights in HOSTED_MODELS:
-            if not os.path.exists(self.model_config.pretrain_weights):
-                logger.info(
-                    f"Downloading pretrained weights for {self.model_config.pretrain_weights}"
-                )
-                download_file(
-                    HOSTED_MODELS[self.model_config.pretrain_weights],
-                    self.model_config.pretrain_weights,
-                )
+        download_pretrain_weights(self.model_config.pretrain_weights)
 
     def get_model_config(self, **kwargs):
         return ModelConfig(**kwargs)


### PR DESCRIPTION
# Description

If you stop weights download during the download step, RF-DETR returns:

```python
Loading pretrain weights
Traceback (most recent call last):
  File "/Users/james/rf-detr-launch/rfdetr/main.py", line 57, in __init__
    checkpoint = torch.load(args.pretrain_weights, map_location='cpu', weights_only=False)
  File "/Users/james/rf-detr-launch/venv/lib/python3.13/site-packages/torch/serialization.py", line 1432, in load
    with _open_zipfile_reader(opened_file) as opened_zipfile:
         ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/Users/james/rf-detr-launch/venv/lib/python3.13/site-packages/torch/serialization.py", line 763, in __init__
    super().__init__(torch._C.PyTorchFileReader(name_or_buffer))
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
RuntimeError: PytorchStreamReader failed reading zip archive: failed finding central directory
```

This PR fixes the bug by attempting to re-download the weights if `pytorch` is unable to open the file.

With this change, a user will now see:

```
Failed to load pretrain weights, re-downloading
rf-detr-base.pth:  96%|███████████████████████████████████████████████████████████████████████████████████████████████████████▊    | 341M/355M [00:59<00:02,
```

## Type of change

-   [X] Bug fix

## How has this change been tested, please provide a testcase or example of how you tested the change?

You can test this change by starting a training job without the base weights locally, pressing Ctrl-C during download, then trying to run your train script again.

## Any specific deployment considerations

N/A

## Docs

N/A
