### PR TITLE
fix missing Medium model in `__all__`

### DIFF
--- a/src/rfdetr/__init__.py
+++ b/src/rfdetr/__init__.py
@@ -28,7 +28,7 @@ from rfdetr.detr import (
 __all__ = [
     "RFDETRNano",
     "RFDETRSmall",
-    "RFDETRSmall",
+    "RFDETRMedium",
     "RFDETRLarge",
     "RFDETRSegNano",
     "RFDETRSegSmall",


### PR DESCRIPTION
Align [RF-DETR Detection Tutorial](https://rfdetr.roboflow.com/latest/learn/run/detection/#pre-trained-checkpoints) package import (`from rfdetr import RFDETRMedium`) with package layout.

## What does this PR do?

`RFDETRSmall` was added to `__all__` twice. Rectified `__all__` duplicating `RFDETRSmall` and missing `RFDETRMedium`.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

Same modification locally, to follow the Detection tutorial

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change

## Additional Context

A very minor change, I just want the tutorial to work as per the website. Let me know if I have done this incorrectly!
