### PR TITLE
tests: migrate `rfdetr_plus` coco inference benchmarks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ metrics = [
     "mlflow",
     "clearml"
 ]
-plus = ["rfdetr_plus>=1.0.0"]
+plus = ["rfdetr_plus>=1.0.1, <2.0.0"]
 
 [dependency-groups]
 build = [

--- a/tests/benchmarks/test_coco_inference.py
+++ b/tests/benchmarks/test_coco_inference.py
@@ -3,11 +3,9 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-import importlib.util
 import json
 import os
 import tempfile
-from functools import partial
 from pathlib import Path
 from typing import Optional
 
@@ -33,23 +31,6 @@ from rfdetr.engine import evaluate
 from rfdetr.models import build_criterion_and_postprocessors
 from rfdetr.util.misc import collate_fn
 
-_PLUS_AVAILABLE = importlib.util.find_spec("rfdetr_plus") is not None
-if _PLUS_AVAILABLE:
-    try:
-        from rfdetr import RFDETR2XLarge, RFDETRXLarge
-
-        RFDETRXLarge_PML = partial(RFDETRXLarge, accept_platform_model_license=True)
-        RFDETR2XLarge_PML = partial(RFDETR2XLarge, accept_platform_model_license=True)
-    except ImportError:
-        _PLUS_AVAILABLE = False
-        RFDETRXLarge_PML = None
-        RFDETR2XLarge_PML = None
-else:
-    RFDETRXLarge_PML = None
-    RFDETR2XLarge_PML = None
-
-_PLUS_SKIP = pytest.mark.skipif(not _PLUS_AVAILABLE, reason="requires rfdetr_plus models")
-
 
 @pytest.mark.gpu
 @pytest.mark.parametrize(
@@ -59,8 +40,6 @@ _PLUS_SKIP = pytest.mark.skipif(not _PLUS_AVAILABLE, reason="requires rfdetr_plu
         pytest.param(RFDETRSmall, 0.72, 0.70, 500, 6, id="small"),
         pytest.param(RFDETRMedium, 0.73, 0.71, 500, 4, id="medium"),
         pytest.param(RFDETRLarge, 0.74, 0.72, 500, 2, id="large"),
-        pytest.param(RFDETRXLarge_PML, 0.77, 0.74, 500, 2, id="xlarge", marks=_PLUS_SKIP),
-        pytest.param(RFDETR2XLarge_PML, 0.78, 0.74, 500, 2, id="2xlarge", marks=_PLUS_SKIP),
     ],
 )
 def test_coco_detection_inference_benchmark(


### PR DESCRIPTION
This pull request updates the dependency version for `rfdetr_plus` and removes all code related to conditional testing of "plus" models in the COCO inference benchmark tests. This simplifies the test code by eliminating dynamic imports and conditional test skipping for unavailable models.

Dependency update:

* Updated the `plus` dependency in `pyproject.toml` to require `rfdetr_plus` version `>=1.0.1, <2.0.0` instead of `>=1.0.0` to ensure compatibility with the latest supported versions.

Testing simplification:

* Removed dynamic import logic and conditional availability checks for `rfdetr_plus` models (`RFDETRXLarge_PML`, `RFDETR2XLarge_PML`) from `tests/benchmarks/test_coco_inference.py`, including the `_PLUS_AVAILABLE` flag, import attempts, and `_PLUS_SKIP` test marker.
* Removed test parameters for the "xlarge" and "2xlarge" models that depended on the conditional logic, so only the core model variants are tested in `test_coco_detection_inference_benchmark`.
* Cleaned up unused imports related to the removed conditional logic in `tests/benchmarks/test_coco_inference.py`.