### PR TITLE
Optimize GitHub Actions by adding uv cache pruning steps

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -35,3 +35,6 @@ jobs:
         with:
           name: dist
           path: dist/
+
+      - name: Minimize uv cache
+        run: uv cache prune --ci

--- a/.github/workflows/ci-build-docs.yml
+++ b/.github/workflows/ci-build-docs.yml
@@ -34,3 +34,6 @@ jobs:
 
       - name: 🧪 Test Docs Build
         run: uv run mkdocs build --verbose
+
+      - name: Minimize uv cache
+        run: uv cache prune --ci

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -59,3 +59,6 @@ jobs:
         run: |
           latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
           uv run mike deploy --push --update-aliases $latest_tag latest
+
+      - name: Minimize uv cache
+        run: uv cache prune --ci


### PR DESCRIPTION
This pull request introduces a small but useful optimization step to the CI workflows by minimizing the `uv` cache after key build and deployment jobs. This helps keep the cache lean and can improve CI performance and reliability.

CI/CD workflow improvements:

* Added a `Minimize uv cache` step (`uv cache prune --ci`) to the build job in `.github/workflows/build-package.yml` to reduce cache size after building the package.
* Added a `Minimize uv cache` step to the docs build job in `.github/workflows/ci-build-docs.yml` to prune unused cache after building documentation.
* Added a `Minimize uv cache` step to the publish docs job in `.github/workflows/publish-docs.yml` to clean up the cache after deploying documentation.