### PR TITLE
Add LightlyTrain Integration for Pretraining Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,24 @@ dataset/
 
 [Roboflow](https://roboflow.com/annotate) allows you to create object detection datasets from scratch or convert existing datasets from formats like YOLO, and then export them in COCO JSON format for training. You can also explore [Roboflow Universe](https://universe.roboflow.com/) to find pre-labeled datasets for a range of use cases.
 
+### Pretraining
+
+If you prefer pretraining RF-DETR, ideally before fine-tuning, you could use [LightlyTrain](https://docs.lightly.ai/train/stable/index.html) with RF-DETR support. LightlyTrain is a novel framework that let you pretrain any computer vision model on your unlabeled data, by leveraging distillation from foundation models and using self-supervised learning.
+
+You can pretrain your RF-DETR model by simply
+
+```python
+import lightly_train
+if __name__ == "__main__":
+    lightly_train.train(
+        out="out/my_experiment",                # Output directory.
+        data="my_data_dir",                     # Directory with images.
+        model="rfdetr/rf-detr-base",            # Pass the RF-DETR model.
+    )
+```
+
+You could also check [this Colab tutoria](colab-link) for full guides on also fine-tuning with RF-DETR on a Roboflow COCO dataset.
+
 ### Fine-tuning
 
 You can fine-tune RF-DETR from pre-trained COCO checkpoints. By default, the RF-DETR-B checkpoint will be used. To get started quickly, please refer to our fine-tuning Google Colab [notebook](https://colab.research.google.com/github/roboflow-ai/notebooks/blob/main/notebooks/how-to-finetune-rf-detr-on-detection-dataset.ipynb).

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ if __name__ == "__main__":
     )
 ```
 
-You could also check [this Colab tutoria](colab-link) for full guides on also fine-tuning with RF-DETR on a Roboflow COCO dataset.
+You could also check [this Colab tutorial](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/rfdetr.ipynb) for full guides on also fine-tuning with RF-DETR on a Roboflow COCO dataset.
 
 ### Fine-tuning
 

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ dataset/
 
 ### Pretraining
 
-If you prefer pretraining RF-DETR, ideally before fine-tuning, you could use [LightlyTrain](https://docs.lightly.ai/train/stable/index.html) with RF-DETR support. LightlyTrain is a novel framework that let you pretrain any computer vision model on your unlabeled data, by leveraging distillation from foundation models and using self-supervised learning.
+If you have unlabeled data and would like to pretrain RF-DETR on it before fine-tuning, you could use [LightlyTrain](https://docs.lightly.ai/train/stable/index.html) with RF-DETR support. LightlyTrain is a novel framework that let you pretrain any computer vision model on your unlabeled data, by leveraging distillation from foundation models and using self-supervised learning.
 
 You can pretrain your RF-DETR model by simply
 


### PR DESCRIPTION
# Description

Add LightlyTrain Integration for Pretraining Support 

[LightlyTrain](https://github.com/lightly-ai/lightly-train) is a novel framework built with PyTorch. It lets you pretrain any computer vision model on your unlabeled data, by leveraging distillation from powerful vision models and using self-supervised learning. With only a few lines of code, the community can pretrain domain-specific backbones for any downstream task with a RF-DETR backbone and beyond. We think pretraining on custom domains is a great addition to the current RF-DETR, which is why we would love to feature our integration to your README.

You can simply start pretraining RF-DETR by:

```python
import lightly_train

if __name__ == "__main__":
    lightly_train.train(
        out="out/my_experiment",                # Output directory.
        data="my_data_dir",                     # Directory with images.
        model="rfdetr/rf-detr-base",            # Pass the RF-DETR model.
    )
```

and fine-tune using the checkpoint by:

```python
# fine_tune.py
from rfdetr import RFDETRBase
from roboflow import Roboflow

if __name__ == "__main__":
    model = RFDETRBase(pretrain_weights="out/my_experiment/exported_models/exported_last.pt")
      
    model.train(dataset_dir=<DATASET_PATH>)
```

You can also check our [docs](https://docs.lightly.ai/train/stable/index.html) and [product page](https://www.lightly.ai/lightlytrain) for more details.

### Changes

This PR contains 
- a short intro to LightlyTrain added to the “Training” section in the README file

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

N/A

## Any specific deployment considerations

N/A

## Docs

-   [ ] Docs updated? What were the changes:
