### PR TITLE
docs: The method `optimize_for_inference` doesn't return anything

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ from rfdetr.util.coco_classes import COCO_CLASSES
 
 model = RFDETRBase()
 
-model = model.optimize_for_inference()
+model.optimize_for_inference()
 
 url = "https://media.roboflow.com/notebooks/examples/dog-2.jpeg"
 


### PR DESCRIPTION
Update example code in the `README.md`, because the method `optimize_for_inference` doesn't return anything.

Current:

```python
model = RFDETRBase()
model = model.optimize_for_inference()
# ...
detections = model.predict(image, threshold=0.5)
```

Fixed:

```python
model = RFDETRBase()
model.optimize_for_inference()  # just call the method
# ...
detections = model.predict(image, threshold=0.5)
```

This fix is related to the issue https://github.com/roboflow/rf-detr/issues/237.