### PR TITLE
Replace`inference_mode()` with `no_grad()` to resolve training

### DIFF
--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -310,7 +310,7 @@ class RFDETR:
                                      "Alternatively, you can recompile the optimized model for a different batch size "
                                      "by calling model.optimize_for_inference(batch_size=<new_batch_size>).")
 
-        with torch.inference_mode() and torch.no_grad():
+        with torch.no_grad():
             if self._is_optimized_for_inference:
                 predictions = self.model.inference_model(batch_tensor.to(dtype=self._optimized_dtype))
             else:

--- a/rfdetr/engine.py
+++ b/rfdetr/engine.py
@@ -113,7 +113,7 @@ def train_one_epoch(
             scales = compute_multi_scale_scales(args.resolution, args.expanded_scales, args.patch_size, args.num_windows)
             random.seed(it)
             scale = random.choice(scales)
-            with torch.inference_mode() and torch.no_grad():
+            with torch.no_grad():
                 samples.tensors = F.interpolate(samples.tensors, size=scale, mode='bilinear', align_corners=False)
                 samples.mask = F.interpolate(samples.mask.unsqueeze(1).float(), size=scale, mode='nearest').squeeze(1).bool()
 

--- a/rfdetr/main.py
+++ b/rfdetr/main.py
@@ -368,7 +368,7 @@ class Model:
 
                         utils.save_on_master(weights, checkpoint_path)
 
-            with torch.inference_mode() and torch.no_grad():
+            with torch.no_grad():
                 test_stats, coco_evaluator = evaluate(
                     model, criterion, postprocess, data_loader_val, base_ds, device, args=args
                 )


### PR DESCRIPTION
This pull request replaces the use of `torch.inference_mode()` with `torch.no_grad()` in several places throughout the codebase. This change ensures compatibility with older versions of PyTorch that may not support `torch.inference_mode()`, while still disabling gradient calculation during inference and evaluation.

**Migration to `torch.no_grad()` for inference and evaluation:**

* Replaced `torch.inference_mode()` with `torch.no_grad()` in the `predict` method of `rfdetr/detr.py` to wrap inference calls.
* Updated the data augmentation step in `train_one_epoch` in `rfdetr/engine.py` to use `torch.no_grad()` instead of `torch.inference_mode()` during tensor interpolation.
* Changed the evaluation phase in the training loop in `rfdetr/main.py` to use `torch.no_grad()` for model evaluation.

---

Fixes #297