### PR TITLE
Add tensorboard support for segmentation metrics.

### DIFF
--- a/rfdetr/util/metrics.py
+++ b/rfdetr/util/metrics.py
@@ -147,11 +147,11 @@ class MetricsTensorBoardSink:
             ap50 = safe_index(coco_eval, 1)
             ar50_90 = safe_index(coco_eval, 8)
             if ap50_90 is not None:
-                self.writer.add_scalar("Metrics/Base/AP50_90", ap50_90, epoch)
+                self.writer.add_scalar("Metrics-BBox/Base/AP50_90", ap50_90, epoch)
             if ap50 is not None:
-                self.writer.add_scalar("Metrics/Base/AP50", ap50, epoch)
+                self.writer.add_scalar("Metrics-BBox/Base/AP50", ap50, epoch)
             if ar50_90 is not None:
-                self.writer.add_scalar("Metrics/Base/AR50_90", ar50_90, epoch)
+                self.writer.add_scalar("Metrics-BBox/Base/AR50_90", ar50_90, epoch)
 
         if 'ema_test_coco_eval_bbox' in values:
             ema_coco_eval = values['ema_test_coco_eval_bbox']
@@ -159,11 +159,35 @@ class MetricsTensorBoardSink:
             ema_ap50 = safe_index(ema_coco_eval, 1)
             ema_ar50_90 = safe_index(ema_coco_eval, 8)
             if ema_ap50_90 is not None:
-                self.writer.add_scalar("Metrics/EMA/AP50_90", ema_ap50_90, epoch)
+                self.writer.add_scalar("Metrics-BBox/EMA/AP50_90", ema_ap50_90, epoch)
             if ema_ap50 is not None:
-                self.writer.add_scalar("Metrics/EMA/AP50", ema_ap50, epoch)
+                self.writer.add_scalar("Metrics-BBox/EMA/AP50", ema_ap50, epoch)
             if ema_ar50_90 is not None:
-                self.writer.add_scalar("Metrics/EMA/AR50_90", ema_ar50_90, epoch)
+                self.writer.add_scalar("Metrics-BBox/EMA/AR50_90", ema_ar50_90, epoch)
+
+        if 'test_coco_eval_masks' in values:
+            coco_eval = values['test_coco_eval_masks']
+            ap50_90 = safe_index(coco_eval, 0)
+            ap50 = safe_index(coco_eval, 1)
+            ar50_90 = safe_index(coco_eval, 8)
+            if ap50_90 is not None:
+                self.writer.add_scalar("Metrics-Masks/Base/AP50_90", ap50_90, epoch)
+            if ap50 is not None:
+                self.writer.add_scalar("Metrics-Masks/Base/AP50", ap50, epoch)
+            if ar50_90 is not None:
+                self.writer.add_scalar("Metrics-Masks/Base/AR50_90", ar50_90, epoch)
+
+        if 'ema_test_coco_eval_masks' in values:
+            ema_coco_eval = values['ema_test_coco_eval_masks']
+            ema_ap50_90 = safe_index(ema_coco_eval, 0)
+            ema_ap50 = safe_index(ema_coco_eval, 1)
+            ema_ar50_90 = safe_index(ema_coco_eval, 8)
+            if ema_ap50_90 is not None:
+                self.writer.add_scalar("Metrics-Masks/EMA/AP50_90", ema_ap50_90, epoch)
+            if ema_ap50 is not None:
+                self.writer.add_scalar("Metrics-Masks/EMA/AP50", ema_ap50, epoch)
+            if ema_ar50_90 is not None:
+                self.writer.add_scalar("Metrics-Masks/EMA/AR50_90", ema_ar50_90, epoch)
 
         self.writer.flush()
 


### PR DESCRIPTION
# Description

Closes: #411 
While training RFDETRSegPreview, the plots in tensorboard still only contain metrics related to BBox. Plots of segmentation metrics are missing.
In order to support this, the class MetricsTensorBoardSink needs to be enhanced. 

Expected behavior when training segmentation models:  

<img width="1678" height="543" alt="Image" src="https://github.com/user-attachments/assets/2de308e8-75c7-4de8-b173-a99f523752d0" />  

<img width="1790" height="1219" alt="Image" src="https://github.com/user-attachments/assets/4eaffcd9-190b-4a12-afe3-cb4152f9c8ef" />  

<img width="1865" height="1202" alt="Image" src="https://github.com/user-attachments/assets/9e919297-ebc6-4b41-9ffb-798045a10e4d" />


## Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Google Colab.  

## Any specific deployment considerations

None

## Docs

None
