### PR TITLE
class names property for easy access

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ import requests
 import supervision as sv
 from PIL import Image
 from rfdetr import RFDETRBase
-from rfdetr.util.coco_classes import COCO_CLASSES
 
 model = RFDETRBase()
+CLASS_NAMES = model.class_names
 
 url = "https://media.roboflow.com/notebooks/examples/dog-2.jpeg"
 
@@ -94,7 +94,7 @@ image = Image.open(io.BytesIO(requests.get(url).content))
 detections = model.predict(image, threshold=0.5)
 
 labels = [
-    f"{COCO_CLASSES[class_id]} {confidence:.2f}"
+    f"{CLASS_NAMES[class_id]} {confidence:.2f}"
     for class_id, confidence
     in zip(detections.class_id, detections.confidence)
 ]
@@ -114,15 +114,15 @@ sv.plot_image(annotated_image)
 ```python
 import supervision as sv
 from rfdetr import RFDETRBase
-from rfdetr.util.coco_classes import COCO_CLASSES
 
 model = RFDETRBase()
+CLASS_NAMES = model.class_names
 
 def callback(frame, index):
     detections = model.predict(frame, threshold=0.5)
         
     labels = [
-        f"{COCO_CLASSES[class_id]} {confidence:.2f}"
+        f"{CLASS_NAMES[class_id]} {confidence:.2f}"
         for class_id, confidence
         in zip(detections.class_id, detections.confidence)
     ]
@@ -150,9 +150,9 @@ sv.process_video(
 import cv2
 import supervision as sv
 from rfdetr import RFDETRBase
-from rfdetr.util.coco_classes import COCO_CLASSES
 
 model = RFDETRBase()
+CLASS_NAMES = model.class_names
 
 cap = cv2.VideoCapture(0)
 while True:
@@ -163,7 +163,7 @@ while True:
     detections = model.predict(frame, threshold=0.5)
     
     labels = [
-        f"{COCO_CLASSES[class_id]} {confidence:.2f}"
+        f"{CLASS_NAMES[class_id]} {confidence:.2f}"
         for class_id, confidence
         in zip(detections.class_id, detections.confidence)
     ]
@@ -192,9 +192,9 @@ cv2.destroyAllWindows()
 import cv2
 import supervision as sv
 from rfdetr import RFDETRBase
-from rfdetr.util.coco_classes import COCO_CLASSES
 
 model = RFDETRBase()
+CLASS_NAMES = model.class_names
 
 cap = cv2.VideoCapture(<RTSP_STREAM_URL>)
 while True:
@@ -205,7 +205,7 @@ while True:
     detections = model.predict(frame, threshold=0.5)
     
     labels = [
-        f"{COCO_CLASSES[class_id]} {confidence:.2f}"
+        f"{CLASS_NAMES[class_id]} {confidence:.2f}"
         for class_id, confidence
         in zip(detections.class_id, detections.confidence)
     ]

--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -13,6 +13,7 @@ from PIL import Image
 from rfdetr.config import RFDETRBaseConfig, RFDETRLargeConfig, TrainConfig, ModelConfig
 from rfdetr.main import Model, download_pretrain_weights
 from rfdetr.util.metrics import MetricsPlotSink, MetricsTensorBoardSink, MetricsWandBSink
+from rfdetr.util.coco_classes import COCO_CLASSES
 
 logger = getLogger(__name__)
 class RFDETR:
@@ -110,6 +111,14 @@ class RFDETR:
 
     def get_model(self, config: ModelConfig):
         return Model(**config.dict())
+    
+    # Get class_names from the model
+    @property
+    def class_names(self):
+        if hasattr(self.model, 'class_names') and self.model.class_names:
+            return {i+1: name for i, name in enumerate(self.model.class_names)}
+            
+        return COCO_CLASSES
 
     def predict(
         self,

--- a/rfdetr/main.py
+++ b/rfdetr/main.py
@@ -86,6 +86,10 @@ class Model:
                 download_pretrain_weights(args.pretrain_weights, redownload=True)
                 checkpoint = torch.load(args.pretrain_weights, map_location='cpu', weights_only=False)
 
+            # Extract class_names from checkpoint if available
+            if 'args' in checkpoint and hasattr(checkpoint['args'], 'class_names'):
+                self.class_names = checkpoint['args'].class_names
+                
             checkpoint_num_classes = checkpoint['model']['class_embed.bias'].shape[0]
             if checkpoint_num_classes != args.num_classes + 1:
                 logger.warning(


### PR DESCRIPTION
# Description

This PR adds a class_names property to the RFDETR class that dynamically provides access to class names in dictionary format. The property retrieves class names from the loaded model if available, otherwise it falls back to COCO_CLASSES. The class IDs in the dictionary start from 1, providing a consistent interface for class identification. I think this small changes will be mostly suitable for the custom model to get access the class_names with ids.


## Type of change

I have changed the main.py to extract the class_names from model args. And added a property in the detr.py file

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested with pre-trained models and custom models.

## Docs

- README.md file is updated
