### PR TITLE
README.md multi-GPU training instructions add bold emphasis to how numGPUs influences batch size

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ You can fine-tune RF-DETR on multiple GPUs using PyTorch’s Distributed Data Pa
 python -m torch.distributed.launch --nproc_per_node=8 --use_env main.py
 ```
 
-Replace `8` in the `--nproc_per_node argument` with the number of GPUs you want to use. This approach creates one training process per GPU and splits the workload automatically. Note that your effective batch size is multiplied by the number of GPUs, so you may need to adjust your `batch_size` and `grad_accum_steps` to maintain the same overall batch size.
+Replace `8` in the `--nproc_per_node argument` with the number of GPUs you want to use. This approach creates one training process per GPU and splits the workload automatically. **Note that your effective batch size is multiplied by the number of GPUs**, so **you may need to adjust your `batch_size` and `grad_accum_steps` to maintain the same overall batch size!**
 
 ### Result checkpoints
 


### PR DESCRIPTION
I found this description to be incredibly subtle, I ran a lot of training runs with the wrong batch size before I saw it

# Description

Simple change to README.md to add bold emphasis under Multi-GPU training instructions:

> Note that your effective batch size is multiplied by the number of GPUs**, so **you may need to adjust your `batch_size` and `grad_accum_steps` to maintain the same overall batch size!**

No dependencies as it is just a documentation update

## Type of change

Please delete options that are not relevant.

-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

With my eyes reading the README.md

## Any specific deployment considerations

May be worth emphasizing in documentation elsewhere to make sure others don't make the same mistake that I did

## Docs

-   [ ] Docs updated? What were the changes:
Just a simple change to README.md
