### PR TITLE
bug: fixed bug where predictions was overwritten loosing data

### DIFF
--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -316,12 +316,13 @@ class RFDETR:
             else:
                 predictions = self.model.model(batch_tensor)
             if isinstance(predictions, tuple):
-                predictions = {
+                tmp_predictions = {
                     "pred_logits": predictions[1],
                     "pred_boxes": predictions[0],
                 }
                 if len(predictions) == 3:
-                    predictions["pred_masks"] = predictions[2]
+                    tmp_predictions["pred_masks"] = predictions[2]
+                predictions = tmp_predictions
             target_sizes = torch.tensor(orig_sizes, device=self.model.device)
             results = self.model.postprocess(predictions, target_sizes=target_sizes)
 


### PR DESCRIPTION
Fixes a logic error in predict() where tuple outputs from the model were converted to a dict before checking their length. As a result, the segmentation branch (len==3) was never reached and pred_masks were dropped.

## Type of change

Please delete options that are not relevant.
-   [X] Bug fix (non-breaking change which fixes an issue)


