### PR TITLE
Modified misleading num_classes Warnings

### DIFF
--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -104,8 +104,7 @@ class RFDETR:
 
         if self.model_config.num_classes != num_classes:
             logger.warning(
-                f"num_classes mismatch: model has {self.model_config.num_classes} classes, but your dataset has {num_classes} classes\n"
-                f"reinitializing your detection head with {num_classes} classes."
+                f"Reinitializing your detection head with {num_classes} classes."
             )
             self.model.reinitialize_detection_head(num_classes)
         

--- a/rfdetr/main.py
+++ b/rfdetr/main.py
@@ -94,8 +94,7 @@ class Model:
             checkpoint_num_classes = checkpoint['model']['class_embed.bias'].shape[0]
             if checkpoint_num_classes != args.num_classes + 1:
                 logger.warning(
-                    f"num_classes mismatch: pretrain weights has {checkpoint_num_classes - 1} classes, but your model has {args.num_classes} classes\n"
-                    f"reinitializing detection head with {checkpoint_num_classes - 1} classes"
+                    f"Reinitializing detection head with {checkpoint_num_classes} classes"
                 )
                 self.reinitialize_detection_head(checkpoint_num_classes)
             # add support to exclude_keys


### PR DESCRIPTION
# Description

I modified the misleading num_classes mismatch: pretrain weights has x classes, but your model has 90 classes, that was appearing during model loading. 
I modified in both files used for training and inference. I just let the warnings report the correct number of classes that the head is reinitializing.

This issue had been addressed in [issue #51](https://github.com/roboflow/rf-detr/issues/51) 
