### PR TITLE
feat: tensorboard class metrics

### DIFF
--- a/src/rfdetr/util/metrics.py
+++ b/src/rfdetr/util/metrics.py
@@ -4,12 +4,12 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
+import math
 import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, TypeVar
 
 import numpy as np
-import math
 
 from rfdetr.util.logger import get_logger
 

--- a/src/rfdetr/util/metrics.py
+++ b/src/rfdetr/util/metrics.py
@@ -243,7 +243,13 @@ class MetricsTensorBoardSink:
         }
 
         for entry in class_map:
-            cname = self._slug(entry.get("class", "unknown"))
+            if not isinstance(entry, dict):
+                # Skip unexpected entry types to avoid crashing TensorBoard logging.
+                continue
+
+            raw_class = entry.get("class")
+            cname_source = str(raw_class) if raw_class is not None else "unknown"
+            cname = self._slug(cname_source)
             for key, value in entry.items():
                 if key == "class" or not self._is_number(value):
                     continue

--- a/src/rfdetr/util/metrics.py
+++ b/src/rfdetr/util/metrics.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, TypeVar
 
 import numpy as np
+import math
 
 from rfdetr.util.logger import get_logger
 
@@ -159,6 +160,27 @@ class MetricsTensorBoardSink:
                 "Unable to initialize TensorBoard. Logging is turned off for this session. Run 'pip install tensorboard' to enable logging."
             )
 
+    @staticmethod
+    def _slug(s: str) -> str:
+        """
+        Make class names safe for TensorBoard tags by removing/normalizing characters
+        that TB treats as separators or that look noisy.
+        """
+        return (
+            s.replace(" ", "_")
+            .replace("/", "_")
+            .replace("\\", "_")
+            .replace("(", "")
+            .replace(")", "")
+            .replace(":", "")
+            .replace(",", "")
+        )
+
+    @staticmethod
+    def _is_number(x: Any) -> bool:
+        """True for finite ints/floats; False for NaN/None/others."""
+        return isinstance(x, (int, float)) and not (isinstance(x, float) and math.isnan(x))
+
     def update(self, values: Dict[str, Any]) -> None:
         if not self.writer:
             return
@@ -194,7 +216,39 @@ class MetricsTensorBoardSink:
             if ema_ar50_90 is not None:
                 self.writer.add_scalar("Metrics/EMA/AR50_90", ema_ar50_90, epoch)
 
+        if "test_results_json" in values:
+            self._log_class_metrics(values["test_results_json"], epoch, variant="Base")
+        if "ema_test_results_json" in values:
+            self._log_class_metrics(values["ema_test_results_json"], epoch, variant="EMA")
+
         self.writer.flush()
+
+    def _log_class_metrics(self, results: Dict[str, Any], epoch: int, variant: str) -> None:
+        """
+        Log per-class metrics:
+        <ClassName>/<MetricName>/<Variant>
+
+        - Logs all numeric fields in each class entry.
+        - Uses a small rename map for readability. Others are sanitized via _slug().
+        - Safely no-ops if the expected structure is missing.
+        """
+        class_map = results.get("class_map", [])
+        if not isinstance(class_map, list) or not class_map:
+            return
+
+        rename = {
+            "map@50:95": "mAP50_95",
+            "map@50": "mAP50",
+            "f1_score": "F1",
+        }
+
+        for entry in class_map:
+            cname = self._slug(entry.get("class", "unknown"))
+            for key, value in entry.items():
+                if key == "class" or not self._is_number(value):
+                    continue
+                metric_name = rename.get(key, self._slug(str(key)))
+                self.writer.add_scalar(f"{cname}/{metric_name}/{variant}", value, epoch)
 
     def close(self):
         if not self.writer:

--- a/tests/util/test_tensorboard_class_logging.py
+++ b/tests/util/test_tensorboard_class_logging.py
@@ -12,7 +12,7 @@ from rfdetr.util.metrics import MetricsTensorBoardSink
 class DummyWriter:
     """Minimal stand-in for torch.utils.tensorboard.SummaryWriter (no real I/O)."""
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         self.scalars = []  # list[(tag, value, step)]
         self.flushed = False
         self.closed = False

--- a/tests/util/test_tensorboard_class_logging.py
+++ b/tests/util/test_tensorboard_class_logging.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
 import pytest
 
 from rfdetr.util.metrics import MetricsTensorBoardSink
@@ -5,8 +11,9 @@ from rfdetr.util.metrics import MetricsTensorBoardSink
 
 class DummyWriter:
     """Minimal stand-in for torch.utils.tensorboard.SummaryWriter (no real I/O)."""
+
     def __init__(self):
-        self.scalars = []   # list[(tag, value, step)]
+        self.scalars = []  # list[(tag, value, step)]
         self.flushed = False
         self.closed = False
 
@@ -56,8 +63,8 @@ def test_class_first_layout_renames_and_filtering(sink):
                     "precision": 0.80,
                     "recall": 0.60,
                     "f1_score": 0.685,
-                    "notes": "ignore-me",            # non-numeric => ignored
-                    "nan_field": float("nan"),       # NaN => ignored
+                    "notes": "ignore-me",  # non-numeric => ignored
+                    "nan_field": float("nan"),  # NaN => ignored
                 },
                 {
                     "class": "cats",

--- a/tests/util/test_tensorboard_class_logging.py
+++ b/tests/util/test_tensorboard_class_logging.py
@@ -1,0 +1,143 @@
+import pytest
+
+from rfdetr.util.metrics import MetricsTensorBoardSink
+
+
+class DummyWriter:
+    """Minimal stand-in for torch.utils.tensorboard.SummaryWriter (no real I/O)."""
+    def __init__(self):
+        self.scalars = []   # list[(tag, value, step)]
+        self.flushed = False
+        self.closed = False
+
+    def add_scalar(self, tag, value, step):
+        self.scalars.append((tag, value, step))
+
+    def flush(self):
+        self.flushed = True
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture
+def sink(tmp_path):
+    """MetricsTensorBoardSink with a dummy writer injected."""
+    s = MetricsTensorBoardSink(output_dir=str(tmp_path))
+    s.writer = DummyWriter()
+    return s
+
+
+def test_no_per_class_when_absent(sink):
+    """No per-class tags when results_json keys are missing."""
+    sink.update({"epoch": 1, "train_loss": 0.5, "test_loss": 0.4})
+    tags = [t for (t, _, _) in sink.writer.scalars]
+    assert "Loss/Train" in tags
+    assert "Loss/Test" in tags
+    # Ensure nothing that looks like <Class>/<Metric>/<Variant> got logged
+    assert not any(t.count("/") >= 1 and not t.startswith(("Loss/", "Metrics/")) for t in tags)
+
+
+def test_class_first_layout_renames_and_filtering(sink):
+    """
+    Verify:
+      - Tag layout: <ClassName>/<MetricName>/<Variant>
+      - Renames: map@50:95->mAP50_95, map@50->mAP50, f1_score->F1
+      - Non-numeric and NaN fields are ignored
+    """
+    values = {
+        "epoch": 7,
+        "test_results_json": {
+            "class_map": [
+                {
+                    "class": "dogs",
+                    "map@50:95": 0.1234,
+                    "map@50": 0.2500,
+                    "precision": 0.80,
+                    "recall": 0.60,
+                    "f1_score": 0.685,
+                    "notes": "ignore-me",            # non-numeric => ignored
+                    "nan_field": float("nan"),       # NaN => ignored
+                },
+                {
+                    "class": "cats",
+                    "map@50:95": 0.3456,
+                    "map@50": 0.5000,
+                    "precision": 0.70,
+                    "recall": 0.75,
+                },
+                {
+                    "class": "elephants",
+                    "map@50:95": 0.05,
+                    "map@50": 0.10,
+                    "precision": 0.20,
+                    "recall": 0.15,
+                },
+            ]
+        },
+        "ema_test_results_json": {
+            "class_map": [
+                {
+                    "class": "dogs",
+                    "map@50:95": 0.1300,
+                    "map@50": 0.2600,
+                    "precision": 0.82,
+                    "recall": 0.62,
+                    "f1_score": 0.705,
+                }
+            ]
+        },
+    }
+
+    sink.update(values)
+
+    logged = sink.writer.scalars
+    tags = [t for (t, _, _) in logged]
+
+    # Class names are already simple; slugging shouldn't change them
+    cls_dogs = "dogs"
+    cls_cats = "cats"
+    cls_ele = "elephants"
+
+    # Base variant checks
+    for cls in (cls_dogs, cls_cats, cls_ele):
+        assert f"{cls}/mAP50_95/Base" in tags
+        assert f"{cls}/mAP50/Base" in tags
+        assert f"{cls}/precision/Base" in tags
+        assert f"{cls}/recall/Base" in tags
+
+    # F1 (from f1_score) should exist for dogs in Base
+    assert f"{cls_dogs}/F1/Base" in tags
+
+    # EMA variant for dogs
+    assert f"{cls_dogs}/mAP50_95/EMA" in tags
+    assert f"{cls_dogs}/mAP50/EMA" in tags
+    assert f"{cls_dogs}/precision/EMA" in tags
+    assert f"{cls_dogs}/recall/EMA" in tags
+    assert f"{cls_dogs}/F1/EMA" in tags
+
+    # Non-numeric / NaN not logged
+    unexpected = [t for t in tags if any(key in t for key in ("notes", "nan_field"))]
+    assert not unexpected, f"Unexpected tags: {unexpected}"
+
+    # Spot-check a couple of values
+    vmap = {tag: val for (tag, val, _) in logged}
+    assert vmap[f"{cls_dogs}/mAP50_95/Base"] == pytest.approx(0.1234)
+    assert vmap[f"{cls_dogs}/F1/EMA"] == pytest.approx(0.705)
+
+
+def test_handles_empty_or_wrong_class_map(sink):
+    """Gracefully ignore when class_map is empty or not a list."""
+    for bad in ([], {}, None):
+        sink.update({"epoch": 2, "test_results_json": {"class_map": bad}})
+    # No per-class tags should have been added
+    assert not any(t[0].count("/") >= 2 and not t[0].startswith(("Loss/", "Metrics/")) for t in sink.writer.scalars)
+
+
+def test_flush_and_close_do_not_crash(sink):
+    """Lifecycle calls should be safe with the dummy writer."""
+    sink.update({"epoch": 0})
+    sink.writer.flush()
+    sink.writer.close()
+    assert sink.writer.flushed is True
+    assert sink.writer.closed is True

--- a/tests/util/test_tensorboard_class_logging.py
+++ b/tests/util/test_tensorboard_class_logging.py
@@ -28,10 +28,11 @@ class DummyWriter:
 
 
 @pytest.fixture
-def sink(tmp_path):
+def sink(tmp_path, monkeypatch):
     """MetricsTensorBoardSink with a dummy writer injected."""
+    # Ensure MetricsTensorBoardSink uses DummyWriter instead of a real SummaryWriter
+    monkeypatch.setattr("rfdetr.util.metrics.SummaryWriter", DummyWriter)
     s = MetricsTensorBoardSink(output_dir=str(tmp_path))
-    s.writer = DummyWriter()
     return s
 
 


### PR DESCRIPTION
## What does this PR do?

This PR adds per‑class TensorBoard logging to `MetricsTensorBoardSink`.
It introduces a class‑first tag layout (e.g., dogs/mAP50_95/Base) that makes per‑class performance easy to inspect without mixing them into loss/global metric groups.

The change is:
- minimal and self‑contained
- backward‑compatible
- only affects TensorBoard logging
- dynamic (logs all numeric per‑class metrics available, including mAP@50:95, mAP@50, precision, recall, F1, etc.)

This makes it much easier to understand which classes perform well or poorly during training.

Related Issue(s): resolves #763

## Type of Change

- New feature (non-breaking change that adds functionality)

## Testing

- [X] I have tested this change locally
- [X] I have added/updated tests for this change

**Test details:**
Added a new test suite using a dummy `SummaryWriter` to avoid I/O.

The tests cover:

- class‑first TensorBoard tag layout
- metric rename mapping (map@50:95 → mAP50_95, etc.)
- numeric filtering (skip NaN and non-numeric values)
- handling of empty/missing class_map
- lifecycle behavior (flush() / close())

All tests are fast and independent of the training engine.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code where necessary, particularly in hard-to-understand areas
- [X] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

The current TensorBoard sink does not expose any per‑class information, which makes it difficult to identify underperforming classes and guide dataset improvements.

These changes provide clear per‑class insights so users can add targeted training samples and track class-specific improvements over time.
