### PR TITLE
Add horizontal_flip_prob parameter for data augmentation

### DIFF
--- a/rfdetr/config.py
+++ b/rfdetr/config.py
@@ -280,6 +280,8 @@ class TrainConfig(BaseModel):
     run_test: bool = True
     segmentation_head: bool = False
     eval_max_dets: int = 500
+    # Data augmentation parameters
+    horizontal_flip_prob: float = 0.5
 
     @field_validator("dataset_dir", "output_dir", mode="after")
     @classmethod

--- a/rfdetr/datasets/coco.py
+++ b/rfdetr/datasets/coco.py
@@ -145,7 +145,7 @@ class ConvertCoco(object):
         return image, target
 
 
-def make_coco_transforms(image_set: str, resolution: int, multi_scale: bool = False, expanded_scales: bool = False, skip_random_resize: bool = False, patch_size: int = 16, num_windows: int = 4) -> T.Compose:
+def make_coco_transforms(image_set: str, resolution: int, multi_scale: bool = False, expanded_scales: bool = False, skip_random_resize: bool = False, patch_size: int = 16, num_windows: int = 4, horizontal_flip_prob: float = 0.5) -> T.Compose:
 
     normalize = T.Compose([
         T.ToTensor(),
@@ -161,8 +161,8 @@ def make_coco_transforms(image_set: str, resolution: int, multi_scale: bool = Fa
         print(scales)
 
     if image_set == 'train':
-        return T.Compose([
-            T.RandomHorizontalFlip(),
+        print(f"Data augmentation: horizontal_flip_prob={horizontal_flip_prob}")
+        transforms_ = [
             T.RandomSelect(
                 T.RandomResize(scales, max_size=1333),
                 T.Compose([
@@ -172,7 +172,11 @@ def make_coco_transforms(image_set: str, resolution: int, multi_scale: bool = Fa
                 ])
             ),
             normalize,
-        ])
+        ]
+        if transforms_ != 0:
+            transforms_.append(T.RandomHorizontalFlip(p=horizontal_flip_prob))
+
+        return T.Compose(transforms_)
 
     if image_set == 'val':
         return T.Compose([
@@ -188,7 +192,7 @@ def make_coco_transforms(image_set: str, resolution: int, multi_scale: bool = Fa
     raise ValueError(f'unknown {image_set}')
 
 
-def make_coco_transforms_square_div_64(image_set: str, resolution: int, multi_scale: bool = False, expanded_scales: bool = False, skip_random_resize: bool = False, patch_size: int = 16, num_windows: int = 4) -> T.Compose:
+def make_coco_transforms_square_div_64(image_set: str, resolution: int, multi_scale: bool = False, expanded_scales: bool = False, skip_random_resize: bool = False, patch_size: int = 16, num_windows: int = 4, horizontal_flip_prob: float = 0.5) -> T.Compose:
 
     normalize = T.Compose([
         T.ToTensor(),
@@ -206,7 +210,7 @@ def make_coco_transforms_square_div_64(image_set: str, resolution: int, multi_sc
 
     if image_set == 'train':
         return T.Compose([
-            T.RandomHorizontalFlip(),
+            T.RandomHorizontalFlip(p=horizontal_flip_prob),
             T.RandomSelect(
                 T.SquareResize(scales),
                 T.Compose([
@@ -250,6 +254,7 @@ def build_coco(image_set: str, args: Any, resolution: int) -> CocoDetection:
 
     square_resize_div_64 = getattr(args, 'square_resize_div_64', False)
     include_masks = getattr(args, "segmentation_head", False)
+    horizontal_flip_prob = getattr(args, "horizontal_flip_prob", 0.5)
 
     if square_resize_div_64:
         dataset = CocoDetection(img_folder, ann_file, transforms=make_coco_transforms_square_div_64(
@@ -259,7 +264,8 @@ def build_coco(image_set: str, args: Any, resolution: int) -> CocoDetection:
             expanded_scales=args.expanded_scales,
             skip_random_resize=not args.do_random_resize_via_padding,
             patch_size=args.patch_size,
-            num_windows=args.num_windows
+            num_windows=args.num_windows,
+            horizontal_flip_prob=horizontal_flip_prob
         ), include_masks=include_masks)
     else:
         dataset = CocoDetection(img_folder, ann_file, transforms=make_coco_transforms(
@@ -269,7 +275,8 @@ def build_coco(image_set: str, args: Any, resolution: int) -> CocoDetection:
             expanded_scales=args.expanded_scales,
             skip_random_resize=not args.do_random_resize_via_padding,
             patch_size=args.patch_size,
-            num_windows=args.num_windows
+            num_windows=args.num_windows,
+            horizontal_flip_prob=horizontal_flip_prob
         ), include_masks=include_masks)
     return dataset
 
@@ -295,6 +302,7 @@ def build_roboflow_from_coco(image_set: str, args: Any, resolution: int) -> Coco
     do_random_resize_via_padding = getattr(args, "do_random_resize_via_padding", False)
     patch_size = getattr(args, "patch_size", 16)
     num_windows = getattr(args, "num_windows", 4)
+    horizontal_flip_prob = getattr(args, "horizontal_flip_prob", 0.5)
 
     if square_resize_div_64:
         dataset = CocoDetection(img_folder, ann_file, transforms=make_coco_transforms_square_div_64(
@@ -304,7 +312,8 @@ def build_roboflow_from_coco(image_set: str, args: Any, resolution: int) -> Coco
             expanded_scales=expanded_scales,
             skip_random_resize=not do_random_resize_via_padding,
             patch_size=patch_size,
-            num_windows=num_windows
+            num_windows=num_windows,
+            horizontal_flip_prob=horizontal_flip_prob
         ), include_masks=include_masks)
     else:
         dataset = CocoDetection(img_folder, ann_file, transforms=make_coco_transforms(
@@ -314,6 +323,7 @@ def build_roboflow_from_coco(image_set: str, args: Any, resolution: int) -> Coco
             expanded_scales=expanded_scales,
             skip_random_resize=not do_random_resize_via_padding,
             patch_size=patch_size,
-            num_windows=num_windows
+            num_windows=num_windows,
+            horizontal_flip_prob=horizontal_flip_prob
         ), include_masks=include_masks)
     return dataset

--- a/rfdetr/datasets/o365.py
+++ b/rfdetr/datasets/o365.py
@@ -28,11 +28,12 @@ def build_o365_raw(image_set: str, args: Any, resolution: int) -> CocoDetection:
 
 
     square_resize_div_64 = getattr(args, 'square_resize_div_64', False)
+    horizontal_flip_prob = getattr(args, "horizontal_flip_prob", 0.5)
 
     if square_resize_div_64:
-        dataset = CocoDetection(img_folder, ann_file, transforms=make_coco_transforms_square_div_64(image_set, resolution, multi_scale=args.multi_scale, expanded_scales=args.expanded_scales))
+        dataset = CocoDetection(img_folder, ann_file, transforms=make_coco_transforms_square_div_64(image_set, resolution, multi_scale=args.multi_scale, expanded_scales=args.expanded_scales, horizontal_flip_prob=horizontal_flip_prob))
     else:
-        dataset = CocoDetection(img_folder, ann_file, transforms=make_coco_transforms(image_set, resolution, multi_scale=args.multi_scale, expanded_scales=args.expanded_scales))
+        dataset = CocoDetection(img_folder, ann_file, transforms=make_coco_transforms(image_set, resolution, multi_scale=args.multi_scale, expanded_scales=args.expanded_scales, horizontal_flip_prob=horizontal_flip_prob))
     return dataset
 
 

--- a/rfdetr/datasets/yolo.py
+++ b/rfdetr/datasets/yolo.py
@@ -499,6 +499,7 @@ def build_roboflow_from_yolo(image_set: str, args: Any, resolution: int) -> Yolo
     do_random_resize_via_padding = getattr(args, "do_random_resize_via_padding", False)
     patch_size = getattr(args, "patch_size", None)
     num_windows = getattr(args, "num_windows", None)
+    horizontal_flip_prob = getattr(args, "horizontal_flip_prob", 0.5)
 
     if square_resize_div_64:
         dataset = YoloDetection(
@@ -512,7 +513,8 @@ def build_roboflow_from_yolo(image_set: str, args: Any, resolution: int) -> Yolo
                 expanded_scales=expanded_scales,
                 skip_random_resize=not do_random_resize_via_padding,
                 patch_size=patch_size,
-                num_windows=num_windows
+                num_windows=num_windows,
+                horizontal_flip_prob=horizontal_flip_prob
             ),
             include_masks=include_masks
         )
@@ -528,7 +530,8 @@ def build_roboflow_from_yolo(image_set: str, args: Any, resolution: int) -> Yolo
                 expanded_scales=expanded_scales,
                 skip_random_resize=not do_random_resize_via_padding,
                 patch_size=patch_size,
-                num_windows=num_windows
+                num_windows=num_windows,
+                horizontal_flip_prob=horizontal_flip_prob
             ),
             include_masks=include_masks
         )


### PR DESCRIPTION
- Add horizontal_flip_prob parameter to TrainConfig (default: 0.5)
- Update make_coco_transforms and make_coco_transforms_square_div_64
- Pass parameter through build_coco, build_roboflow_from_coco, build_roboflow_from_yolo, and build_o365_raw
- Add log message to show horizontal_flip_prob value during training

## What does this PR do?

<!-- Provide a clear and concise description of the changes -->

**Related Issue(s):** <!-- Link to related issues, e.g., Fixes #123 or Related to #456 -->

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
- Refactoring (no functional changes)
- Other:

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
