### PR TITLE
support low res training

### DIFF
--- a/rfdetr/datasets/coco.py
+++ b/rfdetr/datasets/coco.py
@@ -43,7 +43,9 @@ def compute_multi_scale_scales(resolution, expanded_scales=False):
     base_num_patches_per_window = resolution // (patch_size * 4)
     offsets = [-3, -2, -1, 0, 1, 2, 3, 4] if not expanded_scales else [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5]
     scales = [base_num_patches_per_window + offset for offset in offsets]
-    return [scale * patch_size * 4 for scale in scales]
+    proposed_scales = [scale * patch_size * 4 for scale in scales]
+    proposed_scales = [scale for scale in proposed_scales if scale >= patch_size * 4]  # ensure minimum image size
+    return proposed_scales
 
 
 class CocoDetection(torchvision.datasets.CocoDetection):

--- a/rfdetr/models/lwdetr.py
+++ b/rfdetr/models/lwdetr.py
@@ -181,9 +181,9 @@ class LWDETR(nn.Module):
             out['aux_outputs'] = self._set_aux_loss(outputs_class, outputs_coord)
 
         if self.two_stage:
-            hs_enc_list = hs_enc.split(self.num_queries, dim=1)
-            cls_enc = []
             group_detr = self.group_detr if self.training else 1
+            hs_enc_list = hs_enc.chunk(group_detr, dim=1)
+            cls_enc = []
             for g_idx in range(group_detr):
                 cls_enc_gidx = self.transformer.enc_out_class_embed[g_idx](hs_enc_list[g_idx])
                 cls_enc.append(cls_enc_gidx)

--- a/rfdetr/models/ops/functions/ms_deform_attn_func.py
+++ b/rfdetr/models/ops/functions/ms_deform_attn_func.py
@@ -1,7 +1,10 @@
 # ------------------------------------------------------------------------
-# LW-DETR
-# Copyright (c) 2024 Baidu. All Rights Reserved.
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+# Modified from LW-DETR (https://github.com/Atten4Vis/LW-DETR)
+# Copyright (c) 2024 Baidu. All Rights Reserved.
 # ------------------------------------------------------------------------------------------------
 # Modified from Deformable DETR
 # Copyright (c) 2020 SenseTime. All Rights Reserved.


### PR DESCRIPTION
# Description

Our model currently crashes if the number of patches from the backbone is less than the number of queries. This PR fixes that.

This PR also fixes an issue where training a model at low res causes a failure in the data loader due to the multi scale augmentation trying to get an image resized to negative dimensions.

Finally, I forgot to update a copyright notice 

It's worth noting that I don't think training at super low res like this will yield GOOD results. and there may be a better way to implement this. but at least it won't crash now.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

tested training locally with and without multiscale at low and normal resolutions. I also tested inference. Without this change, running inference at a very low resolution failed, and now it succeeds.

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
