### PR TITLE
lock `onnxsim` version to `<0.6.0` to prevent installation hangs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
 [project.optional-dependencies]
 onnxexport = [
     "onnx>=1.16.0,<1.20",
-    "onnxsim<0.6.0",  # fixme: onnxsim 0.6.0+ hangs on install
+    "onnxsim<0.6.0",  # TODO: onnxsim 0.6.0+ hangs on install
     "onnx_graphsurgeon",
     "onnxruntime",
     "polygraphy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
 [project.optional-dependencies]
 onnxexport = [
     "onnx>=1.16.0,<1.20",
-    "onnxsim",
+    "onnxsim<0.6.0",  # fixme: onnxsim 0.6.0+ hangs on install
     "onnx_graphsurgeon",
     "onnxruntime",
     "polygraphy"


### PR DESCRIPTION
This pull request makes a minor update to the `pyproject.toml` dependencies for the optional `onnxexport` group. The change restricts the version of `onnxsim` to below 0.6.0 to avoid installation issues.

* Updated the `onnxsim` dependency to `<0.6.0` in the `onnxexport` optional dependencies group to prevent hanging during installation.