### PR TITLE
fix: handle supercategory filtering in `_load_classes`

### DIFF
--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -150,7 +150,12 @@ class RFDETR:
             coco_path = os.path.join(dataset_dir, "train", "_annotations.coco.json")
             with open(coco_path, "r") as f:
                 anns = json.load(f)
-            class_names = [c["name"] for c in anns["categories"] if c["supercategory"] != "none"]
+            categories = anns["categories"]
+            has_hierarchy = any(c.get("supercategory", "none") != "none" for c in categories)
+            if has_hierarchy:
+                class_names = [c["name"] for c in categories if c["supercategory"] != "none"]
+            else:
+                class_names = [c["name"] for c in categories]
             return class_names
 
         # list all YAML files in the folder

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -151,9 +151,10 @@ class RFDETR:
             with open(coco_path, "r") as f:
                 anns = json.load(f)
             categories = anns["categories"]
-            has_hierarchy = any(c.get("supercategory", "none") != "none" for c in categories)
+            supercategory_names = {c["name"] for c in categories}
+            has_hierarchy = any(c.get("supercategory", "none") in supercategory_names for c in categories)
             if has_hierarchy:
-                class_names = [c["name"] for c in categories if c["supercategory"] != "none"]
+                class_names = [c["name"] for c in categories if c.get("supercategory", "none") != "none"]
             else:
                 class_names = [c["name"] for c in categories]
             return class_names

--- a/tests/datasets/test_coco.py
+++ b/tests/datasets/test_coco.py
@@ -182,13 +182,18 @@ class TestLoadClassesHierarchy:
         result = RFDETR._load_classes(str(tmp_path))
         assert result == ["dog", "cat"]
 
-    def test_standard_coco_keeps_all(self, tmp_path: Path) -> None:
-        """Standard COCO datasets with real supercategories keep all classes."""
+    def test_mixed_supercategories_keeps_all(self, tmp_path: Path) -> None:
+        """Mix of 'none' and non-'none' supercategories that are not category names.
+
+        A simpler ``any(supercategory != 'none')`` detection would incorrectly
+        set has_hierarchy=True here, then filter out 'dog' (supercategory 'none').
+        The set-based check avoids this: 'animal' is not a category name, so no
+        hierarchy is detected and all categories are returned.
+        """
         categories = [
-            {"id": 1, "name": "dog", "supercategory": "animal"},
+            {"id": 1, "name": "dog", "supercategory": "none"},
             {"id": 2, "name": "cat", "supercategory": "animal"},
-            {"id": 3, "name": "car", "supercategory": "vehicle"},
         ]
         _write_coco_json(tmp_path / "train" / "_annotations.coco.json", categories)
         result = RFDETR._load_classes(str(tmp_path))
-        assert result == ["dog", "cat", "car"]
+        assert result == ["dog", "cat"]

--- a/tests/datasets/test_coco.py
+++ b/tests/datasets/test_coco.py
@@ -4,14 +4,15 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
-"""Regression tests for sparse COCO category ID remapping in ConvertCoco.
+"""Regression tests for COCO dataset handling.
 
-COCO category IDs are sparse (1–90 with gaps). Without remapping they are used
-directly as tensor indices, causing out-of-bounds errors during training when
-the model has only 80 classes.  ConvertCoco must remap them to contiguous
-0-indexed labels via the ``cat2label`` mapping built from the annotation file.
+Tests cover:
+- Sparse COCO category ID remapping in ``ConvertCoco``
+- ``_load_classes`` hierarchy detection (GitHub #609)
 """
 
+import json
+from pathlib import Path
 from typing import Dict, List
 
 import pytest
@@ -21,6 +22,7 @@ from pycocotools.coco import COCO
 
 from rfdetr.datasets.coco import ConvertCoco
 from rfdetr.datasets.coco_eval import CocoEvaluator
+from rfdetr.detr import RFDETR
 
 # Minimal image shared across all tests
 _IMAGE = Image.new("RGB", (100, 100))
@@ -142,3 +144,51 @@ class TestCocoEvaluatorCategoryResolution:
         }
         results = evaluator.prepare_for_coco_detection(predictions)
         assert [result["category_id"] for result in results] == expected_category_ids
+
+
+def _write_coco_json(path: Path, categories: List[Dict]) -> None:
+    """Write a minimal valid COCO annotation file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {"images": [], "annotations": [], "categories": categories}
+    path.write_text(json.dumps(data))
+
+
+class TestLoadClassesHierarchy:
+    """Regression tests for ``_load_classes`` supercategory filtering (#609).
+
+    When all categories have ``supercategory: "none"`` (flat COCO datasets),
+    ``_load_classes`` previously returned an empty list. It should only filter
+    when a Roboflow hierarchical export is detected.
+    """
+
+    def test_roboflow_hierarchy_filters_parent(self, tmp_path: Path) -> None:
+        """Roboflow exports include a parent node — only leaf categories kept."""
+        categories = [
+            {"id": 0, "name": "annotations", "supercategory": "none"},
+            {"id": 1, "name": "dog", "supercategory": "annotations"},
+            {"id": 2, "name": "cat", "supercategory": "annotations"},
+        ]
+        _write_coco_json(tmp_path / "train" / "_annotations.coco.json", categories)
+        result = RFDETR._load_classes(str(tmp_path))
+        assert result == ["dog", "cat"]
+
+    def test_flat_none_supercategory_keeps_all(self, tmp_path: Path) -> None:
+        """Flat datasets where every category has supercategory 'none' (#609)."""
+        categories = [
+            {"id": 1, "name": "dog", "supercategory": "none"},
+            {"id": 2, "name": "cat", "supercategory": "none"},
+        ]
+        _write_coco_json(tmp_path / "train" / "_annotations.coco.json", categories)
+        result = RFDETR._load_classes(str(tmp_path))
+        assert result == ["dog", "cat"]
+
+    def test_standard_coco_keeps_all(self, tmp_path: Path) -> None:
+        """Standard COCO datasets with real supercategories keep all classes."""
+        categories = [
+            {"id": 1, "name": "dog", "supercategory": "animal"},
+            {"id": 2, "name": "cat", "supercategory": "animal"},
+            {"id": 3, "name": "car", "supercategory": "vehicle"},
+        ]
+        _write_coco_json(tmp_path / "train" / "_annotations.coco.json", categories)
+        result = RFDETR._load_classes(str(tmp_path))
+        assert result == ["dog", "cat", "car"]


### PR DESCRIPTION
This pull request improves the handling of COCO dataset category hierarchies in the `_load_classes` function and expands the test coverage to ensure correct behavior for both hierarchical and flat category structures. The main focus is to fix a bug where flat COCO datasets (with all categories having `supercategory: "none"`) previously resulted in an empty class list, and to add regression tests for this behavior.

**COCO category hierarchy handling:**

* Updated `_load_classes` in `src/rfdetr/detr.py` to detect if any category has a non-"none" `supercategory`. Only filter out parent categories when a hierarchy is present; otherwise, include all categories. This fixes an issue where flat datasets were incorrectly filtered to an empty list.

**Testing improvements:**

* Expanded `tests/datasets/test_coco.py` to include regression tests for `_load_classes` covering:
  - Roboflow hierarchical export (only leaf categories kept)
  - Flat datasets where all categories have `supercategory: "none"` (all categories kept)
  - Standard COCO datasets with real supercategories (all categories kept)
 
* Added a helper function `_write_coco_json` for creating minimal valid COCO annotation files in tests.
* Updated test module docstring to reflect the broader scope of COCO dataset handling tests.
* Imported `RFDETR` in test file to enable direct testing of `_load_classes`.

---

addressing https://github.com/roboflow/rf-detr/issues/609#issuecomment-3956465927