### PR TITLE
Fix: Missing 'info' key in COCO export format

### DIFF
--- a/src/rfdetr/datasets/yolo.py
+++ b/src/rfdetr/datasets/yolo.py
@@ -278,6 +278,7 @@ class CocoLikeAPI:
                 ann_id += 1
 
         return {
+            "info": {"description": "RF-DETR YOLO dataset"},
             "images": images,
             "annotations": annotations,
             "categories": categories

--- a/tests/datasets/test_yolo.py
+++ b/tests/datasets/test_yolo.py
@@ -32,6 +32,7 @@ class TestCocoLikeAPI:
 
     def test_dataset_structure(self, coco_api):
         """Test the structure of the COCO dataset."""
+        assert "info" in coco_api.dataset
         assert "images" in coco_api.dataset
         assert "annotations" in coco_api.dataset
         assert "categories" in coco_api.dataset


### PR DESCRIPTION
> The current implementation of the dataset export returns a dictionary missing the "info" key. According to the COCO dataset format specification, the "info" section is expected by many downstream tools and validation scripts. Adding this key ensures better compatibility with the COCO API and prevents potential KeyErrors during evaluation.