### PR TITLE
Add hf_hub_download

### DIFF
--- a/rfdetr/main.py
+++ b/rfdetr/main.py
@@ -49,22 +49,22 @@ import os
 
 logger = getLogger(__name__)
 
-HOSTED_MODELS = {
-    "rf-detr-base.pth": "https://storage.googleapis.com/rfdetr/rf-detr-base-coco.pth",
+HOSTED_MODELS = [
+    "rf-detr-base",
     # below is a less converged model that may be better for finetuning but worse for inference
-    "rf-detr-base-2.pth": "https://storage.googleapis.com/rfdetr/rf-detr-base-2.pth",
-    "rf-detr-large.pth": "https://storage.googleapis.com/rfdetr/rf-detr-large.pth"
-}
+    "rf-detr-base-2",
+    "rf-detr-large",
+]
 
-def download_pretrain_weights(pretrain_weights: str, redownload=False):
-    if pretrain_weights in HOSTED_MODELS:
-        if redownload or not os.path.exists(pretrain_weights):
+def download_pretrain_weights(model_name: str, redownload=False):
+    if model_name in HOSTED_MODELS:
+        if redownload or not os.path.exists(model_name):
             logger.info(
-                f"Downloading pretrained weights for {pretrain_weights}"
+                f"Downloading pretrained weights for {model_name}"
             )
-            hf_hub_download(repo_id="roboflow/rfdetr-weights", filename=pretrain_weights, local_dir="weights")
+            hf_hub_download(repo_id=f"roboflow/{model_name}", filename=f"{model_name}.pth", local_dir="weights")
     else:
-        raise ValueError(f"Pretrain weights {pretrain_weights} not found")
+        raise ValueError(f"Pretrain weights of model {model_name} not found")
 
 class Model:
     def __init__(self, **kwargs):

--- a/rfdetr/main.py
+++ b/rfdetr/main.py
@@ -43,7 +43,8 @@ from peft import LoraConfig, get_peft_model
 from typing import DefaultDict, List, Callable
 from logging import getLogger
 import shutil
-from rfdetr.util.files import download_file
+
+from huggingface_hub import hf_hub_download
 import os
 
 logger = getLogger(__name__)
@@ -61,10 +62,9 @@ def download_pretrain_weights(pretrain_weights: str, redownload=False):
             logger.info(
                 f"Downloading pretrained weights for {pretrain_weights}"
             )
-            download_file(
-                HOSTED_MODELS[pretrain_weights],
-                pretrain_weights,
-            )
+            hf_hub_download(repo_id="roboflow/rfdetr-weights", filename=pretrain_weights, local_dir="weights")
+    else:
+        raise ValueError(f"Pretrain weights {pretrain_weights} not found")
 
 class Model:
     def __init__(self, **kwargs):

--- a/rfdetr/main.py
+++ b/rfdetr/main.py
@@ -134,6 +134,27 @@ class Model:
         self.model = self.model.to(self.device)
         self.criterion, self.postprocessors = build_criterion_and_postprocessors(args)
     
+    @classmethod
+    def from_pretrained(cls, repo_id: str):
+        """
+        Load a pretrained model from the Hugging Face Hub.
+        
+        Args:
+            model_id (str): Name of the pretrained model to load. Must be one of: rf-detr-base, rf-detr-base-2, rf-detr-large
+            
+        Returns:
+            Model: A loaded model instance
+        """ 
+        # Download the weights if needed
+        filepath = hf_hub_download(repo_id, filename=f"{repo_id}.pth")
+        state_dict = torch.load(filepath, map_location='cpu')
+        
+        # Load the model
+        model = build_model(args)
+        model.load_state_dict(state_dict, strict=False)
+        
+        return model
+    
     def reinitialize_detection_head(self, num_classes):
         self.model.reinitialize_detection_head(num_classes)
 

--- a/rfdetr/main.py
+++ b/rfdetr/main.py
@@ -140,7 +140,8 @@ class Model:
         Load a pretrained model from the Hugging Face Hub.
         
         Args:
-            model_id (str): Name of the pretrained model to load. Must be one of: rf-detr-base, rf-detr-base-2, rf-detr-large
+            repo_id (str): Name of the repository to download the weights from.
+            Must be one of: roboflow/rf-detr-base, roboflow/rf-detr-base-2, roboflow/rf-detr-large.
             
         Returns:
             Model: A loaded model instance


### PR DESCRIPTION
This PR proposes to make the weights of RF-DETR available at https://huggingface.co/Roboflow.

The `download_pretrain_weights` method is updated correspondingly to download the weights from the 🤗 hub.

This comes with a few benefits:
- the models are easier discoverable for people, as we can add the "object detection" tag, such that people find them at https://huggingface.co/models?pipeline_tag=object-detection&sort=trending. RF-DETR could become one of the top trending models!
- download stats will be provided, such that you can track usage
- we can add descriptive model cards for better documentation.

Additionally, we could optionally leverage [safetensors](https://github.com/huggingface/safetensors) for a safer format for serializing the weights.