### PR TITLE
Add arg `is_deprecated` to `RFDETRLarge` class

### DIFF
--- a/rfdetr/detr.py
+++ b/rfdetr/detr.py
@@ -537,7 +537,7 @@ class RFDETRLarge(RFDETR):
     size = "rfdetr-large"
     def __init__(self, **kwargs):
         self.init_error = None
-        self.is_deprecated = False
+        self.is_deprecated = kwargs.pop('is_deprecated', False)
         try:
             super().__init__(**kwargs)
         except Exception as e:


### PR DESCRIPTION
## What does this PR do?

Hello Roboflow team, this PR exposes the *is_deprecated* parameter of `RFDETRLarge` class so that we can access to the deprecated version of **RFDETR-large**. I am not able to tell if the non-exposure was intentional, so if it was, feel free to reject this PR.

**Related Issue(s):** <!-- Link to related issues, e.g., Fixes #123 or Related to #456 -->

No related issue.

## Type of Change

- New feature (non-breaking change that adds functionality)

## Testing

```python
from rfdetr.detr import RFDETRLarge
RFDETRLarge(is_deprecated=False)
RFDETRLarge(is_deprecated=True) 
```
This script above, with the current `develop` branch, loads the new version of **RFDETR-large** twice (`rf-detr-large-2026.pth`). The only way to load the old version (`rf-detr-large.pth`) is to use the `RFDETRLargeDeprecated` class or if loading the new version from the `RFDETRLarge` class fails. With my commit, we can access the deprecated version from the `RFDETRLarge` class.


- [x] I have tested this change locally
- [ ] I have added/updated tests for this change

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)