### PR TITLE
Fix OpenCV scene mismatching in `DatasetGridSaver`

### DIFF
--- a/src/rfdetr/datasets/save_grids.py
+++ b/src/rfdetr/datasets/save_grids.py
@@ -101,6 +101,8 @@ class DatasetGridSaver:
             box_annotator: ``sv.BoxAnnotator`` instance for drawing bounding boxes.
             label_annotator: ``sv.LabelAnnotator`` instance for drawing class labels.
         """
+        from PIL import Image as PILImage
+
         resized_size = single_target["size"]
         if isinstance(resized_size, torch.Tensor):
             resized_size = resized_size.detach().cpu()
@@ -109,7 +111,9 @@ class DatasetGridSaver:
         de_normalized_img = inv_normalize(single_image)
         if isinstance(de_normalized_img, torch.Tensor):
             de_normalized_img = de_normalized_img.detach().cpu().numpy()
-        img_uint8 = (np.clip(de_normalized_img.transpose(1, 2, 0), 0.0, 1.0) * 255).astype(np.uint8)
+        scene = PILImage.fromarray(
+            (np.clip(de_normalized_img.transpose(1, 2, 0), 0.0, 1.0) * 255).astype(np.uint8)
+        )
 
         if len(single_target["boxes"]) > 0:
             labels_tensor = single_target["labels"]
@@ -130,8 +134,8 @@ class DatasetGridSaver:
             )
             detections = sv.Detections(xyxy=xyxy, class_id=class_ids)
             labels = [str(c) for c in class_ids]
-            img_uint8 = box_annotator.annotate(scene=img_uint8, detections=detections)
-            img_uint8 = label_annotator.annotate(scene=img_uint8, detections=detections, labels=labels)
+            scene = box_annotator.annotate(scene=scene, detections=detections)
+            scene = label_annotator.annotate(scene=scene, detections=detections, labels=labels)
 
-        ax.imshow(img_uint8)
+        ax.imshow(scene)
         ax.axis("off")

--- a/src/rfdetr/datasets/save_grids.py
+++ b/src/rfdetr/datasets/save_grids.py
@@ -111,9 +111,7 @@ class DatasetGridSaver:
         de_normalized_img = inv_normalize(single_image)
         if isinstance(de_normalized_img, torch.Tensor):
             de_normalized_img = de_normalized_img.detach().cpu().numpy()
-        scene = PILImage.fromarray(
-            (np.clip(de_normalized_img.transpose(1, 2, 0), 0.0, 1.0) * 255).astype(np.uint8)
-        )
+        scene = PILImage.fromarray((np.clip(de_normalized_img.transpose(1, 2, 0), 0.0, 1.0) * 255).astype(np.uint8))
 
         if len(single_target["boxes"]) > 0:
             labels_tensor = single_target["labels"]

--- a/tests/datasets/test_save_grids.py
+++ b/tests/datasets/test_save_grids.py
@@ -10,7 +10,7 @@ without OpenCV layout errors across all supported OpenCV versions."""
 from pathlib import Path
 
 import numpy as np
-import pytest
+
 import torch
 from PIL import Image
 from torch.utils.data import DataLoader
@@ -58,6 +58,7 @@ def test_save_grid_writes_files(tmp_path: Path) -> None:
     grids = list(tmp_path.glob("train_batch*_grid.jpg"))
     assert len(grids) == 2, f"Expected 2 grid files, got {len(grids)}"
     for grid_path in grids:
-        img = np.array(Image.open(grid_path))
+        with Image.open(grid_path) as pil_img:
+            img = np.array(pil_img)
         assert img.ndim == 3
         assert img.shape[2] == 3

--- a/tests/datasets/test_save_grids.py
+++ b/tests/datasets/test_save_grids.py
@@ -1,0 +1,63 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Tests for DatasetGridSaver — verifies that annotated grid images are written
+without OpenCV layout errors across all supported OpenCV versions."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+from torch.utils.data import DataLoader
+
+
+class _FakeDataset:
+    """Minimal dataset returning a single synthetic image + target."""
+
+    def __init__(self, num_samples: int = 4) -> None:
+        self.num_samples = num_samples
+
+    def __len__(self) -> int:
+        return self.num_samples
+
+    def __getitem__(self, idx):
+        # CHW float tensor in ImageNet-normalised range
+        image = torch.zeros(3, 224, 224)
+        target = {
+            "size": torch.tensor([224, 224]),
+            "boxes": torch.tensor([[0.25, 0.25, 0.5, 0.5], [0.6, 0.6, 0.2, 0.2]]),
+            "labels": torch.tensor([0, 1]),
+        }
+        return image, target
+
+
+def _collate(batch):
+    import rfdetr.util.misc as utils
+
+    images, targets = zip(*batch)
+    # NestedTensor expected by DatasetGridSaver
+    nested = utils.nested_tensor_from_tensor_list(list(images))
+    return nested, list(targets)
+
+
+def test_save_grid_writes_files(tmp_path: Path) -> None:
+    """DatasetGridSaver must write JPEG grid files without raising OpenCV errors."""
+    from rfdetr.datasets.save_grids import DatasetGridSaver
+
+    dataset = _FakeDataset(num_samples=4)
+    loader = DataLoader(dataset, batch_size=2, collate_fn=_collate)
+
+    saver = DatasetGridSaver(loader, tmp_path, max_batches=2, dataset_type="train")
+    saver.save_grid()
+
+    grids = list(tmp_path.glob("train_batch*_grid.jpg"))
+    assert len(grids) == 2, f"Expected 2 grid files, got {len(grids)}"
+    for grid_path in grids:
+        img = np.array(Image.open(grid_path))
+        assert img.ndim == 3
+        assert img.shape[2] == 3

--- a/tests/datasets/test_save_grids.py
+++ b/tests/datasets/test_save_grids.py
@@ -10,7 +10,6 @@ without OpenCV layout errors across all supported OpenCV versions."""
 from pathlib import Path
 
 import numpy as np
-
 import torch
 from PIL import Image
 from torch.utils.data import DataLoader


### PR DESCRIPTION
This pull request improves the image annotation and saving pipeline in `src/rfdetr/datasets/save_grids.py` by switching from NumPy arrays to PIL images for image processing, which enhances compatibility and reliability when saving annotated grids. Additionally, comprehensive tests are added to ensure that annotated grid images are saved correctly without OpenCV layout errors.

**Image annotation and processing improvements:**

* Replaced NumPy array-based image handling with PIL-based processing in the `_annotate_and_plot` function, converting images to `PILImage` objects before annotation and display. This change improves compatibility with downstream image saving and annotation functions. [[1]](diffhunk://#diff-1733f36e4b11b8699bb4407b7be18aac471a064ec7d3ceec540ae4a18a3b7230R104-R105) [[2]](diffhunk://#diff-1733f36e4b11b8699bb4407b7be18aac471a064ec7d3ceec540ae4a18a3b7230L112-R116) [[3]](diffhunk://#diff-1733f36e4b11b8699bb4407b7be18aac471a064ec7d3ceec540ae4a18a3b7230L133-R140)

**Testing enhancements:**

* Added a new test file `tests/datasets/test_save_grids.py` that introduces a synthetic dataset and validates that `DatasetGridSaver` writes annotated grid JPEG files without OpenCV layout errors, ensuring robust output across OpenCV versions.