### PR TITLE
Fix News order in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ On image segmentation, RF-DETR Seg (Preview) is 3x faster and more accurate than
 - `2025/10/02`: We release RF-DETR-Seg (Preview), a preview of our instance segmentation head for RF-DETR.
 - `2025/07/23`: We release three new checkpoints for RF-DETR: Nano, Small, and Medium.
     - RF-DETR Base is now deprecated. We recommend using RF-DETR Medium which offers subtantially better accuracy at comparable latency.
-- `2025/03/20`: We release RF-DETR real-time object detection model. **Code and checkpoint for RF-DETR-large and RF-DETR-base are available.**
-- `2025/04/03`: We release early stopping, gradient checkpointing, metrics saving, training resume, TensorBoard and W&B logging support.
 - `2025/05/16`: We release an 'optimize_for_inference' method which speeds up native PyTorch by up to 2x, depending on platform.
+- `2025/04/03`: We release early stopping, gradient checkpointing, metrics saving, training resume, TensorBoard and W&B logging support.
+- `2025/03/20`: We release RF-DETR real-time object detection model. **Code and checkpoint for RF-DETR-large and RF-DETR-base are available.**
 
 ## Results
 


### PR DESCRIPTION
# Description

News ordering in README was mixed. Make it newest first.

## Type of change

- [x] Maintenance (non-breaking, non-user facing change)

## How has this change been tested, please provide a testcase or example of how you tested the change?

n/a

## Any specific deployment considerations

n/a

## Docs

n/a