### PR TITLE
feat: step-based seg validation callback with per-class mAP50

### DIFF
--- a/scripts/train_vmi_mrf_seg2x.py
+++ b/scripts/train_vmi_mrf_seg2x.py
@@ -1,0 +1,88 @@
+"""Train RF-DETR segmentation on vmi_mrf with step-based validation callbacks."""
+
+import argparse
+from pathlib import Path
+
+from rfdetr import RFDETRSeg2XLarge
+from rfdetr.util.logger import get_logger
+
+logger = get_logger()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train RF-DETR-Seg-2XL on vmi_mrf")
+    parser.add_argument(
+        "--dataset-dir",
+        type=str,
+        required=True,
+        help="Path to Roboflow-style COCO dataset containing train/valid/test folders",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="output/vmi_mrf/rfdetr_seg_2xl",
+        help="Directory where checkpoints and metrics are saved",
+    )
+    parser.add_argument("--resolution", type=int, default=768, help="Square train/val resolution")
+    parser.add_argument("--epochs", type=int, default=100)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--grad-accum-steps", type=int, default=4)
+    parser.add_argument("--num-workers", type=int, default=4)
+    parser.add_argument("--lr", type=float, default=1e-4)
+    parser.add_argument("--lr-encoder", type=float, default=1.5e-4)
+    parser.add_argument("--weight-decay", type=float, default=1e-4)
+    parser.add_argument(
+        "--checkpoint-interval",
+        type=int,
+        default=10,
+        help="Save checkpoint every N epochs",
+    )
+    parser.add_argument(
+        "--val-interval-steps",
+        type=int,
+        default=200,
+        help="Run validation callback every N global training steps",
+    )
+    parser.add_argument("--run-test", action="store_true", help="Run test split evaluation at train end")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.resolution % 12 != 0:
+        raise ValueError(
+            f"resolution must be divisible by 12 for RFDETRSeg2XLarge, got {args.resolution}"
+        )
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    logger.info(
+        "Starting vmi_mrf segmentation training with RFDETRSeg2XLarge at fixed resolution "
+        f"{args.resolution} (no multiscale)."
+    )
+
+    model = RFDETRSeg2XLarge(resolution=args.resolution)
+    model.train(
+        dataset_file="roboflow",
+        dataset_dir=args.dataset_dir,
+        output_dir=str(output_dir),
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        grad_accum_steps=args.grad_accum_steps,
+        num_workers=args.num_workers,
+        lr=args.lr,
+        lr_encoder=args.lr_encoder,
+        weight_decay=args.weight_decay,
+        checkpoint_interval=args.checkpoint_interval,
+        val_interval_steps=args.val_interval_steps,
+        run_test=args.run_test,
+        # Keep train and validation at the same resolution for this first experiment.
+        multi_scale=False,
+        expanded_scales=False,
+        do_random_resize_via_padding=False,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_vmi_mrf_seg2x.py
+++ b/scripts/train_vmi_mrf_seg2x.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
 """Train RF-DETR segmentation on vmi_mrf with step-based validation callbacks."""
 
 import argparse

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -250,6 +250,7 @@ class TrainConfig(BaseModel):
     ema_tau: int = 100
     lr_drop: int = 100
     checkpoint_interval: int = 10
+    val_interval_steps: int = 0
     warmup_epochs: float = 0.0
     lr_vit_layer_decay: float = 0.8
     lr_component_decay: float = 0.7

--- a/src/rfdetr/engine.py
+++ b/src/rfdetr/engine.py
@@ -452,12 +452,16 @@ def evaluate(model, criterion, postprocess, data_loader, base_ds, device, args=N
         coco_evaluator.summarize()
     stats = {k: meter.global_avg for k, meter in metric_logger.meters.items()}
     if coco_evaluator is not None:
-        results_json = coco_extended_metrics(coco_evaluator.coco_eval["bbox"])
-        stats["results_json"] = results_json
+        bbox_results_json = coco_extended_metrics(coco_evaluator.coco_eval["bbox"])
+        stats["results_json_bbox"] = bbox_results_json
+        stats["results_json"] = bbox_results_json
         if "bbox" in iou_types:
             stats["coco_eval_bbox"] = coco_evaluator.coco_eval["bbox"].stats.tolist()
 
         if "segm" in iou_types:
-            results_json = coco_extended_metrics(coco_evaluator.coco_eval["segm"])
+            segm_results_json = coco_extended_metrics(coco_evaluator.coco_eval["segm"])
+            stats["results_json_masks"] = segm_results_json
+            # Keep `results_json` aligned with the primary validation task.
+            stats["results_json"] = segm_results_json
             stats["coco_eval_masks"] = coco_evaluator.coco_eval["segm"].stats.tolist()
     return stats, coco_evaluator

--- a/src/rfdetr/main.py
+++ b/src/rfdetr/main.py
@@ -29,7 +29,7 @@ import time
 import warnings
 from copy import deepcopy
 from pathlib import Path
-from typing import Callable, DefaultDict, List
+from typing import Any, Callable, DefaultDict, Dict, List
 
 import numpy as np
 import torch
@@ -74,6 +74,26 @@ OPEN_SOURCE_MODELS = {
     "rf-detr-seg-xlarge.pt": "https://storage.googleapis.com/rfdetr/rf-detr-seg-xl-ft.pth",
     "rf-detr-seg-xxlarge.pt": "https://storage.googleapis.com/rfdetr/rf-detr-seg-2xl-ft.pth",
 }
+
+
+def _extract_per_class_map50(results_json: Dict[str, Any]) -> Dict[str, float]:
+    per_class_map50: Dict[str, float] = {}
+    class_map_entries = results_json.get("class_map", [])
+    for class_entry in class_map_entries:
+        class_name = class_entry.get("class")
+        class_map50 = class_entry.get("map@50")
+        if class_name in [None, "all"] or class_map50 is None:
+            continue
+        per_class_map50[str(class_name)] = float(class_map50)
+    return per_class_map50
+
+
+def _extract_overall_map50_95(results_json: Dict[str, Any]) -> float:
+    class_map_entries = results_json.get("class_map", [])
+    for class_entry in class_map_entries:
+        if class_entry.get("class") == "all":
+            return float(class_entry.get("map@50:95", 0.0))
+    return 0.0
 
 def download_pretrain_weights(pretrain_weights: str, redownload=False):
     HOSTED_MODELS = {**OPEN_SOURCE_MODELS}
@@ -352,6 +372,76 @@ class Model:
                 else:
                     save_on_master(coco_evaluator.coco_eval["segm"].eval, output_dir / "eval.pth")
             return
+
+        val_interval_steps = int(getattr(args, "val_interval_steps", 0) or 0)
+        if val_interval_steps < 0:
+            raise ValueError(f"val_interval_steps must be >= 0, got {val_interval_steps}")
+
+        if val_interval_steps > 0:
+            step_val_metrics_path = output_dir / "step_val_metrics.jsonl"
+            last_step_validation = -1
+
+            def _step_validation_callback(callback_dict):
+                nonlocal last_step_validation
+                step = int(callback_dict["step"])
+                epoch = int(callback_dict["epoch"])
+
+                if step <= 0:
+                    return
+                if step == last_step_validation:
+                    return
+                if step % val_interval_steps != 0:
+                    return
+
+                logger.info(f"Running validation callback at step={step}, epoch={epoch}")
+                try:
+                    with torch.no_grad():
+                        step_test_stats, _ = evaluate(
+                            callback_dict["model"],
+                            criterion,
+                            postprocess,
+                            data_loader_val,
+                            base_ds,
+                            device,
+                            args=args,
+                        )
+
+                    if args.segmentation_head:
+                        results_json = step_test_stats.get("results_json_masks", step_test_stats["results_json"])
+                    else:
+                        results_json = step_test_stats.get("results_json_bbox", step_test_stats["results_json"])
+
+                    map50 = float(results_json.get("map", 0.0))
+                    map50_95 = _extract_overall_map50_95(results_json)
+                    per_class_map50 = _extract_per_class_map50(results_json)
+                    step_validation_metrics = {
+                        "step": step,
+                        "epoch": epoch,
+                        "metric_type": "segm" if args.segmentation_head else "bbox",
+                        "map50": map50,
+                        "map50_95": map50_95,
+                        "per_class_map50": per_class_map50,
+                    }
+
+                    if is_main_process():
+                        step_val_metrics_path.parent.mkdir(parents=True, exist_ok=True)
+                        with step_val_metrics_path.open("a") as f:
+                            f.write(json.dumps(step_validation_metrics) + "\n")
+
+                    logger.info(
+                        f"Step validation summary: step={step}, map50={map50:.4f}, "
+                        f"map50_95={map50_95:.4f}, classes={len(per_class_map50)}"
+                    )
+                    last_step_validation = step
+                finally:
+                    callback_dict["model"].train()
+                    criterion.train()
+
+            logger.info(
+                f"Step validation callback enabled with val_interval_steps={val_interval_steps}. "
+                f"Metrics will be logged to {step_val_metrics_path}"
+            )
+            callbacks["on_train_batch_start"].append(_step_validation_callback)
 
         # for drop
         total_batch_size = effective_batch_size * get_world_size()
@@ -706,6 +796,7 @@ if __name__ == '__main__':
             "square_resize_div_64",
             "output_dir",
             "checkpoint_interval",
+            "val_interval_steps",
             "seed",
             "resume",
             "start_epoch",
@@ -855,6 +946,12 @@ def get_args_parser():
     parser.add_argument('--dont_save_weights', action='store_true')
     parser.add_argument('--checkpoint_interval', default=10, type=int,
                         help='epoch interval to save checkpoint')
+    parser.add_argument(
+        '--val_interval_steps',
+        default=0,
+        type=int,
+        help='run full validation every N global training steps (0 disables step validation)',
+    )
     parser.add_argument('--seed', default=42, type=int)
     parser.add_argument('--resume', default='', help='resume from checkpoint')
     parser.add_argument('--start_epoch', default=0, type=int, metavar='N',
@@ -1011,6 +1108,7 @@ def populate_args(
     output_dir='output',
     dont_save_weights=False,
     checkpoint_interval=10,
+    val_interval_steps=0,
     seed=42,
     resume='',
     start_epoch=0,
@@ -1119,6 +1217,7 @@ def populate_args(
         output_dir=output_dir,
         dont_save_weights=dont_save_weights,
         checkpoint_interval=checkpoint_interval,
+        val_interval_steps=val_interval_steps,
         seed=seed,
         resume=resume,
         start_epoch=start_epoch,


### PR DESCRIPTION
## Summary
- add a step-based validation callback (`val_interval_steps`) that runs full validation every N global training steps
- log callback outputs to `step_val_metrics.jsonl`, including per-class `mAP50`
- fix segmentation metric routing so segmentation runs use mask-based `results_json` (per-class metrics now reflect `segm`, not `bbox`)
- add a runnable `vmi_mrf` training script for largest open-source segmentation model (`RFDETRSeg2XLarge`) at fixed resolution

## Code Changes
- `src/rfdetr/config.py`
  - add `TrainConfig.val_interval_steps` (default `0`)
- `src/rfdetr/main.py`
  - add CLI arg `--val_interval_steps`
  - plumb through `populate_args`
  - register `on_train_batch_start` callback to run evaluation every N steps
  - write callback snapshots to `<output_dir>/step_val_metrics.jsonl`
- `src/rfdetr/engine.py`
  - expose both `results_json_bbox` and `results_json_masks`
  - set `results_json` to `results_json_masks` when `segmentation_head=True`
- `scripts/train_vmi_mrf_seg2x.py`
  - new script for `vmi_mrf` with `RFDETRSeg2XLarge`
  - fixed-resolution (no multiscale) first-run setup

## Validation Performed
- `python -m compileall src/rfdetr scripts/train_vmi_mrf_seg2x.py`
- `python -m ruff check src/rfdetr/config.py src/rfdetr/engine.py src/rfdetr/main.py scripts/train_vmi_mrf_seg2x.py`
- end-to-end callback run on `vmi_mrf` with `val_interval_steps=50`

## Metrics Included (requested)
Callback snapshot from first completed step validation:
- run output dir: `/home/georgepearse/data/vmi_mrf/runs/rfdetr_seg2x_val50_val64`
- metrics file: `step_val_metrics.jsonl`
- `step`: `50`
- `metric_type`: `segm`
- overall `mAP50`: `0.22569862233976162`
- overall `mAP50:95`: `0.10713670603390689`
- classes with GT in that callback eval: `13`

Per-class `mAP50` at step 50:
- `Conveyor Belt Metal`: `0.915330`
- `Glass Bottle`: `0.735665`
- `Metal Can`: `0.613284`
- `Lithium Ion Battery`: `0.582245`
- `Metal Lid`: `0.073342`
- `Large Metal Object`: `0.008254`
- `N2O Tank`: `0.002925`
- `Battery In Device`: `0.002330`
- `Multicell Battery Pack`: `0.000707`
- `Glass Jar`: `0.000000`
- `Helium Tank`: `0.000000`
- `Propane Tank`: `0.000000`
- `Vape`: `0.000000`

## Notes
- For practical turnaround while validating callback behavior, the above metrics were collected on a 64-image validation subset (`rfdetr_roboflow_export_val64`).
- Full validation callback on the full val split is significantly slower at this model size/resolution.
