### PR TITLE
refactor to avoid NoneType in optimize_for_inference

### DIFF
--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -319,8 +319,9 @@ class RFDETR:
                 predictions = {
                     "pred_logits": predictions[1],
                     "pred_boxes": predictions[0],
-                    "pred_masks": predictions[2]
                 }
+                if len(predictions) == 3:
+                    predictions["pred_masks"] = predictions[2]
             target_sizes = torch.tensor(orig_sizes, device=self.model.device)
             results = self.model.postprocess(predictions, target_sizes=target_sizes)
 

--- a/rfdetr/models/lwdetr.py
+++ b/rfdetr/models/lwdetr.py
@@ -244,7 +244,10 @@ class LWDETR(nn.Module):
             if self.segmentation_head is not None:
                 outputs_masks = self.segmentation_head(srcs[0], [hs_enc,], tensors.shape[-2:], skip_blocks=True)[0]
 
-        return outputs_coord, outputs_class, outputs_masks
+        if outputs_masks is not None:
+            return outputs_coord, outputs_class, outputs_masks
+        else:
+            return outputs_coord, outputs_class
 
     @torch.jit.unused
     def _set_aux_loss(self, outputs_class, outputs_coord, outputs_masks):


### PR DESCRIPTION
# Description

Fixes an issue where during JIT tracing of an object detector a NoneType would be returned for a placeholder for the mask object which is incompatible with JIT. Fixed by returning a variable-length tuple instead

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

tested locally

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
