### PR TITLE
load best checkpoint for test metrics

### DIFF
--- a/rfdetr/config.py
+++ b/rfdetr/config.py
@@ -88,3 +88,4 @@ class TrainConfig(BaseModel):
     project: Optional[str] = None
     run: Optional[str] = None
     class_names: List[str] = None
+    run_test: bool = True

--- a/rfdetr/main.py
+++ b/rfdetr/main.py
@@ -471,9 +471,14 @@ class Model:
 
 
         if args.run_test:
+            best_state_dict = torch.load(output_dir / 'checkpoint_best_total.pth', map_location='cpu', weights_only=False)['model']
+            model.load_state_dict(best_state_dict)
+            model.eval()
+
             test_stats, _ = evaluate(
                 model, criterion, postprocessors, data_loader_test, base_ds_test, device, args=args
             )
+            print(f"Test results: {test_stats}")
             with open(output_dir / "results.json", "r") as f:
                 results = json.load(f)
             test_metrics = test_stats["results_json"]["class_map"]


### PR DESCRIPTION
# Description

The reported test metrics are not using the best weights, instead using the last weights. This is bad. This is fixed in this PR.

Also fixes a bug where run_test is not defined by default. Now it is both defined and we generate test stats.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally.

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
