### PR TITLE
fix: save segmentation results to results_mask.json when available

### DIFF
--- a/src/rfdetr/main.py
+++ b/src/rfdetr/main.py
@@ -613,6 +613,13 @@ class Model:
             results["class_map"]["test"] = test_metrics
             with open(output_dir / "results.json", "w") as f:
                 json.dump(results, f)
+            
+            # Save mask results if they exist
+            if "results_json_masks" in test_stats:
+                mask_results = test_stats["results_json_masks"]["class_map"]
+                results_mask = {"class_map": {"test": mask_results}}
+                with open(output_dir / "results_mask.json", "w") as f:
+                    json.dump(results_mask, f)
 
         _run_on_train_end_callbacks(callbacks)
 

--- a/src/rfdetr/main.py
+++ b/src/rfdetr/main.py
@@ -613,7 +613,7 @@ class Model:
             results["class_map"]["test"] = test_metrics
             with open(output_dir / "results.json", "w") as f:
                 json.dump(results, f)
-            
+
             # Save mask results if they exist
             if "results_json_masks" in test_stats:
                 mask_results = test_stats["results_json_masks"]["class_map"]

--- a/src/rfdetr/main.py
+++ b/src/rfdetr/main.py
@@ -626,13 +626,17 @@ class Model:
 
             # Save mask results if they exist (read-modify-write to preserve valid split data)
             if "results_json_masks" in test_stats:
-                test_mask_class_map = test_stats["results_json_masks"]["class_map"]
+                test_mask_results = test_stats["results_json_masks"]
+                test_mask_class_map = test_mask_results["class_map"]
                 results_mask_path = output_dir / "results_mask.json"
                 if results_mask_path.exists():
                     with open(results_mask_path, "r") as f:
                         results_mask = json.load(f)
                 else:
-                    results_mask = {"class_map": {}}
+                    # Initialize with top-level scalar metrics (e.g., map, precision, recall, f1_score)
+                    # and an empty class_map, mirroring the structure from the validation phase.
+                    results_mask = {k: v for k, v in test_mask_results.items() if k != "class_map"}
+                    results_mask["class_map"] = {}
                 results_mask["class_map"]["test"] = test_mask_class_map
                 with open(results_mask_path, "w") as f:
                     json.dump(results_mask, f)

--- a/src/rfdetr/main.py
+++ b/src/rfdetr/main.py
@@ -587,6 +587,16 @@ class Model:
             with open(output_dir / "results.json", "w") as f:
                 json.dump(results, f)
 
+            # Save mask results for valid split if available
+            best_stats = ema_test_stats if best_is_ema else test_stats
+            if "results_json_masks" in best_stats:
+                mask_full = best_stats["results_json_masks"]
+                mask_output = {k: v for k, v in mask_full.items() if k != "class_map"}
+                mask_output["class_map"] = {"valid": mask_full["class_map"]}
+                with open(output_dir / "results_mask.json", "w") as f:
+                    json.dump(mask_output, f)
+                logger.info("Mask results saved to %s", output_dir / "results_mask.json")
+
             total_time = time.time() - start_time
             total_time_str = str(datetime.timedelta(seconds=int(total_time)))
             logger.info("Training time %s", total_time_str)
@@ -614,12 +624,19 @@ class Model:
             with open(output_dir / "results.json", "w") as f:
                 json.dump(results, f)
 
-            # Save mask results if they exist
+            # Save mask results if they exist (read-modify-write to preserve valid split data)
             if "results_json_masks" in test_stats:
-                mask_results = test_stats["results_json_masks"]["class_map"]
-                results_mask = {"class_map": {"test": mask_results}}
-                with open(output_dir / "results_mask.json", "w") as f:
+                test_mask_class_map = test_stats["results_json_masks"]["class_map"]
+                results_mask_path = output_dir / "results_mask.json"
+                if results_mask_path.exists():
+                    with open(results_mask_path, "r") as f:
+                        results_mask = json.load(f)
+                else:
+                    results_mask = {"class_map": {}}
+                results_mask["class_map"]["test"] = test_mask_class_map
+                with open(results_mask_path, "w") as f:
                     json.dump(results_mask, f)
+                logger.info("Mask results saved to %s", results_mask_path)
 
         _run_on_train_end_callbacks(callbacks)
 

--- a/tests/datasets/test_augmentations.py
+++ b/tests/datasets/test_augmentations.py
@@ -1273,6 +1273,96 @@ class TestTrainingLoop:
             output_dir=str(output_dir),
         )
 
+    def test_segmentation_training_saves_results_mask_json_with_run_test(self, tmp_path, monkeypatch):
+        """results_mask.json must mirror results.json structure: valid+test keys and top-level scalars."""
+
+        def _write_split(split_name: str) -> None:
+            split_dir = tmp_path / "tiny_seg_dataset" / split_name
+            split_dir.mkdir(parents=True, exist_ok=True)
+            Image.new("RGB", (64, 64), color="white").save(split_dir / "sample.jpg")
+            annotations = {
+                "images": [{"id": 1, "width": 64, "height": 64, "file_name": "sample.jpg"}],
+                "categories": [{"id": 1, "name": "object", "supercategory": "object"}],
+                "annotations": [
+                    {
+                        "id": 1,
+                        "image_id": 1,
+                        "category_id": 1,
+                        "bbox": [8.0, 8.0, 16.0, 16.0],
+                        "area": 256.0,
+                        "iscrowd": 0,
+                        "segmentation": [[8.0, 8.0, 24.0, 8.0, 24.0, 24.0, 8.0, 24.0]],
+                    }
+                ],
+            }
+            (split_dir / "_annotations.coco.json").write_text(json.dumps(annotations))
+
+        for split in ("train", "valid", "test"):
+            _write_split(split)
+
+        def _fake_evaluate_with_masks(*args, **kwargs):
+            return {
+                "coco_eval_masks": [0.5, 0.5],
+                "results_json": {
+                    "map": 0.5,
+                    "precision": 0.5,
+                    "recall": 0.5,
+                    "f1_score": 0.5,
+                    "class_map": [],
+                },
+                "results_json_masks": {
+                    "map": 0.5,
+                    "precision": 0.6,
+                    "recall": 0.7,
+                    "f1_score": 0.65,
+                    "class_map": [
+                        {
+                            "class": "object",
+                            "map@50:95": 0.5,
+                            "map@50": 0.6,
+                            "precision": 0.6,
+                            "recall": 0.7,
+                            "f1_score": 0.65,
+                        }
+                    ],
+                },
+            }, None
+
+        monkeypatch.setattr("rfdetr.main.evaluate", _fake_evaluate_with_masks)
+
+        output_dir = tmp_path / "output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        model = RFDETRSegNano(pretrain_weights=None, device="cpu")
+        model.train(
+            dataset_dir=str(tmp_path / "tiny_seg_dataset"),
+            epochs=1,
+            batch_size=1,
+            grad_accum_steps=1,
+            device="cpu",
+            num_workers=0,
+            resolution=64,
+            amp=False,
+            use_ema=False,
+            run_test=True,
+            tensorboard=False,
+            dont_save_weights=False,
+            min_batches=1,
+            output_dir=str(output_dir),
+        )
+
+        results_mask_path = output_dir / "results_mask.json"
+        assert results_mask_path.exists(), "results_mask.json should be written for segmentation models"
+        with open(results_mask_path) as f:
+            results_mask = json.load(f)
+
+        assert "class_map" in results_mask
+        assert "valid" in results_mask["class_map"], "results_mask.json must have 'valid' key in class_map"
+        assert "test" in results_mask["class_map"], "results_mask.json must have 'test' key in class_map"
+        assert "map" in results_mask, "results_mask.json must have top-level 'map' scalar"
+        assert "precision" in results_mask, "results_mask.json must have top-level 'precision' scalar"
+        assert "recall" in results_mask, "results_mask.json must have top-level 'recall' scalar"
+        assert "f1_score" in results_mask, "results_mask.json must have top-level 'f1_score' scalar"
+
 
 class TestMakeCocoTransformsAugConfig:
     """Tests for aug_config propagation in make_coco_transforms / make_coco_transforms_square_div_64."""


### PR DESCRIPTION
## What does this PR do?

Added a few lines in main.py to check if "results_json_masks" exist in test_stats which is the output of evaluate function from engine.py. If it exists, we save it into results_masks.json.

**Related Issue(s):** <!-- Link to related issues, e.g., Fixes #123 or Related to #456 -->
[https://github.com/roboflow/rf-detr/issues/771](https://github.com/roboflow/rf-detr/issues/771)

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

I ran the train function and both now i have two json file saved for seg model, results.json and results_mask.json

- [x ] I have tested this change locally


## Checklist

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x ] My changes generate no new warnings or errors
- [x ] I have updated the documentation accordingly (if applicable)

I have read the CLA Document and I sign the CLA.