### PR TITLE
Fix inverted probability logic in RandomExpand.__call__

### DIFF
--- a/rfdetr/datasets/transforms.py
+++ b/rfdetr/datasets/transforms.py
@@ -391,7 +391,7 @@ class RandomExpand(object):
         self.fill_value = fill_value
 
     def __call__(self, img, target):
-        if np.random.uniform(0., 1.) < self.prob:
+        if np.random.uniform(0., 1.) >= self.prob:
             return img, target
 
         height, width = img.shape[:2]


### PR DESCRIPTION
This PR fixes a bug in RandomExpand.__call__ where the probability check was inverted.
According to the docstring, prob is the probability to expand, but the previous implementation expanded with probability 1 - prob.
The condition has been corrected so that expansion now happens with the intended probability.