### PR TITLE
Add class names to args in checkpoint

### DIFF
--- a/rfdetr/config.py
+++ b/rfdetr/config.py
@@ -79,3 +79,4 @@ class TrainConfig(BaseModel):
     wandb: bool = False
     project: Optional[str] = None
     run: Optional[str] = None
+    class_names: List[str] = None

--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -44,6 +44,7 @@ class RFDETR:
         ) as f:
             anns = json.load(f)
             num_classes = len(anns["categories"])
+            class_names = [c["name"] for c in anns["categories"] if c["supercategory"] != "none"]
 
         if self.model_config.num_classes != num_classes:
             logger.warning(
@@ -52,9 +53,16 @@ class RFDETR:
             )
             self.model.reinitialize_detection_head(num_classes)
         
+        
         train_config = config.dict()
         model_config = self.model_config.dict()
         model_config.pop("num_classes")
+        if "class_names" in model_config:
+            model_config.pop("class_names")
+        
+        if "class_names" in train_config and train_config["class_names"] is None:
+            train_config["class_names"] = class_names
+
         for k, v in train_config.items():
             if k in model_config:
                 model_config.pop(k)


### PR DESCRIPTION
# Description

Very minimal change for stability, but this will make sure the class names are in the args which are in the checkpoint, so we will have access to them later for models people are training. Tested locally.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

tested training locally, everything saves.

## Any specific deployment considerations

no

## Docs

-   [ ] Docs updated? What were the changes:
