### PR TITLE
fix mask handling & add regression test for empty masks in geometric transforms

### DIFF
--- a/src/rfdetr/datasets/transforms.py
+++ b/src/rfdetr/datasets/transforms.py
@@ -735,7 +735,7 @@ class AlbumentationsWrapper:
             masks_list = [mask for mask in masks_np]
         # Apply transform
         transform_kwargs = {"image": image_np, "bboxes": boxes_np, "category_ids": labels, "idxs": idxs}
-        if masks_list is not None:
+        if masks_list is not None and len(masks_list) > 0:
             transform_kwargs["masks"] = masks_list
         augmented = self.transform(**transform_kwargs)
         target_out: Dict[str, Any] = target.copy()

--- a/src/rfdetr/datasets/transforms.py
+++ b/src/rfdetr/datasets/transforms.py
@@ -745,12 +745,11 @@ class AlbumentationsWrapper:
         if len(bboxes_aug) == 0:
             target_out["boxes"] = torch.zeros((0, 4), dtype=torch.float32)
             target_out["labels"] = torch.zeros((0,), dtype=torch.long)
-            # Explicitly clear masks when all boxes are removed; _clear_per_instance_fields
-            # will also clear per-instance fields (including masks) based on num_boxes.
+            target_out.update(self._clear_per_instance_fields(target, num_boxes))
+            # Override masks after _clear_per_instance_fields to ensure bool dtype.
             if "masks" in target:
                 img_height, img_width = image_np.shape[:2]
                 target_out["masks"] = torch.zeros((0, img_height, img_width), dtype=torch.bool)
-            target_out.update(self._clear_per_instance_fields(target, num_boxes))
         else:
             target_out["boxes"] = torch.as_tensor(bboxes_aug, dtype=torch.float32).reshape(-1, 4)
             target_out["labels"] = torch.tensor(augmented["category_ids"], dtype=torch.long)

--- a/tests/datasets/test_augmentations.py
+++ b/tests/datasets/test_augmentations.py
@@ -442,6 +442,7 @@ class TestAlbumentationsWrapper:
         assert aug_target["labels"].shape == (0,)
         assert "masks" in aug_target
         assert aug_target["masks"].shape[0] == 0
+        assert aug_target["masks"].dtype == torch.bool
 
     def test_pixel_transform_with_masks_no_boxes(self):
         """Test that pixel transforms work with masks but no boxes."""

--- a/tests/datasets/test_augmentations.py
+++ b/tests/datasets/test_augmentations.py
@@ -413,6 +413,36 @@ class TestAlbumentationsWrapper:
         assert aug_target["boxes"].shape == (0, 4)
         assert aug_target["labels"].shape == (0,)
 
+    def test_geometric_transform_with_empty_masks_tensor(self):
+        """Test that a geometric transform does not crash when masks tensor is empty (0 instances).
+
+        Regression test for: when a prior crop removes all annotations, target["masks"]
+        has shape (0, H, W). Passing an empty list to albumentations raises
+        ValueError: masks cannot be empty.
+        """
+        transform = A.HorizontalFlip(p=1.0)
+        wrapper = AlbumentationsWrapper(transform)
+
+        height, width = 100, 100
+        image = Image.new("RGB", (width, height))
+
+        # Simulate what happens after RandomSizeCrop removes all annotations:
+        # target["masks"] has shape (0, H, W)
+        target = {
+            "boxes": torch.zeros((0, 4), dtype=torch.float32),
+            "labels": torch.zeros((0,), dtype=torch.long),
+            "masks": torch.zeros((0, height, width), dtype=torch.uint8),
+        }
+
+        # Should not raise ValueError: masks cannot be empty
+        aug_image, aug_target = wrapper(image, target)
+
+        assert isinstance(aug_image, Image.Image)
+        assert aug_target["boxes"].shape == (0, 4)
+        assert aug_target["labels"].shape == (0,)
+        assert "masks" in aug_target
+        assert aug_target["masks"].shape[0] == 0
+
     def test_pixel_transform_with_masks_no_boxes(self):
         """Test that pixel transforms work with masks but no boxes."""
         # Use a non-geometric transform which doesn't need boxes


### PR DESCRIPTION
This pull request addresses an issue with handling empty mask tensors during geometric data augmentations, ensuring that the transformation pipeline does not crash when no mask annotations are present. It also adds a regression test to verify correct behavior in this scenario.

**Bug fix for geometric transforms with empty masks:**

* Updated the `_apply_geometric_transform` method in `transforms.py` to only include the `masks` argument if the mask list is not empty, preventing errors from the augmentation library when masks are empty.

**Testing and regression coverage:**

* Added a new test `test_geometric_transform_with_empty_masks_tensor` in `test_augmentations.py` to confirm that geometric transforms do not raise an error when passed an empty mask tensor, simulating the case where all annotations are removed by a prior crop.

---

Addressing https://github.com/roboflow/rf-detr/pull/706#discussion_r2842459169