### PR TITLE
Stabilize training tests & centralize seed logic with `seed_all` utility

### DIFF
--- a/rfdetr/util/utils.py
+++ b/rfdetr/util/utils.py
@@ -154,9 +154,10 @@ def seed_all(seed: int = 7) -> None:
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
-    torch.cuda.manual_seed_all(seed)
-    torch.backends.cudnn.deterministic = True
-    torch.backends.cudnn.benchmark = False
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
 
 
 def clean_state_dict(state_dict: Dict[str, Any]) -> OrderedDict[str, Any]:

--- a/rfdetr/util/utils.py
+++ b/rfdetr/util/utils.py
@@ -6,10 +6,12 @@
 
 import json
 import math
+import random
 from collections import OrderedDict
 from copy import deepcopy
 from typing import Any, Callable, Dict, Optional, Union
 
+import numpy as np
 import torch
 
 
@@ -136,6 +138,25 @@ class BestMetricHolder():
 
     def __str__(self) -> str:
         return self.__repr__()
+
+
+def seed_all(seed: int = 7) -> None:
+    """Seed all random number generators for reproducibility.
+
+    Sets seeds for Python's ``random`` module, NumPy, and PyTorch (CPU and all
+    CUDA devices).  Also configures cuDNN to use deterministic algorithms and
+    disables its auto-tuner so that results are reproducible across runs at the
+    cost of a possible slight performance decrease.
+
+    Args:
+        seed: Integer seed value.  Defaults to ``7``.
+    """
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
 
 
 def clean_state_dict(state_dict: Dict[str, Any]) -> OrderedDict[str, Any]:

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -3,16 +3,14 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-import random
 import shutil
 from pathlib import Path
 from typing import Any, Generator
 
-import numpy as np
 import pytest
-import torch
 
 from rfdetr.datasets.synthetic import DatasetSplitRatios, generate_coco_dataset
+from rfdetr.util.utils import seed_all
 
 
 @pytest.fixture(autouse=True)
@@ -25,14 +23,12 @@ def seed_everything(request: pytest.FixtureRequest) -> None:
         def test_foo(seed_everything): ...
     """
     seed = request.param if hasattr(request, "param") else 7
-    random.seed(seed)
-    np.random.seed(seed)
-    torch.manual_seed(seed)
-    torch.cuda.manual_seed_all(seed)
+    seed_all(seed)
 
 
 @pytest.fixture(scope="session")
 def synthetic_shape_dataset_dir(tmp_path_factory: pytest.TempPathFactory) -> Generator[Path, Any, None]:
+    seed_all()
     dataset_dir = tmp_path_factory.mktemp("synthetic_dataset")
     generate_coco_dataset(
         output_dir=str(dataset_dir),

--- a/tests/benchmarks/test_synthetic_convergence.py
+++ b/tests/benchmarks/test_synthetic_convergence.py
@@ -49,6 +49,8 @@ def test_synthetic_training_improves_performance(
     train_config = {
         **vars(args),
         "lr": 1e-3,
+        "warmup_epochs": 1.0,
+        "multi_scale": False,
         "dont_save_weights": False,
         "min_batches": 2,
         "run_test": False,


### PR DESCRIPTION
This pull request focuses on improving reproducibility and code maintainability in the test and utility modules. The main change is the introduction of a centralized `seed_all` utility function to seed all relevant random number generators, which is now used throughout the codebase to ensure consistent results across runs. Additionally, some minor configuration parameters were updated in the synthetic training test.

**Reproducibility and random seed management:**

* Added a `seed_all` function to `rfdetr/util/utils.py` that seeds Python's `random`, NumPy, and PyTorch (CPU and CUDA) random number generators, and configures cuDNN for deterministic behavior.
* Updated test fixtures in `tests/benchmarks/conftest.py` to use the new `seed_all` function instead of duplicating seeding logic, improving maintainability and consistency.
* Removed direct imports of `random`, `numpy`, and `torch` from `tests/benchmarks/conftest.py` since seeding is now handled by `seed_all`.
* Ensured the synthetic dataset fixture also calls `seed_all` for reproducibility.

**Test configuration improvements:**

* Updated the synthetic training test configuration in `tests/benchmarks/test_synthetic_convergence.py` to set `warmup_epochs` to 1.0 and disable `multi_scale` augmentation, likely to improve test determinism or speed.