### PR TITLE
Enable `codespell` hook in pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,5 +42,6 @@ repos:
     rev: v2.4.1
     hooks:
       - id: codespell
+        # args: [--write-changes]
         additional_dependencies:
           - tomli

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,9 +38,9 @@ repos:
   #      args: ["--number"]
   #      exclude: ^docs/
 
-  #- repo: https://github.com/codespell-project/codespell
-  #  rev: v2.4.1
-  #  hooks:
-  #    - id: codespell
-  #      additional_dependencies:
-  #        - tomli
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        additional_dependencies:
+          - tomli

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,3 +124,6 @@ ignore = [
     "E721",  # todo: Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
     "F821",  # todo: Undefined name `...`
 ]
+
+[tool.codespell]
+skip = "*.pth"

--- a/rfdetr/datasets/coco_eval.py
+++ b/rfdetr/datasets/coco_eval.py
@@ -303,7 +303,7 @@ def evaluate(self: COCOeval) -> Tuple[List[int], np.ndarray]:
 def patched_pycocotools_summarize(self):
     '''
     Compute and display summary metrics for evaluation results.
-    Note this functin can *only* be applied on the default parameter setting
+    Note this function can *only* be applied on the default parameter setting
     '''
     def _summarize(ap=1, iouThr=None, areaRng='all', maxDets=100):
         p = self.params

--- a/rfdetr/models/backbone/projector.py
+++ b/rfdetr/models/backbone/projector.py
@@ -189,7 +189,7 @@ class MultiScaleProjector(nn.Module):
                     ])
                     # in_dim // 4
                 elif scale == 2.0:
-                    # a hack to reduce the FLOPs and Params when the dimention of output feature is too large
+                    # a hack to reduce the FLOPs and Params when the dimension of output feature is too large
                     # if in_dim > 512:
                     #     layers = [
                     #         ConvX(in_dim, in_dim // 2, kernel=1),

--- a/rfdetr/models/lwdetr.py
+++ b/rfdetr/models/lwdetr.py
@@ -150,8 +150,8 @@ class LWDETR(nn.Module):
                                (center_x, center_y, width, height). These values are normalized in [0, 1],
                                relative to the size of each individual image (disregarding possible padding).
                                See PostProcess for information on how to retrieve the unnormalized bounding box.
-               - "aux_outputs": Optional, only returned when auxilary losses are activated. It is a list of
-                                dictionnaries containing the two above keys for each decoder layer.
+               - "aux_outputs": Optional, only returned when auxiliary losses are activated. It is a list of
+                                dictionaries containing the two above keys for each decoder layer.
         """
         if isinstance(samples, (list, torch.Tensor)):
             samples = nested_tensor_from_tensor_list(samples)
@@ -583,7 +583,7 @@ class SetCriterion(nn.Module):
         # Retrieve the matching between the outputs of the last layer and the targets
         indices = self.matcher(outputs_without_aux, targets, group_detr=group_detr)
 
-        # Compute the average number of target boxes accross all nodes, for normalization purposes
+        # Compute the average number of target boxes across all nodes, for normalization purposes
         num_boxes = sum(len(t["labels"]) for t in targets)
         if not self.sum_group_losses:
             num_boxes = num_boxes * group_detr

--- a/rfdetr/models/matcher.py
+++ b/rfdetr/models/matcher.py
@@ -48,7 +48,7 @@ class HungarianMatcher(nn.Module):
         self.cost_class = cost_class
         self.cost_bbox = cost_bbox
         self.cost_giou = cost_giou
-        assert cost_class != 0 or cost_bbox != 0 or cost_giou != 0, "all costs cant be 0"
+        assert cost_class != 0 or cost_bbox != 0 or cost_giou != 0, "all costs can't be 0"
         self.focal_alpha = focal_alpha
         self.mask_point_sample_ratio = mask_point_sample_ratio
         self.cost_mask_ce = cost_mask_ce
@@ -87,7 +87,7 @@ class HungarianMatcher(nn.Module):
 
         masks_present = "masks" in targets[0]
 
-        # Compute the giou cost betwen boxes
+        # Compute the giou cost between boxes
         giou = generalized_box_iou(box_cxcywh_to_xyxy(out_bbox), box_cxcywh_to_xyxy(tgt_bbox))
         cost_giou = -giou
 

--- a/rfdetr/models/segmentation_head.py
+++ b/rfdetr/models/segmentation_head.py
@@ -240,7 +240,7 @@ def get_uncertain_point_coords_with_randomness(
 
 def calculate_uncertainty(logits: torch.Tensor) -> torch.Tensor:
     """
-    We estimate uncerainty as L1 distance between 0.0 and the logit prediction in 'logits' for the
+    We estimate uncertainty as L1 distance between 0.0 and the logit prediction in 'logits' for the
         foreground class in `classes`.
     Args:
         logits (Tensor): A tensor of shape (R, 1, ...) for class-specific or

--- a/rfdetr/util/benchmark.py
+++ b/rfdetr/util/benchmark.py
@@ -503,13 +503,13 @@ def flop_count(
     if customized_ops:
         flop_count_ops.update(customized_ops)
 
-    # If whitelist is None, count flops for all suported operations.
+    # If whitelist is None, count flops for all supported operations.
     if whitelist is None:
         whitelist_set = set(flop_count_ops.keys())
     else:
         whitelist_set = set(whitelist)
 
-    # Torch script does not support parallell torch models.
+    # Torch script does not support parallel torch models.
     if isinstance(
         model,
         (nn.parallel.distributed.DistributedDataParallel, nn.DataParallel),

--- a/rfdetr/util/misc.py
+++ b/rfdetr/util/misc.py
@@ -283,7 +283,7 @@ def get_sha() -> str:
         sha = _run(['git', 'rev-parse', 'HEAD'])
         subprocess.check_output(['git', 'diff'], cwd=cwd)
         diff = _run(['git', 'diff-index', 'HEAD'])
-        diff = "has uncommited changes" if diff else "clean"
+        diff = "has uncommitted changes" if diff else "clean"
         branch = _run(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
     except Exception:
         pass


### PR DESCRIPTION
This pull request makes a small change to the pre-commit configuration by enabling the `codespell` linter. This will help catch spelling errors in the codebase before commits are made.

* Enabled the `codespell` linter in `.pre-commit-config.yaml` by uncommenting its configuration, ensuring automated spell checking on commits.