### PR TITLE
Simplify PR conflict labeler workflow

### DIFF
--- a/.github/workflows/pr-conflict-labeler.yml
+++ b/.github/workflows/pr-conflict-labeler.yml
@@ -3,9 +3,7 @@ name: PR Conflict Labeler
 on:
   # So that PRs touching the same files as the push are updated
   push:
-    branches:
-      - main
-      - develop
+    branches: [ main, develop ]
   # So that the `dirtyLabel` is removed if conflicts are resolved
   # We recommend `pull_request_target` so that github secrets are available.
   # In `pull_request` we wouldn't be able to change labels of fork PRs
@@ -15,6 +13,7 @@ on:
 permissions:
   pull-requests: write
   issues: write
+
 jobs:
   main:
     runs-on: ubuntu-latest
@@ -23,5 +22,4 @@ jobs:
         uses: eps1lon/actions-label-merge-conflict@v3
         with:
           dirtyLabel: "has conflicts"
-
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/rfdetr/models/lwdetr.py
+++ b/rfdetr/models/lwdetr.py
@@ -139,7 +139,7 @@ class LWDETR(nn.Module):
                 m.export()
 
     def forward(self, samples: NestedTensor, targets=None):
-        """ The forward expects a NestedTensor, which consists of:
+        """The forward expects a NestedTensor, which consists of:
                - samples.tensor: batched images, of shape [batch_size x 3 x H x W]
                - samples.mask: a binary mask of shape [batch_size x H x W], containing 1 on padded pixels
 


### PR DESCRIPTION
This pull request includes minor improvements to the GitHub Actions workflow configuration and a small documentation correction in the `lwdetr.py` model file.

Workflow configuration cleanup:

* Simplified the branch specification for the `push` event trigger in the `.github/workflows/pr-conflict-labeler.yml` file by using a single-line array format.
* Added a blank line for readability between the `permissions` and `jobs` sections in `.github/workflows/pr-conflict-labeler.yml`.
* Removed an unnecessary blank line in the `with` section of the `main` job in `.github/workflows/pr-conflict-labeler.yml`.

Documentation fix:

* Fixed a minor formatting issue in the docstring of the `forward` method in `rfdetr/models/lwdetr.py` by removing an extraneous character.