### PR TITLE
Add unit tests for critical model utility functions and error handling

### DIFF
--- a/tests/models/test_segmentation_head.py
+++ b/tests/models/test_segmentation_head.py
@@ -1,0 +1,48 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from contextlib import contextmanager
+
+import torch
+
+from rfdetr.models.segmentation_head import DepthwiseConvBlock
+
+
+class _FailingThenPassingDepthwise(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls = 0
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        self.calls += 1
+        if self.calls == 1:
+            raise RuntimeError("GET was unable to find an engine to execute this computation")
+        return x
+
+
+def test_depthwise_conv_retries_with_cudnn_disabled_on_get_engine_error(monkeypatch) -> None:
+    """Retry depthwise conv with cuDNN disabled when engine selection fails."""
+    block = DepthwiseConvBlock(dim=8)
+    fallback_dwconv = _FailingThenPassingDepthwise()
+    block.dwconv = fallback_dwconv
+
+    fallback_context_calls = 0
+
+    @contextmanager
+    def _fake_cudnn_flags(*, enabled: bool):
+        nonlocal fallback_context_calls
+        assert enabled is False
+        fallback_context_calls += 1
+        yield
+
+    monkeypatch.setattr(torch.backends.cudnn, "flags", _fake_cudnn_flags)
+
+    x = torch.randn(1, 8, 4, 4)
+    y = block(x)
+
+    assert y.shape == x.shape
+    assert fallback_dwconv.calls == 2
+    assert fallback_context_calls == 1

--- a/tests/models/test_transformer.py
+++ b/tests/models/test_transformer.py
@@ -1,0 +1,38 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+import torch
+
+from rfdetr.models.transformer import gen_encoder_output_proposals
+
+
+def test_gen_encoder_output_proposals_passes_ij_indexing_to_meshgrid(monkeypatch) -> None:
+    """`gen_encoder_output_proposals` should call `torch.meshgrid` with explicit ij indexing."""
+    original_meshgrid = torch.meshgrid
+    call_count = 0
+
+    def _meshgrid_with_indexing_assertion(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if kwargs.get("indexing") != "ij":
+            raise AssertionError("torch.meshgrid must be called with indexing='ij'")
+        return original_meshgrid(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "meshgrid", _meshgrid_with_indexing_assertion)
+
+    memory = torch.randn(1, 4, 8)
+    spatial_shapes = torch.tensor([[2, 2]], dtype=torch.long)
+
+    output_memory, output_proposals = gen_encoder_output_proposals(
+        memory=memory,
+        memory_padding_mask=None,
+        spatial_shapes=spatial_shapes,
+        unsigmoid=True,
+    )
+
+    assert call_count == 1
+    assert output_memory.shape == memory.shape
+    assert output_proposals.shape == (1, 4, 4)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,25 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+import torch
+
+from rfdetr.engine import _get_cuda_autocast_dtype
+
+
+def test_get_cuda_autocast_dtype_prefers_bfloat16_when_supported(monkeypatch) -> None:
+    """Use bfloat16 when CUDA reports BF16 support."""
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "is_bf16_supported", lambda: True)
+
+    assert _get_cuda_autocast_dtype() == torch.bfloat16
+
+
+def test_get_cuda_autocast_dtype_falls_back_to_float16_when_bfloat16_unsupported(monkeypatch) -> None:
+    """Use float16 on CUDA devices that do not support BF16 (e.g. T4)."""
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "is_bf16_supported", lambda: False)
+
+    assert _get_cuda_autocast_dtype() == torch.float16

--- a/tests/util/test_box_ops.py
+++ b/tests/util/test_box_ops.py
@@ -1,0 +1,33 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+import torch
+
+from rfdetr.util.box_ops import masks_to_boxes
+
+
+def test_masks_to_boxes_passes_ij_indexing_to_meshgrid(monkeypatch) -> None:
+    """`masks_to_boxes` should call `torch.meshgrid` with explicit ij indexing."""
+    original_meshgrid = torch.meshgrid
+    call_count = 0
+
+    def _meshgrid_with_indexing_assertion(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if kwargs.get("indexing") != "ij":
+            raise AssertionError("torch.meshgrid must be called with indexing='ij'")
+        return original_meshgrid(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "meshgrid", _meshgrid_with_indexing_assertion)
+
+    masks = torch.zeros((1, 2, 3), dtype=torch.bool)
+    masks[0, 0, 1] = True
+    masks[0, 1, 2] = True
+
+    boxes = masks_to_boxes(masks)
+
+    assert call_count == 1
+    assert boxes.shape == (1, 4)


### PR DESCRIPTION
This pull request adds new unit tests to improve coverage and robustness for several core components of the RF-DETR codebase. The tests focus on verifying correct behavior in edge cases, especially regarding device-specific operations and function contracts involving PyTorch APIs.

**New tests for device-specific and API contract behaviors:**

*Engine and autocast dtype selection:*
- Added tests for `_get_cuda_autocast_dtype` in `rfdetr.engine` to ensure it selects `bfloat16` when supported by CUDA and falls back to `float16` otherwise.

*Depthwise convolution error handling:*
- Added a test for `DepthwiseConvBlock` in `rfdetr.models.segmentation_head` to verify that it retries with cuDNN disabled if engine selection fails, simulating a failure on the first call and success on retry.

*PyTorch meshgrid API usage:*
- Added a test for `gen_encoder_output_proposals` in `rfdetr.models.transformer` to assert that `torch.meshgrid` is called with `indexing='ij'`, ensuring correct spatial indexing.
- Added a test for `masks_to_boxes` in `rfdetr.util.box_ops` to verify that `torch.meshgrid` is invoked with explicit `ij` indexing, maintaining consistency with PyTorch best practices.