### PR TITLE
fix: replace 5 bare excepts with except Exception

### DIFF
--- a/src/rfdetr/datasets/coco.py
+++ b/src/rfdetr/datasets/coco.py
@@ -69,7 +69,7 @@ def convert_coco_poly_to_mask(segmentations: List[Any], height: int, width: int)
             continue
         try:
             rles = coco_mask.frPyObjects(polygons, height, width)
-        except:
+        except Exception:
             rles = polygons
         mask = coco_mask.decode(rles)
         if mask.ndim < 3:

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -25,7 +25,7 @@ from rfdetr.util.logger import get_logger
 
 try:
     torch.set_float32_matmul_precision("high")
-except:
+except Exception:
     pass
 
 from rfdetr.assets.model_weights import download_pretrain_weights

--- a/src/rfdetr/main.py
+++ b/src/rfdetr/main.py
@@ -127,7 +127,7 @@ class Model:
                         checkpoint["model"][modify_key_to_load] = get_coco_pretrain_from_obj365(
                             model_without_ddp.state_dict()[modify_key_to_load], checkpoint["model"][modify_key_to_load]
                         )
-                    except:
+                    except Exception:
                         logger.error(f"Failed to load {modify_key_to_load}, deleting from checkpoint")
                         checkpoint["model"].pop(modify_key_to_load)
 
@@ -534,7 +534,7 @@ class Model:
             log_stats.update(ep_paras)
             try:
                 log_stats.update({"now_time": str(datetime.datetime.now())})
-            except:
+            except Exception:
                 pass
             log_stats["train_epoch_time"] = train_epoch_time_str
             epoch_time = time.time() - epoch_start_time

--- a/src/rfdetr/models/transformer.py
+++ b/src/rfdetr/models/transformer.py
@@ -626,7 +626,7 @@ def build_transformer(args):
 
     try:
         two_stage = args.two_stage
-    except:
+    except Exception:
         two_stage = False
 
     return Transformer(


### PR DESCRIPTION
Replace 5 bare `except:` with `except Exception:` across 4 files. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors.