### PR TITLE
do random resize on batched images

### DIFF
--- a/rfdetr/config.py
+++ b/rfdetr/config.py
@@ -76,6 +76,7 @@ class TrainConfig(BaseModel):
     output_dir: str = "output"
     multi_scale: bool = True
     expanded_scales: bool = True
+    do_random_resize_via_padding: bool = False
     use_ema: bool = True
     num_workers: int = 2
     weight_decay: float = 1e-4

--- a/rfdetr/datasets/coco.py
+++ b/rfdetr/datasets/coco.py
@@ -107,7 +107,7 @@ class ConvertCoco(object):
         return image, target
 
 
-def make_coco_transforms(image_set, resolution, multi_scale=False, expanded_scales=False):
+def make_coco_transforms(image_set, resolution, multi_scale=False, expanded_scales=False, skip_random_resize=False):
 
     normalize = T.Compose([
         T.ToTensor(),
@@ -118,6 +118,8 @@ def make_coco_transforms(image_set, resolution, multi_scale=False, expanded_scal
     if multi_scale:
         # scales = [448, 512, 576, 640, 704, 768, 832, 896]
         scales = compute_multi_scale_scales(resolution, expanded_scales)
+        if skip_random_resize:
+            scales = [scales[-1]]
         print(scales)
 
     if image_set == 'train':
@@ -148,7 +150,7 @@ def make_coco_transforms(image_set, resolution, multi_scale=False, expanded_scal
     raise ValueError(f'unknown {image_set}')
 
 
-def make_coco_transforms_square_div_64(image_set, resolution, multi_scale=False, expanded_scales=False):
+def make_coco_transforms_square_div_64(image_set, resolution, multi_scale=False, expanded_scales=False, skip_random_resize=False):
     """
     """
 
@@ -162,6 +164,8 @@ def make_coco_transforms_square_div_64(image_set, resolution, multi_scale=False,
     if multi_scale:
         # scales = [448, 512, 576, 640, 704, 768, 832, 896]
         scales = compute_multi_scale_scales(resolution, expanded_scales)
+        if skip_random_resize:
+            scales = [scales[-1]]
         print(scales)
 
     if image_set == 'train':
@@ -215,9 +219,21 @@ def build(image_set, args, resolution):
 
     
     if square_resize_div_64:
-        dataset = CocoDetection(img_folder, ann_file, transforms=make_coco_transforms_square_div_64(image_set, resolution, multi_scale=args.multi_scale, expanded_scales=args.expanded_scales))
+        dataset = CocoDetection(img_folder, ann_file, transforms=make_coco_transforms_square_div_64(
+            image_set,
+            resolution,
+            multi_scale=args.multi_scale,
+            expanded_scales=args.expanded_scales,
+            skip_random_resize=not args.do_random_resize_via_padding
+        ))
     else:
-        dataset = CocoDetection(img_folder, ann_file, transforms=make_coco_transforms(image_set, resolution, multi_scale=args.multi_scale, expanded_scales=args.expanded_scales))
+        dataset = CocoDetection(img_folder, ann_file, transforms=make_coco_transforms(
+            image_set,
+            resolution,
+            multi_scale=args.multi_scale,
+            expanded_scales=args.expanded_scales,
+            skip_random_resize=not args.do_random_resize_via_padding
+        ))
     return dataset
 
 def build_roboflow(image_set, args, resolution):
@@ -244,7 +260,19 @@ def build_roboflow(image_set, args, resolution):
 
     
     if square_resize_div_64:
-        dataset = CocoDetection(img_folder, ann_file, transforms=make_coco_transforms_square_div_64(image_set, resolution, multi_scale=args.multi_scale))
+        dataset = CocoDetection(img_folder, ann_file, transforms=make_coco_transforms_square_div_64(
+            image_set,
+            resolution,
+            multi_scale=args.multi_scale,
+            expanded_scales=args.expanded_scales,
+            skip_random_resize=not args.do_random_resize_via_padding
+        ))
     else:
-        dataset = CocoDetection(img_folder, ann_file, transforms=make_coco_transforms(image_set, resolution, multi_scale=args.multi_scale))
+        dataset = CocoDetection(img_folder, ann_file, transforms=make_coco_transforms(
+            image_set,
+            resolution,
+            multi_scale=args.multi_scale,
+            expanded_scales=args.expanded_scales,
+            skip_random_resize=not args.do_random_resize_via_padding
+        ))
     return dataset

--- a/rfdetr/engine.py
+++ b/rfdetr/engine.py
@@ -20,11 +20,14 @@ Train and eval functions used in main.py
 import math
 import sys
 from typing import Iterable
+import random
 
 import torch
+import torch.nn.functional as F
 
 import rfdetr.util.misc as utils
 from rfdetr.datasets.coco_eval import CocoEvaluator
+from rfdetr.datasets.coco import compute_multi_scale_scales
 
 try:
     from torch.amp import autocast, GradScaler
@@ -106,6 +109,14 @@ def train_one_epoch(
                 model.module.update_dropout(schedules["do"][it])
             else:
                 model.update_dropout(schedules["do"][it])
+
+        if args.multi_scale and not args.do_random_resize_via_padding:
+            scales = compute_multi_scale_scales(args.resolution, args.expanded_scales)
+            random.seed(it)
+            scale = random.choice(scales)
+            with torch.inference_mode():
+                samples.tensors = F.interpolate(samples.tensors, size=scale, mode='bilinear', align_corners=False)
+                samples.mask = F.interpolate(samples.mask.unsqueeze(1).float(), size=scale, mode='nearest').squeeze(1).bool()
 
         for i in range(args.grad_accum_steps):
             start_idx = i * sub_batch_size

--- a/rfdetr/main.py
+++ b/rfdetr/main.py
@@ -774,6 +774,7 @@ def get_args_parser():
     parser.add_argument('--use_cls_token', action='store_true', help='use cls token')
     parser.add_argument('--multi_scale', action='store_true', help='use multi scale')
     parser.add_argument('--expanded_scales', action='store_true', help='use expanded scales')
+    parser.add_argument('--do_random_resize_via_padding', action='store_true', help='use random resize via padding')
     parser.add_argument('--warmup_epochs', default=1, type=float, 
         help='Number of warmup epochs for linear warmup before cosine annealing')
     # Add scheduler type argument: 'step' or 'cosine'
@@ -921,6 +922,7 @@ def populate_args(
     use_cls_token=False,
     multi_scale=False,
     expanded_scales=False,
+    do_random_resize_via_padding=False,
     warmup_epochs=1,
     lr_scheduler='step',
     lr_min_factor=0.0,
@@ -1021,6 +1023,7 @@ def populate_args(
         use_cls_token=use_cls_token,
         multi_scale=multi_scale,
         expanded_scales=expanded_scales,
+        do_random_resize_via_padding=do_random_resize_via_padding,
         warmup_epochs=warmup_epochs,
         lr_scheduler=lr_scheduler,
         lr_min_factor=lr_min_factor,


### PR DESCRIPTION
# Description

Right now we randomly resize each image independently and then pad the batch of images to have the same dimensions as the largest image. This means we waste compute and also that with probability ~1 the model doesn't see images of the target resolution without padding.

This PR moves the random resize to be directly in front of the forward pass. This gives slightly higher accuracy and slightly higher throughput.

It also fixes a bug where the expanded scales argument was ignored for Roboflow datasets. This should give slightly better results but slightly lower throughput.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally via a training script. 

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
