### PR TITLE
fix: typo in windowed attention

### DIFF
--- a/rfdetr/models/backbone/dinov2_with_windowed_attn.py
+++ b/rfdetr/models/backbone/dinov2_with_windowed_attn.py
@@ -317,7 +317,7 @@ class WindowedDinov2WithRegistersEmbeddings(nn.Module):
             num_w_patches_per_window = num_w_patches // self.config.num_windows
             num_h_patches_per_window = num_h_patches // self.config.num_windows
             num_windows = self.config.num_windows
-            windowed_pixel_tokens = pixel_tokens_with_pos_embed.reshape(batch_size * num_windows, num_h_patches_per_window, num_windows, num_h_patches_per_window, -1)
+            windowed_pixel_tokens = pixel_tokens_with_pos_embed.reshape(batch_size * num_windows, num_h_patches_per_window, num_windows, num_w_patches_per_window, -1)
             windowed_pixel_tokens = windowed_pixel_tokens.permute(0, 2, 1, 3, 4)
             windowed_pixel_tokens = windowed_pixel_tokens.reshape(batch_size * num_windows ** 2, num_h_patches_per_window * num_w_patches_per_window, -1)
             windowed_cls_token_with_pos_embed = cls_token_with_pos_embed.repeat(num_windows ** 2, 1, 1)

--- a/tests/datasets/__init__.py
+++ b/tests/datasets/__init__.py
@@ -1,0 +1,5 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------

--- a/tests/models/__init__.py
+++ b/tests/models/__init__.py
@@ -1,0 +1,5 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------

--- a/tests/models/backbone/__init__.py
+++ b/tests/models/backbone/__init__.py
@@ -1,0 +1,5 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------

--- a/tests/models/backbone/test_windowed_dino.py
+++ b/tests/models/backbone/test_windowed_dino.py
@@ -1,110 +1,34 @@
-import types
-from types import SimpleNamespace
-
 import torch
-import pytest
+from rfdetr.models.backbone.dinov2_with_windowed_attn import (
+    WindowedDinov2WithRegistersConfig,
+    WindowedDinov2WithRegistersEmbeddings,
+)
 
 
-def test_window_partition_forward_rectangular_preserves_shapes(monkeypatch):
+def test_window_partition_forward_rectangular_preserves_shapes():
     """
-    Regression test that exercises WindowedDinov2WithRegistersEmbeddings.forward
-    with a rectangular input (H != W) to hit the window partitioning logic.
-
-    The test stubs Dinov2WithRegistersPatchEmbeddings but:
-    - returns patch embeddings whose last dimension equals config.hidden_size
-      (avoids spurious hidden-dim mismatch errors)
-    - provides num_patches used to initialize position_embeddings
-
-    The test asserts the final embeddings tensor has the expected shape:
-    (batch_size * num_windows**2, 1 + num_h_patches_per_window * num_w_patches_per_window, hidden_size)
-
-    On implementations with the height/width mix-up bug this will raise a RuntimeError
-    (or produce an unexpected shape) and the test will fail.
+    Regression test for WindowedDinov2WithRegistersEmbeddings.forward with rectangular input.
+    Ensures window partitioning logic correctly handles H != W.
     """
+    # Params: H_patches=6, W_patches=4, num_windows=2 -> 3x2 patches per window
+    batch_size, hidden_size, patch_size, num_windows = 1, 64, 16, 2
+    hp, wp, nr = 6, 4, 4
+    h, w = hp * patch_size, wp * patch_size
 
-    # Parameters
-    batch_size = 1
-    in_channels = 3
-    hidden_size = 64
-    patch_size = 16
-    num_windows = 2  # exercise the windowing path, must be > 1
-
-    # Rectangular pixel dims that produce different patch-grid sizes (H_patches != W_patches)
-    H_pixels = 96   # 96 // 16 == 6 patches
-    W_pixels = 64   # 64 // 16 == 4 patches
-
-    num_h_patches = H_pixels // patch_size
-    num_w_patches = W_pixels // patch_size
-    assert num_h_patches != num_w_patches, "Test requires non-square patch grid"
-
-    # Ensure both patch dims are divisible by num_windows for clean per-window sizes
-    assert num_h_patches % num_windows == 0 and num_w_patches % num_windows == 0, (
-        "Choose H_pixels and W_pixels such that H_patches and W_patches are divisible by num_windows"
-    )
-
-    config = SimpleNamespace(
+    config = WindowedDinov2WithRegistersConfig(
         hidden_size=hidden_size,
-        num_register_tokens=0,
         patch_size=patch_size,
-        hidden_dropout_prob=0.0,
         num_windows=num_windows,
+        image_size=h,  # square image_size for positional embeddings
+        num_register_tokens=nr,
     )
+    model = WindowedDinov2WithRegistersEmbeddings(config)
 
-    # Import module under test from the repository codebase
-    import rfdetr.models.backbone.dinov2_with_windowed_attn as emb_mod
+    # Input is rectangular
+    pixel_values = torch.randn(batch_size, 3, h, w)
+    result = model(pixel_values)
 
-    # Stub: pretend the pretrained positional grid had a square number of patches (e.g., 4x4 = 16)
-    fake_num_patches_pretrained = 16
+    expected_batch = batch_size * (num_windows**2)
+    expected_seq_len = 1 + nr + (hp // num_windows) * (wp // num_windows)
 
-    # Build a stub that:
-    # - exposes num_patches for __init__
-    # - exposes projection.weight.dtype used by the real class
-    # - when called returns embeddings with last dim == config.hidden_size
-    def _stub_patch_embeddings_factory(cfg):
-        class StubPatchEmb:
-            def __init__(self):
-                self.num_patches = fake_num_patches_pretrained
-                # used as target dtype in the real code
-                self.projection = types.SimpleNamespace(weight=torch.zeros(1, dtype=torch.float32))
-
-            def __call__(self, pixel_values):
-                B, C, H, W = pixel_values.shape
-                nh = H // cfg.patch_size
-                nw = W // cfg.patch_size
-                # Return tensor shaped (B, nh * nw, hidden_size) matching config.hidden_size
-                return torch.randn(B, nh * nw, cfg.hidden_size, dtype=torch.float32)
-
-        return StubPatchEmb()
-
-    # Monkeypatch heavy dependency to our stub
-    monkeypatch.setattr(
-        emb_mod, "Dinov2WithRegistersPatchEmbeddings", _stub_patch_embeddings_factory
-    )
-
-    # Instantiate the real embeddings module (uses stub during __init__)
-    emb_module = emb_mod.WindowedDinov2WithRegistersEmbeddings(config)
-
-    # Build rectangular pixel input
-    pixel_values = torch.randn(batch_size, in_channels, H_pixels, W_pixels, dtype=torch.float32)
-
-    # Expected values after windowing:
-    num_h_patches_per_window = num_h_patches // num_windows
-    num_w_patches_per_window = num_w_patches // num_windows
-    expected_batch = batch_size * (num_windows ** 2)
-    expected_seq_len = 1 + (num_h_patches_per_window * num_w_patches_per_window)
-
-    # Call forward. If the develop branch still has the height/width mix-up bug,
-    # this call is expected to raise (shape mismatch during reshape/permute/reshape or concatenation),
-    # causing the test to fail. If the branch has the fix, this should succeed and assertions below pass.
-    result = emb_module.forward(pixel_values)
-
-    assert isinstance(result, torch.Tensor), "forward should return a tensor of embeddings"
-
-    assert result.shape == (
-        expected_batch,
-        expected_seq_len,
-        hidden_size,
-    ), (
-        f"Unexpected embedding shape {result.shape}, expected "
-        f"({expected_batch}, {expected_seq_len}, {hidden_size})"
-    )
+    assert result.shape == (expected_batch, expected_seq_len, hidden_size)

--- a/tests/models/backbone/test_windowed_dino.py
+++ b/tests/models/backbone/test_windowed_dino.py
@@ -1,8 +1,8 @@
 import types
 from types import SimpleNamespace
 
-import torch
 import pytest
+import torch
 
 
 def test_window_partition_forward_rectangular_preserves_shapes(monkeypatch):

--- a/tests/models/backbone/test_windowed_dino.py
+++ b/tests/models/backbone/test_windowed_dino.py
@@ -1,4 +1,10 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
 import torch
+
 from rfdetr.models.backbone.dinov2_with_windowed_attn import (
     WindowedDinov2WithRegistersConfig,
     WindowedDinov2WithRegistersEmbeddings,

--- a/tests/models/backbone/test_windowed_dino.py
+++ b/tests/models/backbone/test_windowed_dino.py
@@ -1,4 +1,5 @@
 import torch
+
 from rfdetr.models.backbone.dinov2_with_windowed_attn import (
     WindowedDinov2WithRegistersConfig,
     WindowedDinov2WithRegistersEmbeddings,

--- a/tests/models/backbone/test_windowed_dino.py
+++ b/tests/models/backbone/test_windowed_dino.py
@@ -1,0 +1,110 @@
+import types
+from types import SimpleNamespace
+
+import torch
+import pytest
+
+
+def test_window_partition_forward_rectangular_preserves_shapes(monkeypatch):
+    """
+    Regression test that exercises WindowedDinov2WithRegistersEmbeddings.forward
+    with a rectangular input (H != W) to hit the window partitioning logic.
+
+    The test stubs Dinov2WithRegistersPatchEmbeddings but:
+    - returns patch embeddings whose last dimension equals config.hidden_size
+      (avoids spurious hidden-dim mismatch errors)
+    - provides num_patches used to initialize position_embeddings
+
+    The test asserts the final embeddings tensor has the expected shape:
+    (batch_size * num_windows**2, 1 + num_h_patches_per_window * num_w_patches_per_window, hidden_size)
+
+    On implementations with the height/width mix-up bug this will raise a RuntimeError
+    (or produce an unexpected shape) and the test will fail.
+    """
+
+    # Parameters
+    batch_size = 1
+    in_channels = 3
+    hidden_size = 64
+    patch_size = 16
+    num_windows = 2  # exercise the windowing path, must be > 1
+
+    # Rectangular pixel dims that produce different patch-grid sizes (H_patches != W_patches)
+    H_pixels = 96   # 96 // 16 == 6 patches
+    W_pixels = 64   # 64 // 16 == 4 patches
+
+    num_h_patches = H_pixels // patch_size
+    num_w_patches = W_pixels // patch_size
+    assert num_h_patches != num_w_patches, "Test requires non-square patch grid"
+
+    # Ensure both patch dims are divisible by num_windows for clean per-window sizes
+    assert num_h_patches % num_windows == 0 and num_w_patches % num_windows == 0, (
+        "Choose H_pixels and W_pixels such that H_patches and W_patches are divisible by num_windows"
+    )
+
+    config = SimpleNamespace(
+        hidden_size=hidden_size,
+        num_register_tokens=0,
+        patch_size=patch_size,
+        hidden_dropout_prob=0.0,
+        num_windows=num_windows,
+    )
+
+    # Import module under test from the repository codebase
+    import rfdetr.models.backbone.dinov2_with_windowed_attn as emb_mod
+
+    # Stub: pretend the pretrained positional grid had a square number of patches (e.g., 4x4 = 16)
+    fake_num_patches_pretrained = 16
+
+    # Build a stub that:
+    # - exposes num_patches for __init__
+    # - exposes projection.weight.dtype used by the real class
+    # - when called returns embeddings with last dim == config.hidden_size
+    def _stub_patch_embeddings_factory(cfg):
+        class StubPatchEmb:
+            def __init__(self):
+                self.num_patches = fake_num_patches_pretrained
+                # used as target dtype in the real code
+                self.projection = types.SimpleNamespace(weight=torch.zeros(1, dtype=torch.float32))
+
+            def __call__(self, pixel_values):
+                B, C, H, W = pixel_values.shape
+                nh = H // cfg.patch_size
+                nw = W // cfg.patch_size
+                # Return tensor shaped (B, nh * nw, hidden_size) matching config.hidden_size
+                return torch.randn(B, nh * nw, cfg.hidden_size, dtype=torch.float32)
+
+        return StubPatchEmb()
+
+    # Monkeypatch heavy dependency to our stub
+    monkeypatch.setattr(
+        emb_mod, "Dinov2WithRegistersPatchEmbeddings", _stub_patch_embeddings_factory
+    )
+
+    # Instantiate the real embeddings module (uses stub during __init__)
+    emb_module = emb_mod.WindowedDinov2WithRegistersEmbeddings(config)
+
+    # Build rectangular pixel input
+    pixel_values = torch.randn(batch_size, in_channels, H_pixels, W_pixels, dtype=torch.float32)
+
+    # Expected values after windowing:
+    num_h_patches_per_window = num_h_patches // num_windows
+    num_w_patches_per_window = num_w_patches // num_windows
+    expected_batch = batch_size * (num_windows ** 2)
+    expected_seq_len = 1 + (num_h_patches_per_window * num_w_patches_per_window)
+
+    # Call forward. If the develop branch still has the height/width mix-up bug,
+    # this call is expected to raise (shape mismatch during reshape/permute/reshape or concatenation),
+    # causing the test to fail. If the branch has the fix, this should succeed and assertions below pass.
+    result = emb_module.forward(pixel_values)
+
+    assert isinstance(result, torch.Tensor), "forward should return a tensor of embeddings"
+
+    assert result.shape == (
+        expected_batch,
+        expected_seq_len,
+        hidden_size,
+    ), (
+        f"Unexpected embedding shape {result.shape}, expected "
+        f"({expected_batch}, {expected_seq_len}, {hidden_size})"
+    )


### PR DESCRIPTION
## What does this PR do?

<!-- Provide a clear and concise description of the changes -->

**Related Issue(s):** Bug fix in dinov2 backbone windowed attention reshape
Get error like `RuntimeError: shape '<shape>' is invalid for input of size <size>` when using non-square input image

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
