### PR TITLE
add num_select to the config

### DIFF
--- a/rfdetr/config.py
+++ b/rfdetr/config.py
@@ -31,6 +31,7 @@ class RFDETRBaseConfig(ModelConfig):
     ca_nheads: int = 16
     dec_n_points: int = 2
     num_queries: int = 300
+    num_select: int = 300
     projector_scale: List[Literal["P3", "P4", "P5"]] = ["P4"]
     out_feature_indexes: List[int] = [2, 5, 8, 11]
     pretrain_weights: Optional[str] = "rf-detr-base.pth"


### PR DESCRIPTION
# Description

The num_select parameter was not being set correctly, leading to only 100 predictions being returned despite 300 (determined by num_queries) being made. This may be causing a strict decrease in mAP, although that depends on the mAP implementation, don't remember how ours works. Regardless of the impact on mAP this is a required change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

tested locally to confirm we return 300 predictions instead of the prior 100

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
