### PR TITLE
Fix coco hierarchy filtering

### DIFF
--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -172,8 +172,7 @@ class RFDETR:
                 for c in categories
                 if c["name"] not in has_children
                 and (
-                    c.get("supercategory", "none") not in placeholders
-                    or c.get("supercategory", "none") in placeholders
+                    c.get("supercategory", "none") not in placeholders or c.get("supercategory", "none") in placeholders
                 )
             ]
             # Safety fallback for pathological inputs

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -144,7 +144,7 @@ class RFDETR:
         self.model.export(**kwargs)
 
     @staticmethod
-    def _load_classes(dataset_dir) -> List[str]:
+    def _load_classes(dataset_dir: str) -> List[str]:
         """Load class names from a COCO or YOLO dataset directory."""
         if is_valid_coco_dataset(dataset_dir):
             coco_path = os.path.join(dataset_dir, "train", "_annotations.coco.json")
@@ -160,21 +160,13 @@ class RFDETR:
             if not has_any_sc:
                 return [c["name"] for c in categories]
 
-            # Mixed/Hierarchical:
-            # - leaves: categories that have a parent and are not themselves parents
-            # - standalone top-level: categories that have no parent and are not themselves parents
+            # Mixed/Hierarchical: keep only categories that are not parents of other categories.
+            # Both leaves (with a real supercategory) and standalone top-level nodes (supercategory is a
+            # placeholder) satisfy this condition — neither appears as another category's supercategory.
             parents = {c.get("supercategory") for c in categories if c.get("supercategory", "none") not in placeholders}
             has_children = {c["name"] for c in categories if c["name"] in parents}
 
-            # Preserve original category order while selecting only leaf and standalone top-level classes.
-            class_names = [
-                c["name"]
-                for c in categories
-                if c["name"] not in has_children
-                and (
-                    c.get("supercategory", "none") not in placeholders or c.get("supercategory", "none") in placeholders
-                )
-            ]
+            class_names = [c["name"] for c in categories if c["name"] not in has_children]
             # Safety fallback for pathological inputs
             return class_names or [c["name"] for c in categories]
 

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -151,13 +151,35 @@ class RFDETR:
             with open(coco_path, "r") as f:
                 anns = json.load(f)
             categories = anns["categories"]
-            supercategory_names = {c["name"] for c in categories}
-            has_hierarchy = any(c.get("supercategory", "none") in supercategory_names for c in categories)
-            if has_hierarchy:
-                class_names = [c["name"] for c in categories if c.get("supercategory", "none") != "none"]
-            else:
-                class_names = [c["name"] for c in categories]
-            return class_names
+
+            # Catch possible placeholders for no supercategory
+            placeholders = {"", "none", "null", None}
+
+            # If no meaningful supercategory exists anywhere, treat as flat dataset
+            has_any_sc = any(c.get("supercategory", "none") not in placeholders for c in categories)
+            if not has_any_sc:
+                return [c["name"] for c in categories]
+
+            # Mixed/Hierarchical:
+            # - leaves: categories that have a parent and are not themselves parents
+            # - standalone top-level: categories that have no parent and are not themselves parents
+            parents = {c.get("supercategory") for c in categories if c.get("supercategory", "none") not in placeholders}
+            has_children = {c["name"] for c in categories if c["name"] in parents}
+
+            leaves = [
+                c["name"]
+                for c in categories
+                if c.get("supercategory", "none") not in placeholders and c["name"] not in has_children
+            ]
+            standalone_toplevel = [
+                c["name"]
+                for c in categories
+                if c.get("supercategory", "none") in placeholders and c["name"] not in has_children
+            ]
+
+            class_names = leaves + standalone_toplevel
+            # Safety fallback for pathological inputs
+            return class_names or [c["name"] for c in categories]
 
         # list all YAML files in the folder
         if is_valid_yolo_dataset(dataset_dir):
@@ -173,7 +195,6 @@ class RFDETR:
                 return data["names"]
             else:
                 raise ValueError(f"Found {yaml_path} but it does not contain 'names' field.")
-
         raise FileNotFoundError(
             f"Could not find class names in {dataset_dir}. "
             "Checked for COCO (train/_annotations.coco.json) and YOLO (data.yaml, data.yml) styles."

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -150,7 +150,7 @@ class RFDETR:
             coco_path = os.path.join(dataset_dir, "train", "_annotations.coco.json")
             with open(coco_path, "r") as f:
                 anns = json.load(f)
-            categories = anns["categories"]
+            categories = sorted(anns["categories"], key=lambda category: category.get("id", float("inf")))
 
             # Catch possible placeholders for no supercategory
             placeholders = {"", "none", "null", None}

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -166,18 +166,16 @@ class RFDETR:
             parents = {c.get("supercategory") for c in categories if c.get("supercategory", "none") not in placeholders}
             has_children = {c["name"] for c in categories if c["name"] in parents}
 
-            leaves = [
+            # Preserve original category order while selecting only leaf and standalone top-level classes.
+            class_names = [
                 c["name"]
                 for c in categories
-                if c.get("supercategory", "none") not in placeholders and c["name"] not in has_children
+                if c["name"] not in has_children
+                and (
+                    c.get("supercategory", "none") not in placeholders
+                    or c.get("supercategory", "none") in placeholders
+                )
             ]
-            standalone_toplevel = [
-                c["name"]
-                for c in categories
-                if c.get("supercategory", "none") in placeholders and c["name"] not in has_children
-            ]
-
-            class_names = leaves + standalone_toplevel
             # Safety fallback for pathological inputs
             return class_names or [c["name"] for c in categories]
 

--- a/tests/datasets/test_coco.py
+++ b/tests/datasets/test_coco.py
@@ -170,7 +170,7 @@ class TestLoadClassesHierarchy:
         ]
         _write_coco_json(tmp_path / "train" / "_annotations.coco.json", categories)
         result = RFDETR._load_classes(str(tmp_path))
-        assert result == ["dog", "cat"]
+        assert set(result) == {"dog", "cat"}
 
     def test_flat_none_supercategory_keeps_all(self, tmp_path: Path) -> None:
         """Flat datasets where every category has supercategory 'none' (#609)."""
@@ -180,7 +180,7 @@ class TestLoadClassesHierarchy:
         ]
         _write_coco_json(tmp_path / "train" / "_annotations.coco.json", categories)
         result = RFDETR._load_classes(str(tmp_path))
-        assert result == ["dog", "cat"]
+        assert set(result) == {"dog", "cat"}
 
     def test_mixed_supercategories_keeps_all(self, tmp_path: Path) -> None:
         """Mix of 'none' and non-'none' supercategories that are not category names.
@@ -196,4 +196,60 @@ class TestLoadClassesHierarchy:
         ]
         _write_coco_json(tmp_path / "train" / "_annotations.coco.json", categories)
         result = RFDETR._load_classes(str(tmp_path))
-        assert result == ["dog", "cat"]
+        assert set(result) == {"dog", "cat"}
+
+    def test_category_named_none_does_not_empty_list(self, tmp_path: Path) -> None:
+        """If a category is literally named 'none' and all supercategories
+        are placeholders, the loader must return all class names instead of [].
+        """
+        categories = [
+            {"id": 1, "name": "none", "supercategory": "none"},
+            {"id": 2, "name": "dog",  "supercategory": "none"},
+            {"id": 3, "name": "cat",  "supercategory": "none"},
+        ]
+        _write_coco_json(tmp_path / "train" / "_annotations.coco.json", categories)
+        result = RFDETR._load_classes(str(tmp_path))
+        assert set(result) == {"none", "dog", "cat"}
+
+    def test_mixed_hierarchy_leaf_and_standalone_forwarding(self, tmp_path: Path) -> None:
+        """Mixed hierarchy: only leaf classes + standalone top-level categories
+        should be forwarded. Parent/grouping nodes are dropped.
+        """
+        categories = [
+            {"id": 1,  "name": "animals",    "supercategory": "none"},
+            {"id": 2,  "name": "mammal",     "supercategory": "animals"},
+            {"id": 3,  "name": "dog",        "supercategory": "mammal"},
+            {"id": 4,  "name": "cat",        "supercategory": "mammal"},
+            {"id": 5,  "name": "bird",       "supercategory": "animals"},
+            {"id": 6,  "name": "eagle",      "supercategory": "bird"},
+            {"id": 7,  "name": "pigeon",     "supercategory": "bird"},
+            {"id": 8,  "name": "objects",    "supercategory": "none"},
+            {"id": 9,  "name": "vehicle",    "supercategory": "objects"},
+            {"id": 10, "name": "car",        "supercategory": "vehicle"},
+            {"id": 11, "name": "truck",      "supercategory": "vehicle"},
+            {"id": 12, "name": "appliance",  "supercategory": "objects"},
+            {"id": 13, "name": "toaster",    "supercategory": "appliance"},
+            {"id": 14, "name": "microwave",  "supercategory": "appliance"},
+            {"id": 15, "name": "person",     "supercategory": "none"},
+        ]
+        _write_coco_json(tmp_path / "train" / "_annotations.coco.json", categories)
+        result = RFDETR._load_classes(str(tmp_path))
+        expected = [
+            "dog", "cat", "eagle", "pigeon",
+            "car", "truck", "toaster", "microwave",
+            "person",
+        ]
+        assert set(result) == set(expected)
+
+    def test_placeholder_values_treated_as_no_parent(self, tmp_path: Path) -> None:
+        """Placeholders like None, '', and 'null' should be treated the same 
+        as 'none'.
+        """
+        categories = [
+            {"id": 1, "name": "dog", "supercategory": None},
+            {"id": 2, "name": "cat",  "supercategory": ""},
+            {"id": 3, "name": "elephant", "supercategory": "null"},
+        ]
+        _write_coco_json(tmp_path / "train" / "_annotations.coco.json", categories)
+        result = RFDETR._load_classes(str(tmp_path))
+        assert set(result) == {"dog", "cat", "elephant"}

--- a/tests/datasets/test_coco.py
+++ b/tests/datasets/test_coco.py
@@ -204,8 +204,8 @@ class TestLoadClassesHierarchy:
         """
         categories = [
             {"id": 1, "name": "none", "supercategory": "none"},
-            {"id": 2, "name": "dog",  "supercategory": "none"},
-            {"id": 3, "name": "cat",  "supercategory": "none"},
+            {"id": 2, "name": "dog", "supercategory": "none"},
+            {"id": 3, "name": "cat", "supercategory": "none"},
         ]
         _write_coco_json(tmp_path / "train" / "_annotations.coco.json", categories)
         result = RFDETR._load_classes(str(tmp_path))
@@ -216,38 +216,44 @@ class TestLoadClassesHierarchy:
         should be forwarded. Parent/grouping nodes are dropped.
         """
         categories = [
-            {"id": 1,  "name": "animals",    "supercategory": "none"},
-            {"id": 2,  "name": "mammal",     "supercategory": "animals"},
-            {"id": 3,  "name": "dog",        "supercategory": "mammal"},
-            {"id": 4,  "name": "cat",        "supercategory": "mammal"},
-            {"id": 5,  "name": "bird",       "supercategory": "animals"},
-            {"id": 6,  "name": "eagle",      "supercategory": "bird"},
-            {"id": 7,  "name": "pigeon",     "supercategory": "bird"},
-            {"id": 8,  "name": "objects",    "supercategory": "none"},
-            {"id": 9,  "name": "vehicle",    "supercategory": "objects"},
-            {"id": 10, "name": "car",        "supercategory": "vehicle"},
-            {"id": 11, "name": "truck",      "supercategory": "vehicle"},
-            {"id": 12, "name": "appliance",  "supercategory": "objects"},
-            {"id": 13, "name": "toaster",    "supercategory": "appliance"},
-            {"id": 14, "name": "microwave",  "supercategory": "appliance"},
-            {"id": 15, "name": "person",     "supercategory": "none"},
+            {"id": 1, "name": "animals", "supercategory": "none"},
+            {"id": 2, "name": "mammal", "supercategory": "animals"},
+            {"id": 3, "name": "dog", "supercategory": "mammal"},
+            {"id": 4, "name": "cat", "supercategory": "mammal"},
+            {"id": 5, "name": "bird", "supercategory": "animals"},
+            {"id": 6, "name": "eagle", "supercategory": "bird"},
+            {"id": 7, "name": "pigeon", "supercategory": "bird"},
+            {"id": 8, "name": "objects", "supercategory": "none"},
+            {"id": 9, "name": "vehicle", "supercategory": "objects"},
+            {"id": 10, "name": "car", "supercategory": "vehicle"},
+            {"id": 11, "name": "truck", "supercategory": "vehicle"},
+            {"id": 12, "name": "appliance", "supercategory": "objects"},
+            {"id": 13, "name": "toaster", "supercategory": "appliance"},
+            {"id": 14, "name": "microwave", "supercategory": "appliance"},
+            {"id": 15, "name": "person", "supercategory": "none"},
         ]
         _write_coco_json(tmp_path / "train" / "_annotations.coco.json", categories)
         result = RFDETR._load_classes(str(tmp_path))
         expected = [
-            "dog", "cat", "eagle", "pigeon",
-            "car", "truck", "toaster", "microwave",
+            "dog",
+            "cat",
+            "eagle",
+            "pigeon",
+            "car",
+            "truck",
+            "toaster",
+            "microwave",
             "person",
         ]
         assert set(result) == set(expected)
 
     def test_placeholder_values_treated_as_no_parent(self, tmp_path: Path) -> None:
-        """Placeholders like None, '', and 'null' should be treated the same 
+        """Placeholders like None, '', and 'null' should be treated the same
         as 'none'.
         """
         categories = [
             {"id": 1, "name": "dog", "supercategory": None},
-            {"id": 2, "name": "cat",  "supercategory": ""},
+            {"id": 2, "name": "cat", "supercategory": ""},
             {"id": 3, "name": "elephant", "supercategory": "null"},
         ]
         _write_coco_json(tmp_path / "train" / "_annotations.coco.json", categories)

--- a/tests/datasets/test_coco.py
+++ b/tests/datasets/test_coco.py
@@ -343,7 +343,7 @@ class TestLoadClassesHierarchy:
         ]
         _write_coco_json(tmp_path / "train" / "_annotations.coco.json", categories)
         result = RFDETR._load_classes(str(tmp_path))
-        assert set(result) == {"dog", "cat"}
+        assert result == ["dog", "cat"]
 
     def test_flat_none_supercategory_keeps_all(self, tmp_path: Path) -> None:
         """Flat datasets where every category has supercategory 'none' (#609)."""
@@ -353,7 +353,7 @@ class TestLoadClassesHierarchy:
         ]
         _write_coco_json(tmp_path / "train" / "_annotations.coco.json", categories)
         result = RFDETR._load_classes(str(tmp_path))
-        assert set(result) == {"dog", "cat"}
+        assert result == ["dog", "cat"]
 
     def test_mixed_supercategories_keeps_all(self, tmp_path: Path) -> None:
         """Mix of 'none' and non-'none' supercategories where no category is a parent of another.
@@ -368,7 +368,7 @@ class TestLoadClassesHierarchy:
         ]
         _write_coco_json(tmp_path / "train" / "_annotations.coco.json", categories)
         result = RFDETR._load_classes(str(tmp_path))
-        assert set(result) == {"dog", "cat"}
+        assert result == ["dog", "cat"]
 
     def test_category_named_none_does_not_empty_list(self, tmp_path: Path) -> None:
         """If a category is literally named 'none' and all supercategories
@@ -381,7 +381,7 @@ class TestLoadClassesHierarchy:
         ]
         _write_coco_json(tmp_path / "train" / "_annotations.coco.json", categories)
         result = RFDETR._load_classes(str(tmp_path))
-        assert set(result) == {"none", "dog", "cat"}
+        assert result == ["none", "dog", "cat"]
 
     def test_mixed_hierarchy_leaf_and_standalone_forwarding(self, tmp_path: Path) -> None:
         """Mixed hierarchy: only leaf classes + standalone top-level categories
@@ -417,7 +417,7 @@ class TestLoadClassesHierarchy:
             "microwave",
             "person",
         ]
-        assert set(result) == set(expected)
+        assert result == expected
 
     def test_placeholder_values_treated_as_no_parent(self, tmp_path: Path) -> None:
         """Placeholders like None, '', and 'null' should be treated the same
@@ -430,4 +430,16 @@ class TestLoadClassesHierarchy:
         ]
         _write_coco_json(tmp_path / "train" / "_annotations.coco.json", categories)
         result = RFDETR._load_classes(str(tmp_path))
-        assert set(result) == {"dog", "cat", "elephant"}
+        assert result == ["dog", "cat", "elephant"]
+
+    def test_unsorted_category_ids_return_id_sorted_class_order(self, tmp_path: Path) -> None:
+        """Returned class names must follow category-ID order for stable index mapping."""
+        categories = [
+            {"id": 30, "name": "truck", "supercategory": "vehicle"},
+            {"id": 10, "name": "vehicle", "supercategory": "none"},
+            {"id": 20, "name": "car", "supercategory": "vehicle"},
+            {"id": 40, "name": "person", "supercategory": "none"},
+        ]
+        _write_coco_json(tmp_path / "train" / "_annotations.coco.json", categories)
+        result = RFDETR._load_classes(str(tmp_path))
+        assert result == ["car", "truck", "person"]

--- a/tests/datasets/test_coco.py
+++ b/tests/datasets/test_coco.py
@@ -356,12 +356,11 @@ class TestLoadClassesHierarchy:
         assert set(result) == {"dog", "cat"}
 
     def test_mixed_supercategories_keeps_all(self, tmp_path: Path) -> None:
-        """Mix of 'none' and non-'none' supercategories that are not category names.
+        """Mix of 'none' and non-'none' supercategories where no category is a parent of another.
 
-        A simpler ``any(supercategory != 'none')`` detection would incorrectly
-        set has_hierarchy=True here, then filter out 'dog' (supercategory 'none').
-        The set-based check avoids this: 'animal' is not a category name, so no
-        hierarchy is detected and all categories are returned.
+        'animal' appears as a supercategory but is not itself a category name, so
+        ``has_children`` is empty and all categories pass the ``name not in has_children``
+        filter — both 'dog' and 'cat' are returned.
         """
         categories = [
             {"id": 1, "name": "dog", "supercategory": "none"},


### PR DESCRIPTION
## What does this PR do?

This PR fixes incorrect hierarchy filtering in `_load_classes` for COCO‑style datasets.
It addresses two issues introduced after PR #744:

1. Flat datasets with all `supercategory="none"`
Previously, if a category was literally named "none", the loader detected a fake hierarchy and returned an empty list.
This PR ensures flat datasets always return all categories.

2. Mixed hierarchy handling
Parent/grouping nodes (e.g., "animals", "vehicle") were being forwarded as classes.
The updated logic now forwards:

	- all leaf categories
	- all standalone top‑level categories
	- and filters out grouping parents.


The PR also updates and adds tests to reflect the correct behavior and removes strict ordering expectations where category order is not part of the contract.

Related Issue(s): Closes #609 (regression introduced by #744)

## Type of Change

- Bug fix (non-breaking change that fixes an issue)


## Testing

- [X] I have tested this change locally
- [X] I have added/updated tests for this change

**Test details:**
- Added regression tests covering:

	- category literally named "none"
	- mixed multi‑level hierarchies
	- placeholder supercategories (None, "", "null")

- Updated existing tests to use order‑insensitive assertions (set(...))
- Verified that filtering never produces an empty list due to malformed hierarchy detection

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code where necessary, particularly in hard-to-understand areas
- [X] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

This PR ensures RF-DETR behaves robustly across real-world COCO exports, including Roboflow‑generated datasets and hand‑built datasets containing partial or inconsistent category hierarchies.