### PR TITLE
Fix license link badges in installation section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,9 +16,9 @@ You can install and use `rfdetr` in a [**Python>=3.10**](https://www.python.org/
 
 !!! example "Installation"
     [![version](https://badge.fury.io/py/rfdetr.svg)](https://badge.fury.io/py/rfdetr)
-    [![downloads](https://img.shields.io/pypi/dm/rfdetr)](https://pypistats.org/packages/rfdetr)
-    [![license](https://img.shields.io/pypi/l/rfdetr)](https://github.com/roboflow/rfdetr/blob/main/LICENSE.md)
     [![python-version](https://img.shields.io/pypi/pyversions/rfdetr)](https://badge.fury.io/py/rfdetr)
+    [![license](https://img.shields.io/pypi/l/rfdetr)](https://github.com/roboflow/rfdetr/blob/main/LICENSE)
+    [![downloads](https://img.shields.io/pypi/dm/rfdetr)](https://pypistats.org/packages/rfdetr)
 
     === "pip"
         ```bash


### PR DESCRIPTION
This pull request updates the badge links in the documentation for the `rfdetr` package to improve accuracy and consistency.

Documentation improvements:

* Updated the "license" badge link in `docs/index.md` to point directly to the correct `LICENSE` file, and reordered the badge display for better clarity.