### PR TITLE
Feature/batch inference

### DIFF
--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -2,7 +2,7 @@ import json
 import os
 from collections import defaultdict
 from logging import getLogger
-from typing import Union
+from typing import Union, List
 
 import numpy as np
 import supervision as sv
@@ -113,58 +113,78 @@ class RFDETR:
 
     def predict(
         self,
-        image_or_path: Union[str, Image.Image, np.ndarray, torch.Tensor],
+        images: Union[
+            str, Image.Image, np.ndarray, torch.Tensor,
+            List[Union[str, Image.Image, np.ndarray, torch.Tensor]]
+        ],
         threshold: float = 0.5,
         **kwargs,
     ):
+
         self.model.model.eval()
-        with torch.inference_mode():
-            if isinstance(image_or_path, str):
-                image_or_path = Image.open(image_or_path)
-                w, h = image_or_path.size
+        self.model.device = self.model.device or torch.device("cpu")
 
-            if not isinstance(image_or_path, torch.Tensor):
-                image = F.to_tensor(image_or_path)
-                _, h, w = image.shape
+        if not isinstance(images, list):
+            images = [images]
+
+        orig_sizes = []
+        processed_images = []
+
+        for img in images:
+            # Load image if path
+            if isinstance(img, str):
+                img = Image.open(img).convert("RGB")
+
+            # Convert to tensor if needed
+            if isinstance(img, Image.Image):
+                img_tensor = F.to_tensor(img)  # C, H, W
+                h, w = img_tensor.shape[1:]
+            elif isinstance(img, np.ndarray):
+                img = Image.fromarray(img).convert("RGB")
+                img_tensor = F.to_tensor(img)
+                h, w = img_tensor.shape[1:]
+            elif isinstance(img, torch.Tensor):
+                img_tensor = img
+                h, w = img_tensor.shape[1:]
+                assert img_tensor.shape[0] == 3, "Image tensor must have 3 channels"
             else:
-                logger.warning(
-                    "image_or_path is a torch.Tensor\n",
-                    "we expect an image divided by 255 at (C, H, W)",
-                )
-                image = image_or_path
-                assert image.shape[0] == 3, "image must have 3 channels"
-                h, w = image.shape[1:]
+                raise ValueError(f"Unsupported image type: {type(img)}")
 
-            image = image.to(self.model.device)
-            image = F.normalize(image, self.means, self.stds)
-            image = F.resize(image, (self.model.resolution, self.model.resolution))
+            # Normalize & resize
+            img_tensor = img_tensor.to(self.model.device)
+            img_tensor = F.normalize(img_tensor, self.means, self.stds)
+            img_tensor = F.resize(img_tensor, (self.model.resolution, self.model.resolution))
 
-            predictions = self.model.model.forward(image[None, :])
-            bboxes = predictions["pred_boxes"]
-            results = self.model.postprocessors["bbox"](
-                predictions,
-                target_sizes=torch.tensor([[h, w]], device=self.model.device),
-            )
-            scores, labels, boxes = [], [], []
-            for result in results:
-                scores.append(result["scores"])
-                labels.append(result["labels"])
-                boxes.append(result["boxes"])
+            processed_images.append(img_tensor)
+            orig_sizes.append((h, w))
 
-            scores = torch.stack(scores)
-            labels = torch.stack(labels)
-            boxes = torch.stack(boxes)
+        batch_tensor = torch.stack(processed_images)  # Shape: [B, 3, H, W]
 
-            keep_inds = scores > threshold
-            boxes = boxes[keep_inds]
-            labels = labels[keep_inds]
-            scores = scores[keep_inds]
+        with torch.inference_mode():
+            predictions = self.model.model(batch_tensor)
+
+            target_sizes = torch.tensor(orig_sizes, device=self.model.device)
+            results = self.model.postprocessors["bbox"](predictions, target_sizes=target_sizes)
+
+        detections_list = []
+        for result in results:
+            scores = result["scores"]
+            labels = result["labels"]
+            boxes = result["boxes"]
+
+            keep = scores > threshold
+            scores = scores[keep]
+            labels = labels[keep]
+            boxes = boxes[keep]
+
             detections = sv.Detections(
                 xyxy=boxes.cpu().numpy(),
-                class_id=labels.cpu().numpy(),
                 confidence=scores.cpu().numpy(),
+                class_id=labels.cpu().numpy(),
             )
-            return detections
+            detections_list.append(detections)
+
+        return detections_list if len(detections_list) > 1 else detections_list[0]
 
 
 class RFDETRBase(RFDETR):


### PR DESCRIPTION
# Description

This PR modifies the predict() function in the RF-DETR inference pipeline to support batch inference instead of processing one image at a time. This improves throughput and better utilizes GPU resources when working with multiple images.

This change allows users to pass a list of images and receive predictions for all of them in a single forward pass,

There are no new dependencies introduced with this change.

Ticket : https://github.com/roboflow/rf-detr/issues/64

I tested with 4 images predicting separately and together in one batch and the time results on my Mac M2 laptop on cpu are: 

```
predict batch images: 1,61 sec
predict separately:   1,84 sec
```



## Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- This change has been tested manually by passing a list of string file_paths to predict() and confirming that the output shapes, prediction counts, and class scores match against the original single-image results.

## Any specific deployment considerations

## Docs

-   [ ] Docs updated? What were the changes:
