### PR TITLE
Add W&B Metric Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,35 @@ During training, two model checkpoints (the regular weights and an EMA-based set
   
 </details>
 
+### Logging with Weights and Biases (W&B)
+
+[W&B](https://www.wandb.ai) similar to TensorBoard is a very powerful platform to monitor training metrics. It is cloud-based and offers a more complex feature set compared to TensorBoard.
+
+<details>
+<summary>Get Started</summary>
+
+- To use W&B, make sure you are logged in:
+
+    ```bash
+    wandb login
+    ```
+
+    You will need to specify an API Key for your account that can be retrieved at https://wandb.ai/authorize.
+
+- For those familiar with W&B, you can specify the `project_name` and `run_name` in the `model.train` method:
+
+    ```python
+    from rfdetr import RFDETRBase
+
+    model = RFDETRBase()
+
+    detections = model.train(dataset_dir=<DATASET_PATH>, project_name=<PROJECT_NAME>, run_name=<RUN_NAME>)
+    ```
+
+    For those unfamiliar with W&B: projects are collections of related machine learning experiments, while runs are individual units of computation within a project that record specific experiments, such as training a model or conducting hyperparameter tuning. Not specifying a name, will result in random names provided by W&B.
+  
+</details>
+
 ### Load and run fine-tuned model
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ dependencies = [
     "peft",
     "ninja",
     "einops",
-    "wandb",
     "pandas",
     "pylabel",
     "onnx",
@@ -69,7 +68,8 @@ onnxruntime = [
     "onnxruntime"
 ]
 metrics = [
-    "tensorboard>=2.13.0"
+    "tensorboard>=2.13.0",
+    "wandb"
 ]
 
 [project.urls]

--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -71,7 +71,7 @@ class RFDETR:
         self.callbacks["on_fit_epoch_end"].append(metrics_tensor_board_sink.update)
         self.callbacks["on_train_end"].append(metrics_tensor_board_sink.close)
 
-        metrics_wandb_sink = MetricsWandBSink(output_dir=config.output_dir, project_name = None, run_name = None, config = all_kwargs)
+        metrics_wandb_sink = MetricsWandBSink(output_dir=config.output_dir, project_name = kwargs.get("project_name", None), run_name = kwargs.get("run_name", None), config = all_kwargs)
         self.callbacks["on_fit_epoch_end"].append(metrics_wandb_sink.update)
         self.callbacks["on_train_end"].append(metrics_wandb_sink.close)
 

--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -12,7 +12,7 @@ from PIL import Image
 
 from rfdetr.config import RFDETRBaseConfig, RFDETRLargeConfig, TrainConfig, ModelConfig
 from rfdetr.main import Model, download_pretrain_weights
-from rfdetr.util.metrics import MetricsPlotSink, MetricsTensorBoardSink, MetricsWandbSink
+from rfdetr.util.metrics import MetricsPlotSink, MetricsTensorBoardSink, MetricsWandBSink
 
 logger = getLogger(__name__)
 class RFDETR:
@@ -71,7 +71,7 @@ class RFDETR:
         self.callbacks["on_fit_epoch_end"].append(metrics_tensor_board_sink.update)
         self.callbacks["on_train_end"].append(metrics_tensor_board_sink.close)
 
-        metrics_wandb_sink = MetricsWandbSink(output_dir=config.output_dir, project_name = None, run_name = None, config = None)
+        metrics_wandb_sink = MetricsWandBSink(output_dir=config.output_dir, project_name = None, run_name = None, config = None)
         self.callbacks["on_fit_epoch_end"].append(metrics_wandb_sink.update)
         self.callbacks["on_train_end"].append(metrics_wandb_sink.close)
 

--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -71,7 +71,7 @@ class RFDETR:
         self.callbacks["on_fit_epoch_end"].append(metrics_tensor_board_sink.update)
         self.callbacks["on_train_end"].append(metrics_tensor_board_sink.close)
 
-        metrics_wandb_sink = MetricsWandBSink(output_dir=config.output_dir, project_name = None, run_name = None, config = None)
+        metrics_wandb_sink = MetricsWandBSink(output_dir=config.output_dir, project_name = None, run_name = None, config = all_kwargs)
         self.callbacks["on_fit_epoch_end"].append(metrics_wandb_sink.update)
         self.callbacks["on_train_end"].append(metrics_wandb_sink.close)
 

--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -12,7 +12,7 @@ from PIL import Image
 
 from rfdetr.config import RFDETRBaseConfig, RFDETRLargeConfig, TrainConfig, ModelConfig
 from rfdetr.main import Model, download_pretrain_weights
-from rfdetr.util.metrics import MetricsPlotSink, MetricsTensorBoardSink
+from rfdetr.util.metrics import MetricsPlotSink, MetricsTensorBoardSink, MetricsWandbSink
 
 logger = getLogger(__name__)
 class RFDETR:
@@ -70,6 +70,10 @@ class RFDETR:
         metrics_tensor_board_sink = MetricsTensorBoardSink(output_dir=config.output_dir)
         self.callbacks["on_fit_epoch_end"].append(metrics_tensor_board_sink.update)
         self.callbacks["on_train_end"].append(metrics_tensor_board_sink.close)
+
+        metrics_wandb_sink = MetricsWandbSink(output_dir=config.output_dir, project_name = None, run_name = None, config = None)
+        self.callbacks["on_fit_epoch_end"].append(metrics_wandb_sink.update)
+        self.callbacks["on_train_end"].append(metrics_wandb_sink.close)
 
         self.model.train(
             **all_kwargs,

--- a/rfdetr/util/metrics.py
+++ b/rfdetr/util/metrics.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -177,12 +179,12 @@ class MetricsWandBSink:
 
     Args:
         output_dir (str): Directory where W&B logs will be written locally.
-        project_name (str, optional): W&B project name. If None, W&B will generate a name based on the git repo name.
+        project_name (str, optional): Associate this training run with a W&B project. If None, W&B will generate a name based on the git repo name.
         run_name (str, optional): W&B run name. If None, W&B will generate a random name.
-        config (dict, optional): Input parameters, like hyperparameters or data preprocessing settings for the run.
+        config (dict, optional): Input parameters, like hyperparameters or data preprocessing settings for the run for later comparison.
     """
 
-    def __init__(self, output_dir: str, project_name: str = None, run_name: str = None, config: dict = None):
+    def __init__(self, output_dir: str, project_name: Optional[str] = None, run_name: Optional[str] = None, config: Optional[dict] = None):
         self.output_dir = output_dir
         if wandb:
             self.run = wandb.init(
@@ -194,7 +196,7 @@ class MetricsWandBSink:
             print(f"Weights & Biases initialized. View logs at {wandb.run.url}")
         else:
             self.run = None
-            print("Unable to initialize Weights & Biases. Please install with 'pip install wandb' and log in.")
+            print("Unable to initialize Weights & Biases. Please install with 'pip install wandb' and 'wandb login'.")
 
     def update(self, values: dict):
         if not wandb or not self.run:

--- a/rfdetr/util/misc.py
+++ b/rfdetr/util/misc.py
@@ -23,7 +23,6 @@ from collections import defaultdict, deque
 import datetime
 import pickle
 from typing import Optional, List
-import wandb
 import copy
 import argparse
 
@@ -170,10 +169,14 @@ def reduce_dict(input_dict, average=True):
 
 
 class MetricLogger(object):
-    def __init__(self, delimiter="\t", wandb=False):
+    def __init__(self, delimiter="\t", wandb_logging=False):
         self.meters = defaultdict(SmoothedValue)
         self.delimiter = delimiter
-        self.wandb = wandb
+        if wandb_logging:
+            import wandb
+            self.wandb = wandb
+        else:
+            self.wandb = None
 
     def update(self, **kwargs):
         for k, v in kwargs.items():
@@ -244,7 +247,7 @@ class MetricLogger(object):
                 if self.wandb:
                     if is_main_process():
                         log_dict = {k: v.value for k, v in self.meters.items()}
-                        wandb.log(log_dict)
+                        self.wandb.log(log_dict)
                 if torch.cuda.is_available():
                     print(log_msg.format(
                         i, len(iterable), eta=eta_string,


### PR DESCRIPTION
# Description

This pull request introduces a new logging feature to the `rfdetr` package, specifically adding support for Weights and Biases (W&B) logging. The most important changes include importing the necessary W&B module, adding a new class to handle W&B logging, and integrating this new logger into the training process. No depdency updates are needed, since `wandb` is already a dependency.

### New Feature: Weights and Biases Logging

* [`rfdetr/detr.py`](diffhunk://#diff-9f8117154976f0e714a38740eb63c7b864f2497955660e60fd2c83d8a848c814L15-R15): Imported `MetricsWandBSink` and added the `update` and `save` to the model callbacks.

## Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?
A sample run that is logged to W&B can be seen below. The setup is similar to Tensorboard, whereas all 
`all_kwargs = {**model_config, **train_config, **kwargs, "num_classes": num_classes}` are saved as the `run.config`, as you can see in the second screenshot. This allows the user to compare different training runs, in terms of hyperparameters or specific model changes.
![wandb-metrics](https://github.com/user-attachments/assets/016f151d-f875-4a06-9c10-5d6f84ad6843)
![wandb-config](https://github.com/user-attachments/assets/0f888498-a916-4df8-9684-41c027482544)

## Docs
Question: Should the README be updated, similar to the Tensorboard logging?

## More Questions
- Should the saved models files (`checkpoint.pth`, `checkpoint_best_ema.pth`, `checkpoint_best_regular.pth`, `checkpoint_best_total.pth`) also be uploaded as artifacts to the run at the end of training? Should this be configurable by the user?
- How about also uploading the `results.json` file and `metrics_plot.png` (created by `MetricsPlotSink`)?
