### PR TITLE
[BUG] Predict Correct calculation for width, height 

### DIFF
--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -137,12 +137,13 @@ class RFDETR:
                 img_tensor = img
                 assert img_tensor.shape[0] == 3, "image must have 3 channels"
 
+            h, w = img_tensor.shape[1:]
+            orig_sizes.append((h, w))
+
             img_tensor = img_tensor.to(self.model.device)
             img_tensor = F.normalize(img_tensor, self.means, self.stds)
             img_tensor = F.resize(img_tensor, (self.model.resolution, self.model.resolution))
 
-            h, w = img_tensor.shape[1:]
-            orig_sizes.append((h, w))
             processed_images.append(img_tensor)
 
         batch_tensor = torch.stack(processed_images)


### PR DESCRIPTION
# Description

There was a last minute change in predict batch inference which moved the calculation of the original image size after the resize and this leads to incorrect results

This code should be before the image resize
```
 h, w = img_tensor.shape[1:]
 orig_sizes.append((h, w))
```

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)


## How has this change been tested, please provide a testcase or example of how you tested the change?

Manually with an image to see I get correct results 

## Any specific deployment considerations

## Docs

-   [ ] Docs updated? What were the changes:
