### PR TITLE
Handle multiprocessing edge case for `num_workers` to ensure compatibility with 'spawn' start method

### DIFF
--- a/rfdetr/main.py
+++ b/rfdetr/main.py
@@ -239,8 +239,8 @@ class Model:
 
         num_workers = args.num_workers
         # Hotfix for https://github.com/roboflow/rf-detr/issues/428
-        # On platforms using 'spawn' (Windows, macOS), multiprocessing requires the entry point 
-        # to be protected by `if __name__ == '__main__':`. If it's missing, we force 
+        # On platforms using 'spawn' (Windows, macOS), multiprocessing requires the entry point
+        # to be protected by `if __name__ == '__main__':`. If it's missing, we force
         # num_workers=0 to prevent a RuntimeError that crashes the process.
         if num_workers > 0 and multiprocessing.get_start_method(allow_none=True) == 'spawn':
             import __main__


### PR DESCRIPTION
This pull request addresses a known issue with multiprocessing on platforms that use the 'spawn' start method (such as Windows and macOS) by implementing a hotfix to prevent runtime errors when using multiple workers in data loading. The main change is to automatically set `num_workers` to 0 if the script is not properly wrapped with `if __name__ == '__main__':`, thereby avoiding crashes during training.

Multiprocessing compatibility and data loading robustness:

* Added a check to detect if the script is not wrapped in `if __name__ == '__main__':` when using the 'spawn' multiprocessing start method, and force `num_workers=0` with a warning to prevent a RuntimeError. This hotfix targets issues on Windows/macOS platforms and improves user experience by preventing unexpected crashes.
* Updated all `DataLoader` instantiations to use the (potentially modified) `num_workers` variable instead of directly using `args.num_workers`, ensuring that the hotfix is consistently applied throughout the data loading pipeline. [[1]](diffhunk://#diff-45b476a2293366cc362b0b83d614b490ec5a651cee0a6cf5ae8e7a35995fc721L250-R268) [[2]](diffhunk://#diff-45b476a2293366cc362b0b83d614b490ec5a651cee0a6cf5ae8e7a35995fc721L260-R286)
* Added imports for `multiprocessing` and `warnings` at the top of `rfdetr/main.py` to support the new logic and warning message.

---

fixes #428