### PR TITLE
docs: Add tutorials and link in navigation

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,0 +1,101 @@
+---
+hide:
+- toc
+- navigation
+---
+
+
+# Tutorials
+
+Use the resources below to learn how to train, build with, and deploy RF-DETR models both in the cloud and on your own hardware.
+
+<div class="grid cards" markdown>
+
+- 
+    **SOTA Instance Segmentation with RF-DETR Seg (Preview) [October 2025]**
+
+    ---
+
+    ![](https://blog.roboflow.com/content/images/size/w1000/format/webp/2025/10/rfdetr-seg.png)
+
+    Read more about the RF-DETR Segmentation architecture and how to train an RF-DETR Seg (Preview) model.
+
+    [:octicons-arrow-right-24: Learn more](https://blog.roboflow.com/rf-detr-segmentation-preview/)
+
+- 
+    **Announcing RF-DETR Nano, Small, and Medium [July 2025]**
+
+    ---
+
+    ![](https://blog.roboflow.com/content/images/size/w1000/format/webp/2025/07/img-blog-rf-detr-1.png)
+
+    Read more about the state-of-the-art RF-DETR Nano, Small, and Medium models we released in July 2025.
+
+    [:octicons-arrow-right-24: Learn more](https://blog.roboflow.com/rf-detr-nano-small-medium/)
+
+
+-   **RF-DETR: How to Train SOTA for Object Detection on a Custom Dataset [video]**
+
+    ---
+
+    ![](https://i.ytimg.com/vi/-OvpdLAElFA/maxresdefault.jpg)
+
+    Learn how to train an RF-DETR model on a custom dataset.
+
+    [:octicons-arrow-right-24: Watch the video](https://www.youtube.com/watch?v=-OvpdLAElFA)
+    
+-   **How to Train RF-DETR on a Custom Dataset [article]**
+
+    ---
+
+    ![](https://blog.roboflow.com/content/images/size/w1000/format/webp/2025/03/img-blog-how-to-send-slack-notification-workflows-v4-1.png)
+
+    Learn how to train an RF-DETR model on a custom dataset.
+
+    [:octicons-arrow-right-24: Read the guide](https://blog.roboflow.com/train-rf-detr-on-a-custom-dataset/)
+
+-   **Deploy RF-DETR on iOS [tutorial & example application]**
+
+    ---
+
+    ![](https://blog.roboflow.com/content/images/size/w1000/format/webp/2025/07/img-blog-deep-learning-solves-frustrations--5--min.png)
+
+    Read this guide to learn how to run RF-DETR models on an iPhone using the Roboflow iOS SDK.
+
+    [:octicons-arrow-right-24: Get started](https://blog.roboflow.com/ios-rf-detr-nano/)
+
+
+
+-   **How to Deploy RF-DETR to an NVIDIA Jetson [article]**
+
+    ---
+
+    ![](https://blog.roboflow.com/content/images/size/w1000/format/webp/2025/06/inst-3-.png)
+
+    Learn how to deploy an RF-DETR model to an NVIDIA Jetson using Roboflow Inference.
+
+    [:octicons-arrow-right-24: Read the tutorial](https://blog.roboflow.com/how-to-deploy-rf-detr-to-an-nvidia-jetson/)
+
+-   **Train and Deploy RF-DETR Models with Roboflow**
+
+    ---
+
+    ![](https://blog.roboflow.com/content/images/size/w1000/format/webp/2025/03/img-blog-nycerebro-2.png)
+
+    Learn how to train RF-DETR models in the cloud with Roboflow and deploy your models on your own hardware with Roboflow Inference and Workflows.
+
+    [:octicons-arrow-right-24: Get started](https://blog.roboflow.com/train-deploy-rf-detr/)
+
+-   **RF-DETR: A SOTA Real-Time Object Detection Model**
+
+    ---
+
+    ![](https://blog.roboflow.com/content/images/size/w1000/format/webp/2025/03/img-blog-nycerebro--2--min.png)
+
+    Read our announcement for RF-DETR, the first real-time model to achieve 60+ mean Average Precision when benchmarked on the COCO dataset.
+
+    [:octicons-arrow-right-24: Read the announcement](https://blog.roboflow.com/rf-detr/)
+
+
+
+</div>

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,9 +1,8 @@
 ---
 hide:
-- toc
-- navigation
+  - toc
+  - navigation
 ---
-
 
 # Tutorials
 
@@ -11,8 +10,7 @@ Use the resources below to learn how to train, build with, and deploy RF-DETR mo
 
 <div class="grid cards" markdown>
 
-- 
-    **SOTA Instance Segmentation with RF-DETR Seg (Preview) [October 2025]**
+- **SOTA Instance Segmentation with RF-DETR Seg (Preview) [October 2025]**
 
     ---
 
@@ -22,8 +20,7 @@ Use the resources below to learn how to train, build with, and deploy RF-DETR mo
 
     [:octicons-arrow-right-24: Learn more](https://blog.roboflow.com/rf-detr-segmentation-preview/)
 
-- 
-    **Announcing RF-DETR Nano, Small, and Medium [July 2025]**
+- **Announcing RF-DETR Nano, Small, and Medium [July 2025]**
 
     ---
 
@@ -33,8 +30,7 @@ Use the resources below to learn how to train, build with, and deploy RF-DETR mo
 
     [:octicons-arrow-right-24: Learn more](https://blog.roboflow.com/rf-detr-nano-small-medium/)
 
-
--   **RF-DETR: How to Train SOTA for Object Detection on a Custom Dataset [video]**
+- **RF-DETR: How to Train SOTA for Object Detection on a Custom Dataset [video]**
 
     ---
 
@@ -43,8 +39,8 @@ Use the resources below to learn how to train, build with, and deploy RF-DETR mo
     Learn how to train an RF-DETR model on a custom dataset.
 
     [:octicons-arrow-right-24: Watch the video](https://www.youtube.com/watch?v=-OvpdLAElFA)
-    
--   **How to Train RF-DETR on a Custom Dataset [article]**
+
+- **How to Train RF-DETR on a Custom Dataset [article]**
 
     ---
 
@@ -54,7 +50,7 @@ Use the resources below to learn how to train, build with, and deploy RF-DETR mo
 
     [:octicons-arrow-right-24: Read the guide](https://blog.roboflow.com/train-rf-detr-on-a-custom-dataset/)
 
--   **Deploy RF-DETR on iOS [tutorial & example application]**
+- **Deploy RF-DETR on iOS [tutorial & example application]**
 
     ---
 
@@ -64,9 +60,7 @@ Use the resources below to learn how to train, build with, and deploy RF-DETR mo
 
     [:octicons-arrow-right-24: Get started](https://blog.roboflow.com/ios-rf-detr-nano/)
 
-
-
--   **How to Deploy RF-DETR to an NVIDIA Jetson [article]**
+- **How to Deploy RF-DETR to an NVIDIA Jetson [article]**
 
     ---
 
@@ -76,7 +70,7 @@ Use the resources below to learn how to train, build with, and deploy RF-DETR mo
 
     [:octicons-arrow-right-24: Read the tutorial](https://blog.roboflow.com/how-to-deploy-rf-detr-to-an-nvidia-jetson/)
 
--   **Train and Deploy RF-DETR Models with Roboflow**
+- **Train and Deploy RF-DETR Models with Roboflow**
 
     ---
 
@@ -86,7 +80,7 @@ Use the resources below to learn how to train, build with, and deploy RF-DETR mo
 
     [:octicons-arrow-right-24: Get started](https://blog.roboflow.com/train-deploy-rf-detr/)
 
--   **RF-DETR: A SOTA Real-Time Object Detection Model**
+- **RF-DETR: A SOTA Real-Time Object Detection Model**
 
     ---
 
@@ -95,7 +89,5 @@ Use the resources below to learn how to train, build with, and deploy RF-DETR mo
     Read our announcement for RF-DETR, the first real-time model to achieve 60+ mean Average Precision when benchmarked on the COCO dataset.
 
     [:octicons-arrow-right-24: Read the announcement](https://blog.roboflow.com/rf-detr/)
-
-
 
 </div>

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -59,6 +59,7 @@ nav:
       - Training Configs:
           - Train Config: reference/train_config.md
           - Segmentation Train Config: reference/segmentation_train_config.md
+  - Tutorials: tutorials/index.md
   - Changelog: https://github.com/roboflow/rf-detr/releases
 
 theme:


### PR DESCRIPTION
This pull request adds a new tutorials section to the documentation, making it easier for users to find and access guides on training, deploying, and using RF-DETR models. The main changes include creating a comprehensive tutorials index page and updating the navigation to feature this new section.

Documentation improvements:

* Added a new `tutorials/index.md` file that aggregates guides, articles, and videos related to RF-DETR model training, deployment, and architecture, including recent releases and platform-specific instructions.
* Updated the `mkdocs.yaml` navigation to include a "Tutorials" entry, linking directly to the new tutorials index page for improved discoverability.