### PR TITLE
tests: use `@pytest.mark.parametrize` for improved clarity and test isolation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -230,18 +230,21 @@ Do not write tests that loop through multiple cases internally. Instead, use `@p
 import pytest
 from rfdetr.assets.model_weights import ModelWeights
 
+
 # BAD: Multiple cases in one test - all assertions must pass for test to pass
 def test_all_models_have_valid_urls():
     for model in ModelWeights:
-        assert model.url.startswith('http')  # Hard to identify which model failed
+        assert model.url.startswith("http")  # Hard to identify which model failed
+
 
 # GOOD: Parametrized - each model is a separate test case
 @pytest.mark.parametrize("model", list(ModelWeights), ids=[m.filename for m in ModelWeights])
 def test_all_models_have_valid_urls(model):
-    assert model.url.startswith('http')  # Clear which model failed
+    assert model.url.startswith("http")  # Clear which model failed
 ```
 
 Benefits of parametrization:
+
 - Each case runs as an independent test (failures are isolated)
 - Test IDs clearly identify which case failed
 - Easier to debug and maintain

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -222,6 +222,31 @@ def test_model_loading(model_variant):
     pass
 ```
 
+**Avoid multiple validation cases in a single test:**
+
+Do not write tests that loop through multiple cases internally. Instead, use `@pytest.mark.parametrize` so each case runs as a separate test:
+
+```python
+import pytest
+from rfdetr.assets.model_weights import ModelWeights
+
+# BAD: Multiple cases in one test - all assertions must pass for test to pass
+def test_all_models_have_valid_urls():
+    for model in ModelWeights:
+        assert model.url.startswith('http')  # Hard to identify which model failed
+
+# GOOD: Parametrized - each model is a separate test case
+@pytest.mark.parametrize("model", list(ModelWeights), ids=[m.filename for m in ModelWeights])
+def test_all_models_have_valid_urls(model):
+    assert model.url.startswith('http')  # Clear which model failed
+```
+
+Benefits of parametrization:
+- Each case runs as an independent test (failures are isolated)
+- Test IDs clearly identify which case failed
+- Easier to debug and maintain
+- Better test reporting in CI
+
 **Mark GPU-required or computationally heavy tests:**
 
 ```python

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ pre-commit run --all-files
 - Group related tests in classes
 - Use `@pytest.mark.parametrize` with `pytest.param(..., id="name")`
 - Mark GPU/heavy tests with `@pytest.mark.gpu`
+- Avoid multiple validation cases in a single test - see [CONTRIBUTING.md](.github/CONTRIBUTING.md#avoid-multiple-validation-cases-in-a-single-test) for details
 
 **CI Information:**
 See [CI Testing](.github/CONTRIBUTING.md#ci-testing) in CONTRIBUTING.md for details on OS/Python version matrix and workflow configurations.

--- a/tests/assets/test_downloads.py
+++ b/tests/assets/test_downloads.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from rfdetr.assets import ModelWeightAsset
+from rfdetr.assets import ModelWeightAsset, ModelWeights
 from rfdetr.assets.model_weights import download_pretrain_weights
 
 
@@ -173,7 +173,7 @@ class TestDownloadIntegration:
     """Integration tests for the complete download flow."""
 
     @pytest.mark.parametrize("model", list(ModelWeights), ids=[m.filename for m in ModelWeights])
-    def test_all_models_have_valid_md5_format(self, model):
+    def test_all_models_have_valid_md5_format(self, model: ModelWeightAsset) -> None:
         """Test that MD5 hashes are valid when present (prevent typos)."""
         # MD5 should be None or valid 32-char hex string
         if model.md5_hash is not None:

--- a/tests/assets/test_downloads.py
+++ b/tests/assets/test_downloads.py
@@ -172,17 +172,15 @@ class TestDownloadPretrainWeights:
 class TestDownloadIntegration:
     """Integration tests for the complete download flow."""
 
-    def test_all_models_have_valid_md5_format(self):
+    @pytest.mark.parametrize("model", list(ModelWeights), ids=[m.filename for m in ModelWeights])
+    def test_all_models_have_valid_md5_format(self, model):
         """Test that MD5 hashes are valid when present (prevent typos)."""
-        from rfdetr.assets.model_weights import ModelWeights
-
-        for model in ModelWeights:
-            # MD5 should be None or valid 32-char hex string
-            if model.md5_hash is not None:
-                assert len(model.md5_hash) == 32, \
-                    f"{model.filename} has invalid MD5 length: {len(model.md5_hash)}"
-                assert all(c in '0123456789abcdef' for c in model.md5_hash.lower()), \
-                    f"{model.filename} has invalid MD5 characters"
+        # MD5 should be None or valid 32-char hex string
+        if model.md5_hash is not None:
+            assert len(model.md5_hash) == 32, \
+                f"{model.filename} has invalid MD5 length: {len(model.md5_hash)}"
+            assert all(c in '0123456789abcdef' for c in model.md5_hash.lower()), \
+                f"{model.filename} has invalid MD5 characters"
 
     def test_from_filename_bidirectional_lookup(self):
         """Test that from_filename correctly maps back to enum values."""

--- a/tests/assets/test_model_weights.py
+++ b/tests/assets/test_model_weights.py
@@ -69,14 +69,14 @@ def test_list_models():
 
 
 @pytest.mark.parametrize("asset", list(ModelWeights), ids=[a.filename for a in ModelWeights])
-def test_all_assets_have_valid_urls(asset):
+def test_all_assets_have_valid_urls(asset: ModelWeightAsset) -> None:
     """Test that all assets have valid URLs."""
     assert asset.url.startswith('http')
     assert len(asset.url) > 20  # Reasonable minimum URL length
 
 
 @pytest.mark.parametrize("asset", list(ModelWeights), ids=[a.filename for a in ModelWeights])
-def test_all_assets_have_valid_filenames(asset):
+def test_all_assets_have_valid_filenames(asset: ModelWeightAsset) -> None:
     """Test that all assets have valid filenames."""
     assert len(asset.filename) > 0
     assert asset.filename.endswith(('.pth', '.pt'))

--- a/tests/assets/test_model_weights.py
+++ b/tests/assets/test_model_weights.py
@@ -4,6 +4,8 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
+import pytest
+
 from rfdetr.assets import ModelWeightAsset, ModelWeights, ModelWeightsBase
 
 
@@ -66,18 +68,18 @@ def test_list_models():
     assert all(isinstance(m, str) for m in models)
 
 
-def test_all_assets_have_valid_urls():
+@pytest.mark.parametrize("asset", list(ModelWeights), ids=[a.filename for a in ModelWeights])
+def test_all_assets_have_valid_urls(asset):
     """Test that all assets have valid URLs."""
-    for asset in ModelWeights:
-        assert asset.url.startswith('http')
-        assert len(asset.url) > 20  # Reasonable minimum URL length
+    assert asset.url.startswith('http')
+    assert len(asset.url) > 20  # Reasonable minimum URL length
 
 
-def test_all_assets_have_valid_filenames():
+@pytest.mark.parametrize("asset", list(ModelWeights), ids=[a.filename for a in ModelWeights])
+def test_all_assets_have_valid_filenames(asset):
     """Test that all assets have valid filenames."""
-    for asset in ModelWeights:
-        assert len(asset.filename) > 0
-        assert asset.filename.endswith(('.pth', '.pt'))
+    assert len(asset.filename) > 0
+    assert asset.filename.endswith(('.pth', '.pt'))
 
 
 def test_filenames_are_unique():

--- a/tests/models/test_export.py
+++ b/tests/models/test_export.py
@@ -15,6 +15,7 @@ Use cases covered:
 import importlib.util
 import warnings
 from collections.abc import Iterator
+from typing import Literal
 from contextlib import contextmanager
 from copy import deepcopy
 from pathlib import Path
@@ -156,7 +157,7 @@ def test_export_does_not_change_original_training_state(tmp_path: Path) -> None:
 @pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 @pytest.mark.parametrize("mode", ["train", "eval"], ids=["train_mode", "eval_mode"])
-def test_segmentation_outputs_present_in_train_and_eval(mode) -> None:
+def test_segmentation_outputs_present_in_train_and_eval(mode: Literal["train", "eval"]) -> None:
     """Use case: segmentation outputs are present in both train and eval modes."""
     model = RFDETRSegNano()
 

--- a/tests/models/test_export.py
+++ b/tests/models/test_export.py
@@ -15,10 +15,10 @@ Use cases covered:
 import importlib.util
 import warnings
 from collections.abc import Iterator
-from typing import Literal
 from contextlib import contextmanager
 from copy import deepcopy
 from pathlib import Path
+from typing import Literal
 from unittest.mock import Mock, patch
 
 import pytest

--- a/tests/models/test_export.py
+++ b/tests/models/test_export.py
@@ -155,7 +155,8 @@ def test_export_does_not_change_original_training_state(tmp_path: Path) -> None:
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-def test_segmentation_outputs_present_in_train_and_eval() -> None:
+@pytest.mark.parametrize("mode", ["train", "eval"], ids=["train_mode", "eval_mode"])
+def test_segmentation_outputs_present_in_train_and_eval(mode) -> None:
     """Use case: segmentation outputs are present in both train and eval modes."""
     model = RFDETRSegNano()
 
@@ -166,15 +167,14 @@ def test_segmentation_outputs_present_in_train_and_eval() -> None:
     resolution = model.model.resolution
     dummy_input = torch.randn(1, 3, resolution, resolution, device="cuda")
 
-    torch_model.train()
-    with torch.no_grad():
-        train_output = torch_model(dummy_input)
+    if mode == "train":
+        torch_model.train()
+    else:
+        torch_model.eval()
 
-    torch_model.eval()
     with torch.no_grad():
-        eval_output = torch_model(dummy_input)
+        output = torch_model(dummy_input)
 
-    for output in (train_output, eval_output):
-        assert "pred_boxes" in output
-        assert "pred_logits" in output
-        assert "pred_masks" in output
+    assert "pred_boxes" in output
+    assert "pred_logits" in output
+    assert "pred_masks" in output

--- a/tests/util/test_file_validation.py
+++ b/tests/util/test_file_validation.py
@@ -7,7 +7,7 @@
 import os
 import tempfile
 from pathlib import Path
-from typing import Iterable, Iterator, Optional
+from typing import Iterable, Iterator, Literal, Optional
 from unittest.mock import Mock, patch
 
 import pytest
@@ -131,7 +131,7 @@ class TestFileMD5Validation:
             os.unlink(temp_file)
 
     @pytest.mark.parametrize("hash_case", ["lower", "upper"], ids=["lowercase", "uppercase"])
-    def test_validate_file_md5_case_insensitive(self, hash_case):
+    def test_validate_file_md5_case_insensitive(self, hash_case: Literal["lower", "upper"]) -> None:
         """Test that MD5 validation is case-insensitive."""
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
             f.write("Test content")

--- a/tests/util/test_file_validation.py
+++ b/tests/util/test_file_validation.py
@@ -130,7 +130,8 @@ class TestFileMD5Validation:
         finally:
             os.unlink(temp_file)
 
-    def test_validate_file_md5_case_insensitive(self):
+    @pytest.mark.parametrize("hash_case", ["lower", "upper"], ids=["lowercase", "uppercase"])
+    def test_validate_file_md5_case_insensitive(self, hash_case):
         """Test that MD5 validation is case-insensitive."""
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
             f.write("Test content")
@@ -139,11 +140,10 @@ class TestFileMD5Validation:
         try:
             # Get hash in lowercase
             hash_lower = _compute_file_md5(temp_file)
-            hash_upper = hash_lower.upper()
+            test_hash = hash_lower.upper() if hash_case == "upper" else hash_lower
 
             # Both should validate successfully
-            assert _validate_file_md5(temp_file, hash_lower) is True
-            assert _validate_file_md5(temp_file, hash_upper) is True
+            assert _validate_file_md5(temp_file, test_hash) is True
         finally:
             os.unlink(temp_file)
 

--- a/tests/util/test_file_validation.py
+++ b/tests/util/test_file_validation.py
@@ -142,7 +142,7 @@ class TestFileMD5Validation:
             hash_lower = _compute_file_md5(temp_file)
             test_hash = hash_lower.upper() if hash_case == "upper" else hash_lower
 
-            # Both should validate successfully
+            # Each case variant (lower/upper) should validate successfully
             assert _validate_file_md5(temp_file, test_hash) is True
         finally:
             os.unlink(temp_file)


### PR DESCRIPTION
This pull request introduces improvements to the test suite by converting tests that loop through multiple validation cases into parametrized tests using `pytest.mark.parametrize`. This change ensures each validation case runs as an independent test, resulting in clearer test reporting and easier debugging. Additionally, the `.github/CONTRIBUTING.md` documentation is updated to recommend this testing approach.

**Testing improvements:**

* Converted tests that looped through multiple cases to use `pytest.mark.parametrize`, ensuring each case runs as a separate test with clear reporting and isolation of failures. This includes tests for model MD5 format (`tests/assets/test_downloads.py`), asset URLs and filenames (`tests/assets/test_model_weights.py`), segmentation outputs in train/eval modes (`tests/models/test_export.py`), and MD5 validation case sensitivity (`tests/util/test_file_validation.py`). [[1]](diffhunk://#diff-98617adca20eb316d556ec424d21cf2ab1e7839dca1e40d2bff896b3c5a3ca37L175-L179) [[2]](diffhunk://#diff-0e7805805e644f6e6aea3b4f11b7279ea8102e6fc02ed5002cf866b2ed429e2eL69-L78) [[3]](diffhunk://#diff-e97a53539dd96f9b74f2127e40e8fa3380c87be3f56f9cf6fb36db2175dec6baL158-R159) [[4]](diffhunk://#diff-3a5da10d9c2f28f4c8b942846c74f5e85236ad75cbf4bd35dd78f98c1b92f91eL133-R134)

* Refactored test logic to remove internal loops and instead rely on parametrization, simplifying the test code and improving maintainability. [[1]](diffhunk://#diff-0e7805805e644f6e6aea3b4f11b7279ea8102e6fc02ed5002cf866b2ed429e2eL69-L78) [[2]](diffhunk://#diff-e97a53539dd96f9b74f2127e40e8fa3380c87be3f56f9cf6fb36db2175dec6baR170-L177) [[3]](diffhunk://#diff-3a5da10d9c2f28f4c8b942846c74f5e85236ad75cbf4bd35dd78f98c1b92f91eL142-R146)

**Documentation updates:**

* Added a section to `.github/CONTRIBUTING.md` explaining the benefits of parametrized tests and providing clear examples for contributors.

**Test setup:**

* Added `pytest` import to relevant test files to support the new parametrization approach.