### PR TITLE
[BUG][CLI] Fix error in cli script

### DIFF
--- a/rfdetr/cli/main.py
+++ b/rfdetr/cli/main.py
@@ -15,10 +15,8 @@ import torch
 from rf100vl import get_rf100vl_projects
 
 from rfdetr import RFDETRBase
-
-from rfdetr import RFDETRBase
 from rfdetr.config import DEVICE
-import os
+
 
 def download_dataset(rf_project: roboflow.Project, dataset_version: int):
     versions = rf_project.versions()


### PR DESCRIPTION
# Description

Training with coco_dir option fails due to a small bug from L#52

`NameError: name 'device_supports_cuda' is not defined`

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

"python3 cli/main.py --coco_dir <path>" won't fail anymore due to "NameError" from "device_supports_cuda"

## Any specific deployment considerations

None

## Docs

None
