### PR TITLE
feat: keypoints/pose implementation

### DIFF
--- a/docs/learn/run/pose.md
+++ b/docs/learn/run/pose.md
@@ -3,7 +3,34 @@
 You can run pose estimation models with RF-DETR to detect keypoints and body poses on people and objects. The pose model outputs bounding boxes along with keypoints in (x, y, visibility) format for each detection, following a similar approach to YOLOv11 pose estimation.
 
 !!! note "Training Required"
-    RF-DETR Pose requires training on a keypoint dataset before inference. By default, it loads RF-DETR Medium detection weights (`rf-detr-medium.pth`) as a starting point - the backbone and detection heads are initialized from this checkpoint, while the keypoint head is randomly initialized and learned during fine-tuning.
+    RF-DETR Pose requires training on a keypoint dataset before inference. By default, it loads detection weights as a starting point - the backbone and detection heads are initialized from this checkpoint, while the keypoint head is randomly initialized and learned during fine-tuning.
+
+## Model Sizes
+
+RF-DETR Pose is available in multiple sizes to balance speed and accuracy:
+
+| Model | Class | Resolution | Decoder Layers | Use Case |
+|-------|-------|------------|----------------|----------|
+| Nano | `RFDETRPoseNano` | 384 | 2 | Real-time, edge devices |
+| Small | `RFDETRPoseSmall` | 512 | 3 | Good speed/accuracy balance |
+| Medium | `RFDETRPoseMedium` | 576 | 4 | Default, good accuracy |
+| Large | `RFDETRPoseLarge` | 768 | 6 | Highest accuracy |
+
+```python
+from rfdetr import RFDETRPoseNano, RFDETRPoseSmall, RFDETRPoseMedium, RFDETRPoseLarge
+
+# Choose the size that fits your needs
+model = RFDETRPoseNano()   # Fastest, lowest accuracy
+model = RFDETRPoseSmall()  # Balanced
+model = RFDETRPoseMedium() # Default
+model = RFDETRPoseLarge()  # Slowest, highest accuracy
+```
+
+!!! tip "Choosing a Model Size"
+    - Use **Nano** for real-time applications or when running on edge devices
+    - Use **Small** for a good balance of speed and accuracy
+    - Use **Medium** (default) for most use cases
+    - Use **Large** when accuracy is critical and speed is less important
 
 ## Run a Model
 

--- a/docs/learn/run/pose.md
+++ b/docs/learn/run/pose.md
@@ -54,7 +54,7 @@ model = RFDETRPoseLarge()  # Slowest, highest accuracy
     detections = model.predict(image, threshold=0.5)
 
     # Access keypoints from detections
-    keypoints = detections.data.get("keypoints")  # [N, K, 3] where K=17 for COCO
+    keypoints = detections.data.get("keypoints")  # [N, K, 3] where K=num_keypoints
 
     # Annotate image with boxes
     annotated_image = image.copy()
@@ -138,12 +138,19 @@ model = RFDETRPoseLarge()  # Slowest, highest accuracy
 RF-DETR Pose outputs keypoints in the `detections.data["keypoints"]` field as a NumPy array with shape `[N, K, 3]`:
 
 - `N` = number of detections
-- `K` = number of keypoints (default: 17 for COCO pose)
+- `K` = number of keypoints (configured via `num_keypoints`, default: 17 for COCO pose)
 - `3` = (x, y, visibility) for each keypoint
 
-The visibility value ranges from 0 to 1:
-- Values close to 0 indicate the keypoint is not visible or not confident
-- Values close to 1 indicate the keypoint is visible and confident
+The visibility value follows the COCO format:
+- `0` = keypoint not visible / not confident
+- `2` = keypoint visible and confident
+
+For the raw confidence scores (0.0 to 1.0), use `detections.data["keypoints_confidence"]`:
+
+```python
+keypoints = detections.data["keypoints"]  # [N, K, 3] - (x, y, visibility)
+confidence = detections.data["keypoints_confidence"]  # [N, K] - raw scores 0.0-1.0
+```
 
 ## COCO Keypoint Format
 

--- a/docs/learn/run/pose.md
+++ b/docs/learn/run/pose.md
@@ -1,0 +1,259 @@
+# Run an RF-DETR Pose Estimation Model
+
+You can run pose estimation models with RF-DETR to detect keypoints and body poses on people and objects. The pose model outputs bounding boxes along with keypoints in (x, y, visibility) format for each detection, following a similar approach to YOLOv11 pose estimation.
+
+!!! note "Training Required"
+    RF-DETR Pose requires training on a keypoint dataset before inference. By default, it loads RF-DETR Medium detection weights (`rf-detr-medium.pth`) as a starting point - the backbone and detection heads are initialized from this checkpoint, while the keypoint head is randomly initialized and learned during fine-tuning.
+
+## Run a Model
+
+=== "Run on an Image"
+
+    To run RF-DETR Pose on an image, use the following code:
+
+    ```python
+    import io
+    import requests
+    import supervision as sv
+    import numpy as np
+    from PIL import Image
+    from rfdetr import RFDETRPose
+
+    model = RFDETRPose(pretrain_weights="path/to/pose_weights.pth")
+
+    url = "https://media.roboflow.com/notebooks/examples/dog-2.jpeg"
+    image = Image.open(io.BytesIO(requests.get(url).content))
+
+    detections = model.predict(image, threshold=0.5)
+
+    # Access keypoints from detections
+    keypoints = detections.data.get("keypoints")  # [N, K, 3] where K=17 for COCO
+
+    # Annotate image with boxes
+    annotated_image = image.copy()
+    annotated_image = sv.BoxAnnotator().annotate(annotated_image, detections)
+
+    # Draw keypoints manually
+    if keypoints is not None:
+        annotated_image = draw_keypoints(annotated_image, keypoints)
+
+    sv.plot_image(annotated_image)
+    ```
+
+=== "Run on a Video File"
+
+    To run RF-DETR Pose on a video file, use the following code:
+
+    ```python
+    import cv2
+    import supervision as sv
+    from rfdetr import RFDETRPose
+
+    model = RFDETRPose(pretrain_weights="path/to/pose_weights.pth")
+
+    def callback(frame, index):
+        detections = model.predict(frame[:, :, ::-1], threshold=0.5)
+        keypoints = detections.data.get("keypoints")
+
+        annotated_frame = frame.copy()
+        annotated_frame = sv.BoxAnnotator().annotate(annotated_frame, detections)
+
+        # Draw keypoints on frame
+        if keypoints is not None:
+            annotated_frame = draw_keypoints(annotated_frame, keypoints)
+
+        return annotated_frame
+
+    sv.process_video(
+        source_path=<SOURCE_VIDEO_PATH>,
+        target_path=<TARGET_VIDEO_PATH>,
+        callback=callback
+    )
+    ```
+
+=== "Run on a Webcam Stream"
+
+    To run RF-DETR Pose on a webcam input, use the following code:
+
+    ```python
+    import cv2
+    import supervision as sv
+    from rfdetr import RFDETRPose
+
+    model = RFDETRPose(pretrain_weights="path/to/pose_weights.pth")
+
+    cap = cv2.VideoCapture(0)
+    while True:
+        success, frame = cap.read()
+        if not success:
+            break
+
+        detections = model.predict(frame[:, :, ::-1], threshold=0.5)
+        keypoints = detections.data.get("keypoints")
+
+        annotated_frame = frame.copy()
+        annotated_frame = sv.BoxAnnotator().annotate(annotated_frame, detections)
+
+        if keypoints is not None:
+            annotated_frame = draw_keypoints(annotated_frame, keypoints)
+
+        cv2.imshow("Webcam", annotated_frame)
+
+        if cv2.waitKey(1) & 0xFF == ord('q'):
+            break
+
+    cap.release()
+    cv2.destroyAllWindows()
+    ```
+
+## Keypoint Output Format
+
+RF-DETR Pose outputs keypoints in the `detections.data["keypoints"]` field as a NumPy array with shape `[N, K, 3]`:
+
+- `N` = number of detections
+- `K` = number of keypoints (default: 17 for COCO pose)
+- `3` = (x, y, visibility) for each keypoint
+
+The visibility value ranges from 0 to 1:
+- Values close to 0 indicate the keypoint is not visible or not confident
+- Values close to 1 indicate the keypoint is visible and confident
+
+## COCO Keypoint Format
+
+By default, RF-DETR Pose uses the COCO 17-keypoint format:
+
+| Index | Keypoint Name    |
+|-------|------------------|
+| 0     | nose             |
+| 1     | left_eye         |
+| 2     | right_eye        |
+| 3     | left_ear         |
+| 4     | right_ear        |
+| 5     | left_shoulder    |
+| 6     | right_shoulder   |
+| 7     | left_elbow       |
+| 8     | right_elbow      |
+| 9     | left_wrist       |
+| 10    | right_wrist      |
+| 11    | left_hip         |
+| 12    | right_hip        |
+| 13    | left_knee        |
+| 14    | right_knee       |
+| 15    | left_ankle       |
+| 16    | right_ankle      |
+
+## Drawing Keypoints
+
+Here's a helper function to draw keypoints and skeleton connections:
+
+```python
+import cv2
+import numpy as np
+from rfdetr.models.keypoint_head import COCO_SKELETON
+
+def draw_keypoints(image, keypoints, threshold=0.3):
+    """
+    Draw keypoints and skeleton on image.
+
+    Args:
+        image: PIL Image or numpy array
+        keypoints: [N, K, 3] array of keypoints (x, y, visibility)
+        threshold: Minimum visibility to draw keypoint
+
+    Returns:
+        Annotated image as numpy array
+    """
+    if hasattr(image, 'copy'):
+        image = np.array(image)
+
+    image = image.copy()
+    h, w = image.shape[:2]
+
+    colors = [
+        (255, 0, 0),    # Red
+        (255, 127, 0),  # Orange
+        (255, 255, 0),  # Yellow
+        (0, 255, 0),    # Green
+        (0, 255, 255),  # Cyan
+        (0, 0, 255),    # Blue
+        (127, 0, 255),  # Purple
+    ]
+
+    for person_kpts in keypoints:
+        # Draw skeleton connections
+        for i, (start_idx, end_idx) in enumerate(COCO_SKELETON):
+            start_kpt = person_kpts[start_idx]
+            end_kpt = person_kpts[end_idx]
+
+            if start_kpt[2] > threshold and end_kpt[2] > threshold:
+                start_pos = (int(start_kpt[0]), int(start_kpt[1]))
+                end_pos = (int(end_kpt[0]), int(end_kpt[1]))
+                color = colors[i % len(colors)]
+                cv2.line(image, start_pos, end_pos, color, 2)
+
+        # Draw keypoints
+        for kpt in person_kpts:
+            if kpt[2] > threshold:
+                pos = (int(kpt[0]), int(kpt[1]))
+                cv2.circle(image, pos, 5, (0, 255, 0), -1)
+                cv2.circle(image, pos, 5, (0, 0, 0), 1)
+
+    return image
+```
+
+## Custom Keypoint Configurations
+
+RF-DETR Pose supports custom keypoint configurations. You can specify:
+
+- `num_keypoints`: Number of keypoints to detect
+- `keypoint_names`: List of keypoint names
+- `skeleton`: List of keypoint index pairs for skeleton connections
+
+```python
+from rfdetr import RFDETRPose
+
+# Custom configuration for hand keypoints (21 keypoints)
+model = RFDETRPose(
+    num_keypoints=21,
+    keypoint_names=[
+        "wrist",
+        "thumb_cmc", "thumb_mcp", "thumb_ip", "thumb_tip",
+        "index_mcp", "index_pip", "index_dip", "index_tip",
+        "middle_mcp", "middle_pip", "middle_dip", "middle_tip",
+        "ring_mcp", "ring_pip", "ring_dip", "ring_tip",
+        "pinky_mcp", "pinky_pip", "pinky_dip", "pinky_tip"
+    ],
+    skeleton=[
+        [0, 1], [1, 2], [2, 3], [3, 4],  # thumb
+        [0, 5], [5, 6], [6, 7], [7, 8],  # index
+        # ... additional connections
+    ],
+    pretrain_weights=None  # Train from scratch for custom keypoints
+)
+```
+
+## Batch Inference
+
+You can provide `.predict()` with a list of images for batch inference:
+
+```python
+import io
+import requests
+from PIL import Image
+from rfdetr import RFDETRPose
+
+model = RFDETRPose(pretrain_weights="path/to/pose_weights.pth")
+
+urls = [
+    "https://media.roboflow.com/notebooks/examples/dog-2.jpeg",
+    "https://media.roboflow.com/notebooks/examples/dog-3.jpeg"
+]
+
+images = [Image.open(io.BytesIO(requests.get(url).content)) for url in urls]
+
+detections_list = model.predict(images, threshold=0.5)
+
+for image, detections in zip(images, detections_list):
+    keypoints = detections.data.get("keypoints")
+    print(f"Detected {len(detections)} people with keypoints shape: {keypoints.shape if keypoints is not None else None}")
+```

--- a/docs/learn/train/index.md
+++ b/docs/learn/train/index.md
@@ -100,7 +100,6 @@ For image segmentation, the RF-DETR-Seg (Preview) checkpoint is used by default.
         grad_accum_steps=4,
         lr=1e-4,
         output_dir=<OUTPUT_PATH>,
-        num_keypoints=17,  # Must match model config
     )
     ```
 
@@ -122,7 +121,6 @@ For image segmentation, the RF-DETR-Seg (Preview) checkpoint is used by default.
         grad_accum_steps=4,
         lr=1e-4,
         output_dir=<OUTPUT_PATH>,
-        num_keypoints=2,
     )
     ```
 
@@ -314,7 +312,6 @@ You can resume training from a previously saved checkpoint by passing the path t
         grad_accum_steps=4,
         lr=1e-4,
         output_dir=<OUTPUT_PATH>,
-        num_keypoints=2,
         resume=<CHECKPOINT_PATH>
     )
     ```
@@ -374,7 +371,6 @@ Early stopping monitors validation mAP and halts training if improvements remain
         grad_accum_steps=4,
         lr=1e-4,
         output_dir=<OUTPUT_PATH>,
-        num_keypoints=2,
         early_stopping=True
     )
     ```

--- a/docs/learn/train/index.md
+++ b/docs/learn/train/index.md
@@ -1,8 +1,8 @@
 # Train an RF-DETR Model
 
-You can train RF-DETR object detection and segmentation models on a custom dataset using the `rfdetr` Python package, or in the cloud using Roboflow.
+You can train RF-DETR object detection, segmentation, and pose estimation models on a custom dataset using the `rfdetr` Python package, or in the cloud using Roboflow.
 
-This guide describes how to train both an object detection and segmentation RF-DETR model.
+This guide describes how to train object detection, segmentation, and pose estimation RF-DETR models.
 
 ### Dataset structure
 
@@ -30,6 +30,8 @@ dataset/
 [Roboflow](https://roboflow.com/annotate) allows you to create object detection datasets from scratch or convert existing datasets from formats like YOLO, and then export them in COCO JSON format for training. You can also explore [Roboflow Universe](https://universe.roboflow.com/) to find pre-labeled datasets for a range of use cases.
 
 If you are training a segmentation model, your COCO JSON annotations should have a `segmentation` key with the polygon associated with each annotation.
+
+If you are training a pose estimation model, your COCO JSON annotations should have a `keypoints` key with the keypoint coordinates in the format `[x1, y1, v1, x2, y2, v2, ...]` where `v` is the visibility flag (0=not labeled, 1=labeled but not visible, 2=labeled and visible).
 
 ## Start Training
 
@@ -62,6 +64,23 @@ For image segmentation, the RF-DETR-Seg (Preview) checkpoint is used by default.
     from rfdetr import RFDETRSegPreview
 
     model = RFDETRSegPreview()
+
+    model.train(
+        dataset_dir=<DATASET_PATH>,
+        epochs=100,
+        batch_size=4,
+        grad_accum_steps=4,
+        lr=1e-4,
+        output_dir=<OUTPUT_PATH>
+    )
+    ```
+
+=== "Pose Estimation"
+
+    ```python
+    from rfdetr import RFDETRPose
+
+    model = RFDETRPose()
 
     model.train(
         dataset_dir=<DATASET_PATH>,
@@ -247,6 +266,24 @@ You can resume training from a previously saved checkpoint by passing the path t
     )
     ```
 
+=== "Pose Estimation"
+
+    ```python
+    from rfdetr import RFDETRPose
+
+    model = RFDETRPose()
+
+    model.train(
+        dataset_dir=<DATASET_PATH>,
+        epochs=100,
+        batch_size=4,
+        grad_accum_steps=4,
+        lr=1e-4,
+        output_dir=<OUTPUT_PATH>,
+        resume=<CHECKPOINT_PATH>
+    )
+    ```
+
 
 ### Early stopping
 
@@ -281,6 +318,24 @@ Early stopping monitors validation mAP and halts training if improvements remain
         dataset_dir=<DATASET_PATH>,
         epochs=100,
         batch_size=4
+        grad_accum_steps=4,
+        lr=1e-4,
+        output_dir=<OUTPUT_PATH>,
+        early_stopping=True
+    )
+    ```
+
+=== "Pose Estimation"
+
+    ```python
+    from rfdetr import RFDETRPose
+
+    model = RFDETRPose()
+
+    model.train(
+        dataset_dir=<DATASET_PATH>,
+        epochs=100,
+        batch_size=4,
         grad_accum_steps=4,
         lr=1e-4,
         output_dir=<OUTPUT_PATH>,
@@ -418,6 +473,18 @@ Replace `8` in the `--nproc_per_node argument` with the number of GPUs you want 
     detections = model.predict(<IMAGE_PATH>)
     ```
 
+=== "Pose Estimation"
+
+    ```python
+    from rfdetr import RFDETRPose
+
+    model = RFDETRPose(pretrain_weights=<CHECKPOINT_PATH>)
+
+    detections = model.predict(<IMAGE_PATH>)
+    # Access keypoints
+    keypoints = detections.data.get("keypoints")  # [N, 17, 3]
+    ```
+
 ## ONNX export
 
 RF-DETR supports exporting models to the ONNX format, which enables interoperability with various inference frameworks and can improve deployment efficiency.
@@ -446,6 +513,16 @@ Then, run:
     from rfdetr import RFDETRSegPreview
 
     model = RFDETRSegPreview(pretrain_weights=<CHECKPOINT_PATH>)
+
+    model.export()
+    ```
+
+=== "Pose Estimation"
+
+    ```python
+    from rfdetr import RFDETRPose
+
+    model = RFDETRPose(pretrain_weights=<CHECKPOINT_PATH>)
 
     model.export()
     ```

--- a/docs/learn/train/index.md
+++ b/docs/learn/train/index.md
@@ -77,10 +77,21 @@ For image segmentation, the RF-DETR-Seg (Preview) checkpoint is used by default.
 
 === "Pose Estimation"
 
-    ```python
-    from rfdetr import RFDETRPose
+    RF-DETR Pose is available in multiple sizes. Choose based on your speed/accuracy needs:
 
-    model = RFDETRPose()
+    | Model | Resolution | Speed | Import |
+    |-------|------------|-------|--------|
+    | Nano | 384 | Fastest | `RFDETRPoseNano` |
+    | Small | 512 | Fast | `RFDETRPoseSmall` |
+    | Medium | 576 | Medium | `RFDETRPoseMedium` |
+    | Large | 768 | Slow | `RFDETRPoseLarge` |
+
+    ```python
+    from rfdetr import RFDETRPoseNano  # or RFDETRPoseSmall, RFDETRPoseMedium, RFDETRPoseLarge
+
+    model = RFDETRPoseNano(
+        num_keypoints=17,  # Number of keypoints to detect
+    )
 
     model.train(
         dataset_dir=<DATASET_PATH>,
@@ -88,7 +99,30 @@ For image segmentation, the RF-DETR-Seg (Preview) checkpoint is used by default.
         batch_size=4,
         grad_accum_steps=4,
         lr=1e-4,
-        output_dir=<OUTPUT_PATH>
+        output_dir=<OUTPUT_PATH>,
+        num_keypoints=17,  # Must match model config
+    )
+    ```
+
+    For custom keypoints (e.g., 2 keypoints for start/end points):
+
+    ```python
+    from rfdetr import RFDETRPoseNano
+
+    model = RFDETRPoseNano(
+        num_keypoints=2,
+        keypoint_names=["start", "end"],
+        skeleton=[[0, 1]],  # Connect start to end
+    )
+
+    model.train(
+        dataset_dir=<DATASET_PATH>,
+        epochs=100,
+        batch_size=4,
+        grad_accum_steps=4,
+        lr=1e-4,
+        output_dir=<OUTPUT_PATH>,
+        num_keypoints=2,
     )
     ```
 
@@ -269,9 +303,9 @@ You can resume training from a previously saved checkpoint by passing the path t
 === "Pose Estimation"
 
     ```python
-    from rfdetr import RFDETRPose
+    from rfdetr import RFDETRPoseNano  # Use the same size as original training
 
-    model = RFDETRPose()
+    model = RFDETRPoseNano(num_keypoints=2)  # Match your keypoint config
 
     model.train(
         dataset_dir=<DATASET_PATH>,
@@ -280,6 +314,7 @@ You can resume training from a previously saved checkpoint by passing the path t
         grad_accum_steps=4,
         lr=1e-4,
         output_dir=<OUTPUT_PATH>,
+        num_keypoints=2,
         resume=<CHECKPOINT_PATH>
     )
     ```
@@ -328,9 +363,9 @@ Early stopping monitors validation mAP and halts training if improvements remain
 === "Pose Estimation"
 
     ```python
-    from rfdetr import RFDETRPose
+    from rfdetr import RFDETRPoseNano
 
-    model = RFDETRPose()
+    model = RFDETRPoseNano(num_keypoints=2)
 
     model.train(
         dataset_dir=<DATASET_PATH>,
@@ -339,6 +374,7 @@ Early stopping monitors validation mAP and halts training if improvements remain
         grad_accum_steps=4,
         lr=1e-4,
         output_dir=<OUTPUT_PATH>,
+        num_keypoints=2,
         early_stopping=True
     )
     ```
@@ -476,13 +512,16 @@ Replace `8` in the `--nproc_per_node argument` with the number of GPUs you want 
 === "Pose Estimation"
 
     ```python
-    from rfdetr import RFDETRPose
+    from rfdetr import RFDETRPoseNano  # Use the same size as training
 
-    model = RFDETRPose(pretrain_weights=<CHECKPOINT_PATH>)
+    model = RFDETRPoseNano(
+        pretrain_weights=<CHECKPOINT_PATH>,
+        num_keypoints=2,  # Match your training config
+    )
 
     detections = model.predict(<IMAGE_PATH>)
     # Access keypoints
-    keypoints = detections.data.get("keypoints")  # [N, 17, 3]
+    keypoints = detections.data.get("keypoints")  # [N, K, 3] where K=num_keypoints
     ```
 
 ## ONNX export
@@ -520,9 +559,12 @@ Then, run:
 === "Pose Estimation"
 
     ```python
-    from rfdetr import RFDETRPose
+    from rfdetr import RFDETRPoseNano  # Use the same size as training
 
-    model = RFDETRPose(pretrain_weights=<CHECKPOINT_PATH>)
+    model = RFDETRPoseNano(
+        pretrain_weights=<CHECKPOINT_PATH>,
+        num_keypoints=2,  # Match your training config
+    )
 
     model.export()
     ```

--- a/docs/reference/pose.md
+++ b/docs/reference/pose.md
@@ -1,3 +1,33 @@
+# Pose Estimation Models
+
+RF-DETR Pose is available in multiple sizes for different speed/accuracy trade-offs.
+
+## RFDETRPose (Medium - Default)
+
 :::rfdetr.detr.RFDETRPose
     options:
       inherited_members: true
+
+## RFDETRPoseNano
+
+:::rfdetr.detr.RFDETRPoseNano
+    options:
+      inherited_members: false
+
+## RFDETRPoseSmall
+
+:::rfdetr.detr.RFDETRPoseSmall
+    options:
+      inherited_members: false
+
+## RFDETRPoseMedium
+
+:::rfdetr.detr.RFDETRPoseMedium
+    options:
+      inherited_members: false
+
+## RFDETRPoseLarge
+
+:::rfdetr.detr.RFDETRPoseLarge
+    options:
+      inherited_members: false

--- a/docs/reference/pose.md
+++ b/docs/reference/pose.md
@@ -1,0 +1,3 @@
+:::rfdetr.detr.RFDETRPose
+    options:
+      inherited_members: true

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -26,6 +26,7 @@ nav:
     - Run a Model:
       - Object Detection: learn/run/detection.md
       - Segmentation: learn/run/segmentation.md
+      - Pose Estimation: learn/run/pose.md
     - Train a Model: learn/train/index.md
     - Deploy a Trained Model: learn/deploy.md
     - Benchmarks: learn/benchmarks.md
@@ -40,6 +41,8 @@ nav:
         - RF-DETR Large: reference/large.md
       - Image Segmentation Models:
         - RF-DETR Seg Preview: reference/seg_preview.md
+      - Pose Estimation Models:
+        - RF-DETR Pose: reference/pose.md
   - Changelog: https://github.com/roboflow/rf-detr/releases
 
 theme:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,3 +101,10 @@ include-package-data = false
 
 [tool.setuptools.package-data]
 rfdetr = ["py.typed", "models/backbone/dinov2_configs/*.json"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]

--- a/rfdetr/__init__.py
+++ b/rfdetr/__init__.py
@@ -9,4 +9,16 @@ import os
 if os.environ.get("PYTORCH_ENABLE_MPS_FALLBACK") is None:
     os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
 
-from rfdetr.detr import RFDETRBase, RFDETRLarge, RFDETRNano, RFDETRSmall, RFDETRMedium, RFDETRSegPreview, RFDETRPose
+from rfdetr.detr import (
+    RFDETRBase,
+    RFDETRLarge,
+    RFDETRNano,
+    RFDETRSmall,
+    RFDETRMedium,
+    RFDETRSegPreview,
+    RFDETRPose,
+    RFDETRPoseNano,
+    RFDETRPoseSmall,
+    RFDETRPoseMedium,
+    RFDETRPoseLarge,
+)

--- a/rfdetr/config.py
+++ b/rfdetr/config.py
@@ -164,6 +164,44 @@ class RFDETRPoseConfig(RFDETRBaseConfig):
     num_classes: int = 1  # Typically just "person" class for pose
 
 
+class RFDETRPoseNanoConfig(RFDETRPoseConfig):
+    """
+    Configuration for RF-DETR Pose Nano - smallest and fastest pose model.
+    """
+    dec_layers: int = 2
+    resolution: int = 384
+    positional_encoding_size: int = 24
+    pretrain_weights: Optional[str] = "rf-detr-nano.pth"
+
+
+class RFDETRPoseSmallConfig(RFDETRPoseConfig):
+    """
+    Configuration for RF-DETR Pose Small - balance of speed and accuracy.
+    """
+    dec_layers: int = 3
+    resolution: int = 512
+    positional_encoding_size: int = 32
+    pretrain_weights: Optional[str] = "rf-detr-small.pth"
+
+
+class RFDETRPoseMediumConfig(RFDETRPoseConfig):
+    """
+    Configuration for RF-DETR Pose Medium - default pose model.
+    """
+    # Inherits all defaults from RFDETRPoseConfig (Medium architecture)
+    pass
+
+
+class RFDETRPoseLargeConfig(RFDETRPoseConfig):
+    """
+    Configuration for RF-DETR Pose Large - highest accuracy pose model.
+    """
+    dec_layers: int = 6
+    resolution: int = 768
+    positional_encoding_size: int = 48
+    pretrain_weights: Optional[str] = "rf-detr-large.pth"
+
+
 class TrainConfig(BaseModel):
     lr: float = 1e-4
     lr_encoder: float = 1.5e-4

--- a/rfdetr/config.py
+++ b/rfdetr/config.py
@@ -37,6 +37,11 @@ class ModelConfig(BaseModel):
     cls_loss_coef: float = 1.0
     segmentation_head: bool = False
     mask_downsample_ratio: int = 4
+    # Keypoint/pose estimation settings
+    keypoint_head: bool = False
+    num_keypoints: int = 17
+    keypoint_names: Optional[List[str]] = None
+    skeleton: Optional[List[List[int]]] = None
 
 
 class RFDETRBaseConfig(ModelConfig):
@@ -120,6 +125,45 @@ class RFDETRSegPreviewConfig(RFDETRBaseConfig):
     pretrain_weights: Optional[str] = "rf-detr-seg-preview.pt"
     num_classes: int = 90
 
+
+class RFDETRPoseConfig(RFDETRBaseConfig):
+    """
+    Configuration for RF-DETR Pose estimation model with keypoint detection.
+    """
+    keypoint_head: bool = True
+    num_keypoints: int = 17
+    keypoint_names: List[str] = [
+        "nose",
+        "left_eye", "right_eye",
+        "left_ear", "right_ear",
+        "left_shoulder", "right_shoulder",
+        "left_elbow", "right_elbow",
+        "left_wrist", "right_wrist",
+        "left_hip", "right_hip",
+        "left_knee", "right_knee",
+        "left_ankle", "right_ankle"
+    ]
+    skeleton: List[List[int]] = [
+        [15, 13], [13, 11], [16, 14], [14, 12], [11, 12],  # legs
+        [5, 11], [6, 12],  # torso to hips
+        [5, 6],  # shoulders
+        [5, 7], [6, 8], [7, 9], [8, 10],  # arms
+        [1, 2], [0, 1], [0, 2], [1, 3], [2, 4], [3, 5], [4, 6]  # face
+    ]
+    out_feature_indexes: List[int] = [3, 6, 9, 12]
+    num_windows: int = 2
+    dec_layers: int = 4
+    patch_size: int = 16
+    resolution: int = 576
+    positional_encoding_size: int = 36
+    num_queries: int = 300
+    num_select: int = 300
+    # Uses detection weights as starting point; keypoint_head will be randomly initialized
+    # and learned during fine-tuning on a pose dataset
+    pretrain_weights: Optional[str] = "rf-detr-medium.pth"
+    num_classes: int = 1  # Typically just "person" class for pose
+
+
 class TrainConfig(BaseModel):
     lr: float = 1e-4
     lr_encoder: float = 1.5e-4
@@ -159,6 +203,9 @@ class TrainConfig(BaseModel):
     class_names: List[str] = None
     run_test: bool = True
     segmentation_head: bool = False
+    # Keypoint training settings
+    keypoint_head: bool = False
+    num_keypoints: int = 17
 
 
 class SegmentationTrainConfig(TrainConfig):
@@ -167,3 +214,13 @@ class SegmentationTrainConfig(TrainConfig):
     mask_dice_loss_coef: float = 5.0
     cls_loss_coef: float = 5.0
     segmentation_head: bool = True
+
+
+class KeypointTrainConfig(TrainConfig):
+    """Training configuration for keypoint/pose estimation."""
+    keypoint_head: bool = True
+    num_keypoints: int = 17
+    keypoint_loss_coef: float = 5.0
+    keypoint_visibility_loss_coef: float = 2.0
+    keypoint_oks_loss_coef: float = 2.0
+    cls_loss_coef: float = 2.0  # Slightly higher for pose since fewer classes

--- a/rfdetr/datasets/coco_eval.py
+++ b/rfdetr/datasets/coco_eval.py
@@ -40,6 +40,12 @@ class CocoEvaluator(object):
         self.coco_gt = coco_gt
         self.num_keypoints = num_keypoints
 
+        # Create reverse mapping: contiguous 0-indexed labels -> original COCO category IDs
+        # This is needed because the model predicts 0-indexed class labels, but COCO
+        # evaluation expects the original category IDs from the dataset.
+        cat_ids = sorted(coco_gt.getCatIds())
+        self.continuous_to_cat_id = {i: cat_id for i, cat_id in enumerate(cat_ids)}
+
         self.iou_types = iou_types
         self.coco_eval = {}
         for iou_type in iou_types:
@@ -113,7 +119,8 @@ class CocoEvaluator(object):
                 [
                     {
                         "image_id": original_id,
-                        "category_id": labels[k],
+                        # Convert 0-indexed class label back to original COCO category ID
+                        "category_id": self.continuous_to_cat_id.get(labels[k], labels[k]),
                         "bbox": box,
                         "score": scores[k],
                     }
@@ -148,7 +155,8 @@ class CocoEvaluator(object):
                 [
                     {
                         "image_id": original_id,
-                        "category_id": labels[k],
+                        # Convert 0-indexed class label back to original COCO category ID
+                        "category_id": self.continuous_to_cat_id.get(labels[k], labels[k]),
                         "segmentation": rle,
                         "score": scores[k],
                     }
@@ -174,7 +182,8 @@ class CocoEvaluator(object):
                 [
                     {
                         "image_id": original_id,
-                        "category_id": labels[k],
+                        # Convert 0-indexed class label back to original COCO category ID
+                        "category_id": self.continuous_to_cat_id.get(labels[k], labels[k]),
                         'keypoints': keypoint,
                         "score": scores[k],
                     }

--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -31,6 +31,10 @@ from rfdetr.config import (
     RFDETRMediumConfig,
     RFDETRSegPreviewConfig,
     RFDETRPoseConfig,
+    RFDETRPoseNanoConfig,
+    RFDETRPoseSmallConfig,
+    RFDETRPoseMediumConfig,
+    RFDETRPoseLargeConfig,
     TrainConfig,
     SegmentationTrainConfig,
     KeypointTrainConfig,
@@ -502,3 +506,55 @@ class RFDETRPose(RFDETR):
 
     def get_train_config(self, **kwargs):
         return KeypointTrainConfig(**kwargs)
+
+
+class RFDETRPoseNano(RFDETRPose):
+    """
+    RF-DETR Pose Nano - smallest and fastest pose estimation model.
+
+    Uses rf-detr-nano.pth backbone with keypoint head.
+    Resolution: 384, Decoder layers: 2
+    """
+    size = "rfdetr-pose-nano"
+
+    def get_model_config(self, **kwargs):
+        return RFDETRPoseNanoConfig(**kwargs)
+
+
+class RFDETRPoseSmall(RFDETRPose):
+    """
+    RF-DETR Pose Small - balance of speed and accuracy.
+
+    Uses rf-detr-small.pth backbone with keypoint head.
+    Resolution: 512, Decoder layers: 3
+    """
+    size = "rfdetr-pose-small"
+
+    def get_model_config(self, **kwargs):
+        return RFDETRPoseSmallConfig(**kwargs)
+
+
+class RFDETRPoseMedium(RFDETRPose):
+    """
+    RF-DETR Pose Medium - default pose estimation model.
+
+    Uses rf-detr-medium.pth backbone with keypoint head.
+    Resolution: 576, Decoder layers: 4
+    """
+    size = "rfdetr-pose-medium"
+
+    def get_model_config(self, **kwargs):
+        return RFDETRPoseMediumConfig(**kwargs)
+
+
+class RFDETRPoseLarge(RFDETRPose):
+    """
+    RF-DETR Pose Large - highest accuracy pose estimation model.
+
+    Uses rf-detr-large.pth backbone with keypoint head.
+    Resolution: 768, Decoder layers: 6
+    """
+    size = "rfdetr-pose-large"
+
+    def get_model_config(self, **kwargs):
+        return RFDETRPoseLargeConfig(**kwargs)

--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -362,6 +362,12 @@ class RFDETR:
                 # Store keypoints in the data dict: [N, K, 3] where 3 = (x, y, visibility)
                 detections.data["keypoints"] = keypoints.cpu().numpy()
 
+                # Also copy keypoints_confidence (actual confidence scores 0.0-1.0)
+                if "keypoints_confidence" in result:
+                    keypoints_conf = result["keypoints_confidence"]
+                    keypoints_conf = keypoints_conf[keep]
+                    detections.data["keypoints_confidence"] = keypoints_conf.cpu().numpy()
+
             detections_list.append(detections)
 
         return detections_list if len(detections_list) > 1 else detections_list[0]

--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -505,6 +505,9 @@ class RFDETRPose(RFDETR):
         return RFDETRPoseConfig(**kwargs)
 
     def get_train_config(self, **kwargs):
+        # Automatically use num_keypoints from model config if not specified
+        if 'num_keypoints' not in kwargs:
+            kwargs['num_keypoints'] = self.model_config.num_keypoints
         return KeypointTrainConfig(**kwargs)
 
 

--- a/rfdetr/engine.py
+++ b/rfdetr/engine.py
@@ -261,7 +261,12 @@ def evaluate(model, criterion, postprocess, data_loader, base_ds, device, args=N
     )
     header = "Test:"
 
-    iou_types = ("bbox",) if not args.segmentation_head else ("bbox", "segm")
+    iou_types = ["bbox"]
+    if getattr(args, 'segmentation_head', False):
+        iou_types.append("segm")
+    if getattr(args, 'keypoint_head', False):
+        iou_types.append("keypoints")
+    iou_types = tuple(iou_types)
     coco_evaluator = CocoEvaluator(base_ds, iou_types)
 
     for samples, targets in metric_logger.log_every(data_loader, 10, header):
@@ -338,4 +343,7 @@ def evaluate(model, criterion, postprocess, data_loader, base_ds, device, args=N
         if "segm" in iou_types:
             results_json = coco_extended_metrics(coco_evaluator.coco_eval["segm"])
             stats["coco_eval_masks"] = coco_evaluator.coco_eval["segm"].stats.tolist()
+
+        if "keypoints" in iou_types:
+            stats["coco_eval_keypoints"] = coco_evaluator.coco_eval["keypoints"].stats.tolist()
     return stats, coco_evaluator

--- a/rfdetr/engine.py
+++ b/rfdetr/engine.py
@@ -264,10 +264,11 @@ def evaluate(model, criterion, postprocess, data_loader, base_ds, device, args=N
     iou_types = ["bbox"]
     if getattr(args, 'segmentation_head', False):
         iou_types.append("segm")
+    num_keypoints = getattr(args, 'num_keypoints', 17)
     if getattr(args, 'keypoint_head', False):
         iou_types.append("keypoints")
     iou_types = tuple(iou_types)
-    coco_evaluator = CocoEvaluator(base_ds, iou_types)
+    coco_evaluator = CocoEvaluator(base_ds, iou_types, num_keypoints=num_keypoints)
 
     for samples, targets in metric_logger.log_every(data_loader, 10, header):
         samples = samples.to(device)

--- a/rfdetr/models/keypoint_head.py
+++ b/rfdetr/models/keypoint_head.py
@@ -1,0 +1,177 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""
+Keypoint Head for RF-DETR Pose Estimation
+
+Outputs (x, y, visibility) for each keypoint per detection query,
+following YOLOv11's approach for pose estimation.
+"""
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from typing import List, Optional
+
+
+class MLP(nn.Module):
+    """Simple multi-layer perceptron (also called FFN)"""
+
+    def __init__(self, input_dim: int, hidden_dim: int, output_dim: int, num_layers: int):
+        super().__init__()
+        self.num_layers = num_layers
+        h = [hidden_dim] * (num_layers - 1)
+        self.layers = nn.ModuleList(
+            nn.Linear(n, k) for n, k in zip([input_dim] + h, h + [output_dim])
+        )
+
+    def forward(self, x):
+        for i, layer in enumerate(self.layers):
+            x = F.relu(layer(x)) if i < self.num_layers - 1 else layer(x)
+        return x
+
+
+class KeypointHead(nn.Module):
+    """
+    Predicts keypoints for each detection query.
+
+    For each query, outputs num_keypoints * 3 values:
+    - x coordinate (normalized 0-1)
+    - y coordinate (normalized 0-1)
+    - visibility logit (converted to confidence via sigmoid)
+
+    Args:
+        hidden_dim: Transformer embedding dimension
+        num_keypoints: Number of keypoints to predict (default: 17 for COCO)
+        num_layers: Number of MLP layers for each head
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_keypoints: int = 17,
+        num_layers: int = 3,
+    ):
+        super().__init__()
+        self.num_keypoints = num_keypoints
+        self.hidden_dim = hidden_dim
+
+        # MLP for keypoint coordinate regression
+        # Output: num_keypoints * 2 (x, y for each keypoint)
+        self.coord_head = MLP(hidden_dim, hidden_dim, num_keypoints * 2, num_layers)
+
+        # Separate head for visibility prediction
+        # Output: num_keypoints (visibility logit for each keypoint)
+        self.visibility_head = MLP(hidden_dim, hidden_dim, num_keypoints, num_layers)
+
+        self._reset_parameters()
+
+    def _reset_parameters(self):
+        """Initialize weights for better convergence."""
+        # Initialize coordinate head to predict center initially
+        nn.init.zeros_(self.coord_head.layers[-1].weight)
+        nn.init.constant_(self.coord_head.layers[-1].bias, 0.5)
+
+        # Initialize visibility head with slight negative bias (most keypoints start hidden)
+        nn.init.zeros_(self.visibility_head.layers[-1].weight)
+        nn.init.zeros_(self.visibility_head.layers[-1].bias)
+
+    def forward(
+        self,
+        query_features: List[torch.Tensor],
+        reference_boxes: Optional[torch.Tensor] = None,
+    ) -> List[torch.Tensor]:
+        """
+        Args:
+            query_features: List of query features from decoder layers
+                           Each tensor shape: [B, num_queries, hidden_dim]
+            reference_boxes: Optional reference boxes [B, num_queries, 4]
+                            in cxcywh format for relative keypoint prediction
+
+        Returns:
+            List of keypoint predictions, one per decoder layer
+            Each tensor shape: [B, num_queries, num_keypoints, 3]
+            where 3 = (x, y, visibility_logit)
+        """
+        keypoint_outputs = []
+
+        for qf in query_features:
+            B, N, _ = qf.shape
+
+            # Predict coordinates
+            coords = self.coord_head(qf)  # [B, N, num_keypoints * 2]
+            coords = coords.view(B, N, self.num_keypoints, 2)
+            coords = coords.sigmoid()  # Normalize to [0, 1]
+
+            # If reference boxes provided, make coordinates relative to box center
+            # This allows the model to predict offsets from the detection box
+            if reference_boxes is not None:
+                cx, cy, w, h = reference_boxes.unbind(-1)
+                # Convert keypoints from relative [0,1] within box to absolute [0,1]
+                # Keypoint prediction of 0.5,0.5 means center of box
+                kpt_x = cx.unsqueeze(-1) + (coords[..., 0] - 0.5) * w.unsqueeze(-1)
+                kpt_y = cy.unsqueeze(-1) + (coords[..., 1] - 0.5) * h.unsqueeze(-1)
+                coords = torch.stack([kpt_x, kpt_y], dim=-1)
+                # Clamp to valid range
+                coords = coords.clamp(0, 1)
+
+            # Predict visibility (as logits, will be converted via sigmoid at inference)
+            vis = self.visibility_head(qf)  # [B, N, num_keypoints]
+            vis = vis.unsqueeze(-1)  # [B, N, num_keypoints, 1]
+
+            # Combine: [B, N, num_keypoints, 3] where 3 = (x, y, visibility_logit)
+            keypoints = torch.cat([coords, vis], dim=-1)
+            keypoint_outputs.append(keypoints)
+
+        return keypoint_outputs
+
+
+# COCO keypoint constants for reference
+COCO_KEYPOINT_NAMES = [
+    "nose",
+    "left_eye", "right_eye",
+    "left_ear", "right_ear",
+    "left_shoulder", "right_shoulder",
+    "left_elbow", "right_elbow",
+    "left_wrist", "right_wrist",
+    "left_hip", "right_hip",
+    "left_knee", "right_knee",
+    "left_ankle", "right_ankle"
+]
+
+# Skeleton connections for COCO (pairs of keypoint indices)
+COCO_SKELETON = [
+    [15, 13], [13, 11], [16, 14], [14, 12], [11, 12],  # legs
+    [5, 11], [6, 12],  # torso to hips
+    [5, 6],  # shoulders
+    [5, 7], [6, 8], [7, 9], [8, 10],  # arms
+    [1, 2], [0, 1], [0, 2], [1, 3], [2, 4], [3, 5], [4, 6]  # face
+]
+
+# COCO keypoint sigmas for OKS calculation
+# These control how strict the matching is for each keypoint
+COCO_KEYPOINT_SIGMAS = [
+    0.026,  # nose
+    0.025, 0.025,  # eyes
+    0.035, 0.035,  # ears
+    0.079, 0.079,  # shoulders
+    0.072, 0.072,  # elbows
+    0.062, 0.062,  # wrists
+    0.107, 0.107,  # hips
+    0.087, 0.087,  # knees
+    0.089, 0.089   # ankles
+]
+
+# Flip pairs for horizontal augmentation (left <-> right)
+COCO_KEYPOINT_FLIP_PAIRS = [
+    (1, 2),   # left_eye <-> right_eye
+    (3, 4),   # left_ear <-> right_ear
+    (5, 6),   # left_shoulder <-> right_shoulder
+    (7, 8),   # left_elbow <-> right_elbow
+    (9, 10),  # left_wrist <-> right_wrist
+    (11, 12), # left_hip <-> right_hip
+    (13, 14), # left_knee <-> right_knee
+    (15, 16)  # left_ankle <-> right_ankle
+]

--- a/rfdetr/models/lwdetr.py
+++ b/rfdetr/models/lwdetr.py
@@ -918,9 +918,14 @@ class PostProcess(nn.Module):
                 kpts_i_scaled[..., 0] = kpts_i[..., 0] * w  # x
                 kpts_i_scaled[..., 1] = kpts_i[..., 1] * h  # y
                 # Convert visibility logits to confidence scores via sigmoid
-                kpts_i_scaled[..., 2] = kpts_i[..., 2].sigmoid()
+                vis_conf = kpts_i[..., 2].sigmoid()
+                # For COCO evaluation: 2 = visible, 1 = occluded, 0 = not labeled
+                # We output 2 if confident (>0.5), else 0
+                kpts_i_scaled[..., 2] = (vis_conf > 0.5).float() * 2
 
                 res_i['keypoints'] = kpts_i_scaled
+                # Also store raw visibility confidence for user access
+                res_i['keypoints_confidence'] = vis_conf
 
             results.append(res_i)
 

--- a/rfdetr/util/metrics.py
+++ b/rfdetr/util/metrics.py
@@ -141,6 +141,22 @@ class MetricsTensorBoardSink:
         if 'test_loss' in values:
             self.writer.add_scalar("Loss/Test", values['test_loss'], epoch)
 
+        # Log keypoint losses if present
+        if 'train_loss_keypoints_l1' in values:
+            self.writer.add_scalar("Loss/Keypoints/L1", values['train_loss_keypoints_l1'], epoch)
+        if 'train_loss_keypoints_vis' in values:
+            self.writer.add_scalar("Loss/Keypoints/Visibility", values['train_loss_keypoints_vis'], epoch)
+        if 'train_loss_keypoints_oks' in values:
+            self.writer.add_scalar("Loss/Keypoints/OKS", values['train_loss_keypoints_oks'], epoch)
+
+        # Log bbox and classification losses
+        if 'train_loss_ce' in values:
+            self.writer.add_scalar("Loss/Classification", values['train_loss_ce'], epoch)
+        if 'train_loss_bbox' in values:
+            self.writer.add_scalar("Loss/BBox", values['train_loss_bbox'], epoch)
+        if 'train_loss_giou' in values:
+            self.writer.add_scalar("Loss/GIoU", values['train_loss_giou'], epoch)
+
         if 'test_coco_eval_bbox' in values:
             coco_eval = values['test_coco_eval_bbox']
             ap50_90 = safe_index(coco_eval, 0)
@@ -209,6 +225,22 @@ class MetricsWandBSink:
             log_dict["Loss/Train"] = values['train_loss']
         if 'test_loss' in values:
             log_dict["Loss/Test"] = values['test_loss']
+
+        # Log keypoint losses if present
+        if 'train_loss_keypoints_l1' in values:
+            log_dict["Loss/Keypoints/L1"] = values['train_loss_keypoints_l1']
+        if 'train_loss_keypoints_vis' in values:
+            log_dict["Loss/Keypoints/Visibility"] = values['train_loss_keypoints_vis']
+        if 'train_loss_keypoints_oks' in values:
+            log_dict["Loss/Keypoints/OKS"] = values['train_loss_keypoints_oks']
+
+        # Log bbox and classification losses
+        if 'train_loss_ce' in values:
+            log_dict["Loss/Classification"] = values['train_loss_ce']
+        if 'train_loss_bbox' in values:
+            log_dict["Loss/BBox"] = values['train_loss_bbox']
+        if 'train_loss_giou' in values:
+            log_dict["Loss/GIoU"] = values['train_loss_giou']
 
         if 'test_coco_eval_bbox' in values:
             coco_eval = values['test_coco_eval_bbox']

--- a/rfdetr/util/metrics.py
+++ b/rfdetr/util/metrics.py
@@ -181,6 +181,16 @@ class MetricsTensorBoardSink:
             if ema_ar50_90 is not None:
                 self.writer.add_scalar("Metrics/EMA/AR50_90", ema_ar50_90, epoch)
 
+        # Log keypoint mAP if present
+        if 'test_coco_eval_keypoints' in values:
+            kpt_eval = values['test_coco_eval_keypoints']
+            kpt_ap = safe_index(kpt_eval, 0)
+            kpt_ap50 = safe_index(kpt_eval, 1)
+            if kpt_ap is not None:
+                self.writer.add_scalar("Metrics/Keypoints/AP", kpt_ap, epoch)
+            if kpt_ap50 is not None:
+                self.writer.add_scalar("Metrics/Keypoints/AP50", kpt_ap50, epoch)
+
         self.writer.flush()
 
     def close(self):
@@ -265,6 +275,16 @@ class MetricsWandBSink:
                 log_dict["Metrics/EMA/AP50"] = ema_ap50
             if ema_ar50_90 is not None:
                 log_dict["Metrics/EMA/AR50_90"] = ema_ar50_90
+
+        # Log keypoint mAP if present
+        if 'test_coco_eval_keypoints' in values:
+            kpt_eval = values['test_coco_eval_keypoints']
+            kpt_ap = safe_index(kpt_eval, 0)
+            kpt_ap50 = safe_index(kpt_eval, 1)
+            if kpt_ap is not None:
+                log_dict["Metrics/Keypoints/AP"] = kpt_ap
+            if kpt_ap50 is not None:
+                log_dict["Metrics/Keypoints/AP50"] = kpt_ap50
 
         wandb.log(log_dict)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# RF-DETR Tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,12 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
+"""
+Pytest configuration for RF-DETR tests.
+"""
+import sys
+from pathlib import Path
 
-import os
-if os.environ.get("PYTORCH_ENABLE_MPS_FALLBACK") is None:
-    os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
-
-from rfdetr.detr import RFDETRBase, RFDETRLarge, RFDETRNano, RFDETRSmall, RFDETRMedium, RFDETRSegPreview, RFDETRPose
+# Add the project root to the Python path so rfdetr can be imported
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))

--- a/tests/test_keypoint_head.py
+++ b/tests/test_keypoint_head.py
@@ -1,0 +1,567 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""
+Tests for the keypoint/pose estimation implementation.
+"""
+import pytest
+import torch
+import numpy as np
+from PIL import Image
+
+
+class TestKeypointHead:
+    """Tests for the KeypointHead module."""
+
+    def test_keypoint_head_import(self):
+        """Test that KeypointHead can be imported."""
+        from rfdetr.models.keypoint_head import KeypointHead
+        assert KeypointHead is not None
+
+    def test_keypoint_head_init(self):
+        """Test KeypointHead initialization."""
+        from rfdetr.models.keypoint_head import KeypointHead
+
+        head = KeypointHead(hidden_dim=256, num_keypoints=17, num_layers=3)
+        assert head.num_keypoints == 17
+        assert head.hidden_dim == 256
+
+    def test_keypoint_head_forward(self):
+        """Test KeypointHead forward pass."""
+        from rfdetr.models.keypoint_head import KeypointHead
+
+        head = KeypointHead(hidden_dim=256, num_keypoints=17, num_layers=3)
+
+        # Simulate query features from decoder
+        batch_size = 2
+        num_queries = 300
+        hidden_dim = 256
+
+        query_features = [torch.randn(batch_size, num_queries, hidden_dim)]
+        outputs = head(query_features)
+
+        assert len(outputs) == 1
+        assert outputs[0].shape == (batch_size, num_queries, 17, 3)
+
+    def test_keypoint_head_with_reference_boxes(self):
+        """Test KeypointHead with reference boxes for relative prediction."""
+        from rfdetr.models.keypoint_head import KeypointHead
+
+        head = KeypointHead(hidden_dim=256, num_keypoints=17, num_layers=3)
+
+        batch_size = 2
+        num_queries = 300
+        hidden_dim = 256
+
+        query_features = [torch.randn(batch_size, num_queries, hidden_dim)]
+        # Reference boxes in cxcywh format, normalized [0, 1]
+        reference_boxes = torch.rand(batch_size, num_queries, 4)
+
+        outputs = head(query_features, reference_boxes=reference_boxes)
+
+        assert len(outputs) == 1
+        assert outputs[0].shape == (batch_size, num_queries, 17, 3)
+        # Coordinates should be in [0, 1] range due to clamping
+        assert outputs[0][..., :2].min() >= 0.0
+        assert outputs[0][..., :2].max() <= 1.0
+
+    def test_keypoint_head_custom_keypoints(self):
+        """Test KeypointHead with custom number of keypoints."""
+        from rfdetr.models.keypoint_head import KeypointHead
+
+        num_keypoints = 5
+        head = KeypointHead(hidden_dim=128, num_keypoints=num_keypoints, num_layers=2)
+
+        query_features = [torch.randn(1, 100, 128)]
+        outputs = head(query_features)
+
+        assert outputs[0].shape == (1, 100, num_keypoints, 3)
+
+    def test_keypoint_head_multiple_layers(self):
+        """Test KeypointHead with multiple decoder layers."""
+        from rfdetr.models.keypoint_head import KeypointHead
+
+        head = KeypointHead(hidden_dim=256, num_keypoints=17, num_layers=3)
+
+        # Simulate multiple decoder layers
+        query_features = [
+            torch.randn(2, 300, 256),
+            torch.randn(2, 300, 256),
+            torch.randn(2, 300, 256),
+        ]
+        outputs = head(query_features)
+
+        assert len(outputs) == 3
+        for out in outputs:
+            assert out.shape == (2, 300, 17, 3)
+
+
+class TestKeypointConstants:
+    """Tests for COCO keypoint constants."""
+
+    def test_coco_keypoint_names(self):
+        """Test COCO keypoint names are correctly defined."""
+        from rfdetr.models.keypoint_head import COCO_KEYPOINT_NAMES
+
+        assert len(COCO_KEYPOINT_NAMES) == 17
+        assert COCO_KEYPOINT_NAMES[0] == "nose"
+        assert "left_shoulder" in COCO_KEYPOINT_NAMES
+        assert "right_ankle" in COCO_KEYPOINT_NAMES
+
+    def test_coco_skeleton(self):
+        """Test COCO skeleton connections are valid."""
+        from rfdetr.models.keypoint_head import COCO_SKELETON, COCO_KEYPOINT_NAMES
+
+        for connection in COCO_SKELETON:
+            assert len(connection) == 2
+            assert 0 <= connection[0] < len(COCO_KEYPOINT_NAMES)
+            assert 0 <= connection[1] < len(COCO_KEYPOINT_NAMES)
+
+    def test_coco_sigmas(self):
+        """Test COCO keypoint sigmas are valid."""
+        from rfdetr.models.keypoint_head import COCO_KEYPOINT_SIGMAS
+
+        assert len(COCO_KEYPOINT_SIGMAS) == 17
+        for sigma in COCO_KEYPOINT_SIGMAS:
+            assert 0 < sigma < 1
+
+    def test_coco_flip_pairs(self):
+        """Test COCO flip pairs are valid and symmetric."""
+        from rfdetr.models.keypoint_head import COCO_KEYPOINT_FLIP_PAIRS, COCO_KEYPOINT_NAMES
+
+        for left_idx, right_idx in COCO_KEYPOINT_FLIP_PAIRS:
+            left_name = COCO_KEYPOINT_NAMES[left_idx]
+            right_name = COCO_KEYPOINT_NAMES[right_idx]
+            assert "left" in left_name
+            assert "right" in right_name
+
+
+class TestKeypointConfig:
+    """Tests for keypoint configuration classes."""
+
+    def test_rfdetr_pose_config(self):
+        """Test RFDETRPoseConfig default values."""
+        from rfdetr.config import RFDETRPoseConfig
+
+        config = RFDETRPoseConfig()
+        assert config.keypoint_head is True
+        assert config.num_keypoints == 17
+        assert len(config.keypoint_names) == 17
+        assert config.skeleton is not None
+        assert config.num_classes == 1  # Person class for pose
+
+    def test_keypoint_train_config(self):
+        """Test KeypointTrainConfig default values."""
+        from rfdetr.config import KeypointTrainConfig
+
+        config = KeypointTrainConfig(dataset_dir="/tmp/test")
+        assert config.keypoint_head is True
+        assert config.num_keypoints == 17
+        assert config.keypoint_loss_coef == 5.0
+        assert config.keypoint_visibility_loss_coef == 2.0
+        assert config.keypoint_oks_loss_coef == 2.0
+
+    def test_model_config_keypoint_fields(self):
+        """Test that ModelConfig has keypoint fields."""
+        from rfdetr.config import ModelConfig, RFDETRBaseConfig
+
+        # Base config should have keypoint_head=False by default
+        config = RFDETRBaseConfig()
+        assert config.keypoint_head is False
+        assert config.num_keypoints == 17
+
+
+class TestKeypointDataset:
+    """Tests for keypoint dataset handling."""
+
+    def test_convert_coco_keypoints(self):
+        """Test ConvertCoco extracts keypoints correctly."""
+        from rfdetr.datasets.coco import ConvertCoco
+
+        converter = ConvertCoco(include_keypoints=True, num_keypoints=17)
+        assert converter.include_keypoints is True
+        assert converter.num_keypoints == 17
+
+    def test_extract_keypoints_format(self):
+        """Test keypoint extraction produces correct format."""
+        from rfdetr.datasets.coco import ConvertCoco
+
+        converter = ConvertCoco(include_keypoints=True, num_keypoints=17)
+
+        # Mock annotation with COCO keypoints format
+        anno = [{
+            "keypoints": [
+                100, 50, 2,   # nose: x, y, v
+                90, 45, 2,    # left_eye
+                110, 45, 2,   # right_eye
+                80, 50, 1,    # left_ear
+                120, 50, 1,   # right_ear
+                70, 100, 2,   # left_shoulder
+                130, 100, 2,  # right_shoulder
+                60, 150, 2,   # left_elbow
+                140, 150, 2,  # right_elbow
+                50, 200, 2,   # left_wrist
+                150, 200, 2,  # right_wrist
+                80, 200, 2,   # left_hip
+                120, 200, 2,  # right_hip
+                75, 280, 2,   # left_knee
+                125, 280, 2,  # right_knee
+                70, 350, 2,   # left_ankle
+                130, 350, 2,  # right_ankle
+            ]
+        }]
+
+        w, h = 200, 400
+        keypoints = converter._extract_keypoints(anno, w, h)
+
+        assert keypoints.shape == (1, 17, 3)
+        # Check normalization
+        assert keypoints[..., 0].max() <= 1.0  # x normalized
+        assert keypoints[..., 1].max() <= 1.0  # y normalized
+
+    def test_extract_keypoints_empty(self):
+        """Test keypoint extraction with no annotations."""
+        from rfdetr.datasets.coco import ConvertCoco
+
+        converter = ConvertCoco(include_keypoints=True, num_keypoints=17)
+        keypoints = converter._extract_keypoints([], 200, 400)
+
+        assert keypoints.shape == (0, 17, 3)
+
+
+class TestKeypointTransforms:
+    """Tests for keypoint transforms."""
+
+    def test_hflip_keypoints(self):
+        """Test horizontal flip swaps left/right keypoints."""
+        from rfdetr.datasets import transforms as T
+
+        # Create a mock image and target with keypoints
+        image = Image.new('RGB', (200, 200))
+        target = {
+            "boxes": torch.tensor([[50, 50, 150, 150]]),
+            "keypoints": torch.tensor([[[0.25, 0.5, 2.0],   # left position
+                                         [0.75, 0.5, 2.0]]]) # right position
+        }
+
+        # Apply hflip
+        flipped_image, flipped_target = T.hflip(image, target)
+
+        # Check x coordinates are flipped (1 - x)
+        assert flipped_target["keypoints"][0, 0, 0] == pytest.approx(0.75, rel=1e-5)
+        assert flipped_target["keypoints"][0, 1, 0] == pytest.approx(0.25, rel=1e-5)
+
+    def test_crop_keypoints_visibility(self):
+        """Test crop marks out-of-bounds keypoints as invisible."""
+        from rfdetr.datasets import transforms as T
+
+        image = Image.new('RGB', (400, 400))
+        # Keypoint at (0.1, 0.1) should be outside a crop starting at (0.2, 0.2)
+        target = {
+            "boxes": torch.tensor([[100.0, 100.0, 300.0, 300.0]]),
+            "labels": torch.tensor([1]),
+            "area": torch.tensor([40000.0]),
+            "iscrowd": torch.tensor([0]),
+            "keypoints": torch.tensor([[[0.1, 0.1, 2.0],   # will be outside crop
+                                         [0.5, 0.5, 2.0]]]), # will be inside crop
+            "size": torch.tensor([400, 400]),
+            "orig_size": torch.tensor([400, 400]),
+        }
+
+        # Crop region (region format: top, left, height, width)
+        region = (80, 80, 200, 200)  # crops to (80,80) - (280, 280)
+        cropped_image, cropped_target = T.crop(image, target, region)
+
+        # Keypoint at (0.1, 0.1) = pixel (40, 40) is outside crop (80, 80)-(280, 280)
+        # Should be marked invisible (v=0)
+        if "keypoints" in cropped_target:
+            kpts = cropped_target["keypoints"]
+            # First keypoint should have visibility 0 (outside)
+            assert kpts[0, 0, 2] == 0.0
+
+
+class TestRFDETRPose:
+    """Tests for RFDETRPose class."""
+
+    def test_rfdetr_pose_import(self):
+        """Test that RFDETRPose can be imported."""
+        from rfdetr import RFDETRPose
+        assert RFDETRPose is not None
+
+    def test_rfdetr_pose_config(self):
+        """Test RFDETRPose uses correct configs."""
+        from rfdetr import RFDETRPose
+        from rfdetr.config import RFDETRPoseConfig, KeypointTrainConfig
+
+        pose = RFDETRPose.__new__(RFDETRPose)
+        model_config = pose.get_model_config()
+        train_config = pose.get_train_config(dataset_dir="/tmp")
+
+        assert isinstance(model_config, RFDETRPoseConfig)
+        assert isinstance(train_config, KeypointTrainConfig)
+        assert model_config.keypoint_head is True
+        assert train_config.keypoint_head is True
+
+
+class TestKeypointLoss:
+    """Tests for keypoint loss functions."""
+
+    def test_loss_keypoints_exists(self):
+        """Test that loss_keypoints method exists in SetCriterion."""
+        # This is a basic check - full loss testing requires model setup
+        from rfdetr.models.lwdetr import SetCriterion
+        assert hasattr(SetCriterion, 'loss_keypoints')
+
+    def test_loss_map_includes_keypoints(self):
+        """Test that keypoints is in the loss map."""
+        from rfdetr.models.lwdetr import SetCriterion
+
+        # Create a minimal criterion to check loss_map
+        criterion = SetCriterion.__new__(SetCriterion)
+        criterion.losses = ['keypoints']
+
+        # The get_loss method should handle 'keypoints'
+        loss_map = {
+            'labels': 'loss_labels',
+            'labels_o2o': 'loss_labels',
+            'boxes': 'loss_boxes',
+            'masks': 'loss_masks',
+            'keypoints': 'loss_keypoints',
+        }
+        assert 'keypoints' in loss_map
+
+
+class TestKeypointPostProcess:
+    """Tests for keypoint post-processing."""
+
+    def test_postprocess_handles_keypoints(self):
+        """Test that PostProcess handles keypoint outputs."""
+        from rfdetr.models.lwdetr import PostProcess
+
+        # Create mock outputs
+        batch_size = 2
+        num_queries = 300
+        num_classes = 1
+        num_keypoints = 17
+
+        outputs = {
+            "pred_logits": torch.randn(batch_size, num_queries, num_classes),
+            "pred_boxes": torch.rand(batch_size, num_queries, 4),
+            "pred_keypoints": torch.rand(batch_size, num_queries, num_keypoints, 3),
+        }
+        target_sizes = torch.tensor([[480, 640], [480, 640]])
+
+        postprocess = PostProcess(num_select=100)
+        results = postprocess(outputs, target_sizes)
+
+        assert len(results) == batch_size
+        for result in results:
+            assert "scores" in result
+            assert "labels" in result
+            assert "boxes" in result
+            assert "keypoints" in result
+            # Keypoints should be scaled to image coordinates
+            assert result["keypoints"].shape[-1] == 3  # x, y, visibility
+
+
+class TestKeypointInference:
+    """Tests for keypoint inference pipeline."""
+
+    def test_rfdetr_pose_predict_returns_keypoints(self):
+        """Test that RFDETRPose.predict() returns keypoints in detections."""
+        # This test mocks the model to avoid loading weights
+        from rfdetr import RFDETRPose
+        from unittest.mock import MagicMock, patch
+        import numpy as np
+
+        # Create a mock model that returns keypoints
+        with patch.object(RFDETRPose, '__init__', lambda self, **kwargs: None):
+            model = RFDETRPose()
+            model.model = MagicMock()
+            model.model.device = torch.device('cpu')
+            model.model.resolution = 576
+            model._is_optimized_for_inference = False
+            model._has_warned_about_not_being_optimized_for_inference = True
+            model.means = [0.485, 0.456, 0.406]
+            model.stds = [0.229, 0.224, 0.225]
+
+            # Mock model output with keypoints
+            mock_output = {
+                'pred_logits': torch.randn(1, 300, 1),
+                'pred_boxes': torch.rand(1, 300, 4),
+                'pred_keypoints': torch.rand(1, 300, 17, 3),
+            }
+            model.model.model = MagicMock(return_value=mock_output)
+
+            # Mock postprocess to return keypoints
+            mock_result = [{
+                'scores': torch.tensor([0.9, 0.8]),
+                'labels': torch.tensor([0, 0]),
+                'boxes': torch.tensor([[10, 10, 100, 100], [50, 50, 150, 150]]),
+                'keypoints': torch.rand(2, 17, 3),
+            }]
+            model.model.postprocess = MagicMock(return_value=mock_result)
+
+            # Create a dummy image
+            dummy_image = torch.rand(3, 480, 640)
+
+            # Run predict
+            detections = model.predict(dummy_image, threshold=0.5)
+
+            # Check keypoints are in the result
+            assert 'keypoints' in detections.data
+            assert detections.data['keypoints'].shape == (2, 17, 3)
+
+    def test_keypoints_output_structure(self):
+        """Test that keypoint output has correct structure."""
+        # Test the PostProcess output format directly
+        from rfdetr.models.lwdetr import PostProcess
+
+        postprocess = PostProcess(num_select=10)
+
+        # Mock model outputs
+        outputs = {
+            "pred_logits": torch.randn(1, 300, 1),
+            "pred_boxes": torch.rand(1, 300, 4),
+            "pred_keypoints": torch.rand(1, 300, 17, 3),
+        }
+        target_sizes = torch.tensor([[480, 640]])
+
+        results = postprocess(outputs, target_sizes)
+
+        # Check structure
+        assert len(results) == 1
+        result = results[0]
+
+        assert 'keypoints' in result
+        kpts = result['keypoints']
+
+        # Shape should be [num_select, num_keypoints, 3]
+        assert kpts.shape == (10, 17, 3)
+
+        # x coordinates should be scaled to image width
+        # y coordinates should be scaled to image height
+        # visibility should be sigmoid (0-1)
+        assert kpts[..., 2].min() >= 0.0
+        assert kpts[..., 2].max() <= 1.0
+
+    def test_keypoints_visibility_sigmoid(self):
+        """Test that visibility values are sigmoids in [0, 1]."""
+        from rfdetr.models.lwdetr import PostProcess
+
+        postprocess = PostProcess(num_select=5)
+
+        # Create outputs with known visibility logits
+        outputs = {
+            "pred_logits": torch.randn(1, 100, 1),
+            "pred_boxes": torch.rand(1, 100, 4),
+            "pred_keypoints": torch.zeros(1, 100, 17, 3),
+        }
+        # Set visibility logits to various values across the 100 queries
+        # Use randn to get a range of positive and negative values
+        outputs["pred_keypoints"][..., 2] = torch.randn(1, 100, 17) * 5  # Scale to get large pos/neg values
+
+        target_sizes = torch.tensor([[480, 640]])
+        results = postprocess(outputs, target_sizes)
+
+        vis = results[0]['keypoints'][..., 2]
+
+        # All visibility values should be in [0, 1] after sigmoid
+        assert vis.min() >= 0.0
+        assert vis.max() <= 1.0
+
+    def test_keypoints_coordinate_scaling(self):
+        """Test that keypoint coordinates are properly scaled to image size."""
+        from rfdetr.models.lwdetr import PostProcess
+
+        postprocess = PostProcess(num_select=1)
+
+        # Create outputs with known normalized coordinates
+        outputs = {
+            "pred_logits": torch.tensor([[[10.0]] * 100]),  # High confidence
+            "pred_boxes": torch.tensor([[[0.5, 0.5, 0.2, 0.2]] * 100]),
+            "pred_keypoints": torch.zeros(1, 100, 17, 3),
+        }
+        # Set first keypoint to center (0.5, 0.5) with high visibility
+        outputs["pred_keypoints"][0, :, 0, :] = torch.tensor([0.5, 0.5, 5.0])
+
+        target_sizes = torch.tensor([[480, 640]])  # H, W
+        results = postprocess(outputs, target_sizes)
+
+        kpts = results[0]['keypoints']
+
+        # First keypoint x should be scaled to ~320 (0.5 * 640)
+        # First keypoint y should be scaled to ~240 (0.5 * 480)
+        assert abs(kpts[0, 0, 0].item() - 320) < 1.0
+        assert abs(kpts[0, 0, 1].item() - 240) < 1.0
+
+
+class TestKeypointIntegration:
+    """Integration tests for keypoint functionality."""
+
+    @pytest.mark.slow
+    def test_keypoint_head_gradient_flow(self):
+        """Test that gradients flow through KeypointHead."""
+        from rfdetr.models.keypoint_head import KeypointHead
+
+        head = KeypointHead(hidden_dim=256, num_keypoints=17, num_layers=3)
+
+        query_features = [torch.randn(2, 100, 256)]
+        outputs = head(query_features)
+
+        # Compute a simple loss
+        loss = outputs[0].sum()
+        loss.backward()
+
+        # Check gradients exist on model parameters
+        has_grad = False
+        for param in head.parameters():
+            if param.grad is not None and param.grad.abs().sum() > 0:
+                has_grad = True
+                break
+        assert has_grad, "No gradients found in KeypointHead parameters"
+
+    @pytest.mark.slow
+    def test_keypoint_output_format(self):
+        """Test complete keypoint output format through PostProcess."""
+        from rfdetr.models.lwdetr import PostProcess
+
+        postprocess = PostProcess(num_select=10)
+
+        outputs = {
+            "pred_logits": torch.randn(1, 300, 1),
+            "pred_boxes": torch.rand(1, 300, 4),
+            "pred_keypoints": torch.rand(1, 300, 17, 3),
+        }
+        target_sizes = torch.tensor([[480, 640]])
+
+        results = postprocess(outputs, target_sizes)
+
+        assert len(results) == 1
+        result = results[0]
+
+        # Check all expected keys
+        assert "scores" in result
+        assert "labels" in result
+        assert "boxes" in result
+        assert "keypoints" in result
+
+        # Check shapes
+        assert result["scores"].shape[0] == 10  # num_select
+        assert result["boxes"].shape == (10, 4)
+        assert result["keypoints"].shape == (10, 17, 3)
+
+        # Check keypoint coordinate scaling
+        # x coords should be scaled to image width (640)
+        # y coords should be scaled to image height (480)
+        kpts = result["keypoints"]
+        # Visibility should be sigmoids (0-1)
+        assert kpts[..., 2].min() >= 0.0
+        assert kpts[..., 2].max() <= 1.0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
# Description

For Technical Implementation Details: See [docs](https://github.com/michaelmohamed/rf-detr/blob/169f4beb7bbe0e531e999e8fd5758d3833894380/docs/learn/run/pose.md#technical-architecture).

This PR adds optional keypoint/pose estimation support to RF-DETR, following YOLOv11's approach for pose estimation. The implementation outputs (x, y, visibility) triplets per keypoint per detection, with full support for COCO-style 17-keypoint annotations.

**Key features:**

- Fully configurable number of keypoints, names, and skeleton connections
- Each keypoint outputs (x, y, visibility) like YOLOv11
- Supports COCO-style keypoint annotations for training
- Optional/configurable (like existing segmentation head) - no impact on existing detection/segmentation workflows
- Uses detection weights (rf-detr-medium.pth) as default starting point for training

**Related issues:** 

Addresses community requests for pose estimation support in RF-DETR.

##  Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

##  How has this change been tested, please provide a testcase or example of how you tested the change?

29 unit tests covering both training and inference pipelines:

```python
pytest tests/test_keypoint_head.py -v
```

# 29 passed in 2.28s

**Test coverage includes:**

- KeypointHead module (forward pass, gradient flow, reference boxes, custom keypoints)
- COCO constants validation (names, skeleton, sigmas, flip pairs)
- Config classes (RFDETRPoseConfig, KeypointTrainConfig)
- Training data pipeline (keypoint extraction, hflip/crop transforms)
- Loss functions (L1, BCE visibility, OKS)
- Inference pipeline (predict() returns keypoints, PostProcess, coordinate scaling, visibility sigmoid)

##  Any specific deployment considerations

- No pretrained pose weights yet - Users must fine-tune on a keypoint dataset (e.g., COCO-Pose). The model loads detection weights by default and the keypoint head is learned during training.
- Fully optional - The KeypointHead import is conditional; existing detection/segmentation workflows are unaffected.
- Memory - Adds minimal overhead (~1-2% parameters) when keypoint_head=True.

##  Docs

- Added docs/learn/run/pose.md - Complete usage guide for pose estimation
- Added docs/reference/pose.md - API reference for RFDETRPose
- Updated docs/learn/train/index.md - Added pose tabs to all training examples
- Updated mkdocs.yaml - Added navigation entries for pose documentation

  ---

##  Files Changed

  | File                           | Change                                                                      |
  |--------------------------------|-----------------------------------------------------------------------------|
  | rfdetr/models/keypoint_head.py | New - KeypointHead class with coordinate/visibility MLPs, COCO constants    |
  | rfdetr/config.py               | Added RFDETRPoseConfig, KeypointTrainConfig, keypoint fields to ModelConfig |
  | rfdetr/models/lwdetr.py        | Integrated keypoint head, added loss_keypoints(), updated PostProcess       |
  | rfdetr/datasets/coco.py        | Added keypoint annotation parsing in ConvertCoco                            |
  | rfdetr/datasets/transforms.py  | Updated crop() and hflip() for keypoint transformations                     |
  | rfdetr/detr.py                 | Added RFDETRPose class, updated predict() for keypoints                     |
  | rfdetr/__init__.py             | Exported RFDETRPose                                                         |
  | rfdetr/engine.py               | Added COCO keypoint evaluation support                                      |
  | tests/test_keypoint_head.py    | New - 29 tests for training and inference                                   |
  | tests/conftest.py              | New - pytest configuration                                                  |
  | pyproject.toml                 | Added pytest configuration                                                  |
  | docs/learn/run/pose.md         | New - Pose usage documentation                                              |
  | docs/reference/pose.md         | New - RFDETRPose API reference                                              |
  | docs/learn/train/index.md      | Added pose training examples                                                |
  | mkdocs.yaml                    | Added pose navigation entries                                               |

---
# Usage / Import Example

```python
from rfdetr import RFDETRPose
```

# Training
```python
# Select a model variant
model = RFDETRPose()
model = RFDETRPoseNano()
model = RFDETRPoseSmall()
model = RFDETRPoseMedium()
model = RFDETRPoseLarge()

model.train(dataset_dir="path/to/coco-pose", epochs=50)
```

# Inference
```python
model = RFDETRPose(pretrain_weights="output/checkpoint_best_total.pth")
detections = model.predict("image.jpg", threshold=0.5)

# Access keypoints

# Keypoints: [N, K, 3] where K=num_keypoints, 3 = (x, y, visibility)
keypoints = detections.data["keypoints"]

# Visibility follows COCO format: 0 = not visible, 2 = visible
# For raw confidence scores (0.0-1.0):
confidence = detections.data["keypoints_confidence"]
keypoints = detections.data["keypoints"]
```

---
## **Fix:** Category ID Mapping for COCO Datasets

### Problem

https://github.com/roboflow/rf-detr/issues/330
https://github.com/roboflow/rf-detr/issues/349
https://github.com/roboflow/rf-detr/issues/413

When training on Roboflow or custom COCO datasets where category_id starts at 1 (or has gaps), the model would crash with a CUDA index out of bounds error. This happened because:

- Roboflow exports use 1-indexed category IDs (e.g., [1, 2, 3])
- The model expects 0-indexed class labels (e.g., [0, 1, 2])
- With num_classes=3 and category_id=3, accessing index 3 in a size-3 tensor fails

Additionally, COCO evaluation was returning near-zero mAP scores because predictions used 0-indexed labels but COCO evaluation expected original category IDs.

### Solution

#### Added automatic bidirectional category ID mapping:

**Training (coco.py):**
```
cat_ids = sorted(self.coco.getCatIds())
cat_id_to_continuous = {cat_id: i for i, cat_id in enumerate(cat_ids)}
# [1,2,3] → {1:0, 2:1, 3:2}
```

**Evaluation (coco_eval.py):**
```
continuous_to_cat_id = {i: cat_id for i, cat_id in enumerate(cat_ids)}
# {0:1, 1:2, 2:3} → converts predictions back for COCO metrics
```

#### How It Works

  | Dataset category_ids | Training mapping           | Eval reverse mapping       |
  |----------------------|----------------------------|----------------------------|
  | [0, 1, 2]            | {0:0, 1:1, 2:2} (identity) | {0:0, 1:1, 2:2} (identity) |
  | [1, 2, 3]            | {1:0, 2:1, 3:2}            | {0:1, 1:2, 2:3}            |
  | [1, 5, 10]           | {1:0, 5:1, 10:2}           | {0:1, 1:5, 2:10}           |

### Backwards Compatibility

  - 0-indexed datasets: Identity mapping, behaves exactly as before
  - 1-indexed datasets: Now works correctly instead of crashing
  - Prediction: Returns 0-indexed labels for direct class_names indexing

###  Files Changed

  - rfdetr/datasets/coco.py - Added cat_id_to_continuous mapping in data loading
  - rfdetr/datasets/coco_eval.py - Added continuous_to_cat_id reverse mapping for evaluation
  - docs/learn/train/index.md - Added documentation for category ID handling