### PR TITLE
Update encoder options in ModelConfig and derived classes adding Dino v2 with registers

### DIFF
--- a/rfdetr/config.py
+++ b/rfdetr/config.py
@@ -11,7 +11,7 @@ import torch
 DEVICE = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
 
 class ModelConfig(BaseModel):
-    encoder: Literal["dinov2_windowed_small", "dinov2_windowed_base"]
+    encoder: Literal["dinov2_windowed_small", "dinov2_windowed_base", "dinov2_registers_windowed_small", "dinov2_registers_windowed_base"]
     out_feature_indexes: List[int]
     dec_layers: int = 3
     two_stage: bool = True
@@ -32,7 +32,7 @@ class ModelConfig(BaseModel):
     gradient_checkpointing: bool = False
 
 class RFDETRBaseConfig(ModelConfig):
-    encoder: Literal["dinov2_windowed_small", "dinov2_windowed_base"] = "dinov2_windowed_small"
+    encoder: Literal["dinov2_windowed_small", "dinov2_windowed_base", "dinov2_registers_windowed_small", "dinov2_registers_windowed_base"] = "dinov2_windowed_small"
     hidden_dim: int = 256
     sa_nheads: int = 8
     ca_nheads: int = 16
@@ -44,7 +44,7 @@ class RFDETRBaseConfig(ModelConfig):
     pretrain_weights: Optional[str] = "rf-detr-base.pth"
 
 class RFDETRLargeConfig(RFDETRBaseConfig):
-    encoder: Literal["dinov2_windowed_small", "dinov2_windowed_base"] = "dinov2_windowed_base"
+    encoder: Literal["dinov2_windowed_small", "dinov2_windowed_base", "dinov2_registers_windowed_small", "dinov2_registers_windowed_base"] = "dinov2_windowed_base"
     hidden_dim: int = 384
     sa_nheads: int = 12
     ca_nheads: int = 24


### PR DESCRIPTION
small and base

# Description

This PR adds the `dinov2_registers_windowed_small` and  `dinov2_registers_windowed_base` option to the `ModelConfig.encoder` field.

The model downloads and runs correctly with this encoder, but the literal option was missing from the list. This change allows users to configure the model directly without editing internal code.

No other modifications were necessary and existing functionality remains unchanged.

I have read the CLA Document and I sign the CLA.

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x ] New feature (non-breaking change which adds functionality)
-   [x ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

I train and test a model

## Any specific deployment considerations

## Docs

Not sure if Docs have to change
