### PR TITLE
fix(predict): image variable unbound when passed tensor

### DIFF
--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -131,8 +131,9 @@ class RFDETR:
                     "image_or_path is a torch.Tensor\n",
                     "we expect an image divided by 255 at (C, H, W)",
                 )
-                assert image_or_path.shape[0] == 3, "image must have 3 channels"
-                h, w = image_or_path.shape[1:]
+                image = image_or_path
+                assert image.shape[0] == 3, "image must have 3 channels"
+                h, w = image.shape[1:]
 
             image = image.to(self.model.device)
             image = F.normalize(image, self.means, self.stds)


### PR DESCRIPTION
# Description

When `predict()` is passed a Tensor, the `image` variable is not assigned.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Pass a `torch.Tensor` to `predict()`.

## Docs

-   [ ] Docs updated? What were the changes:
