### PR TITLE
ci: refine GPU test reruns for OutOfMemoryError

### DIFF
--- a/.github/workflows/ci-tests-gpu.yml
+++ b/.github/workflows/ci-tests-gpu.yml
@@ -54,6 +54,7 @@ jobs:
           uv run --no-sync pytest tests/ \
           -m gpu \
           -n 3 \
+          --reruns 1 --only-rerun "OutOfMemoryError" \
           --cov=rfdetr --cov-report=xml
 
       - name: Upload coverage to Codecov


### PR DESCRIPTION
This pull request makes a targeted improvement to the GPU CI workflow by adding a retry mechanism for flaky tests that fail due to out-of-memory errors. This should help reduce spurious failures in CI runs.

- CI workflow reliability:
  * [`.github/workflows/ci-tests-gpu.yml`](diffhunk://#diff-53209bae0cc403f683dfba167d31dbf56132fe37cca436a436c8723bb9fed7e2R57): Added `--reruns 1 --only-rerun "OutOfMemoryError"` to the pytest command, so tests that fail with "OutOfMemoryError" are automatically retried once before marking the job as failed.