### PR TITLE
Enable `mdformat` pre-commit hook and configure with mkdocs extension

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,8 @@ repos:
         additional_dependencies:
           - "mdformat-mkdocs[recommended]>=2.1.0"
         args: ["--number"]
+        # NOTE: docs/ is formatted by separate tooling; keep mdformat-mkdocs for
+        # MkDocs-style markdown in root-level files (e.g., README.md).
         exclude: ^docs/
 
   - repo: https://github.com/codespell-project/codespell

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,14 +29,14 @@ repos:
       #- id: ruff-format
       #  types_or: [ python, pyi, jupyter ]
 
-  #- repo: https://github.com/executablebooks/mdformat
-  #  rev: 1.0.0
-  #  hooks:
-  #    - id: mdformat
-  #      additional_dependencies:
-  #        - "mdformat-mkdocs[recommended]>=2.1.0"
-  #      args: ["--number"]
-  #      exclude: ^docs/
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 1.0.0
+    hooks:
+      - id: mdformat
+        additional_dependencies:
+          - "mdformat-mkdocs[recommended]>=2.1.0"
+        args: ["--number"]
+        exclude: ^docs/
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,16 +18,16 @@ Your contributions can be in many forms—whether it’s enhancing existing feat
 1. [Fork the Repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo): Click the “Fork” button on our GitHub page to create your own copy.
 2. [Clone Locally](https://docs.github.com/en/enterprise-server@3.11/repositories/creating-and-managing-repositories/cloning-a-repository): Download your fork to your local development environment.
 3. [Create a Branch](https://docs.github.com/en/desktop/making-changes-in-a-branch/managing-branches-in-github-desktop): Use a descriptive name to create a new branch (e.g., `feature/your-descriptive-name`):
-   ```bash
-   git checkout -b feature/your-descriptive-name
-   ```
+    ```bash
+    git checkout -b feature/your-descriptive-name
+    ```
 4. Develop Your Changes: Make your updates, ensuring your commit messages clearly describe your modifications.
 5. [Commit and Push](https://docs.github.com/en/desktop/making-changes-in-a-branch/committing-and-reviewing-changes-to-your-project-in-github-desktop): Run:
-   ```bash
-   git add .
-   git commit -m "A brief description of your changes"
-   git push -u origin your-descriptive-name
-   ```
+    ```bash
+    git add .
+    git commit -m "A brief description of your changes"
+    git push -u origin your-descriptive-name
+    ```
 6. [Open a Pull Request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request): Submit your pull request against the main development branch. Please detail your changes and link any related issues.
 
 Before merging, check that all tests pass and that your changes adhere to our development and documentation standards.

--- a/README.md
+++ b/README.md
@@ -51,34 +51,34 @@ RF-DETR achieves state-of-the-art results in both object detection and instance 
 
 <br>
 
-| Architecture | COCO AP<sub>50</sub> |  COCO AP<sub>50:95</sub>   |  RF100VL AP<sub>50</sub>   | RF100VL AP<sub>50:95</sub>  |  Latency (ms)   |   Params (M) |   Resolution  |
-|:------------:|:--------------------:|:--------------------------:|:--------------------------:|:---------------------------:|:---------------:|:------------:|:-------------:|
-|  RF-DETR-N   |         67.6         |            48.4            |            85.0            |            57.7             |       2.3       |         30.5 |       384x384 |
-|  RF-DETR-S   |         72.1         |            53.0            |            86.7            |            60.2             |       3.5       |         32.1 |       512x512 |
-|  RF-DETR-M   |         73.6         |            54.7            |            87.4            |            61.2             |       4.4       |         33.7 |       576x576 |
-|  RF-DETR-L   |         75.1         |            56.5            |            88.2            |            62.2             |       6.8       |         33.9 |       704x704 |
-|  RF-DETR-XL  |         77.4         |            58.6            |            88.5            |            62.9             |       11.5      |        126.4 |       700x700 |
-|  RF-DETR-2XL |         78.5         |            60.1            |            89.0            |            63.2             |       17.2      |        126.9 |       880x880 |
-|   YOLO11-N   |         52.0         |            37.4            |            81.4            |            55.3             |       2.5       |          2.6 |       640x640 |
-|   YOLO11-S   |         59.7         |            44.4            |            82.3            |            56.2             |       3.2       |          9.4 |       640x640 |
-|   YOLO11-M   |         64.1         |            48.6            |            82.5            |            56.5             |       5.1       |         20.1 |       640x640 |
-|   YOLO11-L   |         64.9         |            49.9            |            82.2            |            56.5             |       6.5       |         25.3 |       640x640 |
-|   YOLO11-X   |         66.1         |            50.9            |            81.7            |            56.2             |       10.5      |         56.9 |       640x640 |
-|   YOLO26-N   |         55.8         |            40.3            |            76.7            |            52.0             |       1.7       |          2.6 |       640x640 |
-|   YOLO26-S   |         64.3         |            47.7            |            82.7            |            57.0             |       2.6       |          9.4 |       640x640 |
-|   YOLO26-M   |         69.7         |            52.5            |            84.4            |            58.7             |       4.4       |         20.1 |       640x640 |
-|   YOLO26-L   |         71.1         |            54.1            |            85.0            |            59.3             |       5.7       |         25.3 |       640x640 |
-|   YOLO26-X   |         74.0         |            56.9            |            85.6            |            60.0             |       9.6       |         56.9 |       640x640 |
-|  LW-DETR-T   |         60.7         |            42.9            |            84.7            |            57.1             |       1.9       |         12.1 |       640x640 |
-|  LW-DETR-S   |         66.8         |            48.0            |            85.0            |            57.4             |       2.6       |         14.6 |       640x640 |
-|  LW-DETR-M   |         72.0         |            52.6            |            86.8            |            59.8             |       4.4       |         28.2 |       640x640 |
-|  LW-DETR-L   |         74.6         |            56.1            |            87.4            |            61.5             |       6.9       |         46.8 |       640x640 |
-|  LW-DETR-X   |         76.9         |            58.3            |            87.9            |            62.1             |       13.0      |        118.0 |       640x640 |
-|   D-FINE-N   |         60.2         |            42.7            |            84.4            |            58.2             |       2.1       |          3.8 |       640x640 |
-|   D-FINE-S   |         67.6         |            50.6            |            85.3            |            60.3             |       3.5       |         10.2 |       640x640 |
-|   D-FINE-M   |         72.6         |            55.0            |            85.5            |            60.6             |       5.4       |         19.2 |       640x640 |
-|   D-FINE-L   |         74.9         |            57.2            |            86.4            |            61.6             |       7.5       |         31.0 |       640x640 |
-|   D-FINE-X   |         76.8         |            59.3            |            86.9            |            62.2             |       11.5      |         62.0 |       640x640 |
+| Architecture | COCO AP<sub>50</sub> | COCO AP<sub>50:95</sub> | RF100VL AP<sub>50</sub> | RF100VL AP<sub>50:95</sub> | Latency (ms) | Params (M) | Resolution |
+| :----------: | :------------------: | :---------------------: | :---------------------: | :------------------------: | :----------: | :--------: | :--------: |
+|  RF-DETR-N   |         67.6         |          48.4           |          85.0           |            57.7            |     2.3      |    30.5    |  384x384   |
+|  RF-DETR-S   |         72.1         |          53.0           |          86.7           |            60.2            |     3.5      |    32.1    |  512x512   |
+|  RF-DETR-M   |         73.6         |          54.7           |          87.4           |            61.2            |     4.4      |    33.7    |  576x576   |
+|  RF-DETR-L   |         75.1         |          56.5           |          88.2           |            62.2            |     6.8      |    33.9    |  704x704   |
+|  RF-DETR-XL  |         77.4         |          58.6           |          88.5           |            62.9            |     11.5     |   126.4    |  700x700   |
+| RF-DETR-2XL  |         78.5         |          60.1           |          89.0           |            63.2            |     17.2     |   126.9    |  880x880   |
+|   YOLO11-N   |         52.0         |          37.4           |          81.4           |            55.3            |     2.5      |    2.6     |  640x640   |
+|   YOLO11-S   |         59.7         |          44.4           |          82.3           |            56.2            |     3.2      |    9.4     |  640x640   |
+|   YOLO11-M   |         64.1         |          48.6           |          82.5           |            56.5            |     5.1      |    20.1    |  640x640   |
+|   YOLO11-L   |         64.9         |          49.9           |          82.2           |            56.5            |     6.5      |    25.3    |  640x640   |
+|   YOLO11-X   |         66.1         |          50.9           |          81.7           |            56.2            |     10.5     |    56.9    |  640x640   |
+|   YOLO26-N   |         55.8         |          40.3           |          76.7           |            52.0            |     1.7      |    2.6     |  640x640   |
+|   YOLO26-S   |         64.3         |          47.7           |          82.7           |            57.0            |     2.6      |    9.4     |  640x640   |
+|   YOLO26-M   |         69.7         |          52.5           |          84.4           |            58.7            |     4.4      |    20.1    |  640x640   |
+|   YOLO26-L   |         71.1         |          54.1           |          85.0           |            59.3            |     5.7      |    25.3    |  640x640   |
+|   YOLO26-X   |         74.0         |          56.9           |          85.6           |            60.0            |     9.6      |    56.9    |  640x640   |
+|  LW-DETR-T   |         60.7         |          42.9           |          84.7           |            57.1            |     1.9      |    12.1    |  640x640   |
+|  LW-DETR-S   |         66.8         |          48.0           |          85.0           |            57.4            |     2.6      |    14.6    |  640x640   |
+|  LW-DETR-M   |         72.0         |          52.6           |          86.8           |            59.8            |     4.4      |    28.2    |  640x640   |
+|  LW-DETR-L   |         74.6         |          56.1           |          87.4           |            61.5            |     6.9      |    46.8    |  640x640   |
+|  LW-DETR-X   |         76.9         |          58.3           |          87.9           |            62.1            |     13.0     |   118.0    |  640x640   |
+|   D-FINE-N   |         60.2         |          42.7           |          84.4           |            58.2            |     2.1      |    3.8     |  640x640   |
+|   D-FINE-S   |         67.6         |          50.6           |          85.3           |            60.3            |     3.5      |    10.2    |  640x640   |
+|   D-FINE-M   |         72.6         |          55.0           |          85.5           |            60.6            |     5.4      |    19.2    |  640x640   |
+|   D-FINE-L   |         74.9         |          57.2           |          86.4           |            61.6            |     7.5      |    31.0    |  640x640   |
+|   D-FINE-X   |         76.8         |          59.3           |          86.9           |            62.2            |     11.5     |    62.0    |  640x640   |
 
 </details>
 
@@ -91,29 +91,29 @@ RF-DETR achieves state-of-the-art results in both object detection and instance 
 
 <br>
 
-|   Architecture   | COCO AP<sub>50</sub> | COCO AP<sub>50:95</sub> | Latency (ms) | Params (M) | Resolution |
-|:----------------:|:--------------------:|:-----------------------:|:------------:|:----------:|:----------:|
-|  RF-DETR-Seg-N   |         63.0         |          40.3           |     3.4      |    33.6    |  312x312   |
-|  RF-DETR-Seg-S   |         66.2         |          43.1           |     4.4      |    33.7    |  384x384   |
-|  RF-DETR-Seg-M   |         68.4         |          45.3           |     5.9      |    35.7    |  432x432   |
-|  RF-DETR-Seg-L   |         70.5         |          47.1           |     8.8      |    36.2    |  504x504   |
-|  RF-DETR-Seg-XL  |         72.2         |          48.8           |     13.5     |    38.1    |  624x624   |
-| RF-DETR-Seg-2XL  |         73.1         |          49.9           |     21.8     |    38.6    |  768x768   |
-|   YOLOv8-N-Seg   |         45.6         |          28.3           |     3.5      |    3.4     |  640x640   |
-|   YOLOv8-S-Seg   |         53.8         |          34.0           |     4.2      |    11.8    |  640x640   |
-|   YOLOv8-M-Seg   |         58.2         |          37.3           |     7.0      |    27.3    |  640x640   |
-|   YOLOv8-L-Seg   |         60.5         |          39.0           |     9.7      |    46.0    |  640x640   |
-|  YOLOv8-XL-Seg   |         61.3         |          39.5           |     14.0     |    71.8    |  640x640   |
-|  YOLOv11-N-Seg   |         47.8         |          30.0           |     3.6      |    2.9     |  640x640   |
-|  YOLOv11-S-Seg   |         55.4         |          35.0           |     4.6      |    10.1    |  640x640   |
-|  YOLOv11-M-Seg   |         60.0         |          38.5           |     6.9      |    22.4    |  640x640   |
-|  YOLOv11-L-Seg   |         61.5         |          39.5           |     8.3      |    27.6    |  640x640   |
-|  YOLOv11-XL-Seg  |         62.4         |          40.1           |     13.7     |    62.1    |  640x640   |
-|   YOLO26-N-Seg   |         54.3         |          34.7           |     2.31     |    2.7     |  640x640   |
-|   YOLO26-S-Seg   |         62.4         |          40.2           |     3.47     |    10.4    |  640x640   |
-|   YOLO26-M-Seg   |         67.8         |          44.0           |     6.32     |    23.6    |  640x640   |
-|   YOLO26-L-Seg   |         69.8         |          45.5           |     7.58     |    28.0    |  640x640   |
-|   YOLO26-X-Seg   |         71.6         |          46.8           |    12.92     |    62.8    |  640x640   |
+|  Architecture   | COCO AP<sub>50</sub> | COCO AP<sub>50:95</sub> | Latency (ms) | Params (M) | Resolution |
+| :-------------: | :------------------: | :---------------------: | :----------: | :--------: | :--------: |
+|  RF-DETR-Seg-N  |         63.0         |          40.3           |     3.4      |    33.6    |  312x312   |
+|  RF-DETR-Seg-S  |         66.2         |          43.1           |     4.4      |    33.7    |  384x384   |
+|  RF-DETR-Seg-M  |         68.4         |          45.3           |     5.9      |    35.7    |  432x432   |
+|  RF-DETR-Seg-L  |         70.5         |          47.1           |     8.8      |    36.2    |  504x504   |
+| RF-DETR-Seg-XL  |         72.2         |          48.8           |     13.5     |    38.1    |  624x624   |
+| RF-DETR-Seg-2XL |         73.1         |          49.9           |     21.8     |    38.6    |  768x768   |
+|  YOLOv8-N-Seg   |         45.6         |          28.3           |     3.5      |    3.4     |  640x640   |
+|  YOLOv8-S-Seg   |         53.8         |          34.0           |     4.2      |    11.8    |  640x640   |
+|  YOLOv8-M-Seg   |         58.2         |          37.3           |     7.0      |    27.3    |  640x640   |
+|  YOLOv8-L-Seg   |         60.5         |          39.0           |     9.7      |    46.0    |  640x640   |
+|  YOLOv8-XL-Seg  |         61.3         |          39.5           |     14.0     |    71.8    |  640x640   |
+|  YOLOv11-N-Seg  |         47.8         |          30.0           |     3.6      |    2.9     |  640x640   |
+|  YOLOv11-S-Seg  |         55.4         |          35.0           |     4.6      |    10.1    |  640x640   |
+|  YOLOv11-M-Seg  |         60.0         |          38.5           |     6.9      |    22.4    |  640x640   |
+|  YOLOv11-L-Seg  |         61.5         |          39.5           |     8.3      |    27.6    |  640x640   |
+| YOLOv11-XL-Seg  |         62.4         |          40.1           |     13.7     |    62.1    |  640x640   |
+|  YOLO26-N-Seg   |         54.3         |          34.7           |     2.31     |    2.7     |  640x640   |
+|  YOLO26-S-Seg   |         62.4         |          40.2           |     3.47     |    10.4    |  640x640   |
+|  YOLO26-M-Seg   |         67.8         |          44.0           |     6.32     |    23.6    |  640x640   |
+|  YOLO26-L-Seg   |         69.8         |          45.5           |     7.58     |    28.0    |  640x640   |
+|  YOLO26-X-Seg   |         71.6         |          46.8           |    12.92     |    62.8    |  640x640   |
 
 </details>
 
@@ -132,14 +132,10 @@ from rfdetr.util.coco_classes import COCO_CLASSES
 
 model = RFDETRMedium()
 
-image = Image.open(requests.get('https://media.roboflow.com/dog.jpg', stream=True).raw)
+image = Image.open(requests.get("https://media.roboflow.com/dog.jpg", stream=True).raw)
 detections = model.predict(image, threshold=0.5)
 
-labels = [
-    f"{COCO_CLASSES[class_id]}"
-    for class_id
-    in detections.class_id
-]
+labels = [f"{COCO_CLASSES[class_id]}" for class_id in detections.class_id]
 
 annotated_image = sv.BoxAnnotator().annotate(image, detections)
 annotated_image = sv.LabelAnnotator().annotate(annotated_image, detections, labels)
@@ -160,7 +156,7 @@ from inference import get_model
 
 model = get_model("rfdetr-medium")
 
-image = Image.open(requests.get('https://media.roboflow.com/dog.jpg', stream=True).raw)
+image = Image.open(requests.get("https://media.roboflow.com/dog.jpg", stream=True).raw)
 predictions = model.infer(image, confidence=0.5)[0]
 detections = sv.Detections.from_inference(predictions)
 
@@ -170,14 +166,14 @@ annotated_image = sv.LabelAnnotator().annotate(annotated_image, detections)
 
 </details>
 
-| Size | RF-DETR package class | Inference package alias | COCO AP<sub>50</sub> | COCO AP<sub>50:95</sub>   | Latency (ms) | Params (M) | Resolution |  License   |
-|:----:|:---------------------:|:------------------------|:--------------------:|:-------------------------:|:------------:|:----------:|:----------:|:----------:|
-| N    | `RFDETRNano`          | `rfdetr-nano`           | 67.6                 |           48.4            | 2.3          | 30.5       | 384x384    | Apache 2.0 |
-| S    | `RFDETRSmall`         | `rfdetr-small`          | 72.1                 |           53.0            | 3.5          | 32.1       | 512x512    | Apache 2.0 |
-| M    | `RFDETRMedium`        | `rfdetr-medium`         | 73.6                 |           54.7            | 4.4          | 33.7       | 576x576    | Apache 2.0 |
-| L    | `RFDETRLarge`         | `rfdetr-large`          | 75.1                 |           56.5            | 6.8          | 33.9       | 704x704    | Apache 2.0 |
-| XL   | `RFDETRXLarge`        | `rfdetr-xlarge`         | 77.4                 |           58.6            | 11.5         | 126.4      | 700x700    |  PML 1.0   |
-| 2XL  | `RFDETR2XLarge`       | `rfdetr-2xlarge`        | 78.5                 |           60.1            | 17.2         | 126.9      | 880x880    |  PML 1.0   |
+| Size | RF-DETR package class | Inference package alias | COCO AP<sub>50</sub> | COCO AP<sub>50:95</sub> | Latency (ms) | Params (M) | Resolution |  License   |
+| :--: | :-------------------: | :---------------------- | :------------------: | :---------------------: | :----------: | :--------: | :--------: | :--------: |
+|  N   |     `RFDETRNano`      | `rfdetr-nano`           |         67.6         |          48.4           |     2.3      |    30.5    |  384x384   | Apache 2.0 |
+|  S   |     `RFDETRSmall`     | `rfdetr-small`          |         72.1         |          53.0           |     3.5      |    32.1    |  512x512   | Apache 2.0 |
+|  M   |    `RFDETRMedium`     | `rfdetr-medium`         |         73.6         |          54.7           |     4.4      |    33.7    |  576x576   | Apache 2.0 |
+|  L   |     `RFDETRLarge`     | `rfdetr-large`          |         75.1         |          56.5           |     6.8      |    33.9    |  704x704   | Apache 2.0 |
+|  XL  |    `RFDETRXLarge`     | `rfdetr-xlarge`         |         77.4         |          58.6           |     11.5     |   126.4    |  700x700   |  PML 1.0   |
+| 2XL  |    `RFDETR2XLarge`    | `rfdetr-2xlarge`        |         78.5         |          60.1           |     17.2     |   126.9    |  880x880   |  PML 1.0   |
 
 ### Segmentation
 
@@ -192,14 +188,10 @@ from rfdetr.util.coco_classes import COCO_CLASSES
 
 model = RFDETRSegMedium()
 
-image = Image.open(requests.get('https://media.roboflow.com/dog.jpg', stream=True).raw)
+image = Image.open(requests.get("https://media.roboflow.com/dog.jpg", stream=True).raw)
 detections = model.predict(image, threshold=0.5)
 
-labels = [
-    f"{COCO_CLASSES[class_id]}"
-    for class_id
-    in detections.class_id
-]
+labels = [f"{COCO_CLASSES[class_id]}" for class_id in detections.class_id]
 
 annotated_image = sv.MaskAnnotator().annotate(image, detections)
 annotated_image = sv.LabelAnnotator().annotate(annotated_image, detections, labels)
@@ -220,7 +212,7 @@ from inference import get_model
 
 model = get_model("rfdetr-seg-medium")
 
-image = Image.open(requests.get('https://media.roboflow.com/dog.jpg', stream=True).raw)
+image = Image.open(requests.get("https://media.roboflow.com/dog.jpg", stream=True).raw)
 predictions = model.infer(image, confidence=0.5)[0]
 detections = sv.Detections.from_inference(predictions)
 
@@ -230,14 +222,14 @@ annotated_image = sv.LabelAnnotator().annotate(annotated_image, detections)
 
 </details>
 
-| Size | RF-DETR package class | Inference package alias     | COCO AP<sub>50</sub> | COCO AP<sub>50:95</sub>  | Latency (ms) | Params (M) | Resolution |  License   |
-|:----:|:---------------------:|:----------------------------|:--------------------:|:------------------------:|:------------:|:----------:|:----------:|:----------:|
-| N    | `RFDETRSegNano`       | `rfdetr-seg-nano`           | 63.0                 |           40.3           | 3.4          | 33.6       |  312x312   | Apache 2.0 |
-| S    | `RFDETRSegSmall`      | `rfdetr-seg-small`          | 66.2                 |           43.1           | 4.4          | 33.7       |  384x384   | Apache 2.0 |
-| M    | `RFDETRSegMedium`     | `rfdetr-seg-medium`         | 68.4                 |           45.3           | 5.9          | 35.7       |  432x432   | Apache 2.0 |
-| L    | `RFDETRSegLarge`      | `rfdetr-seg-large`          | 70.5                 |           47.1           | 8.8          | 36.2       |  504x504   | Apache 2.0 |
-| XL   | `RFDETRSegXLarge`     | `rfdetr-seg-xlarge`         | 72.2                 |           48.8           | 13.5         | 38.1       |  624x624   | Apache 2.0 |
-| 2XL  | `RFDETRSeg2XLarge`    | `rfdetr-seg-2xlarge`        | 73.1                 |           49.9           | 21.8         | 38.6       |  768x768   | Apache 2.0 |
+| Size | RF-DETR package class | Inference package alias | COCO AP<sub>50</sub> | COCO AP<sub>50:95</sub> | Latency (ms) | Params (M) | Resolution |  License   |
+| :--: | :-------------------: | :---------------------- | :------------------: | :---------------------: | :----------: | :--------: | :--------: | :--------: |
+|  N   |    `RFDETRSegNano`    | `rfdetr-seg-nano`       |         63.0         |          40.3           |     3.4      |    33.6    |  312x312   | Apache 2.0 |
+|  S   |   `RFDETRSegSmall`    | `rfdetr-seg-small`      |         66.2         |          43.1           |     4.4      |    33.7    |  384x384   | Apache 2.0 |
+|  M   |   `RFDETRSegMedium`   | `rfdetr-seg-medium`     |         68.4         |          45.3           |     5.9      |    35.7    |  432x432   | Apache 2.0 |
+|  L   |   `RFDETRSegLarge`    | `rfdetr-seg-large`      |         70.5         |          47.1           |     8.8      |    36.2    |  504x504   | Apache 2.0 |
+|  XL  |   `RFDETRSegXLarge`   | `rfdetr-seg-xlarge`     |         72.2         |          48.8           |     13.5     |    38.1    |  624x624   | Apache 2.0 |
+| 2XL  |  `RFDETRSeg2XLarge`   | `rfdetr-seg-2xlarge`    |         73.1         |          49.9           |     21.8     |    38.6    |  768x768   | Apache 2.0 |
 
 ### Train Models
 


### PR DESCRIPTION
This pull request makes a small configuration update to the `.pre-commit-config.yaml` file. The change re-enables the `mdformat` pre-commit hook, which was previously commented out, ensuring that Markdown files are automatically formatted according to the specified dependencies and arguments.