### PR TITLE
expand `aug_config` support and augmentation presets

### DIFF
--- a/docs/learn/train/augmentations.md
+++ b/docs/learn/train/augmentations.md
@@ -32,12 +32,12 @@ To disable augmentations: `aug_config={}`. Omitting it uses the default (horizon
 
 ## Built-in Presets
 
-| Preset         | Best for                            |
-| -------------- | ----------------------------------- |
-| `AUG_CONSERVATIVE` | Small datasets (under 500 images)   |
-| `AUG_AGGRESSIVE`   | Large datasets (2000+ images)       |
-| `AUG_AERIAL`       | Satellite / overhead imagery        |
-| `AUG_INDUSTRIAL`   | Manufacturing / inspection data     |
+| Preset             | Best for                          |
+| ------------------ | --------------------------------- |
+| `AUG_CONSERVATIVE` | Small datasets (under 500 images) |
+| `AUG_AGGRESSIVE`   | Large datasets (2000+ images)     |
+| `AUG_AERIAL`       | Satellite / overhead imagery      |
+| `AUG_INDUSTRIAL`   | Manufacturing / inspection data   |
 
 All presets are plain dicts — inspect or extend them before passing:
 
@@ -50,8 +50,8 @@ model.train(dataset_dir="...", aug_config=my_config)
 
 ### Recommendations by Dataset Size
 
-| Dataset Size     | Recommended preset                                          |
-| ---------------- | ----------------------------------------------------------- |
+| Dataset Size     | Recommended preset                                              |
+| ---------------- | --------------------------------------------------------------- |
 | Under 500 images | `AUG_CONSERVATIVE` — flip + mild brightness/contrast            |
 | 500–2000 images  | Default or `AUG_CONSERVATIVE` with a few extra transforms added |
 | 2000+ images     | `AUG_AGGRESSIVE` — rotations, affine, color jitter              |

--- a/docs/learn/train/augmentations.md
+++ b/docs/learn/train/augmentations.md
@@ -1,173 +1,64 @@
-# Custom Augmentations with Albumentations
+# Augmentations
 
-RF-DETR supports custom data augmentations using the [Albumentations](https://albumentations.ai/) library, providing access to over 70 different image transformations optimized for object detection tasks.
+RF-DETR supports custom data augmentations via [Albumentations](https://albumentations.ai/), with automatic bounding box and mask handling for geometric transforms.
 
-## Why Albumentations?
+## Quick Start
 
-- **Detection & Segmentation Support:** Geometric transforms automatically update bounding boxes and segmentation masks
-- **Performance:** Highly optimized, faster than torchvision transforms
-- **Flexibility:** Mix and match over 70 different augmentations
-- **Battle-Tested:** Used in winning solutions of many Kaggle competitions
-
-## Setup
-
-Albumentations is installed automatically with RF-DETR:
-
-```bash
-pip install rfdetr
-```
-
-## Basic Usage
-
-Augmentations are configured via the `AUG_CONFIG` dictionary in `src/rfdetr/augmentation_config.py`:
+Pass `aug_config` to your training call. Import one of the built-in presets:
 
 ```python
-AUG_CONFIG = {
-    "HorizontalFlip": {"p": 0.5},
-    "VerticalFlip": {"p": 0.5},
-    "Rotate": {"limit": (90, 90), "p": 0.5},
-}
+from rfdetr import RFDETRBase
+from rfdetr.datasets.aug_config import AUG_CONSERVATIVE, AUG_AGGRESSIVE, AUG_AERIAL, AUG_INDUSTRIAL
+
+model = RFDETRBase()
+model.train(dataset_dir="path/to/dataset", epochs=100, aug_config=AUG_CONSERVATIVE)
 ```
 
-Simply enable the augmentations you want by uncommenting them or adding new ones. The probability `p` controls how often each transform is applied.
-
-## Available Augmentations
-
-### Geometric Transforms
-
-These transforms automatically update bounding boxes and segmentation masks:
-
-- `HorizontalFlip` - Flip image horizontally
-- `VerticalFlip` - Flip image vertically
-- `Rotate` - Rotate image by random angle
-- `Affine` - Apply affine transformations (scale, translate, rotate, shear)
-- `RandomCrop` - Crop random region
-- `ShiftScaleRotate` - Combination of shifting, scaling, and rotating
-- `Perspective` - Apply perspective transformation
-- `ElasticTransform` - Apply elastic deformation
-- `GridDistortion` - Apply grid distortion
-- `OpticalDistortion` - Apply optical distortion
-
-### Pixel-Level Transforms
-
-These transforms preserve bounding boxes and masks (no coordinate changes):
-
-- `ColorJitter` - Randomly change brightness, contrast, saturation
-- `GaussianBlur` - Apply Gaussian blur
-- `GaussNoise` - Add Gaussian noise
-- `CLAHE` - Contrast Limited Adaptive Histogram Equalization
-- `RandomBrightnessContrast` - Adjust brightness and contrast
-- `HueSaturationValue` - Randomly change hue, saturation, and value
-- `ChannelShuffle` - Randomly shuffle image channels
-- `CoarseDropout` - Apply coarse dropout (cutout)
-
-## Configuration Examples
-
-### Conservative Augmentations
-
-Recommended for small datasets (under 500 images):
+Or pass a custom dict directly — keys are Albumentations transform names:
 
 ```python
-AUG_CONFIG = {
-    "HorizontalFlip": {"p": 0.5},
-    "RandomBrightnessContrast": {
-        "brightness_limit": 0.1,
-        "contrast_limit": 0.1,
-        "p": 0.3,
+model.train(
+    dataset_dir="path/to/dataset",
+    epochs=100,
+    aug_config={
+        "HorizontalFlip": {"p": 0.5},
+        "Rotate": {"limit": 15, "p": 0.3},
+        "GaussianBlur": {"p": 0.2},
     },
-}
+)
 ```
 
-### Aggressive Augmentations
+To disable augmentations: `aug_config={}`. Omitting it uses the default (horizontal flip at 50%).
 
-For larger datasets (2000+ images):
+## Built-in Presets
+
+| Preset         | Best for                            |
+| -------------- | ----------------------------------- |
+| `AUG_CONSERVATIVE` | Small datasets (under 500 images)   |
+| `AUG_AGGRESSIVE`   | Large datasets (2000+ images)       |
+| `AUG_AERIAL`       | Satellite / overhead imagery        |
+| `AUG_INDUSTRIAL`   | Manufacturing / inspection data     |
+
+All presets are plain dicts — inspect or extend them before passing:
 
 ```python
-AUG_CONFIG = {
-    "HorizontalFlip": {"p": 0.5},
-    "VerticalFlip": {"p": 0.5},
-    "Rotate": {"limit": 45, "p": 0.5},
-    "Affine": {
-        "scale": (0.8, 1.2),
-        "translate_percent": (0.1, 0.1),
-        "rotate": (-15, 15),
-        "shear": (-5, 5),
-        "p": 0.5,
-    },
-    "ColorJitter": {
-        "brightness": 0.2,
-        "contrast": 0.2,
-        "saturation": 0.2,
-        "hue": 0.1,
-        "p": 0.5,
-    },
-}
+from rfdetr.datasets.aug_config import AUG_AGGRESSIVE
+
+my_config = {**AUG_AGGRESSIVE, "VerticalFlip": {"p": 0.1}}
+model.train(dataset_dir="...", aug_config=my_config)
 ```
 
-### Aerial Imagery / Satellite Datasets
+### Recommendations by Dataset Size
 
-```python
-AUG_CONFIG = {
-    "HorizontalFlip": {"p": 0.5},
-    "VerticalFlip": {"p": 0.5},  # Important for overhead views
-    "Rotate": {"limit": (90, 90), "p": 0.5},  # 90° rotations common
-    "RandomBrightnessContrast": {
-        "brightness_limit": 0.15,
-        "contrast_limit": 0.15,
-        "p": 0.4,
-    },
-}
-```
+| Dataset Size     | Recommended preset                                          |
+| ---------------- | ----------------------------------------------------------- |
+| Under 500 images | `AUG_CONSERVATIVE` — flip + mild brightness/contrast            |
+| 500–2000 images  | Default or `AUG_CONSERVATIVE` with a few extra transforms added |
+| 2000+ images     | `AUG_AGGRESSIVE` — rotations, affine, color jitter              |
 
-### Industrial / Manufacturing
+## Geometric vs. Pixel-Level Transforms
 
-```python
-AUG_CONFIG = {
-    "HorizontalFlip": {"p": 0.3},  # Less common in manufacturing
-    "RandomBrightnessContrast": {
-        "brightness_limit": 0.2,
-        "contrast_limit": 0.2,
-        "p": 0.5,
-    },
-    "GaussianBlur": {"blur_limit": 3, "p": 0.3},  # Camera focus variations
-    "GaussNoise": {"std_range": (0.01, 0.05), "p": 0.3},  # Sensor noise
-}
-```
-
-## How It Works
-
-Augmentations are automatically applied during training:
-
-1. The `AUG_CONFIG` is read when building the dataset
-2. Transforms are composed into a pipeline
-3. Each training sample is augmented on-the-fly
-4. Bounding boxes and masks are automatically transformed for geometric augmentations
-
-No code changes needed in your training script - just modify `augmentation_config.py`.
-
-## Programmatic Configuration
-
-You can also build augmentations programmatically for advanced use cases:
-
-```python
-from rfdetr.datasets.transforms import AlbumentationsWrapper, ComposeAugmentations
-
-# Custom config
-custom_config = {
-    "HorizontalFlip": {"p": 0.7},
-    "Rotate": {"limit": 15, "p": 0.5},
-    "Blur": {"blur_limit": 3, "p": 0.2},
-}
-
-# Build and compose transforms using the static method
-transforms = AlbumentationsWrapper.from_config(custom_config)
-augmentation_pipeline = ComposeAugmentations(transforms)
-
-# Apply to image and target (works with both detection and segmentation)
-# For detection: target contains "boxes" and "labels"
-# For segmentation: target contains "boxes", "labels", and "masks"
-augmented_image, augmented_target = augmentation_pipeline(image, target)
-```
+RF-DETR automatically handles bounding boxes for **geometric transforms** (flips, rotations, crops, affine, perspective). **Pixel-level transforms** (blur, noise, color) preserve coordinates unchanged. You don't need to handle this distinction — it's automatic based on the transform name.
 
 ## Best Practices
 
@@ -179,178 +70,49 @@ augmented_image, augmented_target = augmentation_pipeline(image, target)
 
     Be careful with aggressive rotations and crops on datasets where object orientation matters (e.g., text detection, oriented objects).
 
-### Recommendations by Dataset Size
-
-| Dataset Size     | Recommended Augmentations                                        |
-| ---------------- | ---------------------------------------------------------------- |
-| Under 500 images | Horizontal flip, small brightness/contrast adjustments           |
-| 500-2000 images  | Add vertical flip (if applicable), color jitter, blur            |
-| 2000+ images     | Add rotations, affine transforms, aggressive color augmentations |
-
-### Performance Tips
-
-- **CPU-bound:** Augmentations run on CPU during data loading
-- **More augmentations = slower loading** (but better model generalization)
-- **Use `num_workers`:** Parallelize augmentation with data loader workers
-- **Monitor GPU utilization:** If GPU isn't saturated, you can add more augmentations
-
-Example data loader configuration:
-
-```python
-from torch.utils.data import DataLoader
-
-dataloader = DataLoader(
-    dataset,
-    batch_size=16,
-    num_workers=4,  # Parallelize augmentations across 4 workers
-    pin_memory=True,
-)
-```
-
-## Monitoring Augmentations
-
-### Visualize Augmented Images
-
-To verify your augmentations are working as expected:
-
-```python
-import matplotlib.pyplot as plt
-from rfdetr.datasets.coco import CocoDetection
-from rfdetr.datasets.aug_config import AUG_CONFIG
-from rfdetr.datasets.transforms import AlbumentationsWrapper, ComposeAugmentations
-
-# Build dataset with augmentations
-transforms = AlbumentationsWrapper.from_config(AUG_CONFIG)
-augmentation_pipeline = ComposeAugmentations(transforms)
-
-dataset = CocoDetection(
-    img_folder="path/to/images",
-    ann_file="path/to/annotations.json",
-    transforms=augmentation_pipeline,
-)
-
-# Visualize
-image, target = dataset[0]
-plt.imshow(image)
-plt.show()
-```
-
-### Expected Training Behavior
-
-!!! note
-
-    With augmentations enabled, it's normal to see:
-
-    - **Training mAP lower than validation mAP** - Training uses augmented (harder) images
-    - **Slower data loading** - CPU preprocessing time increases
-    - **Better generalization** - Model learns from more diverse data
+- **CPU-bound:** Augmentations run on CPU during data loading — more transforms means slower loading
+- **Use `num_workers`:** Parallelize augmentation across data loader workers
+- **Monitor training mAP vs validation mAP:** With strong augmentations it's normal for training mAP to be lower — validation uses original images while training uses augmented (harder) ones
 
 ## Troubleshooting
 
-### Problem: Training is very slow
+**Training is slow** — reduce the number of transforms or increase `num_workers`.
 
-**Solutions:**
+**Boxes disappear after augmentation** — aggressive rotations or crops can push boxes outside the image boundary. Reduce rotation angles or avoid large crops.
 
-- Reduce number of augmentations
-- Reduce augmentation complexity (e.g., smaller rotation angles)
-- Increase `num_workers` in data loader
-- Profile to identify slow transforms
+**Model not improving** — augmentations may be too aggressive. Start with `AUG_CONSERVATIVE` and add transforms gradually. Try removing geometric transforms first to isolate the cause.
 
-### Problem: Validation mAP is much higher than training mAP
+**Validation mAP is much higher than training mAP** — this is expected with strong augmentations and not a bug. See the monitoring tip above.
 
-**This is expected** with strong augmentations:
+## Advanced: Custom Transforms
 
-- Validation uses original images (no augmentation)
-- Training mAP is artificially lower due to augmented data
-- This gap is normal and indicates augmentations are working
-
-### Problem: Some boxes or masks disappear after augmentation
-
-**This is normal behavior:**
-
-- Aggressive transforms (large rotations, crops) can move boxes outside boundaries
-- Albumentations removes boxes and their corresponding masks that fall outside image
-
-**Solutions:**
-
-- Reduce augmentation intensity
-- Use smaller rotation angles
-- Avoid aggressive crops
-- Advanced: Reduce `min_visibility` in `AlbumentationsWrapper` (requires code changes)
-
-### Problem: Model not improving
-
-**Check if augmentations are too aggressive:**
-
-- Try reducing augmentation probabilities
-- Remove geometric transforms temporarily
-- Start with only color augmentations
-- Gradually add back geometric transforms
-
-## Advanced Topics
-
-### Custom Transform Integration
-
-To add a custom Albumentations transform not in the default config:
-
-1. Import the transform in your config:
-
-    ```python
-    # aug_config.py
-    AUG_CONFIG = {
-        "HorizontalFlip": {"p": 0.5},
-        "RandomShadow": {  # Custom shadow augmentation
-            "shadow_roi": (0, 0, 1, 1),
-            "num_shadows_limit": (1, 1),
-            "shadow_dimension": 3,
-            "p": 0.3,
-        },
-    }
-    ```
-
-2. The transform will be automatically loaded if it exists in Albumentations
-
-### Conditional Augmentations
-
-Use different augmentations for different scenarios:
+Any Albumentations transform works by name. If your custom transform is geometric, register it in `rfdetr/datasets/transforms.py` so boxes are updated automatically:
 
 ```python
-# For training
-TRAIN_AUG_CONFIG = {
-    "HorizontalFlip": {"p": 0.5},
-    "Rotate": {"limit": 45, "p": 0.5},
-}
-
-# For fine-tuning (lighter augmentations)
-FINETUNE_AUG_CONFIG = {
-    "HorizontalFlip": {"p": 0.3},
-    "RandomBrightnessContrast": {"brightness_limit": 0.1, "contrast_limit": 0.1, "p": 0.2},
+GEOMETRIC_TRANSFORMS = {
+    ...
+    "YourCustomTransform",
 }
 ```
 
-### Debug Mode
-
-To see augmentation warnings and statistics:
+Then use it like any other transform:
 
 ```python
-import logging
-
-logging.basicConfig(level=logging.INFO)
-
-# Now you'll see messages like:
-# INFO - Built 3 Albumentations transforms from config
-# WARNING - Unknown Albumentations transform: CustomTransform. Skipping.
+model.train(
+    dataset_dir="...",
+    aug_config={
+        "HorizontalFlip": {"p": 0.5},
+        "YourCustomTransform": {"param": 1, "p": 0.3},
+    },
+)
 ```
 
 ## Reference
 
-- **Albumentations Documentation:** [https://albumentations.ai/docs/](https://albumentations.ai/docs/)
-- **Available Transforms:** [https://albumentations.ai/docs/api_reference/augmentations/](https://albumentations.ai/docs/api_reference/augmentations/)
-- **Examples Gallery:** [https://albumentations.ai/docs/examples/](https://albumentations.ai/docs/examples/)
+- [Albumentations docs](https://albumentations.ai/docs/)
+- [All available transforms](https://albumentations.ai/docs/api_reference/augmentations/)
 
 ## Next Steps
-
-After configuring augmentations:
 
 - [Monitor training with TensorBoard](advanced.md#logging-with-tensorboard)
 - [Use early stopping](advanced.md#early-stopping) to prevent overfitting

--- a/docs/learn/train/augmentations.md
+++ b/docs/learn/train/augmentations.md
@@ -114,6 +114,6 @@ model.train(
 
 ## Next Steps
 
-- [Monitor training with TensorBoard](advanced.md#logging-with-tensorboard)
+- [Monitor training with TensorBoard](loggers.md#logging-with-tensorboard)
 - [Use early stopping](advanced.md#early-stopping) to prevent overfitting
 - [Export your trained model](../export.md) for deployment

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -6,7 +6,7 @@
 
 
 import os
-from typing import Any, ClassVar, List, Literal, Mapping, Optional
+from typing import Any, ClassVar, Dict, List, Literal, Mapping, Optional
 
 import torch
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
@@ -313,6 +313,7 @@ class TrainConfig(BaseModel):
     run_test: bool = True
     segmentation_head: bool = False
     eval_max_dets: int = 500
+    aug_config: Optional[Dict[str, Any]] = None
 
     @field_validator("dataset_dir", "output_dir", mode="after")
     @classmethod

--- a/src/rfdetr/datasets/aug_config.py
+++ b/src/rfdetr/datasets/aug_config.py
@@ -4,24 +4,31 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
-"""Default Albumentations augmentation configuration for RF-DETR training.
+"""Augmentation presets and default configuration for RF-DETR training.
 
-This configuration defines the augmentation pipeline used during training.
-The AlbumentationsWrapper automatically handles bounding box transformations
-for geometric transforms (flips, rotations, crops) while preserving boxes
-for pixel-level transforms (blur, color adjustments).
-
-## Usage
-
-Edit AUG_CONFIG to enable or customize augmentations:
+Import a preset and pass it as ``aug_config`` to your training call:
 
 ```python
-AUG_CONFIG = {
-    "HorizontalFlip": {"p": 0.5},  # 50% probability
-    "Rotate": {"limit": 45, "p": 0.3},  # Rotate up to ±45°
-    "GaussianBlur": {"p": 0.2},  # Pixel-level transform
-}
+from rfdetr.datasets.aug_config import AUG_CONSERVATIVE, AUG_AGGRESSIVE, AUG_AERIAL, AUG_INDUSTRIAL
+
+model.train(dataset_dir="...", aug_config=AUG_CONSERVATIVE)
+model.train(dataset_dir="...", aug_config=AUG_AGGRESSIVE)
+
+# Disable all augmentations
+model.train(dataset_dir="...", aug_config={})
+
+# Fully custom
+model.train(dataset_dir="...", aug_config={"HorizontalFlip": {"p": 0.5}})
 ```
+
+## Available presets
+
+| Preset         | Best for                                         |
+| -------------- | ------------------------------------------------ |
+| ``AUG_CONSERVATIVE``  | Small datasets (under 500 images)             |
+| ``AUG_AGGRESSIVE``    | Large datasets (2000+ images)                 |
+| ``AUG_AERIAL``        | Satellite / overhead imagery                  |
+| ``AUG_INDUSTRIAL``    | Manufacturing / inspection data               |
 
 ## Transform Categories
 
@@ -56,8 +63,71 @@ GEOMETRIC_TRANSFORMS = {
 ```
 """
 
+# ---------------------------------------------------------------------------
+# Default configuration (backward-compatible baseline)
+# ---------------------------------------------------------------------------
+
 AUG_CONFIG = {
     "HorizontalFlip": {"p": 0.5},
     # "VerticalFlip": {"p": 0.5},
     # "Rotate": {"limit": 15, "p": 0.5},  # Better keep small angles
+}
+
+# ---------------------------------------------------------------------------
+# Named presets — import and pass directly as aug_config=<preset>
+# ---------------------------------------------------------------------------
+
+#: Minimal augmentations — safe for small datasets (under 500 images).
+AUG_CONSERVATIVE = {
+    "HorizontalFlip": {"p": 0.5},
+    "RandomBrightnessContrast": {
+        "brightness_limit": 0.1,
+        "contrast_limit": 0.1,
+        "p": 0.3,
+    },
+}
+
+#: Aggressive augmentations — for larger datasets (2000+ images).
+AUG_AGGRESSIVE = {
+    "HorizontalFlip": {"p": 0.5},
+    "VerticalFlip": {"p": 0.5},
+    "Rotate": {"limit": 45, "p": 0.5},
+    "Affine": {
+        "scale": (0.8, 1.2),
+        "translate_percent": (0.1, 0.1),
+        "rotate": (-15, 15),
+        "shear": (-5, 5),
+        "p": 0.5,
+    },
+    "ColorJitter": {
+        "brightness": 0.2,
+        "contrast": 0.2,
+        "saturation": 0.2,
+        "hue": 0.1,
+        "p": 0.5,
+    },
+}
+
+#: Optimised for aerial / satellite imagery (overhead views, 90° rotations).
+AUG_AERIAL = {
+    "HorizontalFlip": {"p": 0.5},
+    "VerticalFlip": {"p": 0.5},
+    "Rotate": {"limit": (90, 90), "p": 0.5},
+    "RandomBrightnessContrast": {
+        "brightness_limit": 0.15,
+        "contrast_limit": 0.15,
+        "p": 0.4,
+    },
+}
+
+#: Optimised for industrial / manufacturing data (lighting & sensor noise).
+AUG_INDUSTRIAL = {
+    "HorizontalFlip": {"p": 0.3},
+    "RandomBrightnessContrast": {
+        "brightness_limit": 0.2,
+        "contrast_limit": 0.2,
+        "p": 0.5,
+    },
+    "GaussianBlur": {"blur_limit": 3, "p": 0.3},
+    "GaussNoise": {"std_range": (0.01, 0.05), "p": 0.3},
 }

--- a/src/rfdetr/datasets/coco.py
+++ b/src/rfdetr/datasets/coco.py
@@ -166,7 +166,7 @@ def make_coco_transforms(
         skip_random_resize: bool = False,
         patch_size: int = 16,
         num_windows: int = 4,
-        aug_config=None,
+        aug_config: Optional[Dict[str, Dict[str, Any]]] = None,
 ) -> T.Compose:
 
     normalize = T.Compose([
@@ -246,10 +246,9 @@ def make_coco_transforms_square_div_64(
             patch embedding or stride).
         num_windows: Number of windows used by ``compute_multi_scale_scales`` to
             derive the list of candidate square resolutions.
-        aug_config: Augmentation configuration.  Accepts a preset name
-            (``"conservative"``, ``"aggressive"``, ``"aerial"``,
-            ``"industrial"``, ``"disabled"``), a custom config dict, or
-            ``None`` to use the default :data:`~rfdetr.datasets.aug_config.AUG_CONFIG`.
+        aug_config: Augmentation configuration dictionary compatible with
+            :class:`~rfdetr.datasets.transforms.AlbumentationsWrapper`. If ``None``,
+            the default :data:`~rfdetr.datasets.aug_config.AUG_CONFIG` is used.
 
     Returns:
         A ``T.Compose`` object containing the composed image transforms appropriate

--- a/src/rfdetr/datasets/coco.py
+++ b/src/rfdetr/datasets/coco.py
@@ -38,7 +38,9 @@ logger = get_logger()
 def is_valid_coco_dataset(dataset_dir: str) -> bool:
     return (Path(dataset_dir) / "train" / "_annotations.coco.json").exists()
 
-def compute_multi_scale_scales(resolution: int, expanded_scales: bool = False, patch_size: int = 16, num_windows: int = 4) -> List[int]:
+def compute_multi_scale_scales(
+        resolution: int, expanded_scales: bool = False, patch_size: int = 16, num_windows: int = 4,
+) -> List[int]:
     # round to the nearest multiple of 4*patch_size to enable both patching and windowing
     base_num_patches_per_window = resolution // (patch_size * num_windows)
     offsets = [-3, -2, -1, 0, 1, 2, 3, 4] if not expanded_scales else [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5]
@@ -74,7 +76,13 @@ def convert_coco_poly_to_mask(segmentations: List[Any], height: int, width: int)
 
 
 class CocoDetection(torchvision.datasets.CocoDetection):
-    def __init__(self, img_folder: Union[str, Path], ann_file: Union[str, Path], transforms: Optional[Any], include_masks: bool = False) -> None:
+    def __init__(
+            self,
+            img_folder: Union[str, Path],
+            ann_file: Union[str, Path],
+            transforms: Optional[Any],
+            include_masks: bool = False,
+    ) -> None:
         super(CocoDetection, self).__init__(img_folder, ann_file)
         self._transforms = transforms
         self.include_masks = include_masks
@@ -150,7 +158,16 @@ class ConvertCoco(object):
         return image, target
 
 
-def make_coco_transforms(image_set: str, resolution: int, multi_scale: bool = False, expanded_scales: bool = False, skip_random_resize: bool = False, patch_size: int = 16, num_windows: int = 4) -> T.Compose:
+def make_coco_transforms(
+        image_set: str,
+        resolution: int,
+        multi_scale: bool = False,
+        expanded_scales: bool = False,
+        skip_random_resize: bool = False,
+        patch_size: int = 16,
+        num_windows: int = 4,
+        aug_config=None,
+) -> T.Compose:
 
     normalize = T.Compose([
         T.ToTensor(),
@@ -166,6 +183,7 @@ def make_coco_transforms(image_set: str, resolution: int, multi_scale: bool = Fa
         logger.info(f"Using multi-scale training with scales: {scales}")
 
     if image_set == 'train':
+        resolved_aug_config = aug_config if aug_config is not None else AUG_CONFIG
         return T.Compose([
             T.RandomSelect(
                 T.RandomResize(scales, max_size=1333),
@@ -175,10 +193,7 @@ def make_coco_transforms(image_set: str, resolution: int, multi_scale: bool = Fa
                     T.RandomResize(scales, max_size=1333),
                 ])
             ),
-            # TODO(next PR): AUG_CONFIG should be propagated and exposed as a user-facing parameter
-            #   (e.g. via training args) so callers can override the default augmentation pipeline
-            #   without editing aug_config.py directly.
-            ComposeAugmentations(AlbumentationsWrapper.from_config(AUG_CONFIG)),
+            ComposeAugmentations(AlbumentationsWrapper.from_config(resolved_aug_config)),
             normalize,
         ])
 
@@ -196,7 +211,16 @@ def make_coco_transforms(image_set: str, resolution: int, multi_scale: bool = Fa
     raise ValueError(f'unknown {image_set}')
 
 
-def make_coco_transforms_square_div_64(image_set: str, resolution: int, multi_scale: bool = False, expanded_scales: bool = False, skip_random_resize: bool = False, patch_size: int = 16, num_windows: int = 4) -> T.Compose:
+def make_coco_transforms_square_div_64(
+        image_set: str,
+        resolution: int,
+        multi_scale: bool = False,
+        expanded_scales: bool = False,
+        skip_random_resize: bool = False,
+        patch_size: int = 16,
+        num_windows: int = 4,
+        aug_config=None,
+) -> T.Compose:
     """
     Create COCO transforms with square resizing where the output size is divisible by 64.
 
@@ -222,6 +246,10 @@ def make_coco_transforms_square_div_64(image_set: str, resolution: int, multi_sc
             patch embedding or stride).
         num_windows: Number of windows used by ``compute_multi_scale_scales`` to
             derive the list of candidate square resolutions.
+        aug_config: Augmentation configuration.  Accepts a preset name
+            (``"conservative"``, ``"aggressive"``, ``"aerial"``,
+            ``"industrial"``, ``"disabled"``), a custom config dict, or
+            ``None`` to use the default :data:`~rfdetr.datasets.aug_config.AUG_CONFIG`.
 
     Returns:
         A ``T.Compose`` object containing the composed image transforms appropriate
@@ -242,6 +270,7 @@ def make_coco_transforms_square_div_64(image_set: str, resolution: int, multi_sc
         logger.info(f"Using multi-scale training with square resize and scales: {scales}")
 
     if image_set == 'train':
+        resolved_aug_config = aug_config if aug_config is not None else AUG_CONFIG
         return T.Compose([
             T.RandomSelect(
                 T.SquareResize(scales),
@@ -251,10 +280,7 @@ def make_coco_transforms_square_div_64(image_set: str, resolution: int, multi_sc
                     T.SquareResize(scales),
                 ]),
             ),
-            # TODO(next PR): AUG_CONFIG should be propagated and exposed as a user-facing parameter
-            #   (e.g. via training args) so callers can override the default augmentation pipeline
-            #   without editing aug_config.py directly.
-            ComposeAugmentations(AlbumentationsWrapper.from_config(AUG_CONFIG)),
+            ComposeAugmentations(AlbumentationsWrapper.from_config(resolved_aug_config)),
             normalize,
         ])
 
@@ -293,6 +319,7 @@ def build_coco(image_set: str, args: Any, resolution: int) -> CocoDetection:
 
     square_resize_div_64 = getattr(args, 'square_resize_div_64', False)
     include_masks = getattr(args, "segmentation_head", False)
+    aug_config = getattr(args, 'aug_config', None)
 
     if square_resize_div_64:
         logger.info(f"Building COCO {image_set} dataset with square resize at resolution {resolution}")
@@ -303,7 +330,8 @@ def build_coco(image_set: str, args: Any, resolution: int) -> CocoDetection:
             expanded_scales=args.expanded_scales,
             skip_random_resize=not args.do_random_resize_via_padding,
             patch_size=args.patch_size,
-            num_windows=args.num_windows
+            num_windows=args.num_windows,
+            aug_config=aug_config,
         ), include_masks=include_masks)
     else:
         logger.info(f"Building COCO {image_set} dataset at resolution {resolution}")
@@ -314,7 +342,8 @@ def build_coco(image_set: str, args: Any, resolution: int) -> CocoDetection:
             expanded_scales=args.expanded_scales,
             skip_random_resize=not args.do_random_resize_via_padding,
             patch_size=args.patch_size,
-            num_windows=args.num_windows
+            num_windows=args.num_windows,
+            aug_config=aug_config,
         ), include_masks=include_masks)
     return dataset
 
@@ -343,6 +372,7 @@ def build_roboflow_from_coco(image_set: str, args: Any, resolution: int) -> Coco
     do_random_resize_via_padding = getattr(args, "do_random_resize_via_padding", False)
     patch_size = getattr(args, "patch_size", 16)
     num_windows = getattr(args, "num_windows", 4)
+    aug_config = getattr(args, "aug_config", None)
 
     if square_resize_div_64:
         logger.info(f"Building Roboflow {image_set} dataset with square resize at resolution {resolution}")
@@ -353,7 +383,8 @@ def build_roboflow_from_coco(image_set: str, args: Any, resolution: int) -> Coco
             expanded_scales=expanded_scales,
             skip_random_resize=not do_random_resize_via_padding,
             patch_size=patch_size,
-            num_windows=num_windows
+            num_windows=num_windows,
+            aug_config=aug_config,
         ), include_masks=include_masks)
     else:
         logger.info(f"Building Roboflow {image_set} dataset at resolution {resolution}")
@@ -364,6 +395,7 @@ def build_roboflow_from_coco(image_set: str, args: Any, resolution: int) -> Coco
             expanded_scales=expanded_scales,
             skip_random_resize=not do_random_resize_via_padding,
             patch_size=patch_size,
-            num_windows=num_windows
+            num_windows=num_windows,
+            aug_config=aug_config,
         ), include_masks=include_masks)
     return dataset

--- a/src/rfdetr/main.py
+++ b/src/rfdetr/main.py
@@ -992,6 +992,7 @@ def populate_args(
     coco_path=None,
     dataset_dir=None,
     square_resize_div_64=False,
+    aug_config=None,
 
     # Output parameters
     output_dir='output',
@@ -1102,6 +1103,7 @@ def populate_args(
         coco_path=coco_path,
         dataset_dir=dataset_dir,
         square_resize_div_64=square_resize_div_64,
+        aug_config=aug_config,
         output_dir=output_dir,
         dont_save_weights=dont_save_weights,
         checkpoint_interval=checkpoint_interval,

--- a/tests/datasets/test_augmentations.py
+++ b/tests/datasets/test_augmentations.py
@@ -13,6 +13,7 @@ from PIL import Image
 from torch.utils.data import DataLoader
 
 from rfdetr.datasets.aug_config import AUG_CONFIG
+from rfdetr.datasets.coco import make_coco_transforms, make_coco_transforms_square_div_64
 from rfdetr.datasets.transforms import (
     AlbumentationsWrapper,
     Compose,
@@ -928,3 +929,57 @@ class TestTrainingLoop:
         # Verify they can be stacked
         orig_sizes = torch.stack([t["orig_size"] for t in targets], dim=0)
         assert orig_sizes.shape == torch.Size([len(targets), 2])
+
+
+class TestMakeCocoTransformsAugConfig:
+    """Tests for aug_config propagation in make_coco_transforms / make_coco_transforms_square_div_64."""
+
+    @pytest.mark.parametrize("make_transforms", [
+        make_coco_transforms,
+        make_coco_transforms_square_div_64,
+    ])
+    def test_default_none_uses_aug_config(self, make_transforms):
+        """Omitting aug_config uses the module-level AUG_CONFIG default (HorizontalFlip)."""
+        pipeline = make_transforms("train", 640)
+        aug_step = next(t for t in pipeline.transforms if isinstance(t, ComposeAugmentations))
+
+        expected_names = list(AUG_CONFIG.keys())
+        actual_names = [
+            w.transform.transforms[0].__class__.__name__ for w in aug_step.transforms
+        ]
+        assert actual_names == expected_names
+
+    @pytest.mark.parametrize("make_transforms", [
+        make_coco_transforms,
+        make_coco_transforms_square_div_64,
+    ])
+    def test_empty_dict_disables_augmentations(self, make_transforms):
+        """aug_config={} produces a ComposeAugmentations with no transforms."""
+        pipeline = make_transforms("train", 640, aug_config={})
+        aug_step = next(t for t in pipeline.transforms if isinstance(t, ComposeAugmentations))
+
+        assert aug_step.transforms == []
+
+    @pytest.mark.parametrize("make_transforms", [
+        make_coco_transforms,
+        make_coco_transforms_square_div_64,
+    ])
+    def test_custom_dict_is_used(self, make_transforms):
+        """aug_config with a custom dict wires up exactly those transforms."""
+        custom = {"HorizontalFlip": {"p": 1.0}}
+        pipeline = make_transforms("train", 640, aug_config=custom)
+        aug_step = next(t for t in pipeline.transforms if isinstance(t, ComposeAugmentations))
+
+        assert len(aug_step.transforms) == 1
+        assert aug_step.transforms[0].transform.transforms[0].__class__.__name__ == "HorizontalFlip"
+
+    @pytest.mark.parametrize("make_transforms", [
+        make_coco_transforms,
+        make_coco_transforms_square_div_64,
+    ])
+    def test_aug_config_not_applied_on_val(self, make_transforms):
+        """aug_config is ignored for val splits — no ComposeAugmentations in the pipeline."""
+        pipeline = make_transforms("val", 640, aug_config={"HorizontalFlip": {"p": 1.0}})
+        aug_steps = [t for t in pipeline.transforms if isinstance(t, ComposeAugmentations)]
+
+        assert aug_steps == []


### PR DESCRIPTION
This pull request introduces a major overhaul to how data augmentations are configured and used in RF-DETR, making augmentations fully user-configurable and much easier to use. The changes add multiple built-in augmentation presets, allow passing custom augmentation configs directly to training, and update both the documentation and codebase to reflect this new, flexible approach.

**Key highlights:**
- Users can now select from several built-in augmentation presets or provide their own custom configurations without editing library files.
- The documentation is rewritten for clarity, with practical examples and best practices.
- The codebase is updated to propagate augmentation configs throughout the training pipeline.

The most important changes are:

**User-facing augmentation configuration:**
* Added multiple built-in augmentation presets (`AUG_CONSERVATIVE`, `AUG_AGGRESSIVE`, `AUG_AERIAL`, `AUG_INDUSTRIAL`) and made them easily importable and usable by passing as the `aug_config` argument to training. The default config is still available as `AUG_CONFIG`. [[1]](diffhunk://#diff-659e169f6516e9826760d178daa58ebf52c7ba725c6b10516786c7363ee67fd2L7-R32) [[2]](diffhunk://#diff-659e169f6516e9826760d178daa58ebf52c7ba725c6b10516786c7363ee67fd2R66-R133)
* Updated the documentation (`docs/learn/train/augmentations.md`) to explain the new configuration system, provide usage examples, and offer best practices and troubleshooting tips. [[1]](diffhunk://#diff-f4d7b68f70447d0c218cf9c56a057d1b1db802cf3a4775e8c00e0bb7d852f1c0L1-R61) [[2]](diffhunk://#diff-f4d7b68f70447d0c218cf9c56a057d1b1db802cf3a4775e8c00e0bb7d852f1c0L182-L354)

**Codebase and API updates:**
* Modified the data pipeline (`make_coco_transforms` and `make_coco_transforms_square_div_64` in `src/rfdetr/datasets/coco.py`) to accept an `aug_config` parameter, allowing augmentation configuration to be passed programmatically rather than being hardcoded. [[1]](diffhunk://#diff-a2bf011080a4e4e3f0bf73f2c524e83384f922a65c4cfa89bbb5f0121a08fff9L153-R170) [[2]](diffhunk://#diff-a2bf011080a4e4e3f0bf73f2c524e83384f922a65c4cfa89bbb5f0121a08fff9R186) [[3]](diffhunk://#diff-a2bf011080a4e4e3f0bf73f2c524e83384f922a65c4cfa89bbb5f0121a08fff9L178-R196) [[4]](diffhunk://#diff-a2bf011080a4e4e3f0bf73f2c524e83384f922a65c4cfa89bbb5f0121a08fff9L199-R223)
* Updated the training configuration model (`TrainConfig` in `src/rfdetr/config.py`) to include an optional `aug_config` field, supporting end-to-end propagation of augmentation settings from user input to the data pipeline. [[1]](diffhunk://#diff-8234f50bded952af8b2719bc9dc3bb60e36cce3e81c3c536b813696360577189L9-R9) [[2]](diffhunk://#diff-8234f50bded952af8b2719bc9dc3bb60e36cce3e81c3c536b813696360577189R316)

**General code style improvements:**
* Improved function formatting for readability in `src/rfdetr/datasets/coco.py`. [[1]](diffhunk://#diff-a2bf011080a4e4e3f0bf73f2c524e83384f922a65c4cfa89bbb5f0121a08fff9L41-R43) [[2]](diffhunk://#diff-a2bf011080a4e4e3f0bf73f2c524e83384f922a65c4cfa89bbb5f0121a08fff9L77-R85)

These changes make the augmentation system more flexible, user-friendly, and maintainable, and they clarify best practices for users training detection models with RF-DETR.