### PR TITLE
tests: Update COCO segmentation thresholds in benchmark tests

### DIFF
--- a/tests/benchmarks/test_coco_inference.py
+++ b/tests/benchmarks/test_coco_inference.py
@@ -138,7 +138,7 @@ def test_coco_detection_inference_benchmark(
         pytest.param(RFDETRSegSmall, 0.66, 0.67, 100, id="small"),
         pytest.param(RFDETRSegMedium, 0.68, 0.68, 100, id="medium"),
         pytest.param(RFDETRSegLarge, 0.70, 0.69, 100, id="large"),
-        pytest.param(RFDETRSegXLarge, 0.72, 0.7, 100, id="xlarge"),
+        pytest.param(RFDETRSegXLarge, 0.72, 0.70, 100, id="xlarge"),
         pytest.param(RFDETRSeg2XLarge, 0.73, 0.71, 100, id="2xlarge"),
     ],
 )

--- a/tests/benchmarks/test_coco_inference.py
+++ b/tests/benchmarks/test_coco_inference.py
@@ -31,7 +31,7 @@ from rfdetr.datasets.coco import CocoDetection, make_coco_transforms_square_div_
 from rfdetr.detr import RFDETR
 from rfdetr.engine import evaluate
 from rfdetr.models import build_criterion_and_postprocessors
-from rfdetr.util import misc as utils
+from rfdetr.util.misc import collate_fn
 
 _PLUS_AVAILABLE = importlib.util.find_spec("rfdetr_plus") is not None
 if _PLUS_AVAILABLE:
@@ -187,7 +187,7 @@ def test_coco_segmentation_inference_benchmark(
         batch_size=4,
         sampler=torch.utils.data.SequentialSampler(val_dataset),
         drop_last=False,
-        collate_fn=utils.collate_fn,
+        collate_fn=collate_fn,
         num_workers=os.cpu_count() or 1,
     )
     base_ds = get_coco_api_from_dataset(val_dataset)

--- a/tests/benchmarks/test_coco_inference.py
+++ b/tests/benchmarks/test_coco_inference.py
@@ -98,7 +98,7 @@ def test_coco_detection_inference_benchmark(
         batch_size=4,
         sampler=torch.utils.data.SequentialSampler(val_dataset),
         drop_last=False,
-        collate_fn=utils.collate_fn,
+        collate_fn=collate_fn,
         num_workers=os.cpu_count() or 1,
     )
     base_ds = get_coco_api_from_dataset(val_dataset)

--- a/tests/benchmarks/test_coco_inference.py
+++ b/tests/benchmarks/test_coco_inference.py
@@ -134,12 +134,12 @@ def test_coco_detection_inference_benchmark(
 @pytest.mark.parametrize(
     ("model_cls", "threshold_segm_map", "threshold_segm_f1", "num_samples"),
     [
-        pytest.param(RFDETRSegNano, 0.6, 0.6, 500, id="nano"),
-        pytest.param(RFDETRSegSmall, 0.6, 0.6, 100, id="small"),
-        pytest.param(RFDETRSegMedium, 0.6, 0.6, 100, id="medium"),
-        pytest.param(RFDETRSegLarge, 0.6, 0.6, 100, id="large"),
-        pytest.param(RFDETRSegXLarge, 0.6, 0.6, 100, id="xlarge"),
-        pytest.param(RFDETRSeg2XLarge, 0.6, 0.6, 100, id="2xlarge"),
+        pytest.param(RFDETRSegNano, 0.63, 0.64, 500, id="nano"),
+        pytest.param(RFDETRSegSmall, 0.66, 0.67, 100, id="small"),
+        pytest.param(RFDETRSegMedium, 0.68, 0.68, 100, id="medium"),
+        pytest.param(RFDETRSegLarge, 0.70, 0.69, 100, id="large"),
+        pytest.param(RFDETRSegXLarge, 0.72, 0.7, 100, id="xlarge"),
+        pytest.param(RFDETRSeg2XLarge, 0.73, 0.71, 100, id="2xlarge"),
     ],
 )
 def test_coco_segmentation_inference_benchmark(


### PR DESCRIPTION
This pull request updates the benchmark thresholds for segmentation map and F1 score across various RFDETRSeg model variants in the COCO inference benchmark tests. The thresholds have been increased to reflect new performance expectations for each model.

**Benchmark threshold updates:**

* Increased `threshold_segm_map` and `threshold_segm_f1` values for all tested model classes (`RFDETRSegNano`, `RFDETRSegSmall`, `RFDETRSegMedium`, `RFDETRSegLarge`, `RFDETRSegXLarge`, `RFDETRSeg2XLarge`) in `test_coco_inference.py` to set stricter performance requirements for the segmentation inference benchmarks.