### PR TITLE
fix: masks filtering with aggressive augmentations

### DIFF
--- a/src/rfdetr/datasets/transforms.py
+++ b/src/rfdetr/datasets/transforms.py
@@ -759,6 +759,7 @@ class AlbumentationsWrapper:
         if masks_list is not None and "masks" in augmented:
             height, width = augmented["image"].shape[:2]
             masks_aug = augmented["masks"]
+            masks_aug = [masks_aug[int(i)] for i in kept_idxs]
             if len(masks_aug) == 0:
                 target_out["masks"] = torch.zeros((0, height, width), dtype=torch.bool)
             else:

--- a/tests/datasets/test_augmentations.py
+++ b/tests/datasets/test_augmentations.py
@@ -478,7 +478,6 @@ class TestAlbumentationsWrapper:
         # Output masks should be bool after Albumentations processing
         assert aug_target["masks"].dtype == torch.bool
 
-
     def test_masks_transform_with_dropped_boxes(self):
         """Test wrapper filters masks appropriately when boxes are dropped by transform."""
         # Use a crop transform to ensure a box is dropped

--- a/tests/datasets/test_augmentations.py
+++ b/tests/datasets/test_augmentations.py
@@ -479,6 +479,38 @@ class TestAlbumentationsWrapper:
         assert aug_target["masks"].dtype == torch.bool
 
 
+    def test_masks_transform_with_dropped_boxes(self):
+        """Test wrapper filters masks appropriately when boxes are dropped by transform."""
+        # Use a crop transform to ensure a box is dropped
+        # Original image 100x100
+        # Box 1: [10, 10, 20, 20] (will be kept if we crop top-left)
+        # Box 2: [80, 80, 90, 90] (will be dropped if we crop top-left to 50x50)
+        transform = A.Crop(x_min=0, y_min=0, x_max=50, y_max=50, p=1.0)
+        wrapper = AlbumentationsWrapper(transform)
+
+        height, width = 100, 100
+        image = Image.new("RGB", (width, height))
+
+        masks = torch.zeros((2, height, width), dtype=torch.uint8)
+        masks[0, 10:20, 10:20] = 1
+        masks[1, 80:90, 80:90] = 1
+
+        target = {
+            "boxes": torch.tensor([[10.0, 10.0, 20.0, 20.0], [80.0, 80.0, 90.0, 90.0]]),
+            "labels": torch.tensor([1, 2]),
+            "masks": masks,
+        }
+
+        aug_image, aug_target = wrapper(image, target)
+
+        assert isinstance(aug_image, Image.Image)
+        assert len(aug_target["boxes"]) == 1
+        assert len(aug_target["labels"]) == 1
+        assert "masks" in aug_target
+        assert len(aug_target["masks"]) == 1
+        assert aug_target["masks"].shape == (1, 50, 50)
+
+
 class TestAlbumentationsWrapperFromConfig:
     """Tests for AlbumentationsWrapper.from_config() static method."""
 


### PR DESCRIPTION
## What does this PR do?

Fix masks filtering when running aggressive augmentations (or anything that would erase bboxes/masks)

## Type of Change
- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**
Added test that filters out masks/boxes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

