### PR TITLE
Stable cross entropy

### DIFF
--- a/rfdetr/models/lwdetr.py
+++ b/rfdetr/models/lwdetr.py
@@ -305,7 +305,7 @@ class SetCriterion(nn.Module):
 
             pos_weights[pos_ind] = t.to(pos_weights.dtype)
             neg_weights[pos_ind] = 1 - t.to(neg_weights.dtype)
-            loss_ce = - pos_weights * prob.log() - neg_weights * (1 - prob).log()
+            loss_ce = neg_weights * src_logits - F.logsigmoid(src_logits) * (pos_weights + neg_weights)
             loss_ce = loss_ce.sum() / num_boxes
 
         elif self.use_position_supervised_loss:

--- a/rfdetr/models/lwdetr.py
+++ b/rfdetr/models/lwdetr.py
@@ -305,6 +305,8 @@ class SetCriterion(nn.Module):
 
             pos_weights[pos_ind] = t.to(pos_weights.dtype)
             neg_weights[pos_ind] = 1 - t.to(neg_weights.dtype)
+            # a reformulation of the standard loss_ce = - pos_weights * prob.log() - neg_weights * (1 - prob).log()
+            # with a focus on statistical stability by using fused logsigmoid
             loss_ce = neg_weights * src_logits - F.logsigmoid(src_logits) * (pos_weights + neg_weights)
             loss_ce = loss_ce.sum() / num_boxes
 


### PR DESCRIPTION
# Description

The standard sigmoidal focal loss has a statistical instability issue due to taking the log of a sigmoid, especially with mixed precision training. Normally we'd protect the log via some epsilon. In this case we can refactor to use a logsigmoid directly.

Here's the basic algebra:

![image (5)](https://github.com/user-attachments/assets/76b2611d-5cd7-47c1-99b6-7aef786c71e3)

Notice that we've factored out the log(1-sigmoid), which just leaves a single log(sigmoid) term. Because we use a fused logsigmoid, this seems to prevent an inf loss that we experienced for a client earlier.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Trained on the reference dataset that produced the inf loss before and did not produce that loss.

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
