### PR TITLE
remove network call to huggingface

### DIFF
--- a/rfdetr/models/backbone/__init__.py
+++ b/rfdetr/models/backbone/__init__.py
@@ -61,6 +61,7 @@ def build_backbone(
     backbone_lora,
     force_no_pretrain,
     gradient_checkpointing,
+    load_dinov2_weights,
 ):
     """
     Useful args:
@@ -87,6 +88,7 @@ def build_backbone(
         rms_norm=rms_norm,
         backbone_lora=backbone_lora,
         gradient_checkpointing=gradient_checkpointing,
+        load_dinov2_weights=load_dinov2_weights,
     )
 
     model = Joiner(backbone, position_embedding)

--- a/rfdetr/models/backbone/backbone.py
+++ b/rfdetr/models/backbone/backbone.py
@@ -47,6 +47,7 @@ class Backbone(BackboneBase):
                  rms_norm: bool = False,
                  backbone_lora: bool = False,
                  gradient_checkpointing: bool = False,
+                 load_dinov2_weights: bool = True,
                  ):
         super().__init__()
         # an example name here would be "dinov2_base" or "dinov2_registers_windowed_base"
@@ -73,6 +74,7 @@ class Backbone(BackboneBase):
             use_registers=use_registers,
             use_windowed_attn=use_windowed_attn,
             gradient_checkpointing=gradient_checkpointing,
+            load_dinov2_weights=load_dinov2_weights,
         )
         # build encoder + projector as backbone module
         if freeze_encoder:

--- a/rfdetr/models/backbone/dinov2.py
+++ b/rfdetr/models/backbone/dinov2.py
@@ -1,9 +1,11 @@
 import torch
 import torch.nn as nn
-from transformers import AutoBackbone, AutoConfig
+from transformers import AutoBackbone
 import torch.nn.functional as F
 import types
 import math
+import json
+import os
 
 from .dinov2_with_windowed_attn import WindowedDinov2WithRegistersConfig, WindowedDinov2WithRegistersBackbone
 
@@ -15,8 +17,30 @@ size_to_width = {
     "large": 1024,
 }
 
+size_to_config = {
+    "small": "dinov2_small.json",
+    "base": "dinov2_base.json",
+    "large": "dinov2_large.json",
+}
+
+size_to_config_with_registers = {
+    "small": "dinov2_with_registers_small.json",
+    "base": "dinov2_with_registers_base.json",
+    "large": "dinov2_with_registers_large.json",
+}
+
+def get_config(size, use_registers):
+    config_dict = size_to_config_with_registers if use_registers else size_to_config
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    configs_dir = os.path.join(current_dir, "dinov2_configs")
+    config_path = os.path.join(configs_dir, config_dict[size])
+    with open(config_path, "r") as f:
+        dino_config = json.load(f)
+    return dino_config
+
+
 class DinoV2(nn.Module):
-    def __init__(self, shape=(640, 640), out_feature_indexes=[2, 4, 5, 9], size="base", use_registers=True, use_windowed_attn=True, gradient_checkpointing=False):
+    def __init__(self, shape=(640, 640), out_feature_indexes=[2, 4, 5, 9], size="base", use_registers=True, use_windowed_attn=True, gradient_checkpointing=False, load_dinov2_weights=True):
         super().__init__()
 
         name = f"facebook/dinov2-with-registers-{size}" if use_registers else f"facebook/dinov2-{size}"
@@ -27,6 +51,7 @@ class DinoV2(nn.Module):
         
         if not use_windowed_attn:
             assert not gradient_checkpointing, "Gradient checkpointing is not supported for non-windowed attention"
+            assert load_dinov2_weights, "Using non-windowed attention requires loading dinov2 weights from hub"
             self.encoder = AutoBackbone.from_pretrained(
                 name,
                 out_features=[f"stage{i}" for i in out_feature_indexes],
@@ -37,21 +62,21 @@ class DinoV2(nn.Module):
             window_block_indexes.difference_update(out_feature_indexes)
             window_block_indexes = list(window_block_indexes)
 
-            dino_config = AutoConfig.from_pretrained(
-                name,
-                out_features=[f"stage{i}" for i in out_feature_indexes],
-                return_dict=False,
-            )
+            dino_config = get_config(size, use_registers)
+
+            dino_config["return_dict"] = False
+            dino_config["out_features"] = [f"stage{i}" for i in out_feature_indexes]
+
             if use_registers:
                 windowed_dino_config = WindowedDinov2WithRegistersConfig(
-                    **dino_config.to_dict(),
+                    **dino_config,
                     num_windows=4,
                     window_block_indexes=window_block_indexes,
                     gradient_checkpointing=gradient_checkpointing,
                 )
             else:
                 windowed_dino_config = WindowedDinov2WithRegistersConfig(
-                    **dino_config.to_dict(),
+                    **dino_config,
                     num_windows=4,
                     window_block_indexes=window_block_indexes,
                     num_register_tokens=0,
@@ -60,7 +85,7 @@ class DinoV2(nn.Module):
             self.encoder = WindowedDinov2WithRegistersBackbone.from_pretrained(
                 name,
                 config=windowed_dino_config,
-            )
+            ) if load_dinov2_weights else WindowedDinov2WithRegistersBackbone(windowed_dino_config)
 
 
         self._out_feature_channels = [size_to_width[size]] * len(out_feature_indexes)

--- a/rfdetr/models/backbone/dinov2_configs/dinov2_base.json
+++ b/rfdetr/models/backbone/dinov2_configs/dinov2_base.json
@@ -1,0 +1,24 @@
+{
+    "architectures": [
+      "Dinov2Model"
+    ],
+    "attention_probs_dropout_prob": 0.0,
+    "drop_path_rate": 0.0,
+    "hidden_act": "gelu",
+    "hidden_dropout_prob": 0.0,
+    "hidden_size": 768,
+    "image_size": 518,
+    "initializer_range": 0.02,
+    "layer_norm_eps": 1e-06,
+    "layerscale_value": 1.0,
+    "mlp_ratio": 4,
+    "model_type": "dinov2",
+    "num_attention_heads": 12,
+    "num_channels": 3,
+    "num_hidden_layers": 12,
+    "patch_size": 14,
+    "qkv_bias": true,
+    "torch_dtype": "float32",
+    "transformers_version": "4.31.0.dev0",
+    "use_swiglu_ffn": false
+}

--- a/rfdetr/models/backbone/dinov2_configs/dinov2_large.json
+++ b/rfdetr/models/backbone/dinov2_configs/dinov2_large.json
@@ -1,0 +1,24 @@
+{
+    "architectures": [
+      "Dinov2Model"
+    ],
+    "attention_probs_dropout_prob": 0.0,
+    "drop_path_rate": 0.0,
+    "hidden_act": "gelu",
+    "hidden_dropout_prob": 0.0,
+    "hidden_size": 1024,
+    "image_size": 518,
+    "initializer_range": 0.02,
+    "layer_norm_eps": 1e-06,
+    "layerscale_value": 1.0,
+    "mlp_ratio": 4,
+    "model_type": "dinov2",
+    "num_attention_heads": 16,
+    "num_channels": 3,
+    "num_hidden_layers": 24,
+    "patch_size": 14,
+    "qkv_bias": true,
+    "torch_dtype": "float32",
+    "transformers_version": "4.31.0.dev0",
+    "use_swiglu_ffn": false
+}

--- a/rfdetr/models/backbone/dinov2_configs/dinov2_small.json
+++ b/rfdetr/models/backbone/dinov2_configs/dinov2_small.json
@@ -1,0 +1,24 @@
+{
+    "architectures": [
+      "Dinov2Model"
+    ],
+    "attention_probs_dropout_prob": 0.0,
+    "drop_path_rate": 0.0,
+    "hidden_act": "gelu",
+    "hidden_dropout_prob": 0.0,
+    "hidden_size": 384,
+    "image_size": 518,
+    "initializer_range": 0.02,
+    "layer_norm_eps": 1e-06,
+    "layerscale_value": 1.0,
+    "mlp_ratio": 4,
+    "model_type": "dinov2",
+    "num_attention_heads": 6,
+    "num_channels": 3,
+    "num_hidden_layers": 12,
+    "patch_size": 14,
+    "qkv_bias": true,
+    "torch_dtype": "float32",
+    "transformers_version": "4.32.0.dev0",
+    "use_swiglu_ffn": false
+}

--- a/rfdetr/models/backbone/dinov2_configs/dinov2_with_registers_base.json
+++ b/rfdetr/models/backbone/dinov2_configs/dinov2_with_registers_base.json
@@ -1,0 +1,50 @@
+{
+    "apply_layernorm": true,
+    "architectures": [
+        "Dinov2WithRegistersModel"
+    ],
+    "attention_probs_dropout_prob": 0.0,
+    "drop_path_rate": 0.0,
+    "hidden_act": "gelu",
+    "hidden_dropout_prob": 0.0,
+    "hidden_size": 768,
+    "image_size": 518,
+    "initializer_range": 0.02,
+    "interpolate_antialias": true,
+    "interpolate_offset": 0.0,
+    "layer_norm_eps": 1e-06,
+    "layerscale_value": 1.0,
+    "mlp_ratio": 4,
+    "model_type": "dinov2_with_registers",
+    "num_attention_heads": 12,
+    "num_channels": 3,
+    "num_hidden_layers": 12,
+    "num_register_tokens": 4,
+    "out_features": [
+        "stage12"
+    ],
+    "out_indices": [
+        12
+    ],
+    "patch_size": 14,
+    "qkv_bias": true,
+    "reshape_hidden_states": true,
+    "stage_names": [
+        "stem",
+        "stage1",
+        "stage2",
+        "stage3",
+        "stage4",
+        "stage5",
+        "stage6",
+        "stage7",
+        "stage8",
+        "stage9",
+        "stage10",
+        "stage11",
+        "stage12"
+    ],
+    "torch_dtype": "float32",
+    "transformers_version": "4.48.0.dev0",
+    "use_swiglu_ffn": false
+}

--- a/rfdetr/models/backbone/dinov2_configs/dinov2_with_registers_large.json
+++ b/rfdetr/models/backbone/dinov2_configs/dinov2_with_registers_large.json
@@ -1,0 +1,50 @@
+{
+    "apply_layernorm": true,
+    "architectures": [
+      "Dinov2WithRegistersModel"
+    ],
+    "attention_probs_dropout_prob": 0.0,
+    "drop_path_rate": 0.0,
+    "hidden_act": "gelu",
+    "hidden_dropout_prob": 0.0,
+    "hidden_size": 1024,
+    "image_size": 518,
+    "initializer_range": 0.02,
+    "interpolate_antialias": true,
+    "interpolate_offset": 0.0,
+    "layer_norm_eps": 1e-06,
+    "layerscale_value": 1.0,
+    "mlp_ratio": 4,
+    "model_type": "dinov2_with_registers",
+    "num_attention_heads": 16,
+    "num_channels": 3,
+    "num_hidden_layers": 24,
+    "num_register_tokens": 4,
+    "out_features": [
+      "stage12"
+    ],
+    "out_indices": [
+      12
+    ],
+    "patch_size": 14,
+    "qkv_bias": true,
+    "reshape_hidden_states": true,
+    "stage_names": [
+      "stem",
+      "stage1",
+      "stage2",
+      "stage3",
+      "stage4",
+      "stage5",
+      "stage6",
+      "stage7",
+      "stage8",
+      "stage9",
+      "stage10",
+      "stage11",
+      "stage12"
+    ],
+    "torch_dtype": "float32",
+    "transformers_version": "4.48.0.dev0",
+    "use_swiglu_ffn": false
+}

--- a/rfdetr/models/backbone/dinov2_configs/dinov2_with_registers_small.json
+++ b/rfdetr/models/backbone/dinov2_configs/dinov2_with_registers_small.json
@@ -1,0 +1,50 @@
+{
+    "apply_layernorm": true,
+    "architectures": [
+      "Dinov2WithRegistersModel"
+    ],
+    "attention_probs_dropout_prob": 0.0,
+    "drop_path_rate": 0.0,
+    "hidden_act": "gelu",
+    "hidden_dropout_prob": 0.0,
+    "hidden_size": 384,
+    "image_size": 518,
+    "initializer_range": 0.02,
+    "interpolate_antialias": true,
+    "interpolate_offset": 0.0,
+    "layer_norm_eps": 1e-06,
+    "layerscale_value": 1.0,
+    "mlp_ratio": 4,
+    "model_type": "dinov2_with_registers",
+    "num_attention_heads": 6,
+    "num_channels": 3,
+    "num_hidden_layers": 12,
+    "num_register_tokens": 4,
+    "out_features": [
+      "stage12"
+    ],
+    "out_indices": [
+      12
+    ],
+    "patch_size": 14,
+    "qkv_bias": true,
+    "reshape_hidden_states": true,
+    "stage_names": [
+      "stem",
+      "stage1",
+      "stage2",
+      "stage3",
+      "stage4",
+      "stage5",
+      "stage6",
+      "stage7",
+      "stage8",
+      "stage9",
+      "stage10",
+      "stage11",
+      "stage12"
+    ],
+    "torch_dtype": "float32",
+    "transformers_version": "4.48.0.dev0",
+    "use_swiglu_ffn": false
+}

--- a/rfdetr/models/lwdetr.py
+++ b/rfdetr/models/lwdetr.py
@@ -610,6 +610,7 @@ def build_model(args):
         backbone_lora=args.backbone_lora,
         force_no_pretrain=args.force_no_pretrain,
         gradient_checkpointing=args.gradient_checkpointing,
+        load_dinov2_weights=args.pretrain_weights is None,
     )
     if args.encoder_only:
         return backbone[0].encoder, None, None


### PR DESCRIPTION
# Description

Sometimes our network call to huggingface fails, causing our training code to crash. We don't actually need to reach out to huggingface for the DINOv2 weights in the happy path, as we subsequently overwrite them with our pretrained model weights. This PR removes the network call used to download the weights in the case where we're finetuning a pretrained model. It also removes the network call to retrieve the config files, replacing them with local copies.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

I verified that I could train the model locally without the call to huggingface. I also verified that the call happens when we set pretrain_weights to None

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
