### PR TITLE
deprecate `OPEN_SOURCE_MODELS` in favor of ModelWeights enum

### DIFF
--- a/src/rfdetr/main.py
+++ b/src/rfdetr/main.py
@@ -63,7 +63,11 @@ logger = get_logger()
 # THE FOLLOWING MODEL ASSETS ARE COVERED BY THE APACHE 2.0 LICENSE
 # Legacy dictionary for backward compatibility - DEPRECATED
 # Use ModelWeights enum from rfdetr.assets.model_weights instead
-OPEN_SOURCE_MODELS = _DeprecatedDict({asset.filename: asset.url for asset in ModelWeights})
+OPEN_SOURCE_MODELS = _DeprecatedDict(
+    {asset.filename: asset.url for asset in ModelWeights},
+    deprecated_name="OPEN_SOURCE_MODELS",
+    replacement="`ModelWeights` enum from `rfdetr.assets.model_weights`"
+)
 
 
 class Model:

--- a/src/rfdetr/main.py
+++ b/src/rfdetr/main.py
@@ -51,6 +51,7 @@ from rfdetr.util.get_param_dicts import get_param_dict
 from rfdetr.util.logger import get_logger
 from rfdetr.util.misc import get_rank, get_world_size, is_main_process, save_on_master
 from rfdetr.util.utils import BestMetricHolder, ModelEma, clean_state_dict
+from rfdetr.utils.decorators import _DeprecatedDict
 
 if str(os.environ.get("USE_FILE_SYSTEM_SHARING", "False")).lower() in ["true", "1"]:
     import torch.multiprocessing
@@ -60,8 +61,9 @@ logger = get_logger()
 
 
 # THE FOLLOWING MODEL ASSETS ARE COVERED BY THE APACHE 2.0 LICENSE
-# Legacy dictionary for backward compatibility
-OPEN_SOURCE_MODELS = {asset.filename: asset.url for asset in ModelWeights}
+# Legacy dictionary for backward compatibility - DEPRECATED
+# Use ModelWeights enum from rfdetr.assets.model_weights instead
+OPEN_SOURCE_MODELS = _DeprecatedDict({asset.filename: asset.url for asset in ModelWeights})
 
 
 class Model:

--- a/src/rfdetr/utils/__init__.py
+++ b/src/rfdetr/utils/__init__.py
@@ -1,0 +1,7 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Utility functions and helpers."""

--- a/src/rfdetr/utils/decorators.py
+++ b/src/rfdetr/utils/decorators.py
@@ -1,0 +1,35 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Deprecation utilities and decorators."""
+
+import warnings
+
+
+class _DeprecatedDict(dict):
+    """Dictionary wrapper that emits deprecation warnings when accessing values."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._warning_shown = False
+
+    def _show_warning(self):
+        if not self._warning_shown:
+            warnings.warn(
+                "OPEN_SOURCE_MODELS is deprecated and will be removed in a future version. "
+                "Use 'ModelWeights' enum from 'rfdetr.assets.model_weights' instead.",
+                DeprecationWarning,
+                stacklevel=3
+            )
+            self._warning_shown = True
+
+    def __getitem__(self, key):
+        self._show_warning()
+        return super().__getitem__(key)
+
+    def get(self, key, default=None):
+        self._show_warning()
+        return super().get(key, default)

--- a/src/rfdetr/utils/decorators.py
+++ b/src/rfdetr/utils/decorators.py
@@ -7,26 +7,54 @@
 """Deprecation utilities and decorators."""
 
 import warnings
+from typing import Any, ItemsView, Iterator, KeysView, ValuesView
 
 
 class _DeprecatedDict(dict):
     """Dictionary wrapper that emits deprecation warnings when accessing values.
 
+    This class wraps a regular dictionary and emits a DeprecationWarning the first
+    time any read operation is performed (e.g., getting values, keys, items, or
+    checking membership). The warning is only shown once per instance to avoid
+    cluttering the user's output.
+
+    Note:
+        This class only overrides read operations. Mutation operations like
+        __setitem__ are not overridden since modifications are not an expected
+        use case for deprecated dictionaries.
+
     Args:
-        *args: Positional arguments passed to dict constructor
-        deprecated_name: Name of the deprecated object (e.g., "OPEN_SOURCE_MODELS")
-        replacement: What to use instead (e.g., "ModelWeights enum from 'rfdetr.assets.model_weights'")
-        **kwargs: Keyword arguments passed to dict constructor
+        *args: Positional arguments passed to dict constructor.
+        deprecated_name: Name of the deprecated object (e.g., "OPEN_SOURCE_MODELS").
+        replacement: What to use instead (e.g., "`ModelWeights` enum from `rfdetr.assets.model_weights`").
+        **kwargs: Keyword arguments passed to dict constructor.
+
+    Example:
+        >>> legacy_dict = _DeprecatedDict(
+        ...     {"model_a.pt": "url_a", "model_b.pt": "url_b"},
+        ...     deprecated_name="LEGACY_MODELS",
+        ...     replacement="`ModelRegistry` class"
+        ... )
+        >>> # First access triggers warning
+        >>> url = legacy_dict["model_a.pt"]  # DeprecationWarning emitted
+        >>> # Subsequent accesses don't trigger warning
+        >>> url = legacy_dict["model_b.pt"]  # No warning
     """
 
-    def __init__(self, *args, deprecated_name: str = "this dictionary",
-                 replacement: str = "the new API", **kwargs):
+    def __init__(
+        self,
+        *args: Any,
+        deprecated_name: str = "this dictionary",
+        replacement: str = "the new API",
+        **kwargs: Any
+    ) -> None:
         super().__init__(*args, **kwargs)
         self._warning_shown = False
         self._deprecated_name = deprecated_name
         self._replacement = replacement
 
-    def _show_warning(self):
+    def _show_warning(self) -> None:
+        """Emit deprecation warning once per instance."""
         if not self._warning_shown:
             warnings.warn(
                 f"{self._deprecated_name} is deprecated and will be removed in a future version."
@@ -36,10 +64,37 @@ class _DeprecatedDict(dict):
             )
             self._warning_shown = True
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: Any) -> Any:
+        """Get item by key and emit deprecation warning."""
         self._show_warning()
         return super().__getitem__(key)
 
-    def get(self, key, default=None):
+    def get(self, key: Any, default: Any = None) -> Any:
+        """Get item by key with default and emit deprecation warning."""
         self._show_warning()
         return super().get(key, default)
+
+    def keys(self) -> KeysView:
+        """Return dictionary keys view and emit deprecation warning."""
+        self._show_warning()
+        return super().keys()
+
+    def values(self) -> ValuesView:
+        """Return dictionary values view and emit deprecation warning."""
+        self._show_warning()
+        return super().values()
+
+    def items(self) -> ItemsView:
+        """Return dictionary items view and emit deprecation warning."""
+        self._show_warning()
+        return super().items()
+
+    def __contains__(self, key: Any) -> bool:
+        """Check if key exists in dictionary and emit deprecation warning."""
+        self._show_warning()
+        return super().__contains__(key)
+
+    def __iter__(self) -> Iterator[Any]:
+        """Return iterator over dictionary keys and emit deprecation warning."""
+        self._show_warning()
+        return super().__iter__()

--- a/src/rfdetr/utils/decorators.py
+++ b/src/rfdetr/utils/decorators.py
@@ -10,17 +10,27 @@ import warnings
 
 
 class _DeprecatedDict(dict):
-    """Dictionary wrapper that emits deprecation warnings when accessing values."""
+    """Dictionary wrapper that emits deprecation warnings when accessing values.
 
-    def __init__(self, *args, **kwargs):
+    Args:
+        *args: Positional arguments passed to dict constructor
+        deprecated_name: Name of the deprecated object (e.g., "OPEN_SOURCE_MODELS")
+        replacement: What to use instead (e.g., "ModelWeights enum from 'rfdetr.assets.model_weights'")
+        **kwargs: Keyword arguments passed to dict constructor
+    """
+
+    def __init__(self, *args, deprecated_name: str = "this dictionary",
+                 replacement: str = "the new API", **kwargs):
         super().__init__(*args, **kwargs)
         self._warning_shown = False
+        self._deprecated_name = deprecated_name
+        self._replacement = replacement
 
     def _show_warning(self):
         if not self._warning_shown:
             warnings.warn(
-                "OPEN_SOURCE_MODELS is deprecated and will be removed in a future version. "
-                "Use 'ModelWeights' enum from 'rfdetr.assets.model_weights' instead.",
+                f"{self._deprecated_name} is deprecated and will be removed in a future version."
+                f" Use {self._replacement} instead.",
                 DeprecationWarning,
                 stacklevel=3
             )

--- a/tests/util/test_decorators.py
+++ b/tests/util/test_decorators.py
@@ -1,0 +1,131 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+import warnings
+
+import pytest
+
+from rfdetr.utils.decorators import _DeprecatedDict
+
+
+class TestDeprecatedDict:
+    """Test suite for _DeprecatedDict class."""
+
+    @pytest.mark.parametrize(
+        "init_args,init_kwargs,expected_data",
+        [
+            pytest.param(
+                ({"key1": "value1", "key2": "value2"},),
+                {"deprecated_name": "TEST_DICT", "replacement": "`NewAPI`"},
+                {"key1": "value1", "key2": "value2"},
+                id="dict_init",
+            ),
+            pytest.param(
+                (),
+                {
+                    "key1": "value1",
+                    "key2": "value2",
+                    "deprecated_name": "TEST_DICT",
+                    "replacement": "`NewAPI`",
+                },
+                {"key1": "value1", "key2": "value2"},
+                id="kwargs_init",
+            ),
+        ],
+    )
+    def test_initialization(self, init_args, init_kwargs, expected_data):
+        """Test initialization with different argument patterns."""
+        deprecated_dict = _DeprecatedDict(*init_args, **init_kwargs)
+        # Suppress warnings for this test
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            assert len(deprecated_dict) == len(expected_data)
+            assert dict(deprecated_dict) == expected_data
+
+    def test_warning_emitted_on_access(self):
+        """Test that deprecation warning is emitted on first access."""
+        deprecated_dict = _DeprecatedDict(
+            {"key": "value"},
+            deprecated_name="OLD_DICT",
+            replacement="`NewDict`",
+        )
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            value = deprecated_dict["key"]
+
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "OLD_DICT is deprecated" in str(w[0].message)
+            assert "Use `NewDict` instead" in str(w[0].message)
+            assert value == "value"
+
+    def test_warning_only_shown_once(self):
+        """Test that warning is only shown once per instance."""
+        deprecated_dict = _DeprecatedDict(
+            {"key1": "value1", "key2": "value2"},
+            deprecated_name="OLD_DICT",
+            replacement="`NewDict`",
+        )
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            _ = deprecated_dict["key1"]
+            assert len(w) == 1
+
+            # Subsequent accesses should not emit additional warnings
+            _ = deprecated_dict.get("key2")
+            _ = list(deprecated_dict.keys())
+            assert len(w) == 1
+
+    @pytest.mark.parametrize(
+        "access_method,args,expected_result",
+        [
+            pytest.param(
+                lambda d: d["key1"], (), "value1", id="getitem"
+            ),
+            pytest.param(
+                lambda d: d.get("key1"), (), "value1", id="get"
+            ),
+            pytest.param(
+                lambda d: d.get("missing", "default"), (), "default", id="get_default"
+            ),
+            pytest.param(
+                lambda d: "key1" in d, (), True, id="contains"
+            ),
+            pytest.param(
+                lambda d: set(d.keys()), (), {"key1", "key2"}, id="keys"
+            ),
+            pytest.param(
+                lambda d: set(d.values()), (), {"value1", "value2"}, id="values"
+            ),
+            pytest.param(
+                lambda d: set(d.items()),
+                (),
+                {("key1", "value1"), ("key2", "value2")},
+                id="items",
+            ),
+            pytest.param(
+                lambda d: [k for k in d], (), ["key1", "key2"], id="iter"
+            ),
+        ],
+    )
+    def test_dictionary_functionality(self, access_method, args, expected_result):
+        """Test that dictionary operations work correctly."""
+        data = {"key1": "value1", "key2": "value2"}
+        deprecated_dict = _DeprecatedDict(
+            data, deprecated_name="TEST_DICT", replacement="`NewAPI`"
+        )
+
+        # Suppress warnings for this test
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = access_method(deprecated_dict)
+            if isinstance(expected_result, list):
+                assert result == expected_result or set(result) == set(expected_result)
+            else:
+                assert result == expected_result


### PR DESCRIPTION
This pull request introduces a deprecation mechanism for the legacy `OPEN_SOURCE_MODELS` dictionary in `main.py` and adds supporting utilities for handling deprecation warnings. The main goal is to guide developers toward using the `ModelWeights` enum instead of the old dictionary, while maintaining backward compatibility for now.

Key changes include:

**Deprecation utilities:**

* Added a new file `decorators.py` in `rfdetr/utils` containing the `_DeprecatedDict` class, which wraps dictionaries and emits a deprecation warning when accessed.
* Updated the `__init__.py` in `rfdetr/utils` with copyright and documentation.

**Main module updates:**

* Replaced the legacy `OPEN_SOURCE_MODELS` dictionary in `main.py` with an instance of `_DeprecatedDict`, ensuring that any access to this dictionary triggers a deprecation warning.
* Imported `_DeprecatedDict` from the new `decorators.py` module in `main.py`.