### PR TITLE
enable test parallelization in CI with `pytest-xdist`

### DIFF
--- a/.github/workflows/ci-tests-cpu.yml
+++ b/.github/workflows/ci-tests-cpu.yml
@@ -49,7 +49,7 @@ jobs:
         run: uv pip install -e . --group tests
 
       - name: 🧪 Run the Test
-        run: uv run pytest -m "not gpu" --cov=rfdetr --cov-report=xml
+        run: uv run pytest -n 2 -m "not gpu" --cov=rfdetr --cov-report=xml
 
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/ci-tests-gpu.yml
+++ b/.github/workflows/ci-tests-gpu.yml
@@ -40,7 +40,7 @@ jobs:
         run: uv pip install -e . --group tests
 
       - name: 🧪 Run the Test
-        run: uv run pytest -m gpu --cov=rfdetr --cov-report=xml
+        run: uv run pytest -n 2 -m gpu --cov=rfdetr --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ build = [
 tests = [
   "pytest>=7.2.2,<9",
   "pytest-cov>=4,<8",
+  "pytest-xdist>=3.6.1,<4",
 ]
 
 docs = [


### PR DESCRIPTION
This pull request improves the test workflow by enabling parallel test execution using pytest-xdist. The main changes are to the CI configuration and dependencies, which will help reduce test run times for both CPU and GPU test jobs.

**CI/CD improvements:**

* Updated both `.github/workflows/ci-tests-cpu.yml` and `.github/workflows/ci-tests-gpu.yml` to run tests in parallel using `pytest -n 2`, enabling two concurrent test processes for faster execution. [[1]](diffhunk://#diff-24e5f388bcbc626b2144002ef6a3ab8c25849453349172f1e287a82756bf1a71L52-R52) [[2]](diffhunk://#diff-53209bae0cc403f683dfba167d31dbf56132fe37cca436a436c8723bb9fed7e2L43-R43)

**Dependency management:**

* Added `pytest-xdist` to the `tests` dependencies in `pyproject.toml` to support parallel test execution.