### PR TITLE
fix: correct off-by-one error in windowed DINOv2 early stopping

### DIFF
--- a/rfdetr/models/backbone/dinov2_with_windowed_attn.py
+++ b/rfdetr/models/backbone/dinov2_with_windowed_attn.py
@@ -671,7 +671,7 @@ class WindowedDinov2WithRegistersEncoder(nn.Module):
             if output_hidden_states:
                 all_hidden_states = all_hidden_states + (hidden_states,)
             
-            if i > int(self.config.out_features[-1][5:]):
+            if i > int(self.config.out_features[-1][5:])-1:
                 # early stop if we have reached the last output feature
                 break
             


### PR DESCRIPTION
Fixed an off-by-one error in the early stopping logic of WindowedDinov2WithRegistersEncoder.forward().

Bug: The condition if i > int(self.config.out_features[-1][5:]): incorrectly compares a 0-based layer index (i) with a 1-based stage number.

Fix: Changed to if i > int(self.config.out_features[-1][5:]) - 1: to properly convert the stage number to a 0-based index before comparison.

Example:
If out_features[-1] = "stage8", stage number = 8
Corresponding layer index = 7 (0-based)
Old condition: i > 8 → never true for i in [0, 11]
New condition: i > 7 → stops when i reaches 8

Impact: The encoder now correctly stops after processing the last required transformer layer, improving computational efficiency.

