### PR TITLE
Fixed code typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ from rfdetr.util.coco_classes import COCO_CLASSES
 
 model = RFDETRBase()
 
-model = model.optimize_for_inference()
+model.optimize_for_inference()
 
 url = "https://media.roboflow.com/notebooks/examples/dog-2.jpeg"
 


### PR DESCRIPTION
# Description
In the `predict` section of the Readme.md file, there is a minor issue/typo.

The `optimize_for_inference()` method was being assigned back to the `model` variable. After running through the codebase, I found out that this method modifies the model in-place and doesn't return the initialized and optimized model. This was causing the `model` variable to become `None` when we try to use `model.predict()` method.

## Type of change

-   [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

No specific test case(s) required. 

## Any specific deployment considerations

No

## Docs

-   [ ] Docs updated? What were the changes:
- I have fixed the typo in the readme file. Now when we try to use the code under the `predict` section, it works.
