### PR TITLE
support local-encoder-weights

### DIFF
--- a/rfdetr/config.py
+++ b/rfdetr/config.py
@@ -12,6 +12,7 @@ DEVICE = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is
 
 class ModelConfig(BaseModel):
     encoder: Literal["dinov2_windowed_small", "dinov2_windowed_base"]
+    pretrained_encoder:Optional[str] = None
     out_feature_indexes: List[int]
     dec_layers: int = 3
     two_stage: bool = True

--- a/rfdetr/models/backbone/backbone.py
+++ b/rfdetr/models/backbone/backbone.py
@@ -77,6 +77,7 @@ class Backbone(BackboneBase):
             use_registers=use_registers,
             use_windowed_attn=use_windowed_attn,
             gradient_checkpointing=gradient_checkpointing,
+            encoder_weights_path = pretrained_encoder,
             load_dinov2_weights=load_dinov2_weights,
         )
         # build encoder + projector as backbone module

--- a/rfdetr/models/backbone/dinov2.py
+++ b/rfdetr/models/backbone/dinov2.py
@@ -46,10 +46,13 @@ def get_config(size, use_registers):
 
 
 class DinoV2(nn.Module):
-    def __init__(self, shape=(640, 640), out_feature_indexes=[2, 4, 5, 9], size="base", use_registers=True, use_windowed_attn=True, gradient_checkpointing=False, load_dinov2_weights=True):
+    def __init__(self, shape=(640, 640), out_feature_indexes=[2, 4, 5, 9], size="base", use_registers=True, use_windowed_attn=True, gradient_checkpointing=False,encoder_weights_path=None, load_dinov2_weights=True):
         super().__init__()
 
-        name = f"facebook/dinov2-with-registers-{size}" if use_registers else f"facebook/dinov2-{size}"
+        if encoder_weights_path is None:
+            name = f"facebook/dinov2-with-registers-{size}" if use_registers else f"facebook/dinov2-{size}"
+        else:
+            name = encoder_weights_path
 
         self.shape = shape
         


### PR DESCRIPTION
# Description

This change adds support for **local encoder weights***, which is very similar to the existing **'pretrain_weights'** parameter. The **'pretrained_encoder'** parameter already exists in the backbone but is not exposed in the config.py.  This parameter is essential when the user is not able to download the weights from the huggingface hub in the target machine.  If this parameter is not specified, the default behavior will kick in, and it will try to download weights from huggingface. 

Users can download the weights separately and set this parameter:
```
model = RFDETRBase(pretrain_weights=pretrain_weights,pretrained_encoder=pretrained_encoder)
```

