### PR TITLE
Loading a COCO dataset now supports custom paths

### DIFF
--- a/rfdetr/config.py
+++ b/rfdetr/config.py
@@ -141,6 +141,7 @@ class TrainConfig(BaseModel):
     dataset_file: Literal["coco", "o365", "roboflow"] = "roboflow"
     square_resize_div_64: bool = True
     dataset_dir: str
+    image_root: Optional[str] = None
     output_dir: str = "output"
     multi_scale: bool = True
     expanded_scales: bool = True

--- a/rfdetr/datasets/o365.py
+++ b/rfdetr/datasets/o365.py
@@ -25,6 +25,7 @@ def build_o365_raw(image_set, args, resolution):
         "val": (root, root / 'zhiyuan_objv2_minival5k.json'),
     }
     img_folder, ann_file = PATHS[image_set]
+    image_root = getattr(args, "image_root", None)
     
     try:
         square_resize = args.square_resize
@@ -37,9 +38,19 @@ def build_o365_raw(image_set, args, resolution):
         square_resize_div_64 = False
 
     if square_resize_div_64:
-        dataset = CocoDetection(img_folder, ann_file, transforms=make_coco_transforms_square_div_64(image_set, resolution, multi_scale=args.multi_scale, expanded_scales=args.expanded_scales))
+        dataset = CocoDetection(img_folder, ann_file, transforms=make_coco_transforms_square_div_64(
+            image_set,
+            resolution,
+            multi_scale=args.multi_scale,
+            expanded_scales=args.expanded_scales
+        ), image_root=image_root)
     else:
-        dataset = CocoDetection(img_folder, ann_file, transforms=make_coco_transforms(image_set, resolution, multi_scale=args.multi_scale, expanded_scales=args.expanded_scales))
+        dataset = CocoDetection(img_folder, ann_file, transforms=make_coco_transforms(
+            image_set,
+            resolution,
+            multi_scale=args.multi_scale,
+            expanded_scales=args.expanded_scales
+        ), image_root=image_root)
     return dataset
 
 

--- a/rfdetr/main.py
+++ b/rfdetr/main.py
@@ -784,6 +784,8 @@ def get_args_parser():
     parser.add_argument('--dataset_file', default='coco')
     parser.add_argument('--coco_path', type=str)
     parser.add_argument('--dataset_dir', type=str)
+    parser.add_argument('--image_root', type=str, default=None,
+                        help='Optional base directory for resolving COCO image file_name entries')
     parser.add_argument('--square_resize_div_64', action='store_true')
 
     parser.add_argument('--output_dir', default='output',
@@ -940,6 +942,7 @@ def populate_args(
     dataset_file='coco',
     coco_path=None,
     dataset_dir=None,
+    image_root=None,
     square_resize_div_64=False,
     
     # Output parameters
@@ -1049,6 +1052,7 @@ def populate_args(
         dataset_file=dataset_file,
         coco_path=coco_path,
         dataset_dir=dataset_dir,
+        image_root=image_root,
         square_resize_div_64=square_resize_div_64,
         output_dir=output_dir,
         dont_save_weights=dont_save_weights,


### PR DESCRIPTION
# Description

Solving issue [#313](https://github.com/roboflow/rf-detr/issues/313?utm_source=chatgpt.com) where it was suggested to add a custom path when loading from a COCO dataset.
Add an optional image_root config/CLI flag and pass it through the dataset builders. Override COCO image loading to resolve absolute/relative file_name values against image_root.

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Not run.

## Any specific deployment considerations

None.

## Docs

-   [ ] Docs updated? What were the changes:
