### PR TITLE
Update CODEOWNERS to include more reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # These owners will be the default owners for everything in the repo.
 # They will be requested for review when someone opens a pull request.
-* @SkalskiP @Borda
+* @SkalskiP @Borda @probicheaux @isaacrob-roboflow
 
 # supervise the core model modules
 /rfdetr @probicheaux @isaacrob-roboflow @Matvezy


### PR DESCRIPTION
This pull request makes a small update to the `.github/CODEOWNERS` file by adding two additional users as default code owners for the repository. This ensures that these users will be automatically requested for reviews on new pull requests.

---

They asked to be added to the general review squad because they want to be more active on resolving any contributorsa PRs