### PR TITLE
fix: always set class_names from dataset annotations

### DIFF
--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -144,8 +144,8 @@ class RFDETR:
         if "class_names" in model_config:
             model_config.pop("class_names")
         
-        if "class_names" in train_config and train_config["class_names"] is None:
-            train_config["class_names"] = class_names
+        #if "class_names" in train_config and train_config["class_names"] is None:
+        train_config["class_names"] = class_names
 
         for k, v in train_config.items():
             if k in model_config:

--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -144,7 +144,6 @@ class RFDETR:
         if "class_names" in model_config:
             model_config.pop("class_names")
         
-        #if "class_names" in train_config and train_config["class_names"] is None:
         train_config["class_names"] = class_names
 
         for k, v in train_config.items():


### PR DESCRIPTION
- Remove conditional check that only set class_names when None
- Unconditionally assign dataset-derived class_names to train_config
- Ensure consistency between dataset annotations and training configuration

# Description

The current code in train_from_config method contains an incorrect conditional check:
if "class_names" in train_config and train_config["class_names"] is None:
    train_config["class_names"] = class_names

This logic is flawed because:
1.It only sets class_names when it already exists in train_config AND is None
2.It doesn't handle the case where class_names might not exist in train_config at all
3.It doesn't override potentially incorrect class_names values that are non-None

The correct behavior should be to always set train_config["class_names"] to the class_names variable derived from the dataset (Roboflow or COCO), ensuring consistency between the dataset annotations and the training configuration.

#Changes:

Remove the conditional check and unconditionally set train_config["class_names"] = class_names
This ensures the class names from the actual dataset annotations are always used for training

#Impact:

Fixes potential mismatches between dataset classes and training configuration
Ensures consistent behavior regardless of initial train_config["class_names"] value
Maintains backward compatibility while fixing the logic error