### PR TITLE
remove outdated lr scheduler state control for resume

### DIFF
--- a/rfdetr/main.py
+++ b/rfdetr/main.py
@@ -246,11 +246,7 @@ class Model:
                 else:
                     del self.ema_m
                     self.ema_m = ModelEma(model, decay=args.ema_decay, tau=args.ema_tau) 
-            if not args.eval and 'optimizer' in checkpoint and 'lr_scheduler' in checkpoint and 'epoch' in checkpoint:
-                checkpoint['optimizer']["param_groups"] = optimizer.state_dict()["param_groups"]
-                checkpoint['lr_scheduler'].pop("step_size")
-                checkpoint['lr_scheduler'].pop("_last_lr")
-                
+            if not args.eval and 'optimizer' in checkpoint and 'lr_scheduler' in checkpoint and 'epoch' in checkpoint:                
                 optimizer.load_state_dict(checkpoint['optimizer'])
                 lr_scheduler.load_state_dict(checkpoint['lr_scheduler'])
                 args.start_epoch = checkpoint['epoch'] + 1


### PR DESCRIPTION
# Description

We originally used a different learning rate scheduler framework but then switched to LambdaLR and forgot to update our resume training logic. This fixes that.

I am also removing a param group update during the resume. Probably there to make it easier to change learning rates in different parts of the model during resume, but it reeks of code smell to me so I'm taking it out as iirc we don't plan to support that anyway

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

YOUR_ANSWER

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
