### PR TITLE
Update CODEOWNERS file to adjust default reviewers and add specific ownerships

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,6 @@
-# These owners will be the default owners for everything in
-# the repo. They will be requested for review when someone
-# opens a pull request.
-*   @SkalskiP @probicheaux @isaacrob-roboflow @Matvezy
+# These owners will be the default owners for everything in the repo.
+# They will be requested for review when someone opens a pull request.
+* @SkalskiP @Borda
+
+# supervise the core model modules
+/rfdetr @probicheaux @isaacrob-roboflow @Matvezy


### PR DESCRIPTION
This pull request updates the repository's code ownership assignments to better reflect team responsibilities.

Ownership updates:

* Changed the default code owners for the entire repository to `@SkalskiP` and `@Borda`, replacing the previous broader group.
* Added a new rule assigning ownership of the `/rfdetr` directory to `@probicheaux`, `@isaacrob-roboflow`, and `@Matvezy`.