### PR TITLE
Add COCO inference benchmarking test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,4 +185,7 @@ train_test.py
 # test artifacts
 test_visualizations/
 
+# datasets
+data/
+
 debugging/

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -5,14 +5,49 @@
 # ------------------------------------------------------------------------
 import random
 import shutil
+import zipfile
 from pathlib import Path
 from typing import Any, Generator
+from urllib.request import urlretrieve
 
 import numpy as np
 import pytest
 import torch
 
 from rfdetr.datasets.synthetic import DatasetSplitRatios, generate_coco_dataset
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DATA_DIR = PROJECT_ROOT / "data"
+
+_COCO_URLS = {
+    "val2017": "http://images.cocodataset.org/zips/val2017.zip",
+    "annotations": "http://images.cocodataset.org/annotations/annotations_trainval2017.zip",
+}
+
+
+def _download_and_extract(url: str, dest_dir: Path) -> None:
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    zip_path = dest_dir / url.rsplit("/", 1)[-1]
+    print(f"Downloading {url} ...")
+    urlretrieve(url, str(zip_path))
+    print(f"Extracting {zip_path} ...")
+    with zipfile.ZipFile(str(zip_path), "r") as zf:
+        zf.extractall(str(dest_dir))
+    zip_path.unlink()
+
+
+@pytest.fixture(scope="session")
+def download_coco_val() -> tuple[Path, Path]:
+    """Download COCO val2017 images and annotations if not already present."""
+    images_root = DATA_DIR / "val2017"
+    annotations_path = DATA_DIR / "annotations" / "instances_val2017.json"
+
+    if not images_root.exists():
+        _download_and_extract(_COCO_URLS["val2017"], DATA_DIR)
+    if not annotations_path.exists():
+        _download_and_extract(_COCO_URLS["annotations"], DATA_DIR)
+
+    return images_root, annotations_path
 
 
 @pytest.fixture(autouse=True)

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -31,8 +31,22 @@ def _download_and_extract(url: str, dest_dir: Path) -> None:
     print(f"Downloading {url} ...")
     urlretrieve(url, str(zip_path))
     print(f"Extracting {zip_path} ...")
+    dest_dir_resolved = dest_dir.resolve()
     with zipfile.ZipFile(str(zip_path), "r") as zf:
-        zf.extractall(str(dest_dir))
+        for member in zf.infolist():
+            if not member.filename:
+                continue
+            target_path = (dest_dir_resolved / member.filename).resolve()
+            if not target_path.is_relative_to(dest_dir_resolved):
+                raise RuntimeError(
+                    f"Unsafe path detected in ZIP file: {member.filename!r}"
+                )
+            if member.is_dir():
+                target_path.mkdir(parents=True, exist_ok=True)
+            else:
+                target_path.parent.mkdir(parents=True, exist_ok=True)
+                with zf.open(member, "r") as src, open(target_path, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
     zip_path.unlink()
 
 

--- a/tests/benchmarks/test_coco_inference.py
+++ b/tests/benchmarks/test_coco_inference.py
@@ -3,7 +3,10 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
+import os
+import zipfile
 from pathlib import Path
+from urllib.request import urlretrieve
 
 import pytest
 import torch
@@ -16,6 +19,18 @@ from rfdetr.engine import evaluate
 from rfdetr.main import Model
 from rfdetr.models import build_criterion_and_postprocessors
 from rfdetr.util import misc as utils
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DATA_DIR = PROJECT_ROOT / "data"
+
+_COCO_URLS = {
+    "val2017": "http://images.cocodataset.org/zips/val2017.zip",
+    "annotations": "http://images.cocodataset.org/annotations/annotations_trainval2017.zip",
+}
+
+_MODEL_CONFIGS = {
+    "nano": RFDETRNanoConfig,
+}
 
 
 class CocoDetectionWithTargets(CocoDetection):
@@ -34,30 +49,46 @@ class CocoDetectionWithTargets(CocoDetection):
         return img, target
 
 
-def _project_coco_paths(project_root: Path) -> tuple[Path, Path, Path]:
-    images_root = project_root / "val2017"
-    annotations_path = project_root / "annotations" / "instances_val2017.json"
-    weights_path = project_root / "rf-detr-nano.pth"
-    return images_root, annotations_path, weights_path
+def _download_and_extract(url: str, dest_dir: Path) -> None:
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    zip_path = dest_dir / url.rsplit("/", 1)[-1]
+    print(f"Downloading {url} ...")
+    urlretrieve(url, str(zip_path))
+    print(f"Extracting {zip_path} ...")
+    with zipfile.ZipFile(str(zip_path), "r") as zf:
+        zf.extractall(str(dest_dir))
+    zip_path.unlink()
 
 
-def _require_paths(*paths: Path) -> None:
-    missing = [path for path in paths if not path.exists()]
-    if missing:
-        missing_list = ", ".join(str(path) for path in missing)
-        pytest.skip(f"COCO assets missing: {missing_list}")
+@pytest.fixture(scope="session")
+def download_coco_val() -> tuple[Path, Path]:
+    """Download COCO val2017 images and annotations if not already present."""
+    images_root = DATA_DIR / "val2017"
+    annotations_path = DATA_DIR / "annotations" / "instances_val2017.json"
+
+    if not images_root.exists():
+        _download_and_extract(_COCO_URLS["val2017"], DATA_DIR)
+    if not annotations_path.exists():
+        _download_and_extract(_COCO_URLS["annotations"], DATA_DIR)
+
+    return images_root, annotations_path
 
 
-def test_coco_inference_benchmark() -> None:
-    project_root = Path(__file__).resolve().parents[2]
-    images_root, annotations_path, weights_path = _project_coco_paths(project_root)
-    _require_paths(images_root, annotations_path, weights_path)
+@pytest.mark.gpu
+def test_coco_inference_benchmark(
+    download_coco_val: tuple[Path, Path],
+    model_size: str = "nano",
+    threshold_map: float = 0.30,
+    threshold_map50: float = 0.45,
+    threshold_f1: float = 0.30,
+) -> None:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    images_root, annotations_path = download_coco_val
 
-    config = RFDETRNanoConfig(pretrain_weights=str(weights_path), device="cpu")
+    config_cls = _MODEL_CONFIGS[model_size]
+    config = config_cls(device=device.type)
     model_wrapper = Model(**config.dict())
     args = model_wrapper.args
-    if not hasattr(args, "eval_max_dets"):
-        args.eval_max_dets = 500
 
     transforms = make_coco_transforms(
         image_set="val",
@@ -66,22 +97,31 @@ def test_coco_inference_benchmark() -> None:
         num_windows=config.num_windows,
     )
     val_dataset = CocoDetectionWithTargets(images_root, annotations_path, transforms=transforms)
-    print(f"Loaded {len(val_dataset)} images for evaluation.")
-
     data_loader = torch.utils.data.DataLoader(
         val_dataset,
-        batch_size=1,
+        batch_size=4,
         sampler=torch.utils.data.SequentialSampler(val_dataset),
         drop_last=False,
         collate_fn=utils.collate_fn,
-        num_workers=0,
+        num_workers=max(1, (os.cpu_count() or 1) // 2),
     )
     base_ds = get_coco_api_from_dataset(val_dataset)
-
     criterion, postprocess = build_criterion_and_postprocessors(args)
-    device = torch.device("cpu")
+
     model_wrapper.model.eval()
     with torch.no_grad():
-        stats, _ = evaluate(model_wrapper.model, criterion, postprocess, data_loader, base_ds, device, args=args)
+        stats, _ = evaluate(
+            model_wrapper.model, criterion, postprocess,
+            data_loader, base_ds, device, args=args,
+        )
 
-    assert "results_json" in stats, "COCO evaluation did not return JSON metrics."
+    results = stats["results_json"]
+    map_val = results["map"]
+    map50_val = results["map50"]
+    f1_val = results["f1_score"]
+
+    assert map_val >= threshold_map, f"mAP {map_val:.4f} < {threshold_map}"
+    assert map50_val >= threshold_map50, f"mAP50 {map50_val:.4f} < {threshold_map50}"
+    assert f1_val >= threshold_f1, f"F1 {f1_val:.4f} < {threshold_f1}"
+
+    print(f"COCO val2017 [{model_size}]: mAP={map_val:.4f}, mAP50={map50_val:.4f}, F1={f1_val:.4f}")

--- a/tests/benchmarks/test_coco_inference.py
+++ b/tests/benchmarks/test_coco_inference.py
@@ -4,32 +4,21 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 import os
-import zipfile
 from pathlib import Path
-from urllib.request import urlretrieve
 
 import pytest
 import torch
 from torchvision.datasets import CocoDetection
 
-from rfdetr.config import RFDETRNanoConfig
+from rfdetr import RFDETRNano
 from rfdetr.datasets import get_coco_api_from_dataset
 from rfdetr.datasets.coco import ConvertCoco, make_coco_transforms
 from rfdetr.engine import evaluate
-from rfdetr.main import Model
 from rfdetr.models import build_criterion_and_postprocessors
 from rfdetr.util import misc as utils
 
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-DATA_DIR = PROJECT_ROOT / "data"
-
-_COCO_URLS = {
-    "val2017": "http://images.cocodataset.org/zips/val2017.zip",
-    "annotations": "http://images.cocodataset.org/annotations/annotations_trainval2017.zip",
-}
-
-_MODEL_CONFIGS = {
-    "nano": RFDETRNanoConfig,
+_MODEL_CLASSES = {
+    "nano": RFDETRNano,
 }
 
 
@@ -49,31 +38,6 @@ class CocoDetectionWithTargets(CocoDetection):
         return img, target
 
 
-def _download_and_extract(url: str, dest_dir: Path) -> None:
-    dest_dir.mkdir(parents=True, exist_ok=True)
-    zip_path = dest_dir / url.rsplit("/", 1)[-1]
-    print(f"Downloading {url} ...")
-    urlretrieve(url, str(zip_path))
-    print(f"Extracting {zip_path} ...")
-    with zipfile.ZipFile(str(zip_path), "r") as zf:
-        zf.extractall(str(dest_dir))
-    zip_path.unlink()
-
-
-@pytest.fixture(scope="session")
-def download_coco_val() -> tuple[Path, Path]:
-    """Download COCO val2017 images and annotations if not already present."""
-    images_root = DATA_DIR / "val2017"
-    annotations_path = DATA_DIR / "annotations" / "instances_val2017.json"
-
-    if not images_root.exists():
-        _download_and_extract(_COCO_URLS["val2017"], DATA_DIR)
-    if not annotations_path.exists():
-        _download_and_extract(_COCO_URLS["annotations"], DATA_DIR)
-
-    return images_root, annotations_path
-
-
 @pytest.mark.gpu
 def test_coco_inference_benchmark(
     download_coco_val: tuple[Path, Path],
@@ -82,13 +46,13 @@ def test_coco_inference_benchmark(
     threshold_map50: float = 0.45,
     threshold_f1: float = 0.30,
 ) -> None:
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = "cuda" if torch.cuda.is_available() else "cpu"
     images_root, annotations_path = download_coco_val
 
-    config_cls = _MODEL_CONFIGS[model_size]
-    config = config_cls(device=device.type)
-    model_wrapper = Model(**config.dict())
-    args = model_wrapper.args
+    model_cls = _MODEL_CLASSES[model_size]
+    rfdetr = model_cls(device=device)
+    config = rfdetr.model_config
+    args = rfdetr.model.args
 
     transforms = make_coco_transforms(
         image_set="val",
@@ -108,11 +72,11 @@ def test_coco_inference_benchmark(
     base_ds = get_coco_api_from_dataset(val_dataset)
     criterion, postprocess = build_criterion_and_postprocessors(args)
 
-    model_wrapper.model.eval()
+    rfdetr.model.model.eval()
     with torch.no_grad():
         stats, _ = evaluate(
-            model_wrapper.model, criterion, postprocess,
-            data_loader, base_ds, device, args=args,
+            rfdetr.model.model, criterion, postprocess,
+            data_loader, base_ds, torch.device(device), args=args,
         )
 
     results = stats["results_json"]

--- a/tests/benchmarks/test_coco_inference.py
+++ b/tests/benchmarks/test_coco_inference.py
@@ -5,14 +5,14 @@
 # ------------------------------------------------------------------------
 import os
 from pathlib import Path
+from typing import Optional
 
 import pytest
 import torch
-from torchvision.datasets import CocoDetection
 
 from rfdetr import RFDETRNano
 from rfdetr.datasets import get_coco_api_from_dataset
-from rfdetr.datasets.coco import ConvertCoco, make_coco_transforms_square_div_64
+from rfdetr.datasets.coco import CocoDetection, make_coco_transforms_square_div_64
 from rfdetr.engine import evaluate
 from rfdetr.models import build_criterion_and_postprocessors
 from rfdetr.util import misc as utils
@@ -22,28 +22,13 @@ _MODEL_CLASSES = {
 }
 
 
-class CocoDetectionWithTargets(CocoDetection):
-    def __init__(self, img_folder: Path, ann_file: Path, transforms) -> None:
-        super().__init__(root=str(img_folder), annFile=str(ann_file))
-        self._transforms = transforms
-        self.prepare = ConvertCoco(include_masks=False)
-
-    def __getitem__(self, idx: int):
-        img, target = super().__getitem__(idx)
-        image_id = self.ids[idx]
-        target = {"image_id": image_id, "annotations": target}
-        img, target = self.prepare(img, target)
-        if self._transforms is not None:
-            img, target = self._transforms(img, target)
-        return img, target
-
-
 @pytest.mark.gpu
 def test_coco_inference_benchmark(
     download_coco_val: tuple[Path, Path],
     model_size: str = "nano",
     threshold_map: float = 0.65,
     threshold_f1: float = 0.65,
+    num_samples: Optional[int] = None,
 ) -> None:
     device = "cuda" if torch.cuda.is_available() else "cpu"
     images_root, annotations_path = download_coco_val
@@ -61,7 +46,9 @@ def test_coco_inference_benchmark(
         patch_size=config.patch_size,
         num_windows=config.num_windows,
     )
-    val_dataset = CocoDetectionWithTargets(images_root, annotations_path, transforms=transforms)
+    val_dataset = CocoDetection(images_root, annotations_path, transforms=transforms)
+    if num_samples is not None:
+        val_dataset = torch.utils.data.Subset(val_dataset, list(range(min(num_samples, len(val_dataset)))))
     data_loader = torch.utils.data.DataLoader(
         val_dataset,
         batch_size=4,

--- a/tests/benchmarks/test_coco_inference.py
+++ b/tests/benchmarks/test_coco_inference.py
@@ -1,0 +1,87 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+from pathlib import Path
+
+import pytest
+import torch
+from torchvision.datasets import CocoDetection
+
+from rfdetr.config import RFDETRNanoConfig
+from rfdetr.datasets import get_coco_api_from_dataset
+from rfdetr.datasets.coco import ConvertCoco, make_coco_transforms
+from rfdetr.engine import evaluate
+from rfdetr.main import Model
+from rfdetr.models import build_criterion_and_postprocessors
+from rfdetr.util import misc as utils
+
+
+class CocoDetectionWithTargets(CocoDetection):
+    def __init__(self, img_folder: Path, ann_file: Path, transforms) -> None:
+        super().__init__(root=str(img_folder), annFile=str(ann_file))
+        self._transforms = transforms
+        self.prepare = ConvertCoco(include_masks=False)
+
+    def __getitem__(self, idx: int):
+        img, target = super().__getitem__(idx)
+        image_id = self.ids[idx]
+        target = {"image_id": image_id, "annotations": target}
+        img, target = self.prepare(img, target)
+        if self._transforms is not None:
+            img, target = self._transforms(img, target)
+        return img, target
+
+
+def _project_coco_paths(project_root: Path) -> tuple[Path, Path, Path]:
+    images_root = project_root / "val2017"
+    annotations_path = project_root / "annotations" / "instances_val2017.json"
+    weights_path = project_root / "rf-detr-nano.pth"
+    return images_root, annotations_path, weights_path
+
+
+def _require_paths(*paths: Path) -> None:
+    missing = [path for path in paths if not path.exists()]
+    if missing:
+        missing_list = ", ".join(str(path) for path in missing)
+        pytest.skip(f"COCO assets missing: {missing_list}")
+
+
+def test_coco_inference_benchmark() -> None:
+    project_root = Path(__file__).resolve().parents[2]
+    images_root, annotations_path, weights_path = _project_coco_paths(project_root)
+    _require_paths(images_root, annotations_path, weights_path)
+
+    config = RFDETRNanoConfig(pretrain_weights=str(weights_path), device="cpu")
+    model_wrapper = Model(**config.dict())
+    args = model_wrapper.args
+    if not hasattr(args, "eval_max_dets"):
+        args.eval_max_dets = 500
+
+    transforms = make_coco_transforms(
+        image_set="val",
+        resolution=config.resolution,
+        patch_size=config.patch_size,
+        num_windows=config.num_windows,
+    )
+    val_dataset = CocoDetectionWithTargets(images_root, annotations_path, transforms=transforms)
+    print(f"Loaded {len(val_dataset)} images for evaluation.")
+
+    data_loader = torch.utils.data.DataLoader(
+        val_dataset,
+        batch_size=1,
+        sampler=torch.utils.data.SequentialSampler(val_dataset),
+        drop_last=False,
+        collate_fn=utils.collate_fn,
+        num_workers=0,
+    )
+    base_ds = get_coco_api_from_dataset(val_dataset)
+
+    criterion, postprocess = build_criterion_and_postprocessors(args)
+    device = torch.device("cpu")
+    model_wrapper.model.eval()
+    with torch.no_grad():
+        stats, _ = evaluate(model_wrapper.model, criterion, postprocess, data_loader, base_ds, device, args=args)
+
+    assert "results_json" in stats, "COCO evaluation did not return JSON metrics."

--- a/tests/benchmarks/test_coco_inference.py
+++ b/tests/benchmarks/test_coco_inference.py
@@ -12,7 +12,7 @@ from torchvision.datasets import CocoDetection
 
 from rfdetr import RFDETRNano
 from rfdetr.datasets import get_coco_api_from_dataset
-from rfdetr.datasets.coco import ConvertCoco, make_coco_transforms
+from rfdetr.datasets.coco import ConvertCoco, make_coco_transforms_square_div_64
 from rfdetr.engine import evaluate
 from rfdetr.models import build_criterion_and_postprocessors
 from rfdetr.util import misc as utils
@@ -42,9 +42,8 @@ class CocoDetectionWithTargets(CocoDetection):
 def test_coco_inference_benchmark(
     download_coco_val: tuple[Path, Path],
     model_size: str = "nano",
-    threshold_map: float = 0.30,
-    threshold_map50: float = 0.45,
-    threshold_f1: float = 0.30,
+    threshold_map: float = 0.65,
+    threshold_f1: float = 0.65,
 ) -> None:
     device = "cuda" if torch.cuda.is_available() else "cpu"
     images_root, annotations_path = download_coco_val
@@ -53,8 +52,10 @@ def test_coco_inference_benchmark(
     rfdetr = model_cls(device=device)
     config = rfdetr.model_config
     args = rfdetr.model.args
+    if not hasattr(args, "eval_max_dets"):
+        args.eval_max_dets = 500
 
-    transforms = make_coco_transforms(
+    transforms = make_coco_transforms_square_div_64(
         image_set="val",
         resolution=config.resolution,
         patch_size=config.patch_size,
@@ -81,11 +82,9 @@ def test_coco_inference_benchmark(
 
     results = stats["results_json"]
     map_val = results["map"]
-    map50_val = results["map50"]
     f1_val = results["f1_score"]
 
-    assert map_val >= threshold_map, f"mAP {map_val:.4f} < {threshold_map}"
-    assert map50_val >= threshold_map50, f"mAP50 {map50_val:.4f} < {threshold_map50}"
-    assert f1_val >= threshold_f1, f"F1 {f1_val:.4f} < {threshold_f1}"
+    print(f"COCO val2017 [{model_size}]: mAP@50={map_val:.4f}, F1={f1_val:.4f}")
 
-    print(f"COCO val2017 [{model_size}]: mAP={map_val:.4f}, mAP50={map50_val:.4f}, F1={f1_val:.4f}")
+    assert map_val >= threshold_map, f"mAP@50 {map_val:.4f} < {threshold_map}"
+    assert f1_val >= threshold_f1, f"F1 {f1_val:.4f} < {threshold_f1}"


### PR DESCRIPTION
This pull request introduces a new benchmark test for COCO inference, specifically targeting the RF-DETR Nano model. The test ensures that the required assets are present, loads the validation dataset, applies the necessary transformations, and runs evaluation to verify that the expected metrics are produced. This addition enhances the test coverage for model inference and evaluation.

New COCO inference benchmark test:

* Added `test_coco_inference_benchmark` to `tests/benchmarks/test_coco_inference.py`, which loads COCO validation images, applies RF-DETR-specific transforms, and evaluates the model, asserting the presence of JSON metrics in the results.

Utility and dataset handling improvements:

* Introduced `CocoDetectionWithTargets` class to wrap COCO images and targets with proper transformation and annotation handling for evaluation.
* Added helper functions `_project_coco_paths` and `_require_paths` to manage asset paths and skip tests if required files are missing.