### PR TITLE
fix: Readme instructions pointed to obsolete WoW.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ import requests
 import supervision as sv
 from PIL import Image
 from rfdetr import RFDETRBase
+from rfdetr.util.coco_classes import COCO_CLASSES
 
 model = RFDETRBase()
-CLASS_NAMES = model.class_names
 
 url = "https://media.roboflow.com/notebooks/examples/dog-2.jpeg"
 
@@ -94,7 +94,7 @@ image = Image.open(io.BytesIO(requests.get(url).content))
 detections = model.predict(image, threshold=0.5)
 
 labels = [
-    f"{CLASS_NAMES[class_id]} {confidence:.2f}"
+    f"{COCO_CLASSES[class_id]} {confidence:.2f}"
     for class_id, confidence
     in zip(detections.class_id, detections.confidence)
 ]
@@ -114,15 +114,15 @@ sv.plot_image(annotated_image)
 ```python
 import supervision as sv
 from rfdetr import RFDETRBase
+from rfdetr.util.coco_classes import COCO_CLASSES
 
 model = RFDETRBase()
-CLASS_NAMES = model.class_names
 
 def callback(frame, index):
     detections = model.predict(frame[:, :, ::-1], threshold=0.5)
         
     labels = [
-        f"{CLASS_NAMES[class_id]} {confidence:.2f}"
+        f"{COCO_CLASSES[class_id]} {confidence:.2f}"
         for class_id, confidence
         in zip(detections.class_id, detections.confidence)
     ]
@@ -150,9 +150,9 @@ sv.process_video(
 import cv2
 import supervision as sv
 from rfdetr import RFDETRBase
+from rfdetr.util.coco_classes import COCO_CLASSES
 
 model = RFDETRBase()
-CLASS_NAMES = model.class_names
 
 cap = cv2.VideoCapture(0)
 while True:
@@ -163,7 +163,7 @@ while True:
     detections = model.predict(frame[:, :, ::-1], threshold=0.5)
     
     labels = [
-        f"{CLASS_NAMES[class_id]} {confidence:.2f}"
+        f"{COCO_CLASSES[class_id]} {confidence:.2f}"
         for class_id, confidence
         in zip(detections.class_id, detections.confidence)
     ]
@@ -192,9 +192,9 @@ cv2.destroyAllWindows()
 import cv2
 import supervision as sv
 from rfdetr import RFDETRBase
+from rfdetr.util.coco_classes import COCO_CLASSES
 
 model = RFDETRBase()
-CLASS_NAMES = model.class_names
 
 cap = cv2.VideoCapture(<RTSP_STREAM_URL>)
 while True:
@@ -205,7 +205,7 @@ while True:
     detections = model.predict(frame[:, :, ::-1], threshold=0.5)
     
     labels = [
-        f"{CLASS_NAMES[class_id]} {confidence:.2f}"
+        f"{COCO_CLASSES[class_id]} {confidence:.2f}"
         for class_id, confidence
         in zip(detections.class_id, detections.confidence)
     ]


### PR DESCRIPTION
# Description

Readme instructions are incorrect. Following it results in:

```shell
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[8], line 8
      5 from rfdetr import RFDETRBase
      7 model = RFDETRBase()
----> 8 CLASS_NAMES = model.class_names
     10 url = "https://media.roboflow.com/notebooks/examples/dog-2.jpeg"
     12 image = Image.open(io.BytesIO(requests.get(url).content))

AttributeError: 'RFDETRBase' object has no attribute 'class_names'
```


## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

YOUR_ANSWER

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
