### PR TITLE
Refactor: raise early on invalid PIL input, removed else block

### DIFF
--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -170,20 +170,20 @@ class RFDETR:
                 img = Image.open(img)
 
             if not isinstance(img, torch.Tensor):
-                img_tensor = F.to_tensor(img)
-            else:
-                if (img > 1).any():
-                    raise ValueError(
-                        "Image has pixel values above 1. Please ensure the image is "
-                        "normalized (scaled to [0, 1])."
-                    )
-                if img.shape[0] != 3:
-                    raise ValueError(
-                        f"Invalid image shape. Expected 3 channels (RGB), but got "
-                        f"{img.shape[0]} channels."
-                    )
-                img_tensor = img
-
+                img = F.to_tensor(img)
+            
+            if (img > 1).any():
+                raise ValueError(
+                    "Image has pixel values above 1. Please ensure the image is "
+                    "normalized (scaled to [0, 1])."
+                )
+            if img.shape[0] != 3:
+                raise ValueError(
+                    f"Invalid image shape. Expected 3 channels (RGB), but got "
+                    f"{img.shape[0]} channels."
+                )
+            img_tensor = img
+            
             h, w = img_tensor.shape[1:]
             orig_sizes.append((h, w))
 


### PR DESCRIPTION
# Description

As mentionned in issue #66, the input shape was not being checked when a PIL image was given to the RFDETR.predict function. To address this, the else block has been removed, and now a grayscale image will raise the same error as a wrongly shaped torch tensor.

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

The following script was used for testing. I could add it to the PR, but I believe you need to first define clear unit test guidelines:

```python

import pytest
import torch
from PIL import Image

from .detr import  RFDETRBase


model = RFDETRBase()

@pytest.mark.parametrize("image", [
    torch.rand(3, 100, 100),
    Image.new("RGB", (100, 100)),
])
def test_predict_with_valid_tensor(image):
    detections = model.predict(image)
    assert detections is not None

def test_predict_with_pixels_above_one():
    image = torch.rand(3, 100, 100) * 255  # not normalized
    with pytest.raises(ValueError, match="Image has pixel values above 1"):
        model.predict(image)

@pytest.mark.parametrize("image", [
    torch.rand(1, 100, 100),
    Image.new("L", (100, 100)),
])
def test_predict_with_invalid_tensor_shape(image):
    with pytest.raises(ValueError, match="Invalid image shape"):
        model.predict(image)
```

## Any specific deployment considerations

There are no deployment considerations as no functionality change was made, just a bug fix related to input validation.

## Docs

No documentation was updated.
