### PR TITLE
Add tutorial grid and page to RF-DETR docs

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -12,6 +12,17 @@ Use the resources below to learn how to train, build with, and deploy RF-DETR mo
 <div class="grid cards" markdown>
 
 - 
+    **SOTA Instance Segmentation with RF-DETR Seg (Preview) [October 2025]**
+
+    ---
+
+    ![](https://blog.roboflow.com/content/images/size/w1000/format/webp/2025/10/rfdetr-seg.png)
+
+    Read more about the RF-DETR Segmentation architecture and how to train an RF-DETR Seg (Preview) model.
+
+    [:octicons-arrow-right-24: Learn more](https://blog.roboflow.com/rf-detr-segmentation-preview/)
+
+- 
     **Announcing RF-DETR Nano, Small, and Medium [July 2025]**
 
     ---

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,0 +1,90 @@
+---
+hide:
+- toc
+- navigation
+---
+
+
+# Tutorials
+
+Use the resources below to learn how to train, build with, and deploy RF-DETR models both in the cloud and on your own hardware.
+
+<div class="grid cards" markdown>
+
+- 
+    **Announcing RF-DETR Nano, Small, and Medium [July 2025]**
+
+    ---
+
+    ![](https://blog.roboflow.com/content/images/size/w1000/format/webp/2025/07/img-blog-rf-detr-1.png)
+
+    Read more about the state-of-the-art RF-DETR Nano, Small, and Medium models we released in July 2025.
+
+    [:octicons-arrow-right-24: Learn more](https://blog.roboflow.com/rf-detr-nano-small-medium/)
+
+
+-   **RF-DETR: How to Train SOTA for Object Detection on a Custom Dataset [video]**
+
+    ---
+
+    ![](https://i.ytimg.com/vi/-OvpdLAElFA/maxresdefault.jpg)
+
+    Learn how to train an RF-DETR model on a custom dataset.
+
+    [:octicons-arrow-right-24: Watch the video](https://www.youtube.com/watch?v=-OvpdLAElFA)
+    
+-   **How to Train RF-DETR on a Custom Dataset [article]**
+
+    ---
+
+    ![](https://blog.roboflow.com/content/images/size/w1000/format/webp/2025/03/img-blog-how-to-send-slack-notification-workflows-v4-1.png)
+
+    Learn how to train an RF-DETR model on a custom dataset.
+
+    [:octicons-arrow-right-24: Read the guide](https://blog.roboflow.com/train-rf-detr-on-a-custom-dataset/)
+
+-   **Deploy RF-DETR on iOS [tutorial & example application]**
+
+    ---
+
+    ![](https://blog.roboflow.com/content/images/size/w1000/format/webp/2025/07/img-blog-deep-learning-solves-frustrations--5--min.png)
+
+    Read this guide to learn how to run RF-DETR models on an iPhone using the Roboflow iOS SDK.
+
+    [:octicons-arrow-right-24: Get started](https://blog.roboflow.com/ios-rf-detr-nano/)
+
+
+
+-   **How to Deploy RF-DETR to an NVIDIA Jetson [article]**
+
+    ---
+
+    ![](https://blog.roboflow.com/content/images/size/w1000/format/webp/2025/06/inst-3-.png)
+
+    Learn how to deploy an RF-DETR model to an NVIDIA Jetson using Roboflow Inference.
+
+    [:octicons-arrow-right-24: Read the tutorial](https://blog.roboflow.com/how-to-deploy-rf-detr-to-an-nvidia-jetson/)
+
+-   **Train and Deploy RF-DETR Models with Roboflow**
+
+    ---
+
+    ![](https://blog.roboflow.com/content/images/size/w1000/format/webp/2025/03/img-blog-nycerebro-2.png)
+
+    Learn how to train RF-DETR models in the cloud with Roboflow and deploy your models on your own hardware with Roboflow Inference and Workflows.
+
+    [:octicons-arrow-right-24: Get started](https://blog.roboflow.com/content/images/size/w1000/format/webp/2025/03/img-blog-nycerebro-2.png)
+
+-   **RF-DETR: A SOTA Real-Time Object Detection Model**
+
+    ---
+
+    ![](https://blog.roboflow.com/content/images/size/w1000/format/webp/2025/03/img-blog-nycerebro--2--min.png)
+
+    Read our announcement for RF-DETR, the first real-time model to achieve 60+ mean Average Precision when benchmarked on the COCO dataset.
+
+    [:octicons-arrow-right-24: Read the announcement](https://blog.roboflow.com/rf-detr/)
+
+
+
+</div>

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -27,6 +27,7 @@ nav:
      - Train an RF-DETR Model: learn/train.md
      - Deploy a Trained Model: learn/deploy.md
      - Benchmarks: learn/benchmarks.md
+  - Tutorials: tutorials/index.md
   - Reference:
       - RF-DETR: reference/rfdetr.md
       - Models:


### PR DESCRIPTION
# Description

This PR adds a new /tutorials page that lists various video and blog guides written by the Roboflow team.

<img width="1472" height="682" alt="Screenshot 2025-09-29 at 11 13 54" src="https://github.com/user-attachments/assets/51f64daa-84f0-4d33-8976-b489e9a73778" />

## Type of change

- [ ] Documentation

## How has this change been tested, please provide a testcase or example of how you tested the change?

You can test this change by running `mkdocs serve` and following the link in the navigation bar to the "Tutorials" page.

## Any specific deployment considerations

N/A

## Docs

See above.