### PR TITLE
RF-DETR 1.2.1 release 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ RF-DETR is small enough to run on the edge using [Inference](https://github.com/
 - `2025/03/20`: We release RF-DETR real-time object detection model. **Code and checkpoint for RF-DETR-large and RF-DETR-base are available.**
 - `2025/04/03`: We release early stopping, gradient checkpointing, metrics saving, training resume, TensorBoard and W&B logging support.
 - `2025/05/16`: We release an 'optimize_for_inference' method which speeds up native PyTorch by up to 2x, depending on platform.
-- `2025/07/23`: We release new SOTA model sizes: RF-DETR-Nano, RF-DETR-Small, RF-DETR-Medium.
 
 ## Results
 
@@ -33,7 +32,7 @@ RF-DETR achieves state-of-the-art performance on both the Microsoft COCO and the
 
 The table below shows the performance of RF-DETR medium, compared to comparable medium models:
 
-![rf-detr-coco-rf100-vl-9](https://media.roboflow.com/rfdetr/pareto.png)
+![rf-detr-coco-rf100-vl-9](https://media.roboflow.com/rfdetr/pareto1.png)
 
 |family|size  |coco_map50|coco_map50@95|rf100vl_map50|rv100vl_map50@95|latency|
 |------|------|----------|------------|-------------|---------------|-------|

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ We validated the performance of RF-DETR on both Microsoft COCO and the RF100-VL 
 
 [See our full benchmarks.](learn/benchmarks/)
 
-<img src="https://media.roboflow.com/rfdetr/pareto.png" style="max-height: 50rem" />
+<img src="https://media.roboflow.com/rfdetr/pareto1.png" style="max-height: 50rem" />
 
 ## 💻 Install
 
@@ -116,7 +116,7 @@ You can install and use `rfdetr` in a
 
     Load and run a pre-trained RF-DETR model.
 
-    [:octicons-arrow-right-24: Tutorial](how_to/detect_and_annotate.md)
+    [:octicons-arrow-right-24: Tutorial](/learn/pretrained)
 
 - **Train an RF-DETR Model**
 
@@ -124,6 +124,14 @@ You can install and use `rfdetr` in a
 
     Learn how to train an RF-DETR model with the `rfdetr` Python package.
 
-    [:octicons-arrow-right-24: Tutorial](how_to/track_objects.md)
+    [:octicons-arrow-right-24: Tutorial](/learn/train/)
+
+- **Deploy an RF-DETR Model**
+
+    ---
+
+    Learn how to deploy an RF-DETR model in the cloud and on your device.
+
+    [:octicons-arrow-right-24: Tutorial](/learn/deploy/)
 
 </div>

--- a/docs/learn/benchmarks.md
+++ b/docs/learn/benchmarks.md
@@ -4,7 +4,7 @@ On this page, we outline our results from our Microsoft COCO benchmarks, benchma
 
 The table below shows the performance of RF-DETR, compared to other object detection models:
 
-![rf-detr-coco-rf100-vl-9](https://media.roboflow.com/rfdetr/pareto.png)
+![rf-detr-coco-rf100-vl-9](https://media.roboflow.com/rfdetr/pareto1.png)
 
 |family|size  |coco_map50|coco_map5095|rf100vl_map50|rv100vl_map5095|latency|
 |------|------|----------|------------|-------------|---------------|-------|

--- a/docs/learn/deploy.md
+++ b/docs/learn/deploy.md
@@ -9,10 +9,11 @@ To deploy your model to Roboflow, run:
 ```python
 from rfdetr import RFDETRNano
 
-x = RFDETRNano(pretrain_weights="<path/to/prtrain/weights/dir>")
+x = RFDETRNano(pretrain_weights="<path/to/pretrain/weights/dir>")
 x.deploy_to_roboflow(
   workspace="<your-workspace>",
-  project_ids=["<your-project-id>"],
+  project_id="<your-project-id>",
+  version=1,
   api_key="<YOUR_API_KEY>"
 )
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rfdetr"
-version = "1.1.0"
+version = "1.2.0rc0"
 description = "RF-DETR"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rfdetr"
-version = "1.2.0"
+version = "1.2.1"
 description = "RF-DETR"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rfdetr"
-version = "1.2.0rc0"
+version = "1.2.0"
 description = "RF-DETR"
 readme = "README.md"
 authors = [

--- a/rfdetr/main.py
+++ b/rfdetr/main.py
@@ -164,6 +164,10 @@ class Model:
                     f"Currently supported callbacks: {currently_supported_callbacks}"
                 )
         args = populate_args(**kwargs)
+        if getattr(args, 'class_names') is not None:
+            self.args.class_names = args.class_names
+            self.args.num_classes = args.num_classes
+
         utils.init_distributed_mode(args)
         print("git:\n  {}\n".format(utils.get_sha()))
         print(args)


### PR DESCRIPTION
# Description

* Corrected the `pretrain_weights` path and updated the `deploy_to_roboflow` function in `docs/learn/deploy.md` to fix parameter names and add a `version` argument.

* In `rfdetr/main.py`, added support for setting `class_names` and `num_classes` in the training arguments if provided.