### PR TITLE
Add testing of `rfdetr_plus` models in COCO inference benchmarks

### DIFF
--- a/.github/workflows/ci-tests-cpu.yml
+++ b/.github/workflows/ci-tests-cpu.yml
@@ -1,4 +1,4 @@
-name: CPU/tests Workflow
+name: CPU tests Workflow
 
 on:
   push:

--- a/.github/workflows/ci-tests-cpu.yml
+++ b/.github/workflows/ci-tests-cpu.yml
@@ -24,7 +24,7 @@ jobs:
     uses: ./.github/workflows/build-package.yml
 
   run-tests:
-    name: Pytest Run
+    name: Testing
     # needs: build  # todo: consider using this build package for testing
     timeout-minutes: 10
     strategy:

--- a/.github/workflows/ci-tests-cpu.yml
+++ b/.github/workflows/ci-tests-cpu.yml
@@ -1,4 +1,4 @@
-name: Pytest/Test Workflow
+name: CPU/tests Workflow
 
 on:
   push:

--- a/.github/workflows/ci-tests-gpu.yml
+++ b/.github/workflows/ci-tests-gpu.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   run-gpu-tests:
-    name: GPU Pytest Run
+    name: Testing
     if: github.event_name == 'push' || !github.event.pull_request.draft
     timeout-minutes: 20
     runs-on: Roboflow-GPU-VM-Runner

--- a/.github/workflows/ci-tests-gpu.yml
+++ b/.github/workflows/ci-tests-gpu.yml
@@ -44,7 +44,7 @@ jobs:
           activate-environment: true
 
       - name: 🚀 Install Packages
-        run: uv sync --group tests --extra onnxexport # --extra plus
+        run: uv sync --group tests --extra onnxexport --extra plus
 
       - name: 🧪 Run the Test
         run: uv run --no-sync pytest tests/ -n 3 -m gpu --cov=rfdetr --cov-report=xml

--- a/.github/workflows/ci-tests-gpu.yml
+++ b/.github/workflows/ci-tests-gpu.yml
@@ -1,4 +1,4 @@
-name: GPU/tests Workflow
+name: GPU tests Workflow
 
 on:
   push:

--- a/.github/workflows/ci-tests-gpu.yml
+++ b/.github/workflows/ci-tests-gpu.yml
@@ -1,4 +1,4 @@
-name: GPU Pytest/Test Workflow
+name: GPU/tests Workflow
 
 on:
   push:

--- a/src/rfdetr/platform/platform_downloads.py
+++ b/src/rfdetr/platform/platform_downloads.py
@@ -6,18 +6,21 @@
 
 try:
     from rfdetr_plus.models.downloads import _PLATFORM_MODELS as PLATFORM_MODELS
-except ImportError as ex:
-    missing_name = getattr(ex, "name", "")
-    if missing_name.startswith("rfdetr_plus") or "rfdetr_plus" in str(ex):
-        import warnings
+except ImportError:
+    try:
+        from rfdetr_plus.models.downloads import PLATFORM_MODELS
+    except ImportError as ex:
+        missing_name = getattr(ex, "name", "")
+        if missing_name.startswith("rfdetr_plus") or "rfdetr_plus" in str(ex):
+            import warnings
 
-        from rfdetr.platform import _INSTALL_MSG
+            from rfdetr.platform import _INSTALL_MSG
 
-        warnings.warn(
-            _INSTALL_MSG.format(name="platform model downloads"),
-            ImportWarning,
-            stacklevel=2,
-        )
-        PLATFORM_MODELS = {}
-    else:
-        raise
+            warnings.warn(
+                _INSTALL_MSG.format(name="platform model downloads"),
+                ImportWarning,
+                stacklevel=2,
+            )
+            PLATFORM_MODELS = {}
+        else:
+            raise

--- a/src/rfdetr/platform/platform_downloads.py
+++ b/src/rfdetr/platform/platform_downloads.py
@@ -5,7 +5,12 @@
 # ------------------------------------------------------------------------
 
 try:
-    from rfdetr_plus.models.downloads import _PLATFORM_MODELS as PLATFORM_MODELS
+    from rfdetr_plus.models import downloads as _downloads
+
+    try:
+        PLATFORM_MODELS = _downloads._PLATFORM_MODELS
+    except AttributeError:
+        PLATFORM_MODELS = _downloads.PLATFORM_MODELS
 except ImportError:
     try:
         from rfdetr_plus.models.downloads import PLATFORM_MODELS

--- a/tests/benchmarks/test_coco_inference.py
+++ b/tests/benchmarks/test_coco_inference.py
@@ -3,14 +3,13 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
+import importlib.util
 import os
 from pathlib import Path
 from typing import Optional
 
 import pytest
 import torch
-
-import importlib.util
 
 from rfdetr import RFDETRLarge, RFDETRMedium, RFDETRNano, RFDETRSmall
 from rfdetr.datasets import get_coco_api_from_dataset

--- a/tests/benchmarks/test_coco_inference.py
+++ b/tests/benchmarks/test_coco_inference.py
@@ -28,7 +28,9 @@ if _PLUS_AVAILABLE:
         RFDETRXLarge_accepted_PML = partial(RFDETRXLarge, accept_platform_model_license=True)
         RFDETR2XLarge_accepted_PML = partial(RFDETR2XLarge, accept_platform_model_license=True)
     except ImportError:
-        raise
+        _PLUS_AVAILABLE = False
+        RFDETRXLarge_accepted_PML = None
+        RFDETR2XLarge_accepted_PML = None
 else:
     RFDETRXLarge_accepted_PML = None
     RFDETR2XLarge_accepted_PML = None

--- a/tests/benchmarks/test_coco_inference.py
+++ b/tests/benchmarks/test_coco_inference.py
@@ -10,14 +10,7 @@ from typing import Optional
 import pytest
 import torch
 
-from rfdetr import (
-    # RFDETR2XLarge,
-    RFDETRLarge,
-    RFDETRMedium,
-    RFDETRNano,
-    RFDETRSmall,
-    # RFDETRXLarge,
-)
+from rfdetr import RFDETRLarge, RFDETRMedium, RFDETRNano, RFDETRSmall
 from rfdetr.datasets import get_coco_api_from_dataset
 from rfdetr.datasets.coco import CocoDetection, make_coco_transforms_square_div_64
 from rfdetr.detr import RFDETR
@@ -26,17 +19,30 @@ from rfdetr.models import build_criterion_and_postprocessors
 from rfdetr.util import misc as utils
 
 
+try:
+    from rfdetr import RFDETR2XLarge, RFDETRXLarge
+except ImportError:
+    RFDETRXLarge = None
+    RFDETR2XLarge = None
+    _PLUS_AVAILABLE = False
+else:
+    _PLUS_AVAILABLE = True
+
+_PLUS_SKIP = pytest.mark.skipif(not _PLUS_AVAILABLE, reason="requires rfdetr_plus models")
+
+_BASE_PARAMS = [
+    pytest.param(RFDETRNano, 0.65, 0.65, None, id="nano"),
+    pytest.param(RFDETRSmall, 0.65, 0.65, 500, id="small"),
+    pytest.param(RFDETRMedium, 0.65, 0.65, 500, id="medium"),
+    pytest.param(RFDETRLarge, 0.65, 0.65, 500, id="large"),
+    pytest.param(RFDETRXLarge, 0.65, 0.65, 500, id="xlarge", marks=_PLUS_SKIP),
+    pytest.param(RFDETR2XLarge, 0.65, 0.65, 500, id="2xlarge", marks=_PLUS_SKIP),
+]
+
 @pytest.mark.gpu
 @pytest.mark.parametrize(
     ("model_cls", "threshold_map", "threshold_f1", "num_samples"),
-    [
-        pytest.param(RFDETRNano, 0.65, 0.65, None, id="nano"),
-        pytest.param(RFDETRSmall, 0.65, 0.65, 500, id="small"),
-        pytest.param(RFDETRMedium, 0.65, 0.65, 500, id="medium"),
-        pytest.param(RFDETRLarge, 0.65, 0.65, 500, id="large"),
-        # pytest.param(RFDETRXLarge, 0.65, 0.65, 500, id="xlarge"),
-        # pytest.param(RFDETR2XLarge, 0.65, 0.65, 500, id="2xlarge"),
-    ],
+    _BASE_PARAMS,
 )
 def test_coco_inference_benchmark(
     download_coco_val: tuple[Path, Path],

--- a/tests/benchmarks/test_coco_inference.py
+++ b/tests/benchmarks/test_coco_inference.py
@@ -5,6 +5,7 @@
 # ------------------------------------------------------------------------
 import importlib.util
 import os
+from functools import partial
 from pathlib import Path
 from typing import Optional
 
@@ -23,27 +24,33 @@ _PLUS_AVAILABLE = importlib.util.find_spec("rfdetr_plus") is not None
 if _PLUS_AVAILABLE:
     try:
         from rfdetr import RFDETR2XLarge, RFDETRXLarge
+
+        RFDETRXLarge_accepted_PML = partial(RFDETRXLarge, accept_platform_model_license=True)
+        RFDETR2XLarge_accepted_PML = partial(RFDETR2XLarge, accept_platform_model_license=True)
     except ImportError:
         raise
 else:
-    RFDETRXLarge = None
-    RFDETR2XLarge = None
+    RFDETRXLarge_accepted_PML = None
+    RFDETR2XLarge_accepted_PML = None
 
 _PLUS_SKIP = pytest.mark.skipif(not _PLUS_AVAILABLE, reason="requires rfdetr_plus models")
 
-_BASE_PARAMS = [
-    pytest.param(RFDETRNano, 0.65, 0.65, None, id="nano"),
-    pytest.param(RFDETRSmall, 0.65, 0.65, 500, id="small"),
-    pytest.param(RFDETRMedium, 0.65, 0.65, 500, id="medium"),
-    pytest.param(RFDETRLarge, 0.65, 0.65, 500, id="large"),
-    pytest.param(RFDETRXLarge, 0.65, 0.65, 500, id="xlarge", marks=_PLUS_SKIP),
-    pytest.param(RFDETR2XLarge, 0.65, 0.65, 500, id="2xlarge", marks=_PLUS_SKIP),
-]
 
 @pytest.mark.gpu
 @pytest.mark.parametrize(
     ("model_cls", "threshold_map", "threshold_f1", "num_samples"),
-    _BASE_PARAMS,
+    [
+        pytest.param(RFDETRNano, 0.65, 0.65, None, id="nano"),
+        pytest.param(RFDETRSmall, 0.65, 0.65, 500, id="small"),
+        pytest.param(RFDETRMedium, 0.65, 0.65, 500, id="medium"),
+        pytest.param(RFDETRLarge, 0.65, 0.65, 500, id="large"),
+        pytest.param(
+            RFDETRXLarge_accepted_PML, 0.65, 0.65, 500, id="xlarge", marks=_PLUS_SKIP,
+        ),
+        pytest.param(
+            RFDETR2XLarge_accepted_PML, 0.65, 0.65, 500, id="2xlarge", marks=_PLUS_SKIP,
+        ),
+    ],
 )
 def test_coco_inference_benchmark(
     download_coco_val: tuple[Path, Path],

--- a/tests/benchmarks/test_coco_inference.py
+++ b/tests/benchmarks/test_coco_inference.py
@@ -10,6 +10,8 @@ from typing import Optional
 import pytest
 import torch
 
+import importlib.util
+
 from rfdetr import RFDETRLarge, RFDETRMedium, RFDETRNano, RFDETRSmall
 from rfdetr.datasets import get_coco_api_from_dataset
 from rfdetr.datasets.coco import CocoDetection, make_coco_transforms_square_div_64
@@ -18,14 +20,15 @@ from rfdetr.engine import evaluate
 from rfdetr.models import build_criterion_and_postprocessors
 from rfdetr.util import misc as utils
 
-try:
-    from rfdetr import RFDETR2XLarge, RFDETRXLarge
-except ImportError:
+_PLUS_AVAILABLE = importlib.util.find_spec("rfdetr_plus") is not None
+if _PLUS_AVAILABLE:
+    try:
+        from rfdetr import RFDETR2XLarge, RFDETRXLarge
+    except ImportError:
+        raise
+else:
     RFDETRXLarge = None
     RFDETR2XLarge = None
-    _PLUS_AVAILABLE = False
-else:
-    _PLUS_AVAILABLE = True
 
 _PLUS_SKIP = pytest.mark.skipif(not _PLUS_AVAILABLE, reason="requires rfdetr_plus models")
 

--- a/tests/benchmarks/test_coco_inference.py
+++ b/tests/benchmarks/test_coco_inference.py
@@ -18,7 +18,6 @@ from rfdetr.engine import evaluate
 from rfdetr.models import build_criterion_and_postprocessors
 from rfdetr.util import misc as utils
 
-
 try:
     from rfdetr import RFDETR2XLarge, RFDETRXLarge
 except ImportError:


### PR DESCRIPTION
This pull request updates the COCO inference benchmark tests to conditionally include the `RFDETRXLarge` and `RFDETR2XLarge` models only if they are available, improving test robustness and flexibility. It also streamlines the import statements and refactors the test parameterization for clarity.

Test improvements for optional models:

* Added conditional imports for `RFDETRXLarge` and `RFDETR2XLarge`, skipping related tests if these models are not available, which prevents import errors when the "plus" models are missing.
* Updated the test parameterization to use `pytest.param` with conditional skipping for the "plus" models, ensuring tests only run when supported.

Code cleanup:

* Simplified the import statement for model classes by removing commented-out imports and only importing available models.