### PR TITLE
Introduce background_class83422 so that class names index from 1

### DIFF
--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -130,7 +130,9 @@ class RFDETR:
             ) as f:
                 anns = json.load(f)
                 num_classes = len(anns["categories"])
-                class_names = [c["name"] for c in anns["categories"] if c["supercategory"] != "none"]
+                class_names = [c["name"] for c in anns["categories"] if c["supercategory"] != "none" and c["name"] != "background_class83422"]
+                class_names.insert(0, "background_class83422")
+                num_classes = len(class_names)
                 self.model.class_names = class_names
         elif config.dataset_file == "coco":
             class_names = COCO_CLASSES


### PR DESCRIPTION
# Description

Introduce background_class83422 so that class_names index from 1, keeping in line with COCO standard format for class names.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested in notebook with new training.

## Any specific deployment considerations

none

## Docs

-   [ ] Docs updated? What were the changes:
