### PR TITLE
ci: Enable doctests for all modules in pytest configuration

### DIFF
--- a/.github/workflows/ci-tests-cpu.yml
+++ b/.github/workflows/ci-tests-cpu.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: 🚀 Install Packages
         # Install PyTorch CPU-only first (UV_TORCH_BACKEND=cpu works with 'uv pip')
-        run: uv pip install -e . --group tests
+        run: uv pip install -e . --group tests --extra onnxexport
 
       - name: 🧪 Run the Test
         run: |

--- a/.github/workflows/ci-tests-cpu.yml
+++ b/.github/workflows/ci-tests-cpu.yml
@@ -53,7 +53,7 @@ jobs:
       - name: 🚀 Install Packages
         timeout-minutes: 5
         # Install PyTorch CPU-only first (UV_TORCH_BACKEND=cpu works with 'uv pip')
-        run: uv pip install -e ".[onnxexport]" --group tests
+        run: uv pip install -e . --group tests
 
       - name: 🧪 Run the Test
         run: |

--- a/.github/workflows/ci-tests-cpu.yml
+++ b/.github/workflows/ci-tests-cpu.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: 🚀 Install Packages
         # Install PyTorch CPU-only first (UV_TORCH_BACKEND=cpu works with 'uv pip')
-        run: uv pip install -e . --group tests --extra onnxexport
+        run: uv pip install -e ".[onnxexport]" --group tests
 
       - name: 🧪 Run the Test
         run: |

--- a/.github/workflows/ci-tests-cpu.yml
+++ b/.github/workflows/ci-tests-cpu.yml
@@ -55,7 +55,11 @@ jobs:
         run: uv pip install -e . --group tests
 
       - name: 🧪 Run the Test
-        run: uv run --no-sync pytest src/ tests/ -n 2 -m "not gpu" --cov=rfdetr --cov-report=xml
+        run: |
+          uv run --no-sync pytest src/ tests/ \
+            -n 2 -m "not gpu" \
+            --ignore=tests/try_instantiate_all_models.py \
+            --cov=rfdetr --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,7 @@ ignore = [
 addopts = [
     "-v",                   # verbose output
     "--color=yes",          # colored output
-#    "--doctest-modules",    # TODO: run doctests from all modules
+    "--doctest-modules",    # run doctests from all modules
 ]
 pythonpath = ["src"]
 markers = [

--- a/src/rfdetr/datasets/transforms.py
+++ b/src/rfdetr/datasets/transforms.py
@@ -575,7 +575,7 @@ class AlbumentationsWrapper:
         >>> import albumentations as A
         >>> # Geometric transform - automatically transforms boxes
         >>> wrapper = AlbumentationsWrapper(A.HorizontalFlip(p=1.0))
-        >>> image = Image.open("image.jpg")
+        >>> image = Image.new("RGB", (300, 400))
         >>> target = {"boxes": torch.tensor([[10, 20, 100, 200]]), "labels": torch.tensor([1])}
         >>> aug_image, aug_target = wrapper(image, target)
 
@@ -913,9 +913,11 @@ class ComposeAugmentations:
         transforms: List of transforms to apply sequentially.
 
     Examples:
-        >>> from rfdetr.augmentation_config import AUG_CONFIG
+        >>> from rfdetr.datasets.aug_config import AUG_CONFIG
         >>> aug_transforms = AlbumentationsWrapper.from_config(AUG_CONFIG)
         >>> composed = ComposeAugmentations(aug_transforms)
+        >>> image = Image.new("RGB", (100, 100))
+        >>> target = {"boxes": torch.zeros((0, 4)), "labels": torch.zeros(0, dtype=torch.long)}
         >>> image, target = composed(image, target)
     """
 

--- a/src/rfdetr/datasets/yolo.py
+++ b/src/rfdetr/datasets/yolo.py
@@ -167,7 +167,7 @@ class CocoLikeAPI:
 
     Examples:
         >>> mock = _MockSvDataset()
-        >>> coco = YoloCoco(mock.classes, mock)
+        >>> coco = CocoLikeAPI(mock.classes, mock)
         >>> # dataset structure
         >>> len(coco.dataset["images"]), len(coco.dataset["categories"]), len(coco.dataset["annotations"])
         (2, 2, 2)

--- a/src/rfdetr/deploy/_onnx/optimizer.py
+++ b/src/rfdetr/deploy/_onnx/optimizer.py
@@ -53,8 +53,7 @@ class OnnxOptimizer:
         if missing_deps:
             missing_str = ", ".join(missing_deps)
             raise ImportError(
-                f"ONNX export dependencies are missing ({missing_str}). "
-                "Install with: pip install rfdetr[onnxexport]"
+                f"ONNX export dependencies are missing ({missing_str}). Install with: pip install rfdetr[onnxexport]"
             )
         if severity is None:
             severity = G_LOGGER.INFO

--- a/src/rfdetr/deploy/_onnx/optimizer.py
+++ b/src/rfdetr/deploy/_onnx/optimizer.py
@@ -16,17 +16,37 @@ from collections import OrderedDict
 from copy import deepcopy
 
 import numpy as np
-import onnx
-import onnx_graphsurgeon as gs
-from onnx import shape_inference
-from onnx_graphsurgeon.logger.logger import G_LOGGER
-from polygraphy.backend.onnx.loader import fold_constants
+
+try:
+    import onnx
+    from onnx import shape_inference
+except ImportError:
+    onnx = None  # type: ignore[assignment]
+    shape_inference = None  # type: ignore[assignment]
+
+try:
+    import onnx_graphsurgeon as gs
+    from onnx_graphsurgeon.logger.logger import G_LOGGER
+except ImportError:
+    gs = None  # type: ignore[assignment]
+    G_LOGGER = None  # type: ignore[assignment]
+
+try:
+    from polygraphy.backend.onnx.loader import fold_constants
+except ImportError:
+    fold_constants = None  # type: ignore[assignment]
 
 from rfdetr.deploy._onnx.symbolic import CustomOpSymbolicRegistry
 
 
 class OnnxOptimizer:
-    def __init__(self, input, severity=G_LOGGER.INFO):
+    def __init__(self, input, severity=None):
+        if gs is None:
+            raise ImportError(
+                "ONNX export dependencies are missing. Install with: pip install rfdetr[onnxexport]"
+            )
+        if severity is None:
+            severity = G_LOGGER.INFO
         if isinstance(input, str):
             onnx_graph = self.load_onnx(input)
         else:

--- a/src/rfdetr/deploy/_onnx/optimizer.py
+++ b/src/rfdetr/deploy/_onnx/optimizer.py
@@ -41,8 +41,21 @@ from rfdetr.deploy._onnx.symbolic import CustomOpSymbolicRegistry
 
 class OnnxOptimizer:
     def __init__(self, input, severity=None):
-        if gs is None:
-            raise ImportError("ONNX export dependencies are missing. Install with: pip install rfdetr[onnxexport]")
+        missing_deps = []
+        if onnx is None:
+            missing_deps.append("onnx")
+        if shape_inference is None:
+            missing_deps.append("onnx.shape_inference")
+        if gs is None or G_LOGGER is None:
+            missing_deps.append("onnx_graphsurgeon")
+        if fold_constants is None:
+            missing_deps.append("polygraphy.backend.onnx.loader.fold_constants")
+        if missing_deps:
+            missing_str = ", ".join(missing_deps)
+            raise ImportError(
+                f"ONNX export dependencies are missing ({missing_str}). "
+                "Install with: pip install rfdetr[onnxexport]"
+            )
         if severity is None:
             severity = G_LOGGER.INFO
         if isinstance(input, str):

--- a/src/rfdetr/deploy/_onnx/optimizer.py
+++ b/src/rfdetr/deploy/_onnx/optimizer.py
@@ -42,9 +42,7 @@ from rfdetr.deploy._onnx.symbolic import CustomOpSymbolicRegistry
 class OnnxOptimizer:
     def __init__(self, input, severity=None):
         if gs is None:
-            raise ImportError(
-                "ONNX export dependencies are missing. Install with: pip install rfdetr[onnxexport]"
-            )
+            raise ImportError("ONNX export dependencies are missing. Install with: pip install rfdetr[onnxexport]")
         if severity is None:
             severity = G_LOGGER.INFO
         if isinstance(input, str):

--- a/src/rfdetr/deploy/benchmark.py
+++ b/src/rfdetr/deploy/benchmark.py
@@ -25,16 +25,23 @@ import time
 from collections import OrderedDict, namedtuple
 
 import numpy as np
-import onnxruntime as nxrun
-import pycuda.driver as cuda
 import supervision as sv
-import tensorrt as trt
 import torch
 import torchvision.transforms.functional as F
 from PIL import Image
 from pycocotools.coco import COCO
 from pycocotools.cocoeval import COCOeval
 from tqdm.auto import tqdm
+
+try:
+    import tensorrt as trt
+except ImportError:
+    trt = None
+
+try:
+    import pycuda.driver as cuda
+except ImportError:
+    cuda = None
 
 from rfdetr.util.box_ops import box_xyxy_to_cxcywh
 from rfdetr.util.logger import get_logger
@@ -386,6 +393,9 @@ class TRTInference(object):
     def __init__(
         self, engine_path="dino.engine", device="cuda:0", sync_mode: bool = False, max_batch_size=32, verbose=False
     ):
+        if not trt:
+            raise ImportError("TensorRT is not installed. Please install TensorRT to use TRTInference.")
+
         self.engine_path = engine_path
         self.device = device
         self.sync_mode = sync_mode
@@ -404,6 +414,11 @@ class TRTInference(object):
         self.output_names = self.get_output_names()
 
         if not self.sync_mode:
+            if not cuda:
+                raise ImportError(
+                    "pycuda is not installed. Please install `pycuda` to use TRTInference with async mode."
+                )
+
             self.stream = cuda.Stream()
 
         # self.time_profile = TimeProfiler()
@@ -452,16 +467,6 @@ class TRTInference(object):
 
             if shape[0] == -1:
                 raise NotImplementedError
-
-            if False:
-                if engine.get_tensor_mode(name) == trt.TensorIOMode.INPUT:
-                    data = np.random.randn(*shape).astype(dtype)
-                    ptr = cuda.mem_alloc(data.nbytes)
-                    bindings[name] = Binding(name, dtype, shape, data, ptr)
-                else:
-                    data = cuda.pagelocked_empty(trt.volume(shape), dtype)
-                    ptr = cuda.mem_alloc(data.nbytes)
-                    bindings[name] = Binding(name, dtype, shape, data, ptr)
 
             else:
                 data = torch.from_numpy(np.empty(shape, dtype=dtype)).to(device)
@@ -582,6 +587,8 @@ def main(args):
     time_profile = TimeProfiler()
 
     if args.path.endswith(".onnx"):
+        import onnxruntime as nxrun
+
         sess = nxrun.InferenceSession(args.path, providers=["CUDAExecutionProvider"])
         infer_onnx(sess, coco_evaluator, time_profile, prefix, img_list, device=f"cuda:{args.device}", repeats=repeats)
     elif args.path.endswith(".engine"):

--- a/src/rfdetr/deploy/benchmark.py
+++ b/src/rfdetr/deploy/benchmark.py
@@ -412,6 +412,7 @@ class TRTInference(object):
 
         self.input_names = self.get_input_names()
         self.output_names = self.get_output_names()
+        self.stream = None
 
         if not self.sync_mode:
             if not cuda:
@@ -497,10 +498,15 @@ class TRTInference(object):
     def synchronize(
         self,
     ):
-        if not self.sync_mode and torch.cuda.is_available():
-            torch.cuda.synchronize()
-        elif self.sync_mode:
+        if self.sync_mode:
+            if torch.cuda.is_available():
+                torch.cuda.synchronize()
+            return
+
+        if self.stream is not None:
             self.stream.synchronize()
+        elif torch.cuda.is_available():
+            torch.cuda.synchronize()
 
     def speed(self, blob, n):
         self.time_profile.reset()

--- a/src/rfdetr/deploy/export.py
+++ b/src/rfdetr/deploy/export.py
@@ -18,14 +18,11 @@ import re
 import subprocess
 
 import numpy as np
-import onnx
-import onnxsim
 import torch
 import torch.nn as nn
 from PIL import Image
 
 import rfdetr.datasets.transforms as T
-from rfdetr.deploy._onnx import OnnxOptimizer
 from rfdetr.models import build_model
 from rfdetr.util.logger import get_logger
 from rfdetr.util.misc import get_rank, get_sha
@@ -108,6 +105,11 @@ def export_onnx(
 
 
 def onnx_simplify(onnx_dir: str, input_names, input_tensors, force=False):
+    import onnx
+    import onnxsim
+
+    from rfdetr.deploy._onnx import OnnxOptimizer
+
     sim_onnx_dir = onnx_dir.replace(".onnx", ".sim.onnx")
     if os.path.isfile(sim_onnx_dir) and not force:
         return sim_onnx_dir

--- a/src/rfdetr/models/backbone/dinov2_with_windowed_attn.py
+++ b/src/rfdetr/models/backbone/dinov2_with_windowed_attn.py
@@ -25,6 +25,7 @@ from transformers.modeling_outputs import (
 from transformers.modeling_utils import PreTrainedModel
 from transformers.pytorch_utils import find_pruneable_heads_and_indices, prune_linear_layer
 from transformers.utils import (
+    add_code_sample_docstrings,
     add_start_docstrings,
     add_start_docstrings_to_model_forward,
     logging,
@@ -38,6 +39,9 @@ from transformers.utils.backbone_utils import (
 )
 
 logger = logging.get_logger(__name__)
+
+# Base docstring
+_CHECKPOINT_FOR_DOC = "facebook/dinov2_with_registers-base"
 
 # General docstring
 _CONFIG_FOR_DOC = "WindowedDinov2WithRegistersConfig"
@@ -762,6 +766,9 @@ class WindowedDinov2WithRegistersPreTrainedModel(PreTrainedModel):
             ).to(module.cls_token.dtype)
 
 
+_EXPECTED_OUTPUT_SHAPE = [1, 257, 768]
+
+
 DINOV2_WITH_REGISTERS_START_DOCSTRING = r"""
     This model is a PyTorch [torch.nn.Module](https://pytorch.org/docs/stable/nn.html#torch.nn.Module) subclass. Use it
     as a regular PyTorch Module and refer to the PyTorch documentation for all matter related to general usage and
@@ -829,7 +836,13 @@ class WindowedDinov2WithRegistersModel(WindowedDinov2WithRegistersPreTrainedMode
             self.encoder.layer[layer].attention.prune_heads(heads)
 
     @add_start_docstrings_to_model_forward(DINOV2_WITH_REGISTERS_BASE_INPUTS_DOCSTRING)
-    @replace_return_docstrings(output_type=BaseModelOutputWithPooling, config_class=_CONFIG_FOR_DOC)
+    @add_code_sample_docstrings(
+        checkpoint=_CHECKPOINT_FOR_DOC,
+        output_type=BaseModelOutputWithPooling,
+        config_class=_CONFIG_FOR_DOC,
+        modality="vision",
+        expected_output=_EXPECTED_OUTPUT_SHAPE,
+    )
     def forward(
         self,
         pixel_values: Optional[torch.Tensor] = None,
@@ -839,30 +852,6 @@ class WindowedDinov2WithRegistersModel(WindowedDinov2WithRegistersPreTrainedMode
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
     ) -> Union[Tuple, BaseModelOutputWithPooling]:
-        """
-        Returns:
-
-        Examples:
-
-        >>> import torch
-        >>> from rfdetr.models.backbone.dinov2_with_windowed_attn import (
-        ...     WindowedDinov2WithRegistersConfig,
-        ...     WindowedDinov2WithRegistersModel,
-        ... )
-        >>> config = WindowedDinov2WithRegistersConfig(
-        ...     image_size=32,
-        ...     patch_size=16,
-        ...     hidden_size=32,
-        ...     num_hidden_layers=2,
-        ...     num_attention_heads=4,
-        ...     num_register_tokens=2,
-        ... )
-        >>> model = WindowedDinov2WithRegistersModel(config)
-        >>> pixel_values = torch.randn(1, 3, 32, 32)
-        >>> outputs = model(pixel_values)
-        >>> list(outputs.last_hidden_state.shape)
-        [1, 7, 32]
-        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -903,6 +892,10 @@ class WindowedDinov2WithRegistersModel(WindowedDinov2WithRegistersPreTrainedMode
             attentions=encoder_outputs.attentions,
         )
 
+
+# Image classification docstring
+_IMAGE_CLASS_CHECKPOINT = "facebook/dinov2_with_registers-small-imagenet1k-1-layer"
+_IMAGE_CLASS_EXPECTED_OUTPUT = "tabby, tabby cat"
 
 DINOV2_WITH_REGISTERS_INPUTS_DOCSTRING = r"""
     Args:
@@ -950,9 +943,11 @@ class WindowedDinov2WithRegistersForImageClassification(WindowedDinov2WithRegist
         self.post_init()
 
     @add_start_docstrings_to_model_forward(DINOV2_WITH_REGISTERS_INPUTS_DOCSTRING)
-    @replace_return_docstrings(
+    @add_code_sample_docstrings(
+        checkpoint=_IMAGE_CLASS_CHECKPOINT,
         output_type=ImageClassifierOutput,
         config_class=_CONFIG_FOR_DOC,
+        expected_output=_IMAGE_CLASS_EXPECTED_OUTPUT,
     )
     def forward(
         self,
@@ -968,30 +963,6 @@ class WindowedDinov2WithRegistersForImageClassification(WindowedDinov2WithRegist
             Labels for computing the image classification/regression loss. Indices should be in `[0, ...,
             config.num_labels - 1]`. If `config.num_labels == 1` a regression loss is computed (Mean-Square loss), If
             `config.num_labels > 1` a classification loss is computed (Cross-Entropy).
-
-        Returns:
-
-        Example:
-
-        >>> import torch
-        >>> from rfdetr.models.backbone.dinov2_with_windowed_attn import (
-        ...     WindowedDinov2WithRegistersConfig,
-        ...     WindowedDinov2WithRegistersForImageClassification,
-        ... )
-        >>> config = WindowedDinov2WithRegistersConfig(
-        ...     image_size=32,
-        ...     patch_size=16,
-        ...     hidden_size=32,
-        ...     num_hidden_layers=2,
-        ...     num_attention_heads=4,
-        ...     num_register_tokens=2,
-        ...     num_labels=3,
-        ... )
-        >>> model = WindowedDinov2WithRegistersForImageClassification(config)
-        >>> pixel_values = torch.randn(1, 3, 32, 32)
-        >>> outputs = model(pixel_values)
-        >>> list(outputs.logits.shape)
-        [1, 3]
         """
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 

--- a/src/rfdetr/models/backbone/dinov2_with_windowed_attn.py
+++ b/src/rfdetr/models/backbone/dinov2_with_windowed_attn.py
@@ -108,16 +108,20 @@ class WindowedDinov2WithRegistersConfig(BackboneConfigMixin, PretrainedConfig):
 
     Example:
 
-    >>> from transformers import Dinov2WithRegistersConfig, Dinov2WithRegistersModel
+    >>> from rfdetr.models.backbone.dinov2_with_windowed_attn import WindowedDinov2WithRegistersConfig
 
-    >>> # Initializing a Dinov2WithRegisters base style configuration
-    >>> configuration = Dinov2WithRegistersConfig()
+    >>> # Initializing a tiny configuration suitable for doctests
+    >>> configuration = WindowedDinov2WithRegistersConfig(
+    ...     image_size=32,
+    ...     patch_size=16,
+    ...     hidden_size=32,
+    ...     num_hidden_layers=2,
+    ...     num_attention_heads=4,
+    ...     num_register_tokens=2,
+    ... )
 
-    >>> # Initializing a model (with random weights) from the base style configuration
-    >>> model = Dinov2WithRegistersModel(configuration)
-
-    >>> # Accessing the model configuration
-    >>> configuration = model.config
+    >>> configuration.hidden_size
+    32
 
     """
 

--- a/src/rfdetr/models/backbone/dinov2_with_windowed_attn.py
+++ b/src/rfdetr/models/backbone/dinov2_with_windowed_attn.py
@@ -25,7 +25,6 @@ from transformers.modeling_outputs import (
 from transformers.modeling_utils import PreTrainedModel
 from transformers.pytorch_utils import find_pruneable_heads_and_indices, prune_linear_layer
 from transformers.utils import (
-    add_code_sample_docstrings,
     add_start_docstrings,
     add_start_docstrings_to_model_forward,
     logging,
@@ -39,9 +38,6 @@ from transformers.utils.backbone_utils import (
 )
 
 logger = logging.get_logger(__name__)
-
-# Base docstring
-_CHECKPOINT_FOR_DOC = "facebook/dinov2_with_registers-base"
 
 # General docstring
 _CONFIG_FOR_DOC = "WindowedDinov2WithRegistersConfig"
@@ -766,9 +762,6 @@ class WindowedDinov2WithRegistersPreTrainedModel(PreTrainedModel):
             ).to(module.cls_token.dtype)
 
 
-_EXPECTED_OUTPUT_SHAPE = [1, 257, 768]
-
-
 DINOV2_WITH_REGISTERS_START_DOCSTRING = r"""
     This model is a PyTorch [torch.nn.Module](https://pytorch.org/docs/stable/nn.html#torch.nn.Module) subclass. Use it
     as a regular PyTorch Module and refer to the PyTorch documentation for all matter related to general usage and
@@ -836,13 +829,7 @@ class WindowedDinov2WithRegistersModel(WindowedDinov2WithRegistersPreTrainedMode
             self.encoder.layer[layer].attention.prune_heads(heads)
 
     @add_start_docstrings_to_model_forward(DINOV2_WITH_REGISTERS_BASE_INPUTS_DOCSTRING)
-    @add_code_sample_docstrings(
-        checkpoint=_CHECKPOINT_FOR_DOC,
-        output_type=BaseModelOutputWithPooling,
-        config_class=_CONFIG_FOR_DOC,
-        modality="vision",
-        expected_output=_EXPECTED_OUTPUT_SHAPE,
-    )
+    @replace_return_docstrings(output_type=BaseModelOutputWithPooling, config_class=_CONFIG_FOR_DOC)
     def forward(
         self,
         pixel_values: Optional[torch.Tensor] = None,
@@ -852,6 +839,30 @@ class WindowedDinov2WithRegistersModel(WindowedDinov2WithRegistersPreTrainedMode
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
     ) -> Union[Tuple, BaseModelOutputWithPooling]:
+        """
+        Returns:
+
+        Examples:
+
+        >>> import torch
+        >>> from rfdetr.models.backbone.dinov2_with_windowed_attn import (
+        ...     WindowedDinov2WithRegistersConfig,
+        ...     WindowedDinov2WithRegistersModel,
+        ... )
+        >>> config = WindowedDinov2WithRegistersConfig(
+        ...     image_size=32,
+        ...     patch_size=16,
+        ...     hidden_size=32,
+        ...     num_hidden_layers=2,
+        ...     num_attention_heads=4,
+        ...     num_register_tokens=2,
+        ... )
+        >>> model = WindowedDinov2WithRegistersModel(config)
+        >>> pixel_values = torch.randn(1, 3, 32, 32)
+        >>> outputs = model(pixel_values)
+        >>> list(outputs.last_hidden_state.shape)
+        [1, 7, 32]
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -892,10 +903,6 @@ class WindowedDinov2WithRegistersModel(WindowedDinov2WithRegistersPreTrainedMode
             attentions=encoder_outputs.attentions,
         )
 
-
-# Image classification docstring
-_IMAGE_CLASS_CHECKPOINT = "facebook/dinov2_with_registers-small-imagenet1k-1-layer"
-_IMAGE_CLASS_EXPECTED_OUTPUT = "tabby, tabby cat"
 
 DINOV2_WITH_REGISTERS_INPUTS_DOCSTRING = r"""
     Args:
@@ -943,11 +950,9 @@ class WindowedDinov2WithRegistersForImageClassification(WindowedDinov2WithRegist
         self.post_init()
 
     @add_start_docstrings_to_model_forward(DINOV2_WITH_REGISTERS_INPUTS_DOCSTRING)
-    @add_code_sample_docstrings(
-        checkpoint=_IMAGE_CLASS_CHECKPOINT,
+    @replace_return_docstrings(
         output_type=ImageClassifierOutput,
         config_class=_CONFIG_FOR_DOC,
-        expected_output=_IMAGE_CLASS_EXPECTED_OUTPUT,
     )
     def forward(
         self,
@@ -963,6 +968,30 @@ class WindowedDinov2WithRegistersForImageClassification(WindowedDinov2WithRegist
             Labels for computing the image classification/regression loss. Indices should be in `[0, ...,
             config.num_labels - 1]`. If `config.num_labels == 1` a regression loss is computed (Mean-Square loss), If
             `config.num_labels > 1` a classification loss is computed (Cross-Entropy).
+
+        Returns:
+
+        Example:
+
+        >>> import torch
+        >>> from rfdetr.models.backbone.dinov2_with_windowed_attn import (
+        ...     WindowedDinov2WithRegistersConfig,
+        ...     WindowedDinov2WithRegistersForImageClassification,
+        ... )
+        >>> config = WindowedDinov2WithRegistersConfig(
+        ...     image_size=32,
+        ...     patch_size=16,
+        ...     hidden_size=32,
+        ...     num_hidden_layers=2,
+        ...     num_attention_heads=4,
+        ...     num_register_tokens=2,
+        ...     num_labels=3,
+        ... )
+        >>> model = WindowedDinov2WithRegistersForImageClassification(config)
+        >>> pixel_values = torch.randn(1, 3, 32, 32)
+        >>> outputs = model(pixel_values)
+        >>> list(outputs.logits.shape)
+        [1, 3]
         """
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
@@ -1058,25 +1087,27 @@ class WindowedDinov2WithRegistersBackbone(WindowedDinov2WithRegistersPreTrainedM
 
         Examples:
 
-        >>> from transformers import AutoImageProcessor, AutoBackbone
         >>> import torch
-        >>> from PIL import Imag
-        >>> import requests
-
-        >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
-        >>> image = Image.open(requests.get(url, stream=True).raw)
-
-        >>> processor = AutoImageProcessor.from_pretrained("facebook/dinov2-with-registers-base")
-        >>> model = AutoBackbone.from_pretrained(
-        ...     "facebook/dinov2-with-registers-base", out_features=["stage2", "stage5", "stage8", "stage11"]
+        >>> from rfdetr.models.backbone.dinov2_with_windowed_attn import (
+        ...     WindowedDinov2WithRegistersBackbone,
+        ...     WindowedDinov2WithRegistersConfig,
         ... )
-
-        >>> inputs = processor(image, return_tensors="pt")  # doctest: +SKIP
-
-        >>> outputs = model(**inputs)
-        >>> feature_maps = outputs.feature_maps
-        >>> list(feature_maps[-1].shape)
-        [1, 768, 16, 16]
+        >>> config = WindowedDinov2WithRegistersConfig(
+        ...     image_size=32,
+        ...     patch_size=16,
+        ...     hidden_size=32,
+        ...     num_hidden_layers=2,
+        ...     num_attention_heads=4,
+        ...     num_register_tokens=2,
+        ...     out_indices=[2],
+        ... )
+        >>> model = WindowedDinov2WithRegistersBackbone(config)
+        >>> pixel_values = torch.randn(1, 3, 32, 32)
+        >>> outputs = model(pixel_values)
+        >>> len(outputs.feature_maps)
+        1
+        >>> list(outputs.feature_maps[0].shape)
+        [1, 32, 2, 2]
 
         """
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
@@ -1141,8 +1172,6 @@ class WindowedDinov2WithRegistersBackbone(WindowedDinov2WithRegistersPreTrainedM
             hidden_states=outputs.hidden_states if output_hidden_states else None,
             attentions=outputs.attentions if output_attentions else None,
         )
-
-
 __all__ = [
     "WindowedDinov2WithRegistersPreTrainedModel",
     "WindowedDinov2WithRegistersModel",

--- a/src/rfdetr/models/backbone/dinov2_with_windowed_attn.py
+++ b/src/rfdetr/models/backbone/dinov2_with_windowed_attn.py
@@ -25,11 +25,12 @@ from transformers.modeling_outputs import (
 from transformers.modeling_utils import PreTrainedModel
 from transformers.pytorch_utils import find_pruneable_heads_and_indices, prune_linear_layer
 from transformers.utils import (
+    add_code_sample_docstrings,
     add_start_docstrings,
     add_start_docstrings_to_model_forward,
     logging,
     replace_return_docstrings,
-    torch_int, add_code_sample_docstrings,
+    torch_int,
 )
 from transformers.utils.backbone_utils import (
     BackboneConfigMixin,

--- a/src/rfdetr/models/backbone/dinov2_with_windowed_attn.py
+++ b/src/rfdetr/models/backbone/dinov2_with_windowed_attn.py
@@ -25,7 +25,6 @@ from transformers.modeling_outputs import (
 from transformers.modeling_utils import PreTrainedModel
 from transformers.pytorch_utils import find_pruneable_heads_and_indices, prune_linear_layer
 from transformers.utils import (
-    add_code_sample_docstrings,
     add_start_docstrings,
     add_start_docstrings_to_model_forward,
     logging,
@@ -39,9 +38,6 @@ from transformers.utils.backbone_utils import (
 )
 
 logger = logging.get_logger(__name__)
-
-# Base docstring
-_CHECKPOINT_FOR_DOC = "facebook/dinov2_with_registers-base"
 
 # General docstring
 _CONFIG_FOR_DOC = "WindowedDinov2WithRegistersConfig"
@@ -766,9 +762,6 @@ class WindowedDinov2WithRegistersPreTrainedModel(PreTrainedModel):
             ).to(module.cls_token.dtype)
 
 
-_EXPECTED_OUTPUT_SHAPE = [1, 257, 768]
-
-
 DINOV2_WITH_REGISTERS_START_DOCSTRING = r"""
     This model is a PyTorch [torch.nn.Module](https://pytorch.org/docs/stable/nn.html#torch.nn.Module) subclass. Use it
     as a regular PyTorch Module and refer to the PyTorch documentation for all matter related to general usage and
@@ -836,13 +829,7 @@ class WindowedDinov2WithRegistersModel(WindowedDinov2WithRegistersPreTrainedMode
             self.encoder.layer[layer].attention.prune_heads(heads)
 
     @add_start_docstrings_to_model_forward(DINOV2_WITH_REGISTERS_BASE_INPUTS_DOCSTRING)
-    @add_code_sample_docstrings(
-        checkpoint=_CHECKPOINT_FOR_DOC,
-        output_type=BaseModelOutputWithPooling,
-        config_class=_CONFIG_FOR_DOC,
-        modality="vision",
-        expected_output=_EXPECTED_OUTPUT_SHAPE,
-    )
+    @replace_return_docstrings(output_type=BaseModelOutputWithPooling, config_class=_CONFIG_FOR_DOC)
     def forward(
         self,
         pixel_values: Optional[torch.Tensor] = None,
@@ -852,6 +839,30 @@ class WindowedDinov2WithRegistersModel(WindowedDinov2WithRegistersPreTrainedMode
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
     ) -> Union[Tuple, BaseModelOutputWithPooling]:
+        """
+        Returns:
+
+        Examples:
+
+        >>> import torch
+        >>> from rfdetr.models.backbone.dinov2_with_windowed_attn import (
+        ...     WindowedDinov2WithRegistersConfig,
+        ...     WindowedDinov2WithRegistersModel,
+        ... )
+        >>> config = WindowedDinov2WithRegistersConfig(
+        ...     image_size=32,
+        ...     patch_size=16,
+        ...     hidden_size=32,
+        ...     num_hidden_layers=2,
+        ...     num_attention_heads=4,
+        ...     num_register_tokens=2,
+        ... )
+        >>> model = WindowedDinov2WithRegistersModel(config)
+        >>> pixel_values = torch.randn(1, 3, 32, 32)
+        >>> outputs = model(pixel_values)
+        >>> list(outputs.last_hidden_state.shape)
+        [1, 7, 32]
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -892,10 +903,6 @@ class WindowedDinov2WithRegistersModel(WindowedDinov2WithRegistersPreTrainedMode
             attentions=encoder_outputs.attentions,
         )
 
-
-# Image classification docstring
-_IMAGE_CLASS_CHECKPOINT = "facebook/dinov2_with_registers-small-imagenet1k-1-layer"
-_IMAGE_CLASS_EXPECTED_OUTPUT = "tabby, tabby cat"
 
 DINOV2_WITH_REGISTERS_INPUTS_DOCSTRING = r"""
     Args:
@@ -943,11 +950,9 @@ class WindowedDinov2WithRegistersForImageClassification(WindowedDinov2WithRegist
         self.post_init()
 
     @add_start_docstrings_to_model_forward(DINOV2_WITH_REGISTERS_INPUTS_DOCSTRING)
-    @add_code_sample_docstrings(
-        checkpoint=_IMAGE_CLASS_CHECKPOINT,
+    @replace_return_docstrings(
         output_type=ImageClassifierOutput,
         config_class=_CONFIG_FOR_DOC,
-        expected_output=_IMAGE_CLASS_EXPECTED_OUTPUT,
     )
     def forward(
         self,
@@ -963,6 +968,30 @@ class WindowedDinov2WithRegistersForImageClassification(WindowedDinov2WithRegist
             Labels for computing the image classification/regression loss. Indices should be in `[0, ...,
             config.num_labels - 1]`. If `config.num_labels == 1` a regression loss is computed (Mean-Square loss), If
             `config.num_labels > 1` a classification loss is computed (Cross-Entropy).
+
+        Returns:
+
+        Example:
+
+        >>> import torch
+        >>> from rfdetr.models.backbone.dinov2_with_windowed_attn import (
+        ...     WindowedDinov2WithRegistersConfig,
+        ...     WindowedDinov2WithRegistersForImageClassification,
+        ... )
+        >>> config = WindowedDinov2WithRegistersConfig(
+        ...     image_size=32,
+        ...     patch_size=16,
+        ...     hidden_size=32,
+        ...     num_hidden_layers=2,
+        ...     num_attention_heads=4,
+        ...     num_register_tokens=2,
+        ...     num_labels=3,
+        ... )
+        >>> model = WindowedDinov2WithRegistersForImageClassification(config)
+        >>> pixel_values = torch.randn(1, 3, 32, 32)
+        >>> outputs = model(pixel_values)
+        >>> list(outputs.logits.shape)
+        [1, 3]
         """
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 

--- a/src/rfdetr/models/backbone/dinov2_with_windowed_attn.py
+++ b/src/rfdetr/models/backbone/dinov2_with_windowed_attn.py
@@ -25,12 +25,11 @@ from transformers.modeling_outputs import (
 from transformers.modeling_utils import PreTrainedModel
 from transformers.pytorch_utils import find_pruneable_heads_and_indices, prune_linear_layer
 from transformers.utils import (
-    add_code_sample_docstrings,
     add_start_docstrings,
     add_start_docstrings_to_model_forward,
     logging,
     replace_return_docstrings,
-    torch_int,
+    torch_int, add_code_sample_docstrings,
 )
 from transformers.utils.backbone_utils import (
     BackboneConfigMixin,
@@ -112,7 +111,6 @@ class WindowedDinov2WithRegistersConfig(BackboneConfigMixin, PretrainedConfig):
 
     Example:
 
-    ```python
     >>> from transformers import Dinov2WithRegistersConfig, Dinov2WithRegistersModel
 
     >>> # Initializing a Dinov2WithRegisters base style configuration
@@ -123,7 +121,8 @@ class WindowedDinov2WithRegistersConfig(BackboneConfigMixin, PretrainedConfig):
 
     >>> # Accessing the model configuration
     >>> configuration = model.config
-    ```"""
+
+    """
 
     model_type = "dinov2_with_registers"
 
@@ -1057,15 +1056,10 @@ class WindowedDinov2WithRegistersBackbone(WindowedDinov2WithRegistersPreTrainedM
         Returns:
 
         Examples:
-        Returns:
 
-        Examples:
-
-
-        ```python
         >>> from transformers import AutoImageProcessor, AutoBackbone
         >>> import torch
-        >>> from PIL import Image
+        >>> from PIL import Imag
         >>> import requests
 
         >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
@@ -1076,13 +1070,14 @@ class WindowedDinov2WithRegistersBackbone(WindowedDinov2WithRegistersPreTrainedM
         ...     "facebook/dinov2-with-registers-base", out_features=["stage2", "stage5", "stage8", "stage11"]
         ... )
 
-        >>> inputs = processor(image, return_tensors="pt")
+        >>> inputs = processor(image, return_tensors="pt")  # doctest: +SKIP
 
         >>> outputs = model(**inputs)
         >>> feature_maps = outputs.feature_maps
         >>> list(feature_maps[-1].shape)
         [1, 768, 16, 16]
-        ```"""
+
+        """
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states

--- a/src/rfdetr/models/backbone/dinov2_with_windowed_attn.py
+++ b/src/rfdetr/models/backbone/dinov2_with_windowed_attn.py
@@ -1172,6 +1172,8 @@ class WindowedDinov2WithRegistersBackbone(WindowedDinov2WithRegistersPreTrainedM
             hidden_states=outputs.hidden_states if output_hidden_states else None,
             attentions=outputs.attentions if output_attentions else None,
         )
+
+
 __all__ = [
     "WindowedDinov2WithRegistersPreTrainedModel",
     "WindowedDinov2WithRegistersModel",

--- a/tests/models/test_export.py
+++ b/tests/models/test_export.py
@@ -33,25 +33,7 @@ import torch
 from torch.jit import TracerWarning
 
 from rfdetr import RFDETRSegNano
-
-# Temporarily inject stubs for optional onnx packages so deploy.export can be
-# imported at module level without them being installed.  The stubs are removed
-# immediately after so that importlib.util.find_spec() used in the
-# @pytest.mark.skipif decorators below still returns None for missing packages.
-_stub_deploy_onnx = types.ModuleType("rfdetr.deploy._onnx")
-_stub_deploy_onnx.OnnxOptimizer = MagicMock()
-_onnx_injected = "onnx" not in sys.modules
-_onnxsim_injected = "onnxsim" not in sys.modules
-sys.modules.setdefault("onnx", types.ModuleType("onnx"))
-sys.modules.setdefault("onnxsim", types.ModuleType("onnxsim"))
-sys.modules.setdefault("rfdetr.deploy._onnx", _stub_deploy_onnx)
-
-from rfdetr.deploy import export as _cli_export_module  # noqa: E402
-
-if _onnx_injected:
-    del sys.modules["onnx"]
-if _onnxsim_injected:
-    del sys.modules["onnxsim"]
+from rfdetr.deploy import export as _cli_export_module
 
 _IS_ONNX_INSTALLED = importlib.util.find_spec("onnx") is not None
 

--- a/tests/models/test_export.py
+++ b/tests/models/test_export.py
@@ -53,6 +53,8 @@ if _onnx_injected:
 if _onnxsim_injected:
     del sys.modules["onnxsim"]
 
+_IS_ONNX_INSTALLED = importlib.util.find_spec("onnx") is not None
+
 
 @contextmanager
 def ignore_tracer_warnings() -> Iterator[None]:
@@ -95,10 +97,7 @@ def test_export_onnx_uses_legacy_exporter_when_dynamo_flag_exists(
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for export test")
-@pytest.mark.skipif(
-    importlib.util.find_spec("onnx") is None,
-    reason="onnx not installed, run: pip install rfdetr[onnxexport]",
-)
+@pytest.mark.skipif(not _IS_ONNX_INSTALLED, reason="onnx not installed, run: pip install rfdetr[onnxexport]")
 def test_segmentation_model_export_no_crash(tmp_path: Path) -> None:
     """
     Integration test: exporting a segmentation model should not crash.
@@ -118,10 +117,7 @@ def test_segmentation_model_export_no_crash(tmp_path: Path) -> None:
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for export test")
-@pytest.mark.skipif(
-    importlib.util.find_spec("onnx") is None,
-    reason="onnx not installed, run: pip install rfdetr[onnxexport]",
-)
+@pytest.mark.skipif(not _IS_ONNX_INSTALLED, reason="onnx not installed, run: pip install rfdetr[onnxexport]")
 def test_export_calls_eval_on_deepcopy_not_original(tmp_path: Path) -> None:
     """
     Verify that Model.export() calls eval() on the deepcopy, not the original model.
@@ -183,10 +179,7 @@ def test_export_calls_eval_on_deepcopy_not_original(tmp_path: Path) -> None:
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for export test")
-@pytest.mark.skipif(
-    importlib.util.find_spec("onnx") is None,
-    reason="onnx not installed, run: pip install rfdetr[onnxexport]",
-)
+@pytest.mark.skipif(not _IS_ONNX_INSTALLED, reason="onnx not installed, run: pip install rfdetr[onnxexport]")
 def test_export_does_not_change_original_training_state(tmp_path: Path) -> None:
     """
     Verify that calling export() does not change the original model's train/eval state.


### PR DESCRIPTION
This pull request makes a minor configuration change to the `pyproject.toml` file, enabling the running of doctests from all modules during test execution. This will help ensure that code examples in docstrings are tested automatically.