### PR TITLE
In Model.export(), remove the shape arg and the requirement for the shape to be divisible by 14.

### DIFF
--- a/rfdetr/main.py
+++ b/rfdetr/main.py
@@ -516,7 +516,7 @@ class Model:
         for callback in callbacks["on_train_end"]:
             callback()
     
-    def export(self, output_dir="output", infer_dir=None, simplify=False,  backbone_only=False, opset_version=17, verbose=True, force=False, shape=None, batch_size=1, **kwargs):
+    def export(self, output_dir="output", infer_dir=None, simplify=False,  backbone_only=False, opset_version=17, verbose=True, force=False, batch_size=1, **kwargs):
         """Export the trained model to ONNX format"""
         print(f"Exporting model to ONNX format")
         try:
@@ -532,11 +532,7 @@ class Model:
 
         os.makedirs(output_dir, exist_ok=True)
         output_dir = Path(output_dir)
-        if shape is None:
-            shape = (self.resolution, self.resolution)
-        else:
-            if shape[0] % 14 != 0 or shape[1] % 14 != 0:
-                raise ValueError("Shape must be divisible by 14")
+        shape = (self.resolution, self.resolution)
 
         input_tensors = make_infer_image(infer_dir, shape, batch_size, device).to(device)
         input_names = ['input']


### PR DESCRIPTION
# Description
Closes: #396 
In main.py, the Model.export() has the argument `shape`. Developers often try to use it and find it broken. This makes the export process confusing. See: #396 and https://github.com/roboflow/rf-detr/issues/99#issuecomment-2773602920

The clean solution is to define resolution during model initialization. Then just call model.export(). Furthermore, the requirement for the input shape to be divisible by 14 is outdated. See: https://github.com/roboflow/rf-detr/issues/396#issuecomment-3379348924
All this makes the `shape` argument in `Model.export()` call redundant and confusing.

This MR simply proposes to remove this argument and the requirement that the shape be divisible by 14 from the Model.export() call.


## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tried these and both worked:
```
from rfdetr import RFDETRSegPreview, RFDETRMedium
model = RFDETRMedium()
mode.export()
model = RFDETRSegPreview()
model.export()
```

