### PR TITLE
Debugging workflow permissions and add PR dry-run

### DIFF
--- a/.github/workflows/publish-pre-release.yml
+++ b/.github/workflows/publish-pre-release.yml
@@ -42,6 +42,8 @@ jobs:
         with:
           name: dist
           path: dist/
+      - name: Display distribution files
+        run: ls -lh dist/
 
       - name: 🚀 Publish to PyPi
         if: github.event_name != 'pull_request'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -36,6 +36,8 @@ jobs:
         with:
           name: dist
           path: dist/
+      - name: Display distribution files
+        run: ls -lh dist/
 
       - name: 🚀 Publish to PyPi
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for both pre-release and release publishing to improve safety and visibility when running on pull requests, and to provide better feedback during the build process. The main changes ensure that publishing to PyPI does not occur on pull requests, add a step to display built distribution files, and adjust permissions for workflow runs.

Workflow trigger and permission updates:

* Added `pull_request` triggers for `main` and `develop` branches, scoped to changes in the relevant workflow files, so that workflows are tested on pull requests without publishing to PyPI. Also set permissions to `contents: read` instead of an empty permissions block. (`.github/workflows/publish-pre-release.yml`, `.github/workflows/publish-release.yml`) [[1]](diffhunk://#diff-b4219a56ad03f746dc054c7747e46c5352d2c05712015a7b4e2d15d30ef67986R16-R23) [[2]](diffhunk://#diff-232ead425069ad86b523a739aa18b77f9088cd61a4b40c6a374d9774ff78cfc8L9-R17)

Build process visibility:

* Added a step to display the files in the `dist/` directory after building, making it easier to debug and verify build outputs in workflow logs. (`.github/workflows/publish-pre-release.yml`, `.github/workflows/publish-release.yml`) [[1]](diffhunk://#diff-b4219a56ad03f746dc054c7747e46c5352d2c05712015a7b4e2d15d30ef67986R45-R49) [[2]](diffhunk://#diff-232ead425069ad86b523a739aa18b77f9088cd61a4b40c6a374d9774ff78cfc8R39-R43)

Publishing safeguards:

* Updated the PyPI publish step to run only if the workflow was not triggered by a pull request, preventing accidental publishing from PR builds. (`.github/workflows/publish-pre-release.yml`, `.github/workflows/publish-release.yml`) [[1]](diffhunk://#diff-b4219a56ad03f746dc054c7747e46c5352d2c05712015a7b4e2d15d30ef67986R45-R49) [[2]](diffhunk://#diff-232ead425069ad86b523a739aa18b77f9088cd61a4b40c6a374d9774ff78cfc8R39-R43)