### PR TITLE
ci: remove hardcoded SHA references in GHA workflows

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 🐍 Install uv and set Python version ${{ inputs.python-version }}
-        uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
+        uses: astral-sh/setup-uv@v7.1.6
         with:
           python-version: ${{ inputs.python-version }}
           activate-environment: true

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.1
 
       - name: 🐍 Install uv and set Python version ${{ inputs.python-version }}
-        uses: astral-sh/setup-uv@v7.1.6
+        uses: astral-sh/setup-uv@v7.2.0
         with:
           python-version: ${{ inputs.python-version }}
           activate-environment: true

--- a/.github/workflows/ci-build-docs.yml
+++ b/.github/workflows/ci-build-docs.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: 📥 Checkout the repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci-build-docs.yml
+++ b/.github/workflows/ci-build-docs.yml
@@ -19,12 +19,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: 📥 Checkout the repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
 
       - name: 🐍 Install uv and set Python
-        uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
+        uses: astral-sh/setup-uv@v7.2.0
         with:
           python-version: "3.10"
           activate-environment: true

--- a/.github/workflows/ci-integrations.yml
+++ b/.github/workflows/ci-integrations.yml
@@ -28,10 +28,10 @@ jobs:
         python-version: ["3.10", "3.13"]
     steps:
       - name: 📥 Checkout the repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@v6.0.1
 
       - name: 🐍 Install uv and set Python version ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
+        uses: astral-sh/setup-uv@v7.2.0
         with:
           python-version: ${{ matrix.python-version }}
           activate-environment: true

--- a/.github/workflows/ci-tests-cpu.yml
+++ b/.github/workflows/ci-tests-cpu.yml
@@ -42,10 +42,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: 📥 Checkout the repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@v6.0.1
 
       - name: 🐍 Install uv and set Python version ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
+        uses: astral-sh/setup-uv@v7.2.0
         with:
           python-version: ${{ matrix.python-version }}
           activate-environment: true

--- a/.github/workflows/ci-tests-gpu.yml
+++ b/.github/workflows/ci-tests-gpu.yml
@@ -37,10 +37,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake
       - name: 📥 Checkout the repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@v6.0.1
 
       - name: 🐍 Install uv and set Python version
-        uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
+        uses: astral-sh/setup-uv@v7.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           activate-environment: true

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: 📥 Checkout the repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -28,12 +28,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: 📥 Checkout the repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
 
       - name: 🐍 Install uv and set Python
-        uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
+        uses: astral-sh/setup-uv@v7.2.0
         with:
           python-version: "3.10"
           activate-environment: true


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow files to use tag-based references for action versions instead of commit-based references. This improves maintainability and clarity by making it easier to track which version of each action is being used.

Updates to action references in workflow files:

**Checkout action updates:**
* Replaced commit-based references with tag-based references for `actions/checkout` in `.github/workflows/ci-build-docs.yml`, `.github/workflows/publish-docs.yml`, `.github/workflows/ci-integrations.yml`, `.github/workflows/ci-tests-cpu.yml`, and `.github/workflows/ci-tests-gpu.yml`. [[1]](diffhunk://#diff-61fc86768decdb974bea5fae038250c463e7d9d35c980b0ec5fcda4ef46ae31dL22-R27) [[2]](diffhunk://#diff-dd751c654ce34c435239f846704cbba01f2aef90c73ad219db2d47789b369544L31-R36) [[3]](diffhunk://#diff-0dd73e14818b55120e653268df1c4bc44367a18b84821c6418641580e3d76b47L31-R34) [[4]](diffhunk://#diff-24e5f388bcbc626b2144002ef6a3ab8c25849453349172f1e287a82756bf1a71L45-R48) [[5]](diffhunk://#diff-53209bae0cc403f683dfba167d31dbf56132fe37cca436a436c8723bb9fed7e2L40-R43)

**Python setup action updates:**
* Replaced commit-based references with tag-based references for `astral-sh/setup-uv` in `.github/workflows/build-package.yml`, `.github/workflows/ci-build-docs.yml`, `.github/workflows/publish-docs.yml`, `.github/workflows/ci-integrations.yml`, `.github/workflows/ci-tests-cpu.yml`, and `.github/workflows/ci-tests-gpu.yml`. [[1]](diffhunk://#diff-c37cf2bffb2cde25cbcedc64387a46a1b752a13b0f310ecc68058b87889a3ac0L22-R22) [[2]](diffhunk://#diff-61fc86768decdb974bea5fae038250c463e7d9d35c980b0ec5fcda4ef46ae31dL22-R27) [[3]](diffhunk://#diff-dd751c654ce34c435239f846704cbba01f2aef90c73ad219db2d47789b369544L31-R36) [[4]](diffhunk://#diff-0dd73e14818b55120e653268df1c4bc44367a18b84821c6418641580e3d76b47L31-R34) [[5]](diffhunk://#diff-24e5f388bcbc626b2144002ef6a3ab8c25849453349172f1e287a82756bf1a71L45-R48) [[6]](diffhunk://#diff-53209bae0cc403f683dfba167d31dbf56132fe37cca436a436c8723bb9fed7e2L40-R43)