### PR TITLE
Support gradient checkpointing to reduce memory load

### DIFF
--- a/rfdetr/config.py
+++ b/rfdetr/config.py
@@ -22,6 +22,7 @@ class ModelConfig(BaseModel):
     device: Literal["cpu", "cuda", "mps"] = DEVICE
     resolution: int = 560
     group_detr: int = 13
+    gradient_checkpointing: bool = False
 
 class RFDETRBaseConfig(ModelConfig):
     encoder: Literal["dinov2_windowed_small", "dinov2_windowed_base"] = "dinov2_windowed_small"

--- a/rfdetr/main.py
+++ b/rfdetr/main.py
@@ -870,6 +870,7 @@ def populate_args(
     warmup_epochs=1,
     lr_scheduler='step',
     lr_min_factor=0.0,
+    gradient_checkpointing=False,
     # Additional
     subcommand=None,
     **extra_kwargs  # To handle any unexpected arguments
@@ -964,6 +965,7 @@ def populate_args(
         warmup_epochs=warmup_epochs,
         lr_scheduler=lr_scheduler,
         lr_min_factor=lr_min_factor,
+        gradient_checkpointing=gradient_checkpointing,
         **extra_kwargs
     )
     return args

--- a/rfdetr/models/backbone/__init__.py
+++ b/rfdetr/models/backbone/__init__.py
@@ -60,6 +60,7 @@ def build_backbone(
     rms_norm,
     backbone_lora,
     force_no_pretrain,
+    gradient_checkpointing,
 ):
     """
     Useful args:
@@ -85,6 +86,7 @@ def build_backbone(
         target_shape=target_shape,
         rms_norm=rms_norm,
         backbone_lora=backbone_lora,
+        gradient_checkpointing=gradient_checkpointing,
     )
 
     model = Joiner(backbone, position_embedding)

--- a/rfdetr/models/backbone/backbone.py
+++ b/rfdetr/models/backbone/backbone.py
@@ -46,6 +46,7 @@ class Backbone(BackboneBase):
                  target_shape: tuple[int, int] = (640, 640),
                  rms_norm: bool = False,
                  backbone_lora: bool = False,
+                 gradient_checkpointing: bool = False,
                  ):
         super().__init__()
         # an example name here would be "dinov2_base" or "dinov2_registers_windowed_base"
@@ -71,6 +72,7 @@ class Backbone(BackboneBase):
             shape=target_shape,
             use_registers=use_registers,
             use_windowed_attn=use_windowed_attn,
+            gradient_checkpointing=gradient_checkpointing,
         )
         # build encoder + projector as backbone module
         if freeze_encoder:

--- a/rfdetr/models/backbone/dinov2_with_windowed_attn.py
+++ b/rfdetr/models/backbone/dinov2_with_windowed_attn.py
@@ -160,6 +160,7 @@ class WindowedDinov2WithRegistersConfig(BackboneConfigMixin, PretrainedConfig):
         reshape_hidden_states=True,
         num_windows=1,
         window_block_indexes=None,
+        gradient_checkpointing=False,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -189,7 +190,7 @@ class WindowedDinov2WithRegistersConfig(BackboneConfigMixin, PretrainedConfig):
         self.reshape_hidden_states = reshape_hidden_states
         self.num_windows = num_windows
         self.window_block_indexes = list(range(num_hidden_layers)) if window_block_indexes is None else window_block_indexes
-
+        self.gradient_checkpointing = gradient_checkpointing
 
 
 class Dinov2WithRegistersPatchEmbeddings(nn.Module):
@@ -666,7 +667,7 @@ class WindowedDinov2WithRegistersEncoder(nn.Module):
         super().__init__()
         self.config = config
         self.layer = nn.ModuleList([WindowedDinov2WithRegistersLayer(config) for _ in range(config.num_hidden_layers)])
-        self.gradient_checkpointing = False
+        self.gradient_checkpointing = config.gradient_checkpointing
 
     def forward(
         self,

--- a/rfdetr/models/lwdetr.py
+++ b/rfdetr/models/lwdetr.py
@@ -609,6 +609,7 @@ def build_model(args):
         rms_norm=args.rms_norm,
         backbone_lora=args.backbone_lora,
         force_no_pretrain=args.force_no_pretrain,
+        gradient_checkpointing=args.gradient_checkpointing,
     )
     if args.encoder_only:
         return backbone[0].encoder, None, None


### PR DESCRIPTION
# Description

Our DINOv2 backbone already supports gradient checkpointing. This PR just pipes the config option to the backbone. 

When training RFDETRLarge, this saves me some 25% memory.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

I tested it locally by loading the model via
```
from rfdetr import RFDETRBase, RFDETRLarge
import roboflow

dataset = roboflow.download_dataset("https://universe.roboflow.com/rf100-vl/circuit-voltages-ysajo-tbpd/dataset/1", model_format="coco")

# model = RFDETRBase(resolution=560, gradient_checkpointing=True)
model = RFDETRLarge(resolution=560, gradient_checkpointing=False)

model.train(dataset_dir=dataset.location, epochs=100, batch_size=4, grad_accum_steps=4, lr=1e-4)
```

with the variable set to true or false, testing both. I saw lower memory usage. I didn't verify that convergence is the same, although looked similar. I think there's an issue with our random seed that makes it so I can't directly reproduce runs. I'm assuming the torch implementation here for grad checkpointing is correct.

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
