### PR TITLE
fix paths by adding  `field_validator` for paths in config options

### DIFF
--- a/rfdetr/config.py
+++ b/rfdetr/config.py
@@ -48,15 +48,7 @@ class ModelConfig(BaseModel):
         """
         if v is None:
             return v
-
-        # Only treat the value as a filesystem path if it has a separator or starts with '~'.
-        has_sep = os.path.sep in v
-        has_altsep = os.path.altsep is not None and os.path.altsep in v
-        if v.startswith("~") or has_sep or has_altsep:
-            return os.path.realpath(os.path.expanduser(v))
-
-        # Leave simple filenames unchanged for downstream logic (e.g., hosted model lookup).
-        return v
+        return os.path.realpath(os.path.expanduser(v))
 
 
 class RFDETRBaseConfig(ModelConfig):
@@ -189,12 +181,7 @@ class TrainConfig(BaseModel):
         """
         if v is None:
             return v
-        # Only treat the value as a filesystem path if it has a separator or starts with '~'.
-        has_sep = os.path.sep in v
-        has_altsep = os.path.altsep is not None and os.path.altsep in v
-        if v.startswith("~") or has_sep or has_altsep:
-            return os.path.realpath(os.path.expanduser(v))
-        # Leave simple filenames unchanged for downstream logic (e.g., hosted model lookup).
+        return os.path.realpath(os.path.expanduser(v))
 
 
 class SegmentationTrainConfig(TrainConfig):


### PR DESCRIPTION
This pull request enhances the configuration handling in `rfdetr/config.py` by ensuring that file path attributes are consistently expanded to their absolute forms. This helps prevent issues related to user-relative paths (like `~`) in configuration files.

**Path handling improvements:**

* Added a `field_validator` to the `ModelConfig` class to automatically expand and resolve the `pretrain_weights` path to its absolute form, ensuring consistent path usage.
* Added a `field_validator` to the `TrainConfig` class to expand and resolve the `dataset_dir` and `output_dir` attributes to their absolute forms, improving robustness in file path handling.

**Dependency update:**

* Updated imports to include `field_validator` from Pydantic and added `os` for path expansion functionality.