### PR TITLE
Add GitHub Action workflow to check GPU availability on CI

### DIFF
--- a/.github/workflows/ci-tests-gpu.yml
+++ b/.github/workflows/ci-tests-gpu.yml
@@ -14,10 +14,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build-pkg:
-    uses: ./.github/workflows/build-package.yml
-
-  run-tests:
+  run-gpu-tests:
     name: GPU Pytest Run
     timeout-minutes: 20
     runs-on: Roboflow-GPU-VM-Runner

--- a/.github/workflows/ci-tests-gpu.yml
+++ b/.github/workflows/ci-tests-gpu.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+env:
+  PYTHON_VERSION: "3.12"
+  UV_TORCH_BACKEND: "auto"
+
 concurrency:
   group: pytest-gpu-test-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -16,6 +20,7 @@ concurrency:
 jobs:
   run-gpu-tests:
     name: GPU Pytest Run
+    if: github.event_name == 'push' || !github.event.pull_request.draft
     timeout-minutes: 20
     runs-on: Roboflow-GPU-VM-Runner
     steps:
@@ -27,7 +32,7 @@ jobs:
       - name: 🐍 Install uv and set Python version
         uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
         with:
-          python-version: "3.12"
+          python-version: ${{ env.PYTHON_VERSION }}
           activate-environment: true
 
       - name: 🚀 Install Packages
@@ -41,7 +46,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: "coverage.xml"
-          flags: gpu,${{ runner.os }}
+          flags: gpu,${{ runner.os }},py${{ env.PYTHON_VERSION }}
           env_vars: OS,PYTHON
           name: codecov-umbrella
           fail_ci_if_error: false

--- a/.github/workflows/ci-tests-gpu.yml
+++ b/.github/workflows/ci-tests-gpu.yml
@@ -1,15 +1,53 @@
-name: Check GPU Availability
+name: GPU Pytest/Test Workflow
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [main, develop]
   pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pytest-gpu-test-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  run-on-gpu:
-    name: Check GPU with nvidia-smi
-    runs-on: Roboflow-GPU-VM-Runner
+  build-pkg:
+    uses: ./.github/workflows/build-package.yml
 
+  run-tests:
+    name: GPU Pytest Run
+    timeout-minutes: 20
+    runs-on: Roboflow-GPU-VM-Runner
     steps:
-      - name: Print GPU information
+      - name: 🖥️ Print GPU information
         run: nvidia-smi
+      - name: 📥 Checkout the repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: 🐍 Install uv and set Python version
+        uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
+        with:
+          python-version: "3.12"
+          activate-environment: true
+
+      - name: 🚀 Install Packages
+        run: uv pip install -e . --group tests
+
+      - name: 🧪 Run the Test
+        run: uv run pytest --cov=rfdetr --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: "coverage.xml"
+          flags: gpu,${{ runner.os }}
+          env_vars: OS,PYTHON
+          name: codecov-umbrella
+          fail_ci_if_error: false
+
+      - name: Minimize uv cache
+        run: uv cache prune --ci

--- a/.github/workflows/ci-tests-gpu.yml
+++ b/.github/workflows/ci-tests-gpu.yml
@@ -1,0 +1,15 @@
+name: Check GPU Availability
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+
+jobs:
+  run-on-gpu:
+    name: Check GPU with nvidia-smi
+    runs-on: Roboflow-GPU-VM-Runner
+
+    steps:
+      - name: Print GPU information
+        run: nvidia-smi

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  UV_TORCH_BACKEND: "cpu"
+
 concurrency:
   group: pytest-test-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -54,7 +57,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: "coverage.xml"
-          flags: cpu,${{ runner.os }},python${{ matrix.python-version }}
+          flags: cpu,${{ runner.os }},py${{ matrix.python-version }}
           env_vars: OS,PYTHON
           name: codecov-umbrella
           fail_ci_if_error: false


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to check GPU availability during CI runs. The workflow is triggered on pushes to the `main` and `develop` branches, as well as on pull requests. It runs on a GPU-enabled runner and prints GPU information using `nvidia-smi`.

CI workflow improvements:

* Added a new `.github/workflows/ci-tests-gpu.yml` workflow that runs on a GPU-enabled runner and prints GPU information with `nvidia-smi` to verify GPU availability during CI.