### PR TITLE
Fix incorrect number for reinitialization of detection heads

### DIFF
--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -126,8 +126,8 @@ class RFDETR:
             os.path.join(config.dataset_dir, "train", "_annotations.coco.json"), "r"
         ) as f:
             anns = json.load(f)
-            num_classes = len(anns["categories"])
             class_names = [c["name"] for c in anns["categories"] if c["supercategory"] != "none"]
+            num_classes = len(class_names)
             self.model.class_names = class_names
 
         if self.model_config.num_classes != num_classes:
@@ -135,7 +135,7 @@ class RFDETR:
                 f"num_classes mismatch: model has {self.model_config.num_classes} classes, but your dataset has {num_classes} classes\n"
                 f"reinitializing your detection head with {num_classes} classes."
             )
-            self.model.reinitialize_detection_head(num_classes)
+            self.model.reinitialize_detection_head(num_classes+1)
         
         train_config = config.dict()
         model_config = self.model_config.dict()


### PR DESCRIPTION
# Description

TL;DR
When creating my own coco dataset (without using roboflow) I noticed an error in the way the number of classes are handled in the `RFDETR.train_from_config` function which only doesn't cause problems using roboflow semantics.

The number of classes in a dataset is set to `num_classes=len(anns["categories"])`. However, the `class_names` are only set to those where `c["supercategory"] != "none"`. 
When I download a dataset from roboflow there is always exactly one category where `c["supercategory"] != "none"` which is the supercategory of all other categories.
So when we have `n+1` classes in our dataset we only have `n` actual classes which perfectly corresponds to the `n+1` heads we have with `n` classes.

However, this **only** works for the way roboflow datasets are created because as far as I know there may be multiple categories with `c["supercategory"] != "none"` or even no at all like in the original coco dataset from [https://cocodataset.org/#download](https://cocodataset.org/#download). 

When using such a dataset (where no category has `c["supercategory"] != "none"`) the value of `num_classes` is set to the actual number of classes causing the line 
`self.model.reinitialize_detection_head(num_classes)` to be incorrect, as you have to reinitialize it to the number of actual classes plus one.

In order to work with any kind of dataset I propose the following change:
just set the `num_classes=len(class_names)` i.e. the actual number of classes and pass `num_classes+1` to the reinitialization

**Also,** this would be more consistent with the other reinitialization warning in the main.py file line 102:
Here you print `checkpoint_num_classes - 1`, i.e. the actual number of classes `n` and not `n+1`.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

I downloaded the soccer players.v2 dataset from roboflow. 
It has the following 4 categories:

```
[
        {
            "id": 0,
            "name": "soccer-players",
            "supercategory": "none"
        },
        {
            "id": 1,
            "name": "football",
            "supercategory": "soccer-players"
        },
        {
            "id": 2,
            "name": "player",
            "supercategory": "soccer-players"
        },
        {
            "id": 3,
            "name": "referee",
            "supercategory": "soccer-players"
        }
]
```
    
As the first category is only a supercategory there are only 3 actual categories. 
**Roboflow also states that there are 3 categories** [https://universe.roboflow.com/roboflow-100/soccer-players-5fuqs](https://universe.roboflow.com/roboflow-100/soccer-players-5fuqs)

When I specify the incorrect number of classes (4):
  ```
model = RFDETRNano(pretrain_weights=None,num_classes=4)

  model.train(
      dataset_dir="soccer players.v2-release.coco"
      )
```

I don't get the reinitialization message as my num_classes matches the number of classes in the dataset even though that is not the actual number of classes.

However, when specifying `num_classes=3` i.e. the actual number of classes, I get the following:
```
num_classes mismatch: model has 3 classes, but your dataset has 4 classes
reinitializing your detection head with 4 classes.
```
I.e. the model will reinitialize the detection head to 3, missing the extra "no category" output

After my changes, this doesn't happen anymore.
