### PR TITLE
ensure tau gets used when computing decay

### DIFF
--- a/rfdetr/util/utils.py
+++ b/rfdetr/util/utils.py
@@ -22,9 +22,10 @@ class ModelEma(torch.nn.Module):
 
     def _get_decay(self):
         if self.tau == 0:
-            return self.decay
+            decay = self.decay
         else:
-            return self.decay * (1 - math.exp(-self.updates / self.tau))
+            decay = self.decay * (1 - math.exp(-self.updates / self.tau))
+        return decay
 
     def _update(self, model, update_fn):
         with torch.no_grad():
@@ -35,7 +36,8 @@ class ModelEma(torch.nn.Module):
                 ema_v.copy_(update_fn(ema_v, model_v))
 
     def update(self, model):
-        self._update(model, update_fn=lambda e, m: self.decay * e + (1. - self.decay) * m)
+        decay = self._get_decay()
+        self._update(model, update_fn=lambda e, m: decay * e + (1. - decay) * m)
         self.updates += 1
 
     def set(self, model):


### PR DESCRIPTION
# Description

Tau wasn't getting used when computing EMA. Fixed.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

tested locally on a simple training script, verified EMA decay now changes with tau and seeing much better EMA results, esp early in training

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
