### PR TITLE
Fix deprecated torch.cuda.amp usage

### DIFF
--- a/rfdetr/engine.py
+++ b/rfdetr/engine.py
@@ -21,7 +21,10 @@ from typing import Iterable
 import torch
 import rfdetr.util.misc as utils
 from rfdetr.datasets.coco_eval import CocoEvaluator
-from torch.amp import autocast, GradScaler
+try:
+    from torch.amp import autocast, GradScaler
+except ImportError:
+    from torch.cuda.amp import autocast, GradScaler
 import torch.nn as nn
 import argparse
 from typing import DefaultDict, List, Callable

--- a/rfdetr/engine.py
+++ b/rfdetr/engine.py
@@ -61,7 +61,7 @@ def train_one_epoch(
     print("Total batch size: ", batch_size * utils.get_world_size())
 
     # Add gradient scaler for AMP
-    scaler = GradScaler('cuda', enabled=args.amp)
+    scaler = GradScaler(enabled=args.amp)
 
     optimizer.zero_grad()
     assert batch_size % args.grad_accum_steps == 0
@@ -99,7 +99,7 @@ def train_one_epoch(
             new_samples = new_samples.to(device)
             new_targets = [{k: v.to(device) for k, v in t.items()} for t in targets[start_idx:final_idx]]
 
-            with autocast('cuda', enabled=args.amp, dtype=torch.bfloat16):
+            with autocast(enabled=args.amp, dtype=torch.bfloat16):
                 outputs = model(new_samples, new_targets)
                 loss_dict = criterion(outputs, new_targets)
                 weight_dict = criterion.weight_dict


### PR DESCRIPTION
Original Author: https://github.com/fazrigading

Original PR: https://github.com/roboflow/rf-detr/pull/15

Original Description:

Description
Please include a summary of the change and which issue is fixed or implemented. Please also include relevant motivation and context (e.g. links, docs, tickets etc.).

torch.cuda.amp is deprecated as of Pytorch 2.4.
This PR updates use to torch.amp when importing GradScaler and autocast line 24 in rfdetr/engine.py and added 'cuda' args in each usage (line 61, 99, 176).

The purpose is to get rid of this warning:

`torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.
List any dependencies that are required for this change.
None required.

Type of change
 Bug fix (non-breaking change which fixes an issue)
How has this change been tested, please provide a testcase or example of how you tested the change?
By fine-tuning the model using Colab and Kaggle, using the notebook provided in Readme file.

Any specific deployment considerations
For example, documentation changes, usability, usage/costs, secrets, etc.
None.

Docs
 Docs updated? What were the changes:
None