### PR TITLE
fix: Adjust class count in `train_from_config` for Roboflow datasets

### DIFF
--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -166,7 +166,7 @@ class RFDETR:
     def train_from_config(self, config: TrainConfig, **kwargs):
         if config.dataset_file == "roboflow":
             class_names = self._load_classes(config.dataset_dir)
-            num_classes = len(class_names)
+            num_classes = len(class_names) + 1
             self.model.class_names = class_names
         elif config.dataset_file == "coco":
             class_names = COCO_CLASSES


### PR DESCRIPTION
This pull request makes a minor adjustment to the way the number of classes is calculated for Roboflow datasets. The change ensures that the model accounts for an additional class, likely representing a background or "no object" class, when training with Roboflow data.

* Changed the calculation of `num_classes` in `train_from_config` to add 1 to the length of `class_names` for Roboflow datasets, ensuring proper handling of background or extra class.