### PR TITLE
Hotfix: pin `transformers` dependency to version range >4.0.0, <5.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "scipy",
     "tqdm",
     "numpy",
-    "transformers>4.50.0, <5.0.0",
+    "transformers>4.0.0, <5.0.0",
     "peft",
     "polygraphy",
     "rf100vl",


### PR DESCRIPTION
This pull request makes a small update to the `pyproject.toml` file to specify a version range for the `transformers` dependency, ensuring compatibility with versions greater than 4.50.0 but less than 5.0.0.