### PR TITLE
fix COCO sparse category ID remapping logic

### DIFF
--- a/src/rfdetr/datasets/coco.py
+++ b/src/rfdetr/datasets/coco.py
@@ -98,6 +98,8 @@ class CocoDetection(torchvision.datasets.CocoDetection):
         # Reverse mapping from contiguous label indices back to COCO category_id
         self.label2cat = {label: cat_id for cat_id, label in self.cat2label.items()}
         self.prepare = ConvertCoco(include_masks=include_masks, cat2label=self.cat2label)
+        # Expose label-to-category mapping on the underlying COCO API object for evaluators
+        setattr(self.coco, "label2cat", self.label2cat)
 
     def __getitem__(self, idx: int) -> Tuple[Any, Any]:
         img, target = super(CocoDetection, self).__getitem__(idx)

--- a/src/rfdetr/datasets/coco.py
+++ b/src/rfdetr/datasets/coco.py
@@ -114,7 +114,7 @@ class CocoDetection(torchvision.datasets.CocoDetection):
 class ConvertCoco(object):
     def __init__(self, include_masks: bool = False, cat2label: Optional[Dict[int, int]] = None) -> None:
         self.include_masks = include_masks
-        self.cat2label = cat2label or {}
+        self.cat2label = cat2label
 
     def __call__(self, image: Image.Image, target: Dict[str, Any]) -> Tuple[Image.Image, Dict[str, Any]]:
         w, h = image.size

--- a/src/rfdetr/datasets/coco.py
+++ b/src/rfdetr/datasets/coco.py
@@ -93,8 +93,11 @@ class CocoDetection(torchvision.datasets.CocoDetection):
         super(CocoDetection, self).__init__(img_folder, ann_file)
         self._transforms = transforms
         self.include_masks = include_masks
-        cat2label = {cat_id: i for i, cat_id in enumerate(sorted(self.coco.cats.keys()))}
-        self.prepare = ConvertCoco(include_masks=include_masks, cat2label=cat2label)
+        # Mapping from original COCO category_id to contiguous label indices
+        self.cat2label = {cat_id: i for i, cat_id in enumerate(sorted(self.coco.cats.keys()))}
+        # Reverse mapping from contiguous label indices back to COCO category_id
+        self.label2cat = {label: cat_id for cat_id, label in self.cat2label.items()}
+        self.prepare = ConvertCoco(include_masks=include_masks, cat2label=self.cat2label)
 
     def __getitem__(self, idx: int) -> Tuple[Any, Any]:
         img, target = super(CocoDetection, self).__getitem__(idx)
@@ -130,7 +133,18 @@ class ConvertCoco(object):
         boxes[:, 0::2].clamp_(min=0, max=w)
         boxes[:, 1::2].clamp_(min=0, max=h)
 
-        classes = [self.cat2label.get(obj["category_id"], obj["category_id"]) for obj in anno]
+        classes: List[int] = []
+        for obj in anno:
+            category_id = obj["category_id"]
+            if getattr(self, "cat2label", None) is not None:
+                if category_id not in self.cat2label:
+                    raise KeyError(
+                        f"Unknown category_id {category_id} for image_id {target.get('image_id')} "
+                        "encountered in annotations. Check that your category mapping matches the dataset."
+                    )
+                classes.append(self.cat2label[category_id])
+            else:
+                classes.append(category_id)
         classes = torch.tensor(classes, dtype=torch.int64)
 
         keep = (boxes[:, 3] > boxes[:, 1]) & (boxes[:, 2] > boxes[:, 0])

--- a/src/rfdetr/datasets/coco.py
+++ b/src/rfdetr/datasets/coco.py
@@ -93,7 +93,8 @@ class CocoDetection(torchvision.datasets.CocoDetection):
         super(CocoDetection, self).__init__(img_folder, ann_file)
         self._transforms = transforms
         self.include_masks = include_masks
-        self.prepare = ConvertCoco(include_masks=include_masks)
+        cat2label = {cat_id: i for i, cat_id in enumerate(sorted(self.coco.cats.keys()))}
+        self.prepare = ConvertCoco(include_masks=include_masks, cat2label=cat2label)
 
     def __getitem__(self, idx: int) -> Tuple[Any, Any]:
         img, target = super(CocoDetection, self).__getitem__(idx)
@@ -108,8 +109,9 @@ class CocoDetection(torchvision.datasets.CocoDetection):
 
 
 class ConvertCoco(object):
-    def __init__(self, include_masks: bool = False) -> None:
+    def __init__(self, include_masks: bool = False, cat2label: Optional[Dict[int, int]] = None) -> None:
         self.include_masks = include_masks
+        self.cat2label = cat2label or {}
 
     def __call__(self, image: Image.Image, target: Dict[str, Any]) -> Tuple[Image.Image, Dict[str, Any]]:
         w, h = image.size
@@ -128,7 +130,7 @@ class ConvertCoco(object):
         boxes[:, 0::2].clamp_(min=0, max=w)
         boxes[:, 1::2].clamp_(min=0, max=h)
 
-        classes = [obj["category_id"] for obj in anno]
+        classes = [self.cat2label.get(obj["category_id"], obj["category_id"]) for obj in anno]
         classes = torch.tensor(classes, dtype=torch.int64)
 
         keep = (boxes[:, 3] > boxes[:, 1]) & (boxes[:, 2] > boxes[:, 0])

--- a/src/rfdetr/datasets/coco.py
+++ b/src/rfdetr/datasets/coco.py
@@ -83,23 +83,65 @@ def convert_coco_poly_to_mask(segmentations: List[Any], height: int, width: int)
 
 
 class CocoDetection(torchvision.datasets.CocoDetection):
+    """COCO detection dataset with optional sparse-to-contiguous category ID remapping.
+
+    Extends ``torchvision.datasets.CocoDetection`` with two additions:
+
+    1. A pluggable transform pipeline (``transforms``) applied after the raw
+       annotation conversion handled by :class:`ConvertCoco`.
+    2. Optional remapping of sparse COCO category IDs to contiguous 0-based label
+       indices via ``remap_category_ids``.
+
+    COCO category IDs are sparse (1–90 with gaps such as 12, 26, 29 …).  When a
+    model has only *N* output slots the IDs cannot be used directly as tensor
+    indices — doing so causes out-of-bounds errors in the matcher and loss.
+    Setting ``remap_category_ids=True`` builds a ``cat2label`` mapping from the
+    annotation file so that IDs are remapped to the range ``[0, N)``.  The
+    reverse ``label2cat`` mapping is attached to the underlying COCO API object
+    so that :class:`~rfdetr.datasets.coco_eval.CocoEvaluator` can convert
+    predicted label indices back to the original category IDs required by
+    pycocotools.
+
+    ``remap_category_ids`` should be ``True`` for Roboflow / custom datasets
+    (via :func:`build_roboflow_from_coco`) and ``False`` (the default) when
+    evaluating pretrained models that were trained with the convention that model
+    output slot *k* corresponds directly to COCO category ID *k*.
+
+    Args:
+        img_folder: Path to the directory containing the dataset images.
+        ann_file: Path to the COCO-format JSON annotation file.
+        transforms: Transform pipeline applied to ``(image, target)`` pairs after
+            annotation conversion.  ``None`` means no additional transforms.
+        include_masks: If ``True``, decode polygon segmentation masks into binary
+            tensors and include them in the target dict under the ``"masks"`` key.
+        remap_category_ids: If ``True``, build a ``cat2label`` mapping from the
+            annotation file that remaps sparse category IDs to contiguous 0-based
+            label indices.  The reverse mapping is stored as ``label2cat`` on both
+            this object and the underlying COCO API object.  Defaults to ``False``.
+    """
+
     def __init__(
         self,
         img_folder: Union[str, Path],
         ann_file: Union[str, Path],
         transforms: Optional[Any],
         include_masks: bool = False,
+        remap_category_ids: bool = False,
     ) -> None:
         super(CocoDetection, self).__init__(img_folder, ann_file)
         self._transforms = transforms
         self.include_masks = include_masks
-        # Mapping from original COCO category_id to contiguous label indices
-        self.cat2label = {cat_id: i for i, cat_id in enumerate(sorted(self.coco.cats.keys()))}
-        # Reverse mapping from contiguous label indices back to COCO category_id
-        self.label2cat = {label: cat_id for cat_id, label in self.cat2label.items()}
+        if remap_category_ids:
+            # Mapping from original COCO category_id to contiguous label indices
+            self.cat2label = {cat_id: i for i, cat_id in enumerate(sorted(self.coco.cats.keys()))}
+            # Reverse mapping from contiguous label indices back to COCO category_id
+            self.label2cat = {label: cat_id for cat_id, label in self.cat2label.items()}
+            # Expose label-to-category mapping on the underlying COCO API object for evaluators
+            setattr(self.coco, "label2cat", self.label2cat)
+        else:
+            self.cat2label = None
+            self.label2cat = None
         self.prepare = ConvertCoco(include_masks=include_masks, cat2label=self.cat2label)
-        # Expose label-to-category mapping on the underlying COCO API object for evaluators
-        setattr(self.coco, "label2cat", self.label2cat)
 
     def __getitem__(self, idx: int) -> Tuple[Any, Any]:
         img, target = super(CocoDetection, self).__getitem__(idx)
@@ -114,6 +156,34 @@ class CocoDetection(torchvision.datasets.CocoDetection):
 
 
 class ConvertCoco(object):
+    """Convert a raw COCO annotation dict into model-ready tensors.
+
+    Accepts the ``(image, target)`` pair produced by
+    ``torchvision.datasets.CocoDetection`` and returns the same image alongside
+    a target dict containing:
+
+    - ``"boxes"`` – ``(N, 4)`` float32 tensor in absolute ``[x_min, y_min, x_max, y_max]`` format.
+    - ``"labels"`` – ``(N,)`` int64 tensor of class indices.
+    - ``"image_id"`` – scalar int64 tensor.
+    - ``"area"`` – ``(N,)`` float32 tensor of annotation areas (used by COCO eval).
+    - ``"iscrowd"`` – ``(N,)`` int64 tensor (0 = instance, 1 = crowd).
+    - ``"masks"`` – ``(N, H, W)`` bool tensor of binary segmentation masks, only
+      present when ``include_masks=True``.
+
+    Crowd annotations (``iscrowd=1``) and degenerate boxes (zero width or height
+    after clamping to image boundaries) are filtered out.
+
+    Args:
+        include_masks: If ``True``, decode polygon segmentation annotations into
+            binary masks and include them in the returned target dict.
+        cat2label: Optional mapping from COCO ``category_id`` values to contiguous
+            0-based label indices.  When ``None`` (default) the raw
+            ``category_id`` values are used as labels directly, which is correct
+            for datasets whose IDs are already 0-indexed.  Pass a non-``None``
+            mapping for sparse COCO-style datasets (e.g. IDs 1–90 with gaps) so
+            that labels stay within the model's output range.
+    """
+
     def __init__(self, include_masks: bool = False, cat2label: Optional[Dict[int, int]] = None) -> None:
         self.include_masks = include_masks
         self.cat2label = cat2label
@@ -194,7 +264,45 @@ def make_coco_transforms(
     num_windows: int = 4,
     aug_config: Optional[Dict[str, Dict[str, Any]]] = None,
 ) -> T.Compose:
+    """Build the standard COCO transform pipeline for a given dataset split.
 
+    Returns a composed transform that resizes images to the target ``resolution``
+    (with optional multi-scale jitter), applies Albumentations-based augmentations
+    during training, and normalises pixel values with ImageNet statistics.
+
+    For the ``"train"`` split the pipeline uses a two-branch random select between
+    a simple random resize and a resize → random-crop → resize sequence, followed
+    by the augmentation stack and normalisation.  For ``"val"`` and ``"val_speed"``
+    only resize and normalisation are applied.
+
+    Args:
+        image_set: Dataset split identifier — ``"train"``, ``"val"``, or
+            ``"val_speed"``.
+        resolution: Target short-side resolution in pixels.  During validation the
+            longest side is capped at 1333 px to preserve aspect ratio.
+        multi_scale: If ``True``, sample the resize target from a range of scales
+            computed by :func:`compute_multi_scale_scales` instead of using a
+            single fixed size.
+        expanded_scales: Passed to :func:`compute_multi_scale_scales`; broadens the
+            scale range when ``multi_scale=True``.
+        skip_random_resize: When ``multi_scale=True``, use only the largest scale
+            and skip random selection among multiple scales.
+        patch_size: Model patch size used by :func:`compute_multi_scale_scales` to
+            ensure all candidate resolutions are compatible with the backbone.
+        num_windows: Number of attention windows; used by
+            :func:`compute_multi_scale_scales` to derive candidate resolutions.
+        aug_config: Albumentations augmentation config dict passed to
+            :class:`~rfdetr.datasets.transforms.AlbumentationsWrapper`.  Falls back
+            to the default :data:`~rfdetr.datasets.aug_config.AUG_CONFIG` when
+            ``None``.
+
+    Returns:
+        A :class:`~rfdetr.datasets.transforms.Compose` pipeline ready to be passed
+        to :class:`CocoDetection`.
+
+    Raises:
+        ValueError: If ``image_set`` is not one of the recognised split names.
+    """
     normalize = T.Compose([T.ToTensor(), T.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])])
 
     scales = [resolution]
@@ -438,6 +546,7 @@ def build_roboflow_from_coco(image_set: str, args: Any, resolution: int) -> Coco
                 aug_config=aug_config,
             ),
             include_masks=include_masks,
+            remap_category_ids=True,
         )
     else:
         logger.info(f"Building Roboflow {image_set} dataset at resolution {resolution}")
@@ -455,5 +564,6 @@ def build_roboflow_from_coco(image_set: str, args: Any, resolution: int) -> Coco
                 aug_config=aug_config,
             ),
             include_masks=include_masks,
+            remap_category_ids=True,
         )
     return dataset

--- a/src/rfdetr/datasets/coco_eval.py
+++ b/src/rfdetr/datasets/coco_eval.py
@@ -46,7 +46,7 @@ class CocoEvaluator(object):
         self.max_dets = max_dets
         # label2cat maps contiguous model label indices back to original COCO category_ids.
         # Set by CocoDetection when cat2label remapping is active; None otherwise.
-        self.label2cat: Dict[int, int] = getattr(coco_gt, "label2cat", None)
+        self.label2cat: Dict[int, int] | None = getattr(coco_gt, "label2cat", None)
 
         self.iou_types = iou_types
         self.coco_eval = {}

--- a/src/rfdetr/datasets/coco_eval.py
+++ b/src/rfdetr/datasets/coco_eval.py
@@ -44,6 +44,9 @@ class CocoEvaluator(object):
         coco_gt = copy.deepcopy(coco_gt)
         self.coco_gt = coco_gt
         self.max_dets = max_dets
+        # label2cat maps contiguous model label indices back to original COCO category_ids.
+        # Set by CocoDetection when cat2label remapping is active; None otherwise.
+        self.label2cat: Dict[int, int] = getattr(coco_gt, "label2cat", None)
 
         self.iou_types = iou_types
         self.coco_eval = {}
@@ -112,11 +115,12 @@ class CocoEvaluator(object):
                 [
                     {
                         "image_id": original_id,
-                        "category_id": labels[k],
+                        "category_id": self.label2cat[labels[k]] if self.label2cat is not None else labels[k],
                         "bbox": box,
                         "score": scores[k],
                     }
                     for k, box in enumerate(boxes)
+                    if self.label2cat is None or labels[k] in self.label2cat
                 ]
             )
         return coco_results
@@ -147,11 +151,12 @@ class CocoEvaluator(object):
                 [
                     {
                         "image_id": original_id,
-                        "category_id": labels[k],
+                        "category_id": self.label2cat[labels[k]] if self.label2cat is not None else labels[k],
                         "segmentation": rle,
                         "score": scores[k],
                     }
                     for k, rle in enumerate(rles)
+                    if self.label2cat is None or labels[k] in self.label2cat
                 ]
             )
         return coco_results
@@ -173,11 +178,12 @@ class CocoEvaluator(object):
                 [
                     {
                         "image_id": original_id,
-                        "category_id": labels[k],
+                        "category_id": self.label2cat[labels[k]] if self.label2cat is not None else labels[k],
                         "keypoints": keypoint,
                         "score": scores[k],
                     }
                     for k, keypoint in enumerate(keypoints)
+                    if self.label2cat is None or labels[k] in self.label2cat
                 ]
             )
         return coco_results

--- a/src/rfdetr/datasets/coco_eval.py
+++ b/src/rfdetr/datasets/coco_eval.py
@@ -24,7 +24,7 @@ in the end of the file, as python3 can suppress prints with contextlib
 import contextlib
 import copy
 import os
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import pycocotools.mask as mask_util
@@ -59,7 +59,7 @@ class CocoEvaluator(object):
         self.cat_ids = set(coco_gt.cats.keys())
         self._prefer_raw_category_ids = False
 
-    def _resolve_category_id(self, label: int, use_raw_category_ids: bool) -> int | None:
+    def _resolve_category_id(self, label: int, use_raw_category_ids: bool) -> Optional[int]:
         """Resolve a predicted label to a COCO category_id.
 
         Supports both:

--- a/src/rfdetr/datasets/coco_eval.py
+++ b/src/rfdetr/datasets/coco_eval.py
@@ -56,6 +56,46 @@ class CocoEvaluator(object):
 
         self.img_ids: List[int] = []
         self.eval_imgs: Dict[str, List[COCOeval]] = {k: [] for k in iou_types}
+        self.cat_ids = set(coco_gt.cats.keys())
+        self._prefer_raw_category_ids = False
+
+    def _resolve_category_id(self, label: int, use_raw_category_ids: bool) -> int | None:
+        """Resolve a predicted label to a COCO category_id.
+
+        Supports both:
+        - contiguous model labels (resolved via ``label2cat``), and
+        - already raw COCO category_ids (legacy checkpoint behavior).
+        """
+        # In raw-ID mode, labels are already COCO category IDs from model output.
+        if use_raw_category_ids:
+            return label if label in self.cat_ids else None
+        # In contiguous mode, map model class indices back to COCO category IDs.
+        if self.label2cat is not None and label in self.label2cat:
+            return self.label2cat[label]
+        # Fallback for mixed/legacy behavior where labels may already be COCO IDs.
+        if label in self.cat_ids:
+            return label
+        return None
+
+    def _should_use_raw_category_ids(self, labels: List[int]) -> bool:
+        """Detect whether current predictions are emitted as raw COCO category IDs.
+
+        If labels include values that are valid COCO category IDs but not valid
+        contiguous-label indices, switch to raw-ID mode and keep it for the rest
+        of the evaluator lifetime.
+        """
+        if self.label2cat is None:
+            return True
+        if self._prefer_raw_category_ids:
+            return True
+
+        # If any label is a COCO category ID but not a valid contiguous index,
+        # treat the whole run as raw-ID output to avoid corrupting eval categories.
+        uses_raw_ids = any((label in self.cat_ids) and (label not in self.label2cat) for label in labels)
+        if uses_raw_ids:
+            self._prefer_raw_category_ids = True
+            return True
+        return False
 
     def update(self, predictions: Dict[int, Any]) -> None:
         img_ids = list(np.unique(list(predictions.keys())))
@@ -110,19 +150,20 @@ class CocoEvaluator(object):
             boxes = sv.xyxy_to_xywh(boxes.cpu().numpy()).tolist()
             scores = prediction["scores"].tolist()
             labels = prediction["labels"].tolist()
-
-            coco_results.extend(
-                [
+            use_raw_category_ids = self._should_use_raw_category_ids(labels)
+            for k, box in enumerate(boxes):
+                category_id = self._resolve_category_id(labels[k], use_raw_category_ids)
+                # Drop predictions that cannot be mapped to a valid COCO category.
+                if category_id is None:
+                    continue
+                coco_results.append(
                     {
                         "image_id": original_id,
-                        "category_id": self.label2cat[labels[k]] if self.label2cat is not None else labels[k],
+                        "category_id": category_id,
                         "bbox": box,
                         "score": scores[k],
                     }
-                    for k, box in enumerate(boxes)
-                    if self.label2cat is None or labels[k] in self.label2cat
-                ]
-            )
+                )
         return coco_results
 
     def prepare_for_coco_segmentation(self, predictions: Dict[int, Any]) -> List[Dict[str, Any]]:
@@ -139,6 +180,7 @@ class CocoEvaluator(object):
 
             scores = prediction["scores"].tolist()
             labels = prediction["labels"].tolist()
+            use_raw_category_ids = self._should_use_raw_category_ids(labels)
 
             rles = [
                 mask_util.encode(np.array(mask.cpu()[0, :, :, np.newaxis], dtype=np.uint8, order="F"))[0]
@@ -147,18 +189,19 @@ class CocoEvaluator(object):
             for rle in rles:
                 rle["counts"] = rle["counts"].decode("utf-8")
 
-            coco_results.extend(
-                [
+            for k, rle in enumerate(rles):
+                category_id = self._resolve_category_id(labels[k], use_raw_category_ids)
+                # Drop predictions that cannot be mapped to a valid COCO category.
+                if category_id is None:
+                    continue
+                coco_results.append(
                     {
                         "image_id": original_id,
-                        "category_id": self.label2cat[labels[k]] if self.label2cat is not None else labels[k],
+                        "category_id": category_id,
                         "segmentation": rle,
                         "score": scores[k],
                     }
-                    for k, rle in enumerate(rles)
-                    if self.label2cat is None or labels[k] in self.label2cat
-                ]
-            )
+                )
         return coco_results
 
     def prepare_for_coco_keypoint(self, predictions: Dict[int, Any]) -> List[Dict[str, Any]]:
@@ -173,19 +216,20 @@ class CocoEvaluator(object):
             labels = prediction["labels"].tolist()
             keypoints = prediction["keypoints"]
             keypoints = keypoints.flatten(start_dim=1).tolist()
-
-            coco_results.extend(
-                [
+            use_raw_category_ids = self._should_use_raw_category_ids(labels)
+            for k, keypoint in enumerate(keypoints):
+                category_id = self._resolve_category_id(labels[k], use_raw_category_ids)
+                # Drop predictions that cannot be mapped to a valid COCO category.
+                if category_id is None:
+                    continue
+                coco_results.append(
                     {
                         "image_id": original_id,
-                        "category_id": self.label2cat[labels[k]] if self.label2cat is not None else labels[k],
+                        "category_id": category_id,
                         "keypoints": keypoint,
                         "score": scores[k],
                     }
-                    for k, keypoint in enumerate(keypoints)
-                    if self.label2cat is None or labels[k] in self.label2cat
-                ]
-            )
+                )
         return coco_results
 
 

--- a/src/rfdetr/datasets/synthetic.py
+++ b/src/rfdetr/datasets/synthetic.py
@@ -7,6 +7,7 @@
 #
 """Synthetic dataset generation with COCO formatting."""
 
+import json
 import logging
 import random
 from dataclasses import dataclass
@@ -318,6 +319,19 @@ def generate_coco_dataset(
         dataset = sv.DetectionDataset(classes=classes, images=images, annotations=annotations)
 
         dataset.as_coco(annotations_path=str(annotations_path))
+
+        # supervision writes 0-indexed sequential category IDs; remap to sparse
+        # 1-based IDs (id * 2 + 1 → 1, 3, 5, …) so synthetic data exercises the
+        # same cat2label remapping path that real COCO datasets require.
+        with open(annotations_path) as read_handle:
+            coco_json = json.load(read_handle)
+        sparse_id = {cat["id"]: cat["id"] * 2 + 1 for cat in coco_json["categories"]}
+        for cat in coco_json["categories"]:
+            cat["id"] = sparse_id[cat["id"]]
+        for ann in coco_json["annotations"]:
+            ann["category_id"] = sparse_id[ann["category_id"]]
+        with open(annotations_path, "w") as write_handle:
+            json.dump(coco_json, write_handle)
 
 
 if __name__ == "__main__":

--- a/tests/datasets/test_coco.py
+++ b/tests/datasets/test_coco.py
@@ -12,8 +12,8 @@ the model has only 80 classes.  ConvertCoco must remap them to contiguous
 0-indexed labels via the ``cat2label`` mapping built from the annotation file.
 """
 
-import torch
 import pytest
+import torch
 from PIL import Image
 from pycocotools.coco import COCO
 

--- a/tests/datasets/test_coco.py
+++ b/tests/datasets/test_coco.py
@@ -13,9 +13,12 @@ the model has only 80 classes.  ConvertCoco must remap them to contiguous
 """
 
 import torch
+import pytest
 from PIL import Image
+from pycocotools.coco import COCO
 
 from rfdetr.datasets.coco import ConvertCoco
+from rfdetr.datasets.coco_eval import CocoEvaluator
 
 # Minimal image shared across all tests
 _IMAGE = Image.new("RGB", (100, 100))
@@ -35,6 +38,30 @@ _CAT2LABEL = {cat_id: i for i, cat_id in enumerate(sorted(_SPARSE_CAT_IDS))}
 
 def _make_target(annotations=_ANNOTATIONS):
     return {"image_id": 1, "annotations": annotations}
+
+
+@pytest.fixture
+def coco_gt() -> COCO:
+    coco = COCO()
+    coco.dataset = {
+        "images": [{"id": 1, "width": 10, "height": 10}],
+        "annotations": [],
+        "categories": [
+            {"id": 1, "name": "cat_1"},
+            {"id": 3, "name": "cat_3"},
+        ],
+    }
+    coco.createIndex()
+    setattr(coco, "label2cat", {0: 1, 1: 3})
+    return coco
+
+
+@pytest.fixture
+def base_prediction() -> dict[str, torch.Tensor]:
+    return {
+        "boxes": torch.tensor([[0.0, 0.0, 1.0, 1.0], [1.0, 1.0, 2.0, 2.0]], dtype=torch.float32),
+        "scores": torch.tensor([0.9, 0.8], dtype=torch.float32),
+    }
 
 
 class TestConvertCocoWithoutMapping:
@@ -87,3 +114,29 @@ class TestConvertCocoWithMapping:
         converter = ConvertCoco(cat2label=_CAT2LABEL)
         _, target = converter(_IMAGE, _make_target())
         assert target["labels"].dtype == torch.int64
+
+
+class TestCocoEvaluatorCategoryResolution:
+    @pytest.mark.parametrize(
+        ("labels", "expected_category_ids"),
+        [
+            pytest.param([0, 1], [1, 3], id="contiguous-labels"),
+            pytest.param([1, 3], [1, 3], id="raw-coco-category-ids"),
+        ],
+    )
+    def test_prepare_detection_resolves_category_ids(
+        self,
+        coco_gt: COCO,
+        base_prediction: dict[str, torch.Tensor],
+        labels: list[int],
+        expected_category_ids: list[int],
+    ) -> None:
+        evaluator = CocoEvaluator(coco_gt, ["bbox"])
+        predictions = {
+            1: {
+                **base_prediction,
+                "labels": torch.tensor(labels, dtype=torch.int64),
+            }
+        }
+        results = evaluator.prepare_for_coco_detection(predictions)
+        assert [result["category_id"] for result in results] == expected_category_ids

--- a/tests/datasets/test_coco.py
+++ b/tests/datasets/test_coco.py
@@ -12,7 +12,6 @@ the model has only 80 classes.  ConvertCoco must remap them to contiguous
 0-indexed labels via the ``cat2label`` mapping built from the annotation file.
 """
 
-import pytest
 import torch
 from PIL import Image
 

--- a/tests/datasets/test_coco.py
+++ b/tests/datasets/test_coco.py
@@ -16,6 +16,7 @@ import pytest
 import torch
 from PIL import Image
 from pycocotools.coco import COCO
+from typing import Dict, List
 
 from rfdetr.datasets.coco import ConvertCoco
 from rfdetr.datasets.coco_eval import CocoEvaluator
@@ -57,7 +58,7 @@ def coco_gt() -> COCO:
 
 
 @pytest.fixture
-def base_prediction() -> dict[str, torch.Tensor]:
+def base_prediction() -> Dict[str, torch.Tensor]:
     return {
         "boxes": torch.tensor([[0.0, 0.0, 1.0, 1.0], [1.0, 1.0, 2.0, 2.0]], dtype=torch.float32),
         "scores": torch.tensor([0.9, 0.8], dtype=torch.float32),
@@ -127,9 +128,9 @@ class TestCocoEvaluatorCategoryResolution:
     def test_prepare_detection_resolves_category_ids(
         self,
         coco_gt: COCO,
-        base_prediction: dict[str, torch.Tensor],
-        labels: list[int],
-        expected_category_ids: list[int],
+        base_prediction: Dict[str, torch.Tensor],
+        labels: List[int],
+        expected_category_ids: List[int],
     ) -> None:
         evaluator = CocoEvaluator(coco_gt, ["bbox"])
         predictions = {

--- a/tests/datasets/test_coco.py
+++ b/tests/datasets/test_coco.py
@@ -42,14 +42,14 @@ class TestConvertCocoWithoutMapping:
     """Without cat2label, sparse IDs pass through unchanged — demonstrating the bug."""
 
     def test_labels_are_raw_category_ids(self):
-        converter = ConvertCoco(cat2label={})
+        converter = ConvertCoco(cat2label=None)
         _, target = converter(_IMAGE, _make_target())
         # Raw COCO IDs — NOT safe to use as indices into an 80-class tensor
         assert target["labels"].tolist() == [1, 7]
 
     def test_raw_ids_would_exceed_num_classes(self):
         """Illustrates why raw IDs cause CUDA out-of-bounds with num_classes=80."""
-        converter = ConvertCoco(cat2label={})
+        converter = ConvertCoco(cat2label=None)
         _, target = converter(_IMAGE, _make_target())
         num_classes = len(_SPARSE_CAT_IDS)  # 5 — same as model would see
         assert any(lbl >= num_classes for lbl in target["labels"].tolist()), (

--- a/tests/datasets/test_coco.py
+++ b/tests/datasets/test_coco.py
@@ -1,0 +1,90 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Regression tests for sparse COCO category ID remapping in ConvertCoco.
+
+COCO category IDs are sparse (1–90 with gaps). Without remapping they are used
+directly as tensor indices, causing out-of-bounds errors during training when
+the model has only 80 classes.  ConvertCoco must remap them to contiguous
+0-indexed labels via the ``cat2label`` mapping built from the annotation file.
+"""
+
+import pytest
+import torch
+from PIL import Image
+
+from rfdetr.datasets.coco import ConvertCoco
+
+# Minimal image shared across all tests
+_IMAGE = Image.new("RGB", (100, 100))
+
+# Sparse COCO-style category IDs (as in the real COCO dataset: 1-90 with gaps)
+# e.g. COCO skips IDs 12, 26, 29, 30, 45, 66, 68, 69, 71, 83, 91
+_SPARSE_CAT_IDS = [1, 2, 3, 7, 8]  # sparse, non-zero-indexed
+
+_ANNOTATIONS = [
+    {"bbox": [10, 10, 30, 30], "category_id": 1, "area": 900, "iscrowd": 0},
+    {"bbox": [50, 50, 20, 20], "category_id": 7, "area": 400, "iscrowd": 0},
+]
+
+_CAT2LABEL = {cat_id: i for i, cat_id in enumerate(sorted(_SPARSE_CAT_IDS))}
+# {1: 0, 2: 1, 3: 2, 7: 3, 8: 4}
+
+
+def _make_target(annotations=_ANNOTATIONS):
+    return {"image_id": 1, "annotations": annotations}
+
+
+class TestConvertCocoWithoutMapping:
+    """Without cat2label, sparse IDs pass through unchanged — demonstrating the bug."""
+
+    def test_labels_are_raw_category_ids(self):
+        converter = ConvertCoco(cat2label={})
+        _, target = converter(_IMAGE, _make_target())
+        # Raw COCO IDs — NOT safe to use as indices into an 80-class tensor
+        assert target["labels"].tolist() == [1, 7]
+
+    def test_raw_ids_would_exceed_num_classes(self):
+        """Illustrates why raw IDs cause CUDA out-of-bounds with num_classes=80."""
+        converter = ConvertCoco(cat2label={})
+        _, target = converter(_IMAGE, _make_target())
+        num_classes = len(_SPARSE_CAT_IDS)  # 5 — same as model would see
+        assert any(lbl >= num_classes for lbl in target["labels"].tolist()), (
+            "At least one raw category_id should exceed num_classes, "
+            "triggering an out-of-bounds index in the matcher/loss."
+        )
+
+
+class TestConvertCocoWithMapping:
+    """With cat2label, sparse IDs are remapped to contiguous 0-indexed labels."""
+
+    def test_labels_are_remapped_to_zero_indexed(self):
+        converter = ConvertCoco(cat2label=_CAT2LABEL)
+        _, target = converter(_IMAGE, _make_target())
+        # category_id 1 → 0, category_id 7 → 3
+        assert target["labels"].tolist() == [0, 3]
+
+    def test_all_labels_within_num_classes(self):
+        converter = ConvertCoco(cat2label=_CAT2LABEL)
+        _, target = converter(_IMAGE, _make_target())
+        num_classes = len(_SPARSE_CAT_IDS)
+        assert all(lbl < num_classes for lbl in target["labels"].tolist())
+
+    def test_roboflow_zero_indexed_is_identity(self):
+        """Roboflow datasets already use 0-indexed IDs — mapping must be identity."""
+        roboflow_cat2label = {0: 0, 1: 1, 2: 2}
+        annotations = [
+            {"bbox": [10, 10, 30, 30], "category_id": 0, "area": 900, "iscrowd": 0},
+            {"bbox": [50, 50, 20, 20], "category_id": 2, "area": 400, "iscrowd": 0},
+        ]
+        converter = ConvertCoco(cat2label=roboflow_cat2label)
+        _, target = converter(_IMAGE, _make_target(annotations))
+        assert target["labels"].tolist() == [0, 2]
+
+    def test_label_tensor_dtype(self):
+        converter = ConvertCoco(cat2label=_CAT2LABEL)
+        _, target = converter(_IMAGE, _make_target())
+        assert target["labels"].dtype == torch.int64


### PR DESCRIPTION
This pull request addresses a critical issue with COCO dataset category ID handling by introducing a mapping from sparse COCO category IDs to contiguous, zero-indexed labels. This prevents out-of-bounds errors during training and ensures compatibility with models expecting contiguous class indices. The changes also add comprehensive regression tests to verify correct remapping behavior and to demonstrate the problem with using raw category IDs.

COCO category ID remapping improvements:

* The `ConvertCoco` class now accepts a `cat2label` mapping to remap sparse COCO category IDs to contiguous, zero-indexed labels, preventing out-of-bounds errors when used as tensor indices. [[1]](diffhunk://#diff-a2bf011080a4e4e3f0bf73f2c524e83384f922a65c4cfa89bbb5f0121a08fff9L96-R97) [[2]](diffhunk://#diff-a2bf011080a4e4e3f0bf73f2c524e83384f922a65c4cfa89bbb5f0121a08fff9L111-R114) [[3]](diffhunk://#diff-a2bf011080a4e4e3f0bf73f2c524e83384f922a65c4cfa89bbb5f0121a08fff9L131-R133)
* The `CocoDetection` dataset class constructs and passes the `cat2label` mapping based on the annotation file, ensuring all category IDs are properly remapped during data loading.

Testing and validation:

* Added a new regression test suite in `tests/datasets/test_coco.py` that verifies both the presence and absence of category ID remapping, demonstrating the bug and confirming the fix. Tests cover edge cases such as Roboflow datasets with already zero-indexed IDs and ensure correct tensor dtype.