### PR TITLE
strip final checkpoint for lighter download

### DIFF
--- a/rfdetr/util/misc.py
+++ b/rfdetr/util/misc.py
@@ -496,3 +496,11 @@ def inverse_sigmoid(x, eps=1e-5):
     x1 = x.clamp(min=eps)
     x2 = (1 - x).clamp(min=eps)
     return torch.log(x1/x2)
+
+
+def strip_checkpoint(checkpoint):
+    state_dict = torch.load(checkpoint, map_location="cpu", weights_only=False)
+    new_state_dict = {
+        'model': state_dict['model'],
+    }
+    torch.save(new_state_dict, checkpoint)


### PR DESCRIPTION
# Description

Our final checkpoint, checkpoint_best_total.pth, contained optimizer weights and other metadata that caused it to bloat. This PR strips it out. It also ensures that file operations at the end of training only happen in the main process, avoiding potential race condition in multi GPU case.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

I tested it locally with a basic train, and confirmed that the checkpoint was about 3x smaller. I also tested that inference works from the saved checkpoint.

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
