### PR TITLE
Add Prettier hook to pre-commit for YAML/TOML files

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -37,7 +37,6 @@ coverage:
 github_checks:
   annotations: false
 
-
 comment:
   layout: header, diff
   require_changes: false

--- a/.github/workflows/ci-tests-cpu.yml
+++ b/.github/workflows/ci-tests-cpu.yml
@@ -67,7 +67,6 @@ jobs:
       - name: Minimize uv cache
         run: uv cache prune --ci
 
-
   testing-guardian:
     runs-on: ubuntu-latest
     needs: run-tests

--- a/.github/workflows/pr-conflict-labeler.yml
+++ b/.github/workflows/pr-conflict-labeler.yml
@@ -3,7 +3,7 @@ name: PR Conflict Labeler
 on:
   # So that PRs touching the same files as the push are updated
   push:
-    branches: [ main, develop ]
+    branches: [main, develop]
   # So that the `dirtyLabel` is removed if conflicts are resolved
   # We recommend `pull_request_target` so that github secrets are available.
   # In `pull_request` we wouldn't be able to change labels of fork PRs

--- a/.github/workflows/publish-pre-release.yml
+++ b/.github/workflows/publish-pre-release.yml
@@ -15,8 +15,8 @@ on:
   pull_request:
     branches: [main, develop]
     paths:
-      - '.github/workflows/build-package.yml'
-      - '.github/workflows/publish-pre-release.yml'
+      - ".github/workflows/build-package.yml"
+      - ".github/workflows/publish-pre-release.yml"
 
 permissions:
   contents: read

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     rev: v3.8.1 # using tag; previously pinned SHA when tags were not persistent
     hooks:
       - id: prettier
-        files: \.(yml|yaml|toml)
+        files: \.(ya?ml|toml)$
         # https://prettier.io/docs/en/options.html#print-width
         args: ["--print-width=120"]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,14 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
 
+  - repo: https://github.com/JoC0de/pre-commit-prettier
+    rev: v3.8.1 # using tag; previously pinned SHA when tags were not persistent
+    hooks:
+      - id: prettier
+        files: \.(yml|yaml|toml)
+        # https://prettier.io/docs/en/options.html#print-width
+        args: ["--print-width=120"]
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: check-added-large-files
       - id: detect-private-key
       - id: pretty-format-json
-        args: ['--autofix', '--no-sort-keys', '--indent=4']
+        args: ["--autofix", "--no-sort-keys", "--indent=4"]
       - id: end-of-file-fixer
       - id: mixed-line-ending
 

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,7 +1,7 @@
 site_name: RF-DETR
 site_url: https://roboflow.github.io/rf-detr/
 site_author: Roboflow
-site_description: 'SOTA Real-Time Object Detection Model'
+site_description: "SOTA Real-Time Object Detection Model"
 repo_name: roboflow/rf-detr
 repo_url: https://github.com/roboflow/rf-detr
 edit_uri: https://github.com/roboflow/rf-detr/tree/main/docs
@@ -23,65 +23,64 @@ extra:
 nav:
   - Home: index.md
   - How to:
-    - Install: learn/install.md
-    - Run Model:
-      - Detection: learn/run/detection.md
-      - Segmentation: learn/run/segmentation.md
-    - Train Model:
-      - Overview: learn/train/index.md
-      - Dataset Formats: learn/train/dataset-formats.md
-      - Training Parameters: learn/train/training-parameters.md
-      - Advanced Training: learn/train/advanced.md
-    - Export Model: learn/export.md
-    - Deploy Model: learn/deploy.md
-    - Benchmarks: learn/benchmarks.md
+      - Install: learn/install.md
+      - Run Model:
+          - Detection: learn/run/detection.md
+          - Segmentation: learn/run/segmentation.md
+      - Train Model:
+          - Overview: learn/train/index.md
+          - Dataset Formats: learn/train/dataset-formats.md
+          - Training Parameters: learn/train/training-parameters.md
+          - Advanced Training: learn/train/advanced.md
+      - Export Model: learn/export.md
+      - Deploy Model: learn/deploy.md
+      - Benchmarks: learn/benchmarks.md
   - API Reference:
       - RF-DETR: reference/rfdetr.md
       - Detection Models:
-        - RF-DETR Nano: reference/nano.md
-        - RF-DETR Small: reference/small.md
-        - RF-DETR Base (Deprecated): reference/base.md
-        - RF-DETR Medium: reference/medium.md
-        - RF-DETR Large: reference/large.md
-        - RF-DETR XLarge: reference/xlarge.md
-        - RF-DETR 2XLarge: reference/2xlarge.md
-        - RF-DETR Large (Deprecated): reference/large_deprecated.md
+          - RF-DETR Nano: reference/nano.md
+          - RF-DETR Small: reference/small.md
+          - RF-DETR Base (Deprecated): reference/base.md
+          - RF-DETR Medium: reference/medium.md
+          - RF-DETR Large: reference/large.md
+          - RF-DETR XLarge: reference/xlarge.md
+          - RF-DETR 2XLarge: reference/2xlarge.md
+          - RF-DETR Large (Deprecated): reference/large_deprecated.md
       - Segmentation Models:
-        - RF-DETR Seg Nano: reference/seg_nano.md
-        - RF-DETR Seg Small: reference/seg_small.md
-        - RF-DETR Seg Medium: reference/seg_medium.md
-        - RF-DETR Seg Large: reference/seg_large.md
-        - RF-DETR Seg XLarge: reference/seg_xlarge.md
-        - RF-DETR Seg 2XLarge: reference/seg_2xlarge.md
-        - RF-DETR Seg Preview (Deprecated): reference/seg_preview.md
+          - RF-DETR Seg Nano: reference/seg_nano.md
+          - RF-DETR Seg Small: reference/seg_small.md
+          - RF-DETR Seg Medium: reference/seg_medium.md
+          - RF-DETR Seg Large: reference/seg_large.md
+          - RF-DETR Seg XLarge: reference/seg_xlarge.md
+          - RF-DETR Seg 2XLarge: reference/seg_2xlarge.md
+          - RF-DETR Seg Preview (Deprecated): reference/seg_preview.md
       - Training Configs:
-        - Train Config: reference/train_config.md
-        - Segmentation Train Config: reference/segmentation_train_config.md
+          - Train Config: reference/train_config.md
+          - Segmentation Train Config: reference/segmentation_train_config.md
   - Changelog: https://github.com/roboflow/rf-detr/releases
 
-
 theme:
-  name: 'material'
+  name: "material"
   icon:
     edit: material/pencil
   logo: assets/roboflow-logo.svg
   favicon: assets/roboflow-logo.svg
   custom_dir: docs/theme
 
-#  palette:
-#    # Palette for light mode
-#    - scheme: default
-#      primary: "custom"
-#      toggle:
-#        icon: material/brightness-7
-#        name: Switch to dark mode
-#
-#    # Palette toggle for dark mode
-#    - scheme: slate
-#      primary: "custom"
-#      toggle:
-#        icon: material/brightness-4
-#        name: Switch to light mode
+  #  palette:
+  #    # Palette for light mode
+  #    - scheme: default
+  #      primary: "custom"
+  #      toggle:
+  #        icon: material/brightness-7
+  #        name: Switch to dark mode
+  #
+  #    # Palette toggle for dark mode
+  #    - scheme: slate
+  #      primary: "custom"
+  #      toggle:
+  #        icon: material/brightness-4
+  #        name: Switch to light mode
 
   font:
     text: Inter


### PR DESCRIPTION
This pull request adds a new pre-commit hook for formatting YAML and TOML files using Prettier. This helps ensure consistent code style for these file types across the project.

Formatting improvements:

* Added the `prettier` pre-commit hook from the `pre-commit-prettier` repository to automatically format `.yml`, `.yaml`, and `.toml` files with a print width of 120 characters. (.pre-commit-config.yaml)