### PR TITLE
[Fix] issue of predictions overwrite regarding instance masks

### DIFF
--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -312,16 +312,16 @@ class RFDETR:
 
         with torch.inference_mode():
             if self._is_optimized_for_inference:
-                predictions = self.model.inference_model(batch_tensor.to(dtype=self._optimized_dtype))
+                model_predictions = self.model.inference_model(batch_tensor.to(dtype=self._optimized_dtype))
             else:
-                predictions = self.model.model(batch_tensor)
-            if isinstance(predictions, tuple):
+                model_predictions = self.model.model(batch_tensor)
+            if isinstance(model_predictions, tuple):
                 predictions = {
-                    "pred_logits": predictions[1],
-                    "pred_boxes": predictions[0],
+                    "pred_logits": model_predictions[1],
+                    "pred_boxes": model_predictions[0],
                 }
-                if len(predictions) == 3:
-                    predictions["pred_masks"] = predictions[2]
+                if len(model_predictions) == 3:
+                    predictions["pred_masks"] = model_predictions[2]
             target_sizes = torch.tensor(orig_sizes, device=self.model.device)
             results = self.model.postprocess(predictions, target_sizes=target_sizes)
 
@@ -338,7 +338,7 @@ class RFDETR:
 
             if "masks" in result:
                 masks = result["masks"]
-                masks = masks[keep]
+                masks = masks[keep.cpu()]
 
                 detections = sv.Detections(
                     xyxy=boxes.float().cpu().numpy(),


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed or implemented. Please also include relevant motivation and context (e.g. links, docs, tickets etc.).

List any dependencies that are required for this change.

## Type of change

Change in the prediction function to avoid an overwrite of predictions, which leads to ```len(predictions)==3``` not being reached in mask inference mode. 

In post process masks are move to cpu(), therefore keep needs to be moved for subsequent  indexing as well. 
With this change ```sv.MaskAnnotator().annotate()``` can be used for mask inference visualisation.  

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)


## How has this change been tested, please provide a testcase or example of how you tested the change?

Via inference script visualisation that is based on predict script +  

```python
import io
import requests
import supervision as sv
from PIL import Image
from rfdetr import RFDETRSegPreview
from rfdetr.util.coco_classes import COCO_CLASSES

model = RFDETRSegPreview()

model.optimize_for_inference()

url = "https://media.roboflow.com/notebooks/examples/dog-2.jpeg"

image = Image.open(io.BytesIO(requests.get(url).content))
detections = model.predict(image, threshold=0.5)

labels = [
    f"{COCO_CLASSES[class_id]} {confidence:.2f}"
    for class_id, confidence
    in zip(detections.class_id, detections.confidence)
]

annotated_image = image.copy()
annotated_image = sv.BoxAnnotator().annotate(annotated_image, detections)
annotated_image = sv.LabelAnnotator().annotate(annotated_image, detections, labels)
annotated_image = sv.MaskAnnotator().annotate(annotated_image, detections)


sv.plot_image(annotated_image)
```

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.


