### PR TITLE
Fix drop path dinov2 backbone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to RF-DETR are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- Fix `AttributeError` crash in `update_drop_path` when the DinoV2 backbone layer structure does not match any known pattern ([#750](https://github.com/roboflow/rf-detr/issues/750)). `_get_backbone_encoder_layers` now returns `None` for unrecognised architectures and `update_drop_path` exits early instead of raising.
+- Add warning when `drop_path_rate > 0.0` is configured with a non-windowed DinoV2 backbone, where drop-path is silently ignored.

--- a/src/rfdetr/models/backbone/backbone.py
+++ b/src/rfdetr/models/backbone/backbone.py
@@ -87,6 +87,7 @@ class Backbone(BackboneBase):
             patch_size=patch_size,
             num_windows=num_windows,
             positional_encoding_size=positional_encoding_size,
+            drop_path_rate=drop_path,
         )
         # build encoder + projector as backbone module
         if freeze_encoder:

--- a/src/rfdetr/models/backbone/dinov2.py
+++ b/src/rfdetr/models/backbone/dinov2.py
@@ -65,6 +65,7 @@ class DinoV2(nn.Module):
         patch_size=14,
         num_windows=4,
         positional_encoding_size=37,
+        drop_path_rate=0.0,
     ):
         super().__init__()
 
@@ -93,6 +94,7 @@ class DinoV2(nn.Module):
 
             dino_config["return_dict"] = False
             dino_config["out_features"] = [f"stage{i}" for i in out_feature_indexes]
+            dino_config["drop_path_rate"] = drop_path_rate
 
             implied_resolution = positional_encoding_size * patch_size
 

--- a/src/rfdetr/models/backbone/dinov2.py
+++ b/src/rfdetr/models/backbone/dinov2.py
@@ -80,6 +80,11 @@ class DinoV2(nn.Module):
         if not use_windowed_attn:
             assert not gradient_checkpointing, "Gradient checkpointing is not supported for non-windowed attention"
             assert load_dinov2_weights, "Using non-windowed attention requires loading dinov2 weights from hub"
+            if drop_path_rate > 0.0:
+                logger.warning(
+                    "drop_path_rate > 0.0 is not supported for non-windowed DinoV2 backbones. "
+                    "drop_path will be ignored."
+                )
             self.encoder = AutoBackbone.from_pretrained(
                 name,
                 out_features=[f"stage{i}" for i in out_feature_indexes],

--- a/src/rfdetr/models/lwdetr.py
+++ b/src/rfdetr/models/lwdetr.py
@@ -22,7 +22,7 @@ LW-DETR model and criterion classes
 
 import copy
 import math
-from typing import Callable
+from typing import Callable, Optional
 
 import torch
 import torch.nn.functional as F
@@ -205,7 +205,9 @@ class LWDETR(nn.Module):
                 out["pred_masks"] = outputs_masks[-1]
             if self.aux_loss:
                 out["aux_outputs"] = self._set_aux_loss(
-                    outputs_class, outputs_coord, outputs_masks if self.segmentation_head is not None else None
+                    outputs_class,
+                    outputs_coord,
+                    outputs_masks if self.segmentation_head is not None else None,
                 )
 
         if self.two_stage:
@@ -300,22 +302,36 @@ class LWDETR(nn.Module):
         else:
             return [{"pred_logits": a, "pred_boxes": b} for a, b in zip(outputs_class[:-1], outputs_coord[:-1])]
 
-    def _get_backbone_encoder_layers(self):
+    def _get_backbone_encoder_layers(self) -> Optional[nn.ModuleList]:
         """Resolve the list of transformer blocks/layers from backbone[0].encoder.
-        Supports: encoder.blocks, encoder.trunk.blocks (aimv2), and encoder.encoder.layer
-        (HuggingFace DinoV2 / WindowedDinov2WithRegistersBackbone). Returns None if not found.
+
+        Supports multiple backbone architectures:
+        - encoder.blocks (standard ViT)
+        - encoder.trunk.blocks (aimv2)
+        - encoder.encoder.encoder.layer (HuggingFace DinoV2)
+
+        Returns:
+            List of transformer layers, or None if not found.
         """
         enc = self.backbone[0].encoder
         if hasattr(enc, "blocks"):
             return enc.blocks
         if hasattr(enc, "trunk") and hasattr(enc.trunk, "blocks"):
             return enc.trunk.blocks
-        if hasattr(enc, "encoder") and hasattr(enc.encoder, "layer"):
-            return enc.encoder.layer
+        if hasattr(enc, "encoder") and hasattr(enc.encoder, "encoder") and hasattr(enc.encoder.encoder, "layer"):
+            return enc.encoder.encoder.layer
         return None
 
-    def update_drop_path(self, drop_path_rate, vit_encoder_num_layers):
-        """ """
+    def update_drop_path(self, drop_path_rate: float, vit_encoder_num_layers: int) -> None:
+        """Update drop_path rates for backbone encoder layers with linear schedule.
+
+        Applies a linear schedule where the first layer has drop_path_rate=0 and the last
+        layer has drop_path_rate=drop_path_rate. Intermediate layers are interpolated linearly.
+
+        Args:
+            drop_path_rate: Maximum drop path rate (applied to last layer).
+            vit_encoder_num_layers: Number of encoder layers to update.
+        """
         layers = self._get_backbone_encoder_layers()
         if layers is None:
             return
@@ -391,7 +407,8 @@ class SetCriterion(nn.Module):
 
             iou_targets = torch.diag(
                 box_ops.box_iou(
-                    box_ops.box_cxcywh_to_xyxy(src_boxes.detach()), box_ops.box_cxcywh_to_xyxy(target_boxes)
+                    box_ops.box_cxcywh_to_xyxy(src_boxes.detach()),
+                    box_ops.box_cxcywh_to_xyxy(target_boxes),
                 )[0]
             )
             pos_ious = iou_targets.clone().detach()
@@ -419,7 +436,8 @@ class SetCriterion(nn.Module):
 
             iou_targets = torch.diag(
                 box_ops.box_iou(
-                    box_ops.box_cxcywh_to_xyxy(src_boxes.detach()), box_ops.box_cxcywh_to_xyxy(target_boxes)
+                    box_ops.box_cxcywh_to_xyxy(src_boxes.detach()),
+                    box_ops.box_cxcywh_to_xyxy(target_boxes),
                 )[0]
             )
             pos_ious = iou_targets.clone().detach()
@@ -441,7 +459,11 @@ class SetCriterion(nn.Module):
             )
             loss_ce = (
                 position_supervised_loss(
-                    src_logits, norm_cls_iou_func_targets, num_boxes, alpha=self.focal_alpha, gamma=2
+                    src_logits,
+                    norm_cls_iou_func_targets,
+                    num_boxes,
+                    alpha=self.focal_alpha,
+                    gamma=2,
                 )
                 * src_logits.shape[1]
             )
@@ -452,7 +474,8 @@ class SetCriterion(nn.Module):
 
             iou_targets = torch.diag(
                 box_ops.box_iou(
-                    box_ops.box_cxcywh_to_xyxy(src_boxes.detach()), box_ops.box_cxcywh_to_xyxy(target_boxes)
+                    box_ops.box_cxcywh_to_xyxy(src_boxes.detach()),
+                    box_ops.box_cxcywh_to_xyxy(target_boxes),
                 )[0]
             )
             pos_ious = iou_targets.clone().detach()
@@ -467,12 +490,21 @@ class SetCriterion(nn.Module):
             pos_ind.append(target_classes_o)
             cls_iou_targets[tuple(pos_ind)] = pos_ious
             loss_ce = (
-                sigmoid_varifocal_loss(src_logits, cls_iou_targets, num_boxes, alpha=self.focal_alpha, gamma=2)
+                sigmoid_varifocal_loss(
+                    src_logits,
+                    cls_iou_targets,
+                    num_boxes,
+                    alpha=self.focal_alpha,
+                    gamma=2,
+                )
                 * src_logits.shape[1]
             )
         else:
             target_classes = torch.full(
-                src_logits.shape[:2], self.num_classes, dtype=torch.int64, device=src_logits.device
+                src_logits.shape[:2],
+                self.num_classes,
+                dtype=torch.int64,
+                device=src_logits.device,
             )
             target_classes[idx] = target_classes_o
 
@@ -486,7 +518,13 @@ class SetCriterion(nn.Module):
 
             target_classes_onehot = target_classes_onehot[:, :, :-1]
             loss_ce = (
-                sigmoid_focal_loss(src_logits, target_classes_onehot, num_boxes, alpha=self.focal_alpha, gamma=2)
+                sigmoid_focal_loss(
+                    src_logits,
+                    target_classes_onehot,
+                    num_boxes,
+                    alpha=self.focal_alpha,
+                    gamma=2,
+                )
                 * src_logits.shape[1]
             )
         losses = {"loss_ce": loss_ce}
@@ -526,7 +564,10 @@ class SetCriterion(nn.Module):
         losses["loss_bbox"] = loss_bbox.sum() / num_boxes
 
         loss_giou = 1 - torch.diag(
-            box_ops.generalized_box_iou(box_ops.box_cxcywh_to_xyxy(src_boxes), box_ops.box_cxcywh_to_xyxy(target_boxes))
+            box_ops.generalized_box_iou(
+                box_ops.box_cxcywh_to_xyxy(src_boxes),
+                box_ops.box_cxcywh_to_xyxy(target_boxes),
+            )
         )
         losses["loss_giou"] = loss_giou.sum() / num_boxes
         return losses
@@ -564,7 +605,12 @@ class SetCriterion(nn.Module):
                     this_batch_spatial_features = spatial_features[idx[0][batch_indices[i + 1] - 1]]
 
                     this_batch_masks = (
-                        torch.einsum("chw,nc->nhw", this_batch_spatial_features, this_batch_queries) + bias
+                        torch.einsum(
+                            "chw,nc->nhw",
+                            this_batch_spatial_features,
+                            this_batch_queries,
+                        )
+                        + bias
                     )
 
                     batched_selected_masks.append(this_batch_masks)
@@ -584,7 +630,10 @@ class SetCriterion(nn.Module):
         src_masks = src_masks.unsqueeze(1)
         target_masks = target_masks.unsqueeze(1).float()
 
-        num_points = max(src_masks.shape[-2], src_masks.shape[-2] * src_masks.shape[-1] // self.mask_point_sample_ratio)
+        num_points = max(
+            src_masks.shape[-2],
+            src_masks.shape[-2] * src_masks.shape[-1] // self.mask_point_sample_ratio,
+        )
 
         with torch.no_grad():
             # sample point_coords
@@ -844,7 +893,10 @@ class PostProcess(nn.Module):
                 )  # [K, Hm, Wm]
                 h, w = target_sizes[i].tolist()
                 masks_i = F.interpolate(
-                    masks_i.unsqueeze(1), size=(int(h), int(w)), mode="bilinear", align_corners=False
+                    masks_i.unsqueeze(1),
+                    size=(int(h), int(w)),
+                    mode="bilinear",
+                    align_corners=False,
                 )  # [K,1,H,W]
                 res_i["masks"] = masks_i > 0.0
                 results.append(res_i)
@@ -895,11 +947,11 @@ def build_model(args):
         position_embedding=args.position_embedding,
         freeze_encoder=args.freeze_encoder,
         layer_norm=args.layer_norm,
-        target_shape=args.shape
-        if hasattr(args, "shape")
-        else (args.resolution, args.resolution)
-        if hasattr(args, "resolution")
-        else (640, 640),
+        target_shape=(
+            args.shape
+            if hasattr(args, "shape")
+            else ((args.resolution, args.resolution) if hasattr(args, "resolution") else (640, 640))
+        ),
         rms_norm=args.rms_norm,
         backbone_lora=args.backbone_lora,
         force_no_pretrain=args.force_no_pretrain,
@@ -918,7 +970,11 @@ def build_model(args):
     transformer = build_transformer(args)
 
     segmentation_head = (
-        SegmentationHead(args.hidden_dim, args.dec_layers, downsample_ratio=args.mask_downsample_ratio)
+        SegmentationHead(
+            args.hidden_dim,
+            args.dec_layers,
+            downsample_ratio=args.mask_downsample_ratio,
+        )
         if args.segmentation_head
         else None
     )

--- a/src/rfdetr/models/lwdetr.py
+++ b/src/rfdetr/models/lwdetr.py
@@ -300,16 +300,29 @@ class LWDETR(nn.Module):
         else:
             return [{"pred_logits": a, "pred_boxes": b} for a, b in zip(outputs_class[:-1], outputs_coord[:-1])]
 
+    def _get_backbone_encoder_layers(self):
+        """Resolve the list of transformer blocks/layers from backbone[0].encoder.
+        Supports: encoder.blocks, encoder.trunk.blocks (aimv2), and encoder.encoder.layer
+        (HuggingFace DinoV2 / WindowedDinov2WithRegistersBackbone). Returns None if not found.
+        """
+        enc = self.backbone[0].encoder
+        if hasattr(enc, "blocks"):
+            return enc.blocks
+        if hasattr(enc, "trunk") and hasattr(enc.trunk, "blocks"):
+            return enc.trunk.blocks
+        if hasattr(enc, "encoder") and hasattr(enc.encoder, "layer"):
+            return enc.encoder.layer
+        return None
+
     def update_drop_path(self, drop_path_rate, vit_encoder_num_layers):
         """ """
+        layers = self._get_backbone_encoder_layers()
+        if layers is None:
+            return
         dp_rates = [x.item() for x in torch.linspace(0, drop_path_rate, vit_encoder_num_layers)]
-        for i in range(vit_encoder_num_layers):
-            if hasattr(self.backbone[0].encoder, "blocks"):  # Not aimv2
-                if hasattr(self.backbone[0].encoder.blocks[i].drop_path, "drop_prob"):
-                    self.backbone[0].encoder.blocks[i].drop_path.drop_prob = dp_rates[i]
-            else:  # aimv2
-                if hasattr(self.backbone[0].encoder.trunk.blocks[i].drop_path, "drop_prob"):
-                    self.backbone[0].encoder.trunk.blocks[i].drop_path.drop_prob = dp_rates[i]
+        for i in range(min(vit_encoder_num_layers, len(layers))):
+            if hasattr(layers[i], "drop_path") and hasattr(layers[i].drop_path, "drop_prob"):
+                layers[i].drop_path.drop_prob = dp_rates[i]
 
     def update_dropout(self, drop_rate):
         for module in self.transformer.modules():

--- a/src/rfdetr/models/lwdetr.py
+++ b/src/rfdetr/models/lwdetr.py
@@ -335,8 +335,9 @@ class LWDETR(nn.Module):
         layers = self._get_backbone_encoder_layers()
         if layers is None:
             return
-        dp_rates = [x.item() for x in torch.linspace(0, drop_path_rate, vit_encoder_num_layers)]
-        for i in range(min(vit_encoder_num_layers, len(layers))):
+        n = min(vit_encoder_num_layers, len(layers))
+        dp_rates = [x.item() for x in torch.linspace(0, drop_path_rate, n)]
+        for i in range(n):
             if hasattr(layers[i], "drop_path") and hasattr(layers[i].drop_path, "drop_prob"):
                 layers[i].drop_path.drop_prob = dp_rates[i]
 

--- a/tests/models/test_drop_path.py
+++ b/tests/models/test_drop_path.py
@@ -15,13 +15,21 @@ import torch.nn as nn
 import rfdetr.models.backbone.dinov2 as dinov2_module
 from rfdetr.main import Model
 from rfdetr.models.backbone.dinov2 import DinoV2
-from rfdetr.models.backbone.dinov2_with_windowed_attn import Dinov2WithRegistersDropPath
+from rfdetr.models.backbone.dinov2_with_windowed_attn import (
+    Dinov2WithRegistersDropPath,
+    WindowedDinov2WithRegistersBackbone,
+)
 from rfdetr.models.lwdetr import LWDETR
 
 
 @pytest.fixture
-def model_with_drop_path() -> Model:
+def model_with_drop_path(monkeypatch: pytest.MonkeyPatch) -> Model:
     """Create RF-DETR Nano model with drop_path enabled."""
+    monkeypatch.setattr(
+        WindowedDinov2WithRegistersBackbone,
+        "from_pretrained",
+        classmethod(lambda cls, name, config: cls(config)),
+    )
     return Model(
         encoder="dinov2_windowed_small",
         num_classes=3,
@@ -42,8 +50,13 @@ def model_with_drop_path() -> Model:
 
 
 @pytest.fixture
-def model_without_drop_path() -> Model:
+def model_without_drop_path(monkeypatch: pytest.MonkeyPatch) -> Model:
     """Create RF-DETR Nano model without drop_path."""
+    monkeypatch.setattr(
+        WindowedDinov2WithRegistersBackbone,
+        "from_pretrained",
+        classmethod(lambda cls, name, config: cls(config)),
+    )
     return Model(
         encoder="dinov2_windowed_small",
         num_classes=3,
@@ -161,8 +174,8 @@ def test_update_drop_path_partial_layers(model_with_drop_path: Model) -> None:
     # Should not raise IndexError
     model.update_drop_path(drop_path_rate, requested_num_layers)
 
-    # Actual layers updated with the rates from the longer linspace
-    expected_rates = [x.item() for x in torch.linspace(0, drop_path_rate, requested_num_layers)]
+    # Each updated layer gets a rate from 0 to drop_path_rate (shorter, capped linspace)
+    expected_rates = [x.item() for x in torch.linspace(0, drop_path_rate, actual_num_layers)]
     for i in range(actual_num_layers):
         actual_prob = layers[i].drop_path.drop_prob
         assert abs(actual_prob - expected_rates[i]) < 1e-6, (

--- a/tests/models/test_drop_path.py
+++ b/tests/models/test_drop_path.py
@@ -65,15 +65,9 @@ def test_get_backbone_encoder_layers_dinov2(model_with_drop_path: Model) -> None
 
     enc = model.backbone[0].encoder
     assert hasattr(enc, "encoder"), "DinoV2 encoder should have encoder attribute"
-    assert hasattr(
-        enc.encoder, "encoder"
-    ), "DinoV2 encoder.encoder should have encoder attribute"
-    assert hasattr(
-        enc.encoder.encoder, "layer"
-    ), "DinoV2 encoder.encoder.encoder should have layer attribute"
-    assert (
-        layers is enc.encoder.encoder.layer
-    ), "Should return encoder.encoder.encoder.layer"
+    assert hasattr(enc.encoder, "encoder"), "DinoV2 encoder.encoder should have encoder attribute"
+    assert hasattr(enc.encoder.encoder, "layer"), "DinoV2 encoder.encoder.encoder should have layer attribute"
+    assert layers is enc.encoder.encoder.layer, "Should return encoder.encoder.encoder.layer"
 
     assert len(layers) > 0, "Should have at least one layer"
     for layer in layers:
@@ -106,27 +100,21 @@ def test_update_drop_path_dinov2(model_with_drop_path: Model) -> None:
         if hasattr(layer, "drop_path") and hasattr(layer.drop_path, "drop_prob"):
             actual_prob = layer.drop_path.drop_prob
             expected_prob = expected_rates[i]
-            assert (
-                abs(actual_prob - expected_prob) < 1e-6
-            ), f"Layer {i} drop_prob should be {expected_prob}, got {actual_prob}"
+            assert abs(actual_prob - expected_prob) < 1e-6, (
+                f"Layer {i} drop_prob should be {expected_prob}, got {actual_prob}"
+            )
 
     first_layer = layers[0]
     last_layer = layers[-1]
-    if hasattr(first_layer, "drop_path") and hasattr(
-        first_layer.drop_path, "drop_prob"
-    ):
-        assert (
-            abs(first_layer.drop_path.drop_prob - 0.0) < 1e-6
-        ), "First layer should have drop_prob = 0"
+    if hasattr(first_layer, "drop_path") and hasattr(first_layer.drop_path, "drop_prob"):
+        assert abs(first_layer.drop_path.drop_prob - 0.0) < 1e-6, "First layer should have drop_prob = 0"
     if hasattr(last_layer, "drop_path") and hasattr(last_layer.drop_path, "drop_prob"):
-        assert (
-            abs(last_layer.drop_path.drop_prob - drop_path_rate) < 1e-6
-        ), f"Last layer should have drop_prob = {drop_path_rate}"
+        assert abs(last_layer.drop_path.drop_prob - drop_path_rate) < 1e-6, (
+            f"Last layer should have drop_prob = {drop_path_rate}"
+        )
 
 
-def test_drop_path_initialization(
-    model_with_drop_path: Model, model_without_drop_path: Model
-) -> None:
+def test_drop_path_initialization(model_with_drop_path: Model, model_without_drop_path: Model) -> None:
     """Verify drop_path initialization: DropPath vs Identity based on rate."""
     model_with_dp: LWDETR = model_with_drop_path.model
     model_without_dp: LWDETR = model_without_drop_path.model
@@ -142,9 +130,7 @@ def test_drop_path_initialization(
         drop_path_module = layer.drop_path
         # When drop_path_rate > 0, it should be Dinov2WithRegistersDropPath (not Identity)
         if hasattr(drop_path_module, "drop_prob"):
-            assert isinstance(
-                drop_path_module, Dinov2WithRegistersDropPath
-            ) or isinstance(
+            assert isinstance(drop_path_module, Dinov2WithRegistersDropPath) or isinstance(
                 drop_path_module, torch.nn.Identity
             ), "drop_path should be Dinov2WithRegistersDropPath or Identity"
 
@@ -155,9 +141,7 @@ def test_drop_path_initialization(
         if isinstance(drop_path_module, torch.nn.Identity):
             pass
         elif hasattr(drop_path_module, "drop_prob"):
-            assert (
-                drop_path_module.drop_prob == 0.0
-            ), "drop_prob should be 0 when drop_path_rate = 0"
+            assert drop_path_module.drop_prob == 0.0, "drop_prob should be 0 when drop_path_rate = 0"
 
 
 def test_update_drop_path_handles_missing_layers(model_with_drop_path: Model) -> None:

--- a/tests/models/test_drop_path.py
+++ b/tests/models/test_drop_path.py
@@ -84,38 +84,27 @@ def test_update_drop_path_dinov2(model_with_drop_path: Model) -> None:
     num_layers = len(layers)
     drop_path_rate = 0.1
 
-    initial_probs = []
-    for layer in layers:
-        if hasattr(layer, "drop_path") and hasattr(layer.drop_path, "drop_prob"):
-            initial_probs.append(layer.drop_path.drop_prob)
-        else:
-            initial_probs.append(None)
-
     model.update_drop_path(drop_path_rate, num_layers)
 
-    # Verify linear schedule: first layer = 0, last layer = drop_path_rate
+    # All layers must be Dinov2WithRegistersDropPath (drop_path_rate=0.1 > 0 at model build time).
     expected_rates = [x.item() for x in torch.linspace(0, drop_path_rate, num_layers)]
-
     for i, layer in enumerate(layers):
-        if hasattr(layer, "drop_path") and hasattr(layer.drop_path, "drop_prob"):
-            actual_prob = layer.drop_path.drop_prob
-            expected_prob = expected_rates[i]
-            assert abs(actual_prob - expected_prob) < 1e-6, (
-                f"Layer {i} drop_prob should be {expected_prob}, got {actual_prob}"
-            )
-
-    first_layer = layers[0]
-    last_layer = layers[-1]
-    if hasattr(first_layer, "drop_path") and hasattr(first_layer.drop_path, "drop_prob"):
-        assert abs(first_layer.drop_path.drop_prob - 0.0) < 1e-6, "First layer should have drop_prob = 0"
-    if hasattr(last_layer, "drop_path") and hasattr(last_layer.drop_path, "drop_prob"):
-        assert abs(last_layer.drop_path.drop_prob - drop_path_rate) < 1e-6, (
-            f"Last layer should have drop_prob = {drop_path_rate}"
+        assert isinstance(layer.drop_path, Dinov2WithRegistersDropPath), (
+            f"Layer {i} drop_path should be Dinov2WithRegistersDropPath, got {type(layer.drop_path)}"
         )
+        actual_prob = layer.drop_path.drop_prob
+        assert abs(actual_prob - expected_rates[i]) < 1e-6, (
+            f"Layer {i} drop_prob should be {expected_rates[i]}, got {actual_prob}"
+        )
+
+    assert abs(layers[0].drop_path.drop_prob - 0.0) < 1e-6, "First layer should have drop_prob = 0"
+    assert abs(layers[-1].drop_path.drop_prob - drop_path_rate) < 1e-6, (
+        f"Last layer should have drop_prob = {drop_path_rate}"
+    )
 
 
 def test_drop_path_initialization(model_with_drop_path: Model, model_without_drop_path: Model) -> None:
-    """Verify drop_path initialization: DropPath vs Identity based on rate."""
+    """Verify drop_path initialization: Dinov2WithRegistersDropPath vs Identity based on rate."""
     model_with_dp: LWDETR = model_with_drop_path.model
     model_without_dp: LWDETR = model_without_drop_path.model
 
@@ -125,40 +114,26 @@ def test_drop_path_initialization(model_with_drop_path: Model, model_without_dro
     assert layers_with_dp is not None
     assert layers_without_dp is not None
 
-    for layer in layers_with_dp:
+    # drop_path_rate=0.1 → every layer initialised as Dinov2WithRegistersDropPath
+    for i, layer in enumerate(layers_with_dp):
         assert hasattr(layer, "drop_path"), "Layer should have drop_path attribute"
-        drop_path_module = layer.drop_path
-        # When drop_path_rate > 0, it should be Dinov2WithRegistersDropPath (not Identity)
-        if hasattr(drop_path_module, "drop_prob"):
-            assert isinstance(drop_path_module, Dinov2WithRegistersDropPath) or isinstance(
-                drop_path_module, torch.nn.Identity
-            ), "drop_path should be Dinov2WithRegistersDropPath or Identity"
+        assert isinstance(layer.drop_path, Dinov2WithRegistersDropPath), (
+            f"Layer {i}: expected Dinov2WithRegistersDropPath, got {type(layer.drop_path)}"
+        )
 
-    for layer in layers_without_dp:
+    # drop_path_rate=0.0 → every layer initialised as nn.Identity
+    for i, layer in enumerate(layers_without_dp):
         assert hasattr(layer, "drop_path"), "Layer should have drop_path attribute"
-        drop_path_module = layer.drop_path
-        # When drop_path_rate = 0, it should be Identity or DropPath with drop_prob=0
-        if isinstance(drop_path_module, torch.nn.Identity):
-            pass
-        elif hasattr(drop_path_module, "drop_prob"):
-            assert drop_path_module.drop_prob == 0.0, "drop_prob should be 0 when drop_path_rate = 0"
+        assert isinstance(layer.drop_path, torch.nn.Identity), (
+            f"Layer {i}: expected nn.Identity for zero drop_path, got {type(layer.drop_path)}"
+        )
 
 
-def test_update_drop_path_handles_missing_layers(model_with_drop_path: Model) -> None:
+def test_update_drop_path_handles_missing_layers(model_with_drop_path: Model, monkeypatch: pytest.MonkeyPatch) -> None:
     """Verify update_drop_path() handles models without recognizable layer structure gracefully."""
     model: LWDETR = model_with_drop_path.model
 
-    # Monkeypatch _get_backbone_encoder_layers to return None, simulating unrecognized structure
-    original_method = model._get_backbone_encoder_layers
-
-    def return_none():
-        return None
-
-    model._get_backbone_encoder_layers = return_none
+    monkeypatch.setattr(model, "_get_backbone_encoder_layers", lambda: None)
 
     # Should not raise an error, just return early
-    try:
-        model.update_drop_path(0.1, 12)
-    finally:
-        # Restore original method
-        model._get_backbone_encoder_layers = original_method
+    model.update_drop_path(0.1, 12)

--- a/tests/models/test_drop_path.py
+++ b/tests/models/test_drop_path.py
@@ -4,10 +4,17 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 import pytest
 import torch
+import torch.nn as nn
 
+import rfdetr.models.backbone.dinov2 as dinov2_module
 from rfdetr.main import Model
+from rfdetr.models.backbone.dinov2 import DinoV2
 from rfdetr.models.backbone.dinov2_with_windowed_attn import Dinov2WithRegistersDropPath
 from rfdetr.models.lwdetr import LWDETR
 
@@ -137,3 +144,66 @@ def test_update_drop_path_handles_missing_layers(model_with_drop_path: Model, mo
 
     # Should not raise an error, just return early
     model.update_drop_path(0.1, 12)
+
+
+def test_update_drop_path_partial_layers(model_with_drop_path: Model) -> None:
+    """Verify min() guard prevents IndexError when vit_encoder_num_layers > len(layers)."""
+    model: LWDETR = model_with_drop_path.model
+
+    layers = model._get_backbone_encoder_layers()
+    assert layers is not None
+    actual_num_layers = len(layers)
+
+    # Request more layers than exist in the backbone
+    requested_num_layers = actual_num_layers + 4
+    drop_path_rate = 0.2
+
+    # Should not raise IndexError
+    model.update_drop_path(drop_path_rate, requested_num_layers)
+
+    # Actual layers updated with the rates from the longer linspace
+    expected_rates = [x.item() for x in torch.linspace(0, drop_path_rate, requested_num_layers)]
+    for i in range(actual_num_layers):
+        actual_prob = layers[i].drop_path.drop_prob
+        assert abs(actual_prob - expected_rates[i]) < 1e-6, (
+            f"Layer {i} drop_prob should be {expected_rates[i]}, got {actual_prob}"
+        )
+
+
+def test_non_windowed_drop_path_warns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify a warning is emitted when drop_path_rate > 0 with non-windowed backbone."""
+    mock_backbone = MagicMock()
+    monkeypatch.setattr(dinov2_module, "AutoBackbone", MagicMock(from_pretrained=MagicMock(return_value=mock_backbone)))
+
+    # The rf-detr logger sets propagate=False, so intercept warning() directly.
+    warning_messages: list[str] = []
+    rf_detr_logger = logging.getLogger("rf-detr")
+    monkeypatch.setattr(rf_detr_logger, "warning", lambda msg, *args, **kwargs: warning_messages.append(msg))
+
+    DinoV2(size="base", use_windowed_attn=False, drop_path_rate=0.1)
+
+    assert any("drop_path_rate" in msg and "ignored" in msg for msg in warning_messages), (
+        "Expected warning about drop_path_rate being ignored for non-windowed backbone"
+    )
+
+
+def test_get_backbone_encoder_layers_blocks_path() -> None:
+    """Verify _get_backbone_encoder_layers() returns enc.blocks for standard ViT backbones."""
+    mock_blocks = nn.ModuleList([nn.Linear(1, 1) for _ in range(3)])
+    # SimpleNamespace gives only the attributes we define, so hasattr checks work correctly.
+    mock_encoder = SimpleNamespace(blocks=mock_blocks)
+    mock_self = SimpleNamespace(backbone=[SimpleNamespace(encoder=mock_encoder)])
+
+    result = LWDETR._get_backbone_encoder_layers(mock_self)  # type: ignore[arg-type]
+    assert result is mock_blocks, "Should return enc.blocks for standard ViT backbone"
+
+
+def test_get_backbone_encoder_layers_trunk_blocks_path() -> None:
+    """Verify _get_backbone_encoder_layers() returns enc.trunk.blocks for aimv2 backbones."""
+    mock_blocks = nn.ModuleList([nn.Linear(1, 1) for _ in range(3)])
+    mock_trunk = SimpleNamespace(blocks=mock_blocks)
+    mock_encoder = SimpleNamespace(trunk=mock_trunk)  # no 'blocks' at top level
+    mock_self = SimpleNamespace(backbone=[SimpleNamespace(encoder=mock_encoder)])
+
+    result = LWDETR._get_backbone_encoder_layers(mock_self)  # type: ignore[arg-type]
+    assert result is mock_blocks, "Should return enc.trunk.blocks for aimv2 backbone"

--- a/tests/models/test_drop_path.py
+++ b/tests/models/test_drop_path.py
@@ -1,0 +1,180 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+import pytest
+import torch
+
+from rfdetr.main import Model
+from rfdetr.models.backbone.dinov2_with_windowed_attn import Dinov2WithRegistersDropPath
+from rfdetr.models.lwdetr import LWDETR
+
+
+@pytest.fixture
+def model_with_drop_path() -> Model:
+    """Create RF-DETR Nano model with drop_path enabled."""
+    return Model(
+        encoder="dinov2_windowed_small",
+        num_classes=3,
+        device="cpu",
+        pretrain_weights=None,
+        drop_path=0.1,
+        resolution=384,
+        vit_encoder_num_layers=12,
+        patch_size=14,
+        num_windows=4,
+        positional_encoding_size=37,
+        out_feature_indexes=[2, 5, 8, 11],
+        projector_scale=["P4"],
+        hidden_dim=256,
+        dec_layers=3,
+        segmentation_head=False,
+    )
+
+
+@pytest.fixture
+def model_without_drop_path() -> Model:
+    """Create RF-DETR Nano model without drop_path."""
+    return Model(
+        encoder="dinov2_windowed_small",
+        num_classes=3,
+        device="cpu",
+        pretrain_weights=None,
+        drop_path=0.0,
+        resolution=384,
+        vit_encoder_num_layers=12,
+        patch_size=14,
+        num_windows=4,
+        positional_encoding_size=37,
+        out_feature_indexes=[2, 5, 8, 11],
+        projector_scale=["P4"],
+        hidden_dim=256,
+        dec_layers=3,
+        segmentation_head=False,
+    )
+
+
+def test_get_backbone_encoder_layers_dinov2(model_with_drop_path: Model) -> None:
+    """Verify _get_backbone_encoder_layers() returns encoder.encoder.layer for DinoV2."""
+    model: LWDETR = model_with_drop_path.model
+
+    layers = model._get_backbone_encoder_layers()
+    assert layers is not None
+
+    enc = model.backbone[0].encoder
+    assert hasattr(enc, "encoder"), "DinoV2 encoder should have encoder attribute"
+    assert hasattr(
+        enc.encoder, "encoder"
+    ), "DinoV2 encoder.encoder should have encoder attribute"
+    assert hasattr(
+        enc.encoder.encoder, "layer"
+    ), "DinoV2 encoder.encoder.encoder should have layer attribute"
+    assert (
+        layers is enc.encoder.encoder.layer
+    ), "Should return encoder.encoder.encoder.layer"
+
+    assert len(layers) > 0, "Should have at least one layer"
+    for layer in layers:
+        assert hasattr(layer, "drop_path"), "Each layer should have drop_path attribute"
+
+
+def test_update_drop_path_dinov2(model_with_drop_path: Model) -> None:
+    """Verify update_drop_path() sets drop_prob values correctly with linear schedule."""
+    model: LWDETR = model_with_drop_path.model
+
+    layers = model._get_backbone_encoder_layers()
+    assert layers is not None
+
+    num_layers = len(layers)
+    drop_path_rate = 0.1
+
+    initial_probs = []
+    for layer in layers:
+        if hasattr(layer, "drop_path") and hasattr(layer.drop_path, "drop_prob"):
+            initial_probs.append(layer.drop_path.drop_prob)
+        else:
+            initial_probs.append(None)
+
+    model.update_drop_path(drop_path_rate, num_layers)
+
+    # Verify linear schedule: first layer = 0, last layer = drop_path_rate
+    expected_rates = [x.item() for x in torch.linspace(0, drop_path_rate, num_layers)]
+
+    for i, layer in enumerate(layers):
+        if hasattr(layer, "drop_path") and hasattr(layer.drop_path, "drop_prob"):
+            actual_prob = layer.drop_path.drop_prob
+            expected_prob = expected_rates[i]
+            assert (
+                abs(actual_prob - expected_prob) < 1e-6
+            ), f"Layer {i} drop_prob should be {expected_prob}, got {actual_prob}"
+
+    first_layer = layers[0]
+    last_layer = layers[-1]
+    if hasattr(first_layer, "drop_path") and hasattr(
+        first_layer.drop_path, "drop_prob"
+    ):
+        assert (
+            abs(first_layer.drop_path.drop_prob - 0.0) < 1e-6
+        ), "First layer should have drop_prob = 0"
+    if hasattr(last_layer, "drop_path") and hasattr(last_layer.drop_path, "drop_prob"):
+        assert (
+            abs(last_layer.drop_path.drop_prob - drop_path_rate) < 1e-6
+        ), f"Last layer should have drop_prob = {drop_path_rate}"
+
+
+def test_drop_path_initialization(
+    model_with_drop_path: Model, model_without_drop_path: Model
+) -> None:
+    """Verify drop_path initialization: DropPath vs Identity based on rate."""
+    model_with_dp: LWDETR = model_with_drop_path.model
+    model_without_dp: LWDETR = model_without_drop_path.model
+
+    layers_with_dp = model_with_dp._get_backbone_encoder_layers()
+    layers_without_dp = model_without_dp._get_backbone_encoder_layers()
+
+    assert layers_with_dp is not None
+    assert layers_without_dp is not None
+
+    for layer in layers_with_dp:
+        assert hasattr(layer, "drop_path"), "Layer should have drop_path attribute"
+        drop_path_module = layer.drop_path
+        # When drop_path_rate > 0, it should be Dinov2WithRegistersDropPath (not Identity)
+        if hasattr(drop_path_module, "drop_prob"):
+            assert isinstance(
+                drop_path_module, Dinov2WithRegistersDropPath
+            ) or isinstance(
+                drop_path_module, torch.nn.Identity
+            ), "drop_path should be Dinov2WithRegistersDropPath or Identity"
+
+    for layer in layers_without_dp:
+        assert hasattr(layer, "drop_path"), "Layer should have drop_path attribute"
+        drop_path_module = layer.drop_path
+        # When drop_path_rate = 0, it should be Identity or DropPath with drop_prob=0
+        if isinstance(drop_path_module, torch.nn.Identity):
+            pass
+        elif hasattr(drop_path_module, "drop_prob"):
+            assert (
+                drop_path_module.drop_prob == 0.0
+            ), "drop_prob should be 0 when drop_path_rate = 0"
+
+
+def test_update_drop_path_handles_missing_layers(model_with_drop_path: Model) -> None:
+    """Verify update_drop_path() handles models without recognizable layer structure gracefully."""
+    model: LWDETR = model_with_drop_path.model
+
+    # Monkeypatch _get_backbone_encoder_layers to return None, simulating unrecognized structure
+    original_method = model._get_backbone_encoder_layers
+
+    def return_none():
+        return None
+
+    model._get_backbone_encoder_layers = return_none
+
+    # Should not raise an error, just return early
+    try:
+        model.update_drop_path(0.1, 12)
+    finally:
+        # Restore original method
+        model._get_backbone_encoder_layers = original_method


### PR DESCRIPTION
# Fix update_drop_path for DinoV2

## Summary

Fixes `AttributeError` when using drop_path > 0 with DinoV2 backbones. Additionally, drop_path_rate was not being passed to the DinoV2 configuration, so stochastic depth was never applied even when configured

Related Issue: #750 

## When the error occurs

The failure happens only when drop_path > 0 With the default `drop_path=0`, main.py never builds the drop-path schedule and engine.py never calls `update_drop_path`, so training runs. When we enable stochastic depth, the first call to `update_drop_path` raises.

---

## Error

```
[rank6]:     self.rfdetr_wrapper.train(
[rank6]:   File ".../rfdetr/detr.py", line 97, in train
[rank6]:     self.train_from_config(config, **kwargs)
[rank6]:   File ".../rfdetr/detr.py", line 238, in train_from_config
[rank6]:     self.model.train(
[rank6]:   File ".../rfdetr/main.py", line 360, in train
[rank6]:     train_stats = train_one_epoch(
[rank6]:   File ".../rfdetr/engine.py", line 113, in train_one_epoch
[rank6]:     model.module.update_drop_path(
[rank6]:   File ".../rfdetr/models/lwdetr.py", line 284, in update_drop_path
[rank6]:     if hasattr(self.backbone[0].encoder.trunk.blocks[i].drop_path, 'drop_prob'):
[rank6]:   File ".../torch/nn/modules/module.py", line 1962, in __getattr__
[rank6]:     raise AttributeError(
[rank6]: AttributeError: 'DinoV2' object has no attribute 'trunk'
```

---

## Cause

`update_drop_path` in assumed the backbone encoder has either:
- `encoder.blocks`, or  
- `encoder.trunk.blocks` (aimv2).

The dinov2 backbone exposes its transformer layers at **`encoder.encoder.encoder.layer`**, not `encoder.trunk.blocks`

also, drop_path_rate was not being passed from training arguments to the DinoV2 configuration

---

## Fix

- Add `_get_backbone_encoder_layers()` helper method: resolves the list of transformer blocks from `backbone[0].encoder` by checking, in order.

- In `update_drop_path`: call the helper; if the result is `None`, return early

- In `backbone.py`: pass `drop_path` from build args into `DinoV2` as `drop_path_rate=drop_path`.
- In `dinov2.py`: accept `drop_path_rate` parameter and set `dino_config["drop_path_rate"] = drop_path_rate` before creating the encoder configuration.

This ensures that when `drop_path > 0`, the DinoV2 layers are instantiated with `Dinov2WithRegistersDropPath` modules instead of `nn.Identity`

## Test

Unit tests added in `tests/models/test_drop_path.py`:
- `test_get_backbone_encoder_layers_dinov2`: Verifies layer discovery for DinoV2
- `test_update_drop_path_dinov2`: Verifies linear schedule application
- `test_drop_path_initialization`: Verifies `DropPath` vs `Identity` based on rate
- `test_update_drop_path_handles_missing_layers`: Verifies handling of unrecognized structures