### PR TITLE
Add YOLO dataset format support (#69)

### DIFF
--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -13,6 +13,7 @@ from PIL import Image
 from rfdetr.config import RFDETRBaseConfig, RFDETRLargeConfig, TrainConfig, ModelConfig
 from rfdetr.main import Model, download_pretrain_weights
 from rfdetr.util.metrics import MetricsPlotSink, MetricsTensorBoardSink
+from rfdetr.util.coco_to_yolo import is_correct_yolo_format, convert_to_coco
 
 logger = getLogger(__name__)
 class RFDETR:
@@ -39,6 +40,9 @@ class RFDETR:
         self.model.export(**kwargs)
 
     def train_from_config(self, config: TrainConfig, **kwargs):
+        if is_correct_yolo_format(config.dataset_dir):
+            config.dataset_dir = convert_to_coco(config.dataset_dir)
+
         with open(
             os.path.join(config.dataset_dir, "train", "_annotations.coco.json"), "r"
         ) as f:

--- a/rfdetr/util/coco_to_yolo.py
+++ b/rfdetr/util/coco_to_yolo.py
@@ -1,0 +1,75 @@
+# ------------------------------------------------------------------------
+# LW-DETR
+# Copyright (c) 2024 Baidu. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Utils to convert a yolo dataset to coco format."""
+import os
+import supervision as sv
+
+YOLO_YAML_FILE = "data.yaml"
+NECESSARY_SPLIT_DIRS = ["train", "valid"]
+NECESSARY_DATA_SUBDIRS = ["images", "labels"]
+OPTIONAL_SPLIT_DIR = "test"
+
+def is_correct_yolo_format(dataset_dir: str) -> bool:
+    """
+    Checks if the specified dataset directory is in yolo format.
+
+    We accept a dataset to be in yolo format if the following conditions are met:
+    - The dataset_dir contains a data.yaml file
+    - The dataset_dir contains "train" and "valid" subdirectories, each containing "images" and "labels" subdirectories
+    - The "test" subdirectory is optional
+
+    Returns a boolean indicating whether the dataset is in correct yolo format.
+    """
+    contains_data_yaml = os.path.exists(os.path.join(dataset_dir, YOLO_YAML_FILE))
+    contains_necessary_split_dirs = all(
+        os.path.exists(os.path.join(dataset_dir, split_dir)) for split_dir in NECESSARY_SPLIT_DIRS
+    )
+    contains_necessary_data_subdirs = all(
+        os.path.exists(os.path.join(dataset_dir, split_dir, data_subdir))
+        for split_dir in NECESSARY_SPLIT_DIRS
+        for data_subdir in NECESSARY_DATA_SUBDIRS
+    )
+    return contains_data_yaml and contains_necessary_split_dirs and contains_necessary_data_subdirs
+
+
+def convert_to_coco(dataset_dir: str) -> str:
+    """
+    Converts the specified dataset directory from yolo format to coco format.
+
+    The converted dataset will be saved in a new directory with the same name as the original dataset directory, but with
+    the suffix "_coco".
+
+    Returns a string containing the path to the converted dataset directory.
+    """
+    coco_dataset_dir = f"{dataset_dir}_coco"
+
+    if os.path.exists(coco_dataset_dir):
+        raise ValueError(f"Directory {coco_dataset_dir} already exists. Please remove or rename it before converting the dataset.")
+    else:
+        os.makedirs(coco_dataset_dir)
+
+    for split_dir in NECESSARY_SPLIT_DIRS:
+        sv.DetectionDataset.from_yolo(
+            images_directory_path=os.path.join(dataset_dir, split_dir, "images"),
+            annotations_directory_path=os.path.join(dataset_dir, split_dir, "labels"),
+            data_yaml_path=os.path.join(dataset_dir, YOLO_YAML_FILE),
+        ).as_coco(
+            images_directory_path=os.path.join(coco_dataset_dir, split_dir),
+            annotations_path=os.path.join(coco_dataset_dir, split_dir, "_annotations.coco.json"),
+        )
+    
+    if os.path.exists(os.path.join(dataset_dir, OPTIONAL_SPLIT_DIR)):
+        sv.DetectionDataset.from_yolo(
+            images_directory_path=os.path.join(dataset_dir, OPTIONAL_SPLIT_DIR, "images"),
+            annotations_directory_path=os.path.join(dataset_dir, OPTIONAL_SPLIT_DIR, "labels"),
+            data_yaml_path=os.path.join(dataset_dir, YOLO_YAML_FILE),
+        ).as_coco(
+            images_directory_path=os.path.join(coco_dataset_dir, OPTIONAL_SPLIT_DIR),
+            annotations_path=os.path.join(coco_dataset_dir, OPTIONAL_SPLIT_DIR, "_annotations.coco.json"),
+        )
+
+    return coco_dataset_dir


### PR DESCRIPTION
This pull request introduces functionality to convert datasets from YOLO format to COCO format within the `rfdetr` package. The key changes include adding utility functions for this conversion and integrating these functions into the training workflow.

New functionality:

* [`rfdetr/util/coco_to_yolo.py`](diffhunk://#diff-bd1add3ccff2c32cd3b37cae6bb2bac898c60f1be5ec5e0e7f88fe58c06e7903R1-R75): Added utility functions `is_correct_yolo_format` and `convert_to_coco` to check the format of YOLO datasets and convert them to COCO format.

Integration into training workflow:

* [`rfdetr/detr.py`](diffhunk://#diff-9f8117154976f0e714a38740eb63c7b864f2497955660e60fd2c83d8a848c814R16): Imported the new utility functions and added logic to convert datasets from YOLO to COCO format during training if they are detected to be in YOLO format. [[1]](diffhunk://#diff-9f8117154976f0e714a38740eb63c7b864f2497955660e60fd2c83d8a848c814R16) [[2]](diffhunk://#diff-9f8117154976f0e714a38740eb63c7b864f2497955660e60fd2c83d8a848c814R43-R45)# Description

## Type of change

-   [ x ] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Will create a collab later.

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs
Will be updated later.
-   [ ] Docs updated? What were the changes:
