### PR TITLE
Fix `aug_config` ignored in YOLO dataset builder

### DIFF
--- a/src/rfdetr/datasets/yolo.py
+++ b/src/rfdetr/datasets/yolo.py
@@ -497,6 +497,7 @@ def build_roboflow_from_yolo(image_set: str, args: Any, resolution: int) -> Yolo
     do_random_resize_via_padding = getattr(args, "do_random_resize_via_padding", False)
     patch_size = getattr(args, "patch_size", None)
     num_windows = getattr(args, "num_windows", None)
+    aug_config = getattr(args, "aug_config", None)
 
     if square_resize_div_64:
         dataset = YoloDetection(
@@ -511,6 +512,7 @@ def build_roboflow_from_yolo(image_set: str, args: Any, resolution: int) -> Yolo
                 skip_random_resize=not do_random_resize_via_padding,
                 patch_size=patch_size,
                 num_windows=num_windows,
+                aug_config=aug_config,
             ),
             include_masks=include_masks,
         )
@@ -527,6 +529,7 @@ def build_roboflow_from_yolo(image_set: str, args: Any, resolution: int) -> Yolo
                 skip_random_resize=not do_random_resize_via_padding,
                 patch_size=patch_size,
                 num_windows=num_windows,
+                aug_config=aug_config,
             ),
             include_masks=include_masks,
         )

--- a/src/rfdetr/datasets/yolo.py
+++ b/src/rfdetr/datasets/yolo.py
@@ -477,6 +477,22 @@ def build_roboflow_from_yolo(image_set: str, args: Any, resolution: int) -> Yolo
 
     This uses Roboflow's standard YOLO directory structure
     (train/valid/test folders with images/ and labels/ subdirectories).
+
+    Args:
+        image_set: Dataset split to load. One of ``"train"``, ``"val"``, or
+            ``"test"``.
+        args: Argument namespace. The following attributes are consumed:
+            ``dataset_dir``, ``square_resize_div_64``, ``aug_config``,
+            ``segmentation_head``, ``multi_scale``, ``expanded_scales``,
+            ``do_random_resize_via_padding``, ``patch_size``, ``num_windows``.
+            ``aug_config`` is forwarded to the transform builder; when
+            ``None`` the builder falls back to the default
+            :data:`~rfdetr.datasets.aug_config.AUG_CONFIG`.
+        resolution: Target square resolution in pixels.
+
+    Returns:
+        A :class:`YoloDetection` dataset instance ready for use with a
+        DataLoader.
     """
     root = Path(args.dataset_dir)
     assert root.exists(), f"provided Roboflow path {root} does not exist"

--- a/tests/datasets/test_yolo.py
+++ b/tests/datasets/test_yolo.py
@@ -287,16 +287,19 @@ class TestBuildRoboflowFromYoloAugConfig:
         )
 
     @pytest.mark.parametrize(
-        "square_resize_div_64,transform_fn",
+        "square_resize_div_64,transform_fn,aug_config",
         [
-            pytest.param(True, "make_coco_transforms_square_div_64", id="square_div_64"),
-            pytest.param(False, "make_coco_transforms", id="standard"),
+            pytest.param(True, "make_coco_transforms_square_div_64", {"HorizontalFlip": {"p": 0.5}}, id="square_div_64_with_config"),
+            pytest.param(False, "make_coco_transforms", {"HorizontalFlip": {"p": 0.5}}, id="standard_with_config"),
+            pytest.param(True, "make_coco_transforms_square_div_64", None, id="square_div_64_none"),
+            pytest.param(False, "make_coco_transforms", None, id="standard_none"),
         ],
     )
-    def test_aug_config_forwarded_to_transform(self, square_resize_div_64: bool, transform_fn: str) -> None:
-        """Regression test for #769: aug_config must be forwarded to transform builders."""
-        custom_aug_config = {"HorizontalFlip": {"p": 0.5}}
-        args = self._make_args(square_resize_div_64=square_resize_div_64, aug_config=custom_aug_config)
+    def test_aug_config_forwarded_to_transform(
+        self, square_resize_div_64: bool, transform_fn: str, aug_config: object
+    ) -> None:
+        """Regression test for #769: aug_config is forwarded to transform builders for all code paths."""
+        args = self._make_args(square_resize_div_64=square_resize_div_64, aug_config=aug_config)
 
         with (
             patch("rfdetr.datasets.yolo.Path") as mock_path,
@@ -314,35 +317,6 @@ class TestBuildRoboflowFromYoloAugConfig:
             build_roboflow_from_yolo("train", args, resolution=640)
 
         _, kwargs = mock_transform.call_args
-        assert kwargs.get("aug_config") == custom_aug_config, (
-            f"{transform_fn} was not called with aug_config; got {kwargs}"
+        assert kwargs.get("aug_config") == aug_config, (
+            f"{transform_fn} was not called with aug_config={aug_config!r}; got {kwargs}"
         )
-
-    @pytest.mark.parametrize(
-        "square_resize_div_64,transform_fn",
-        [
-            pytest.param(True, "make_coco_transforms_square_div_64", id="square_div_64"),
-            pytest.param(False, "make_coco_transforms", id="standard"),
-        ],
-    )
-    def test_none_aug_config_forwarded(self, square_resize_div_64: bool, transform_fn: str) -> None:
-        """When aug_config is None, transform builders receive None (use default)."""
-        args = self._make_args(square_resize_div_64=square_resize_div_64, aug_config=None)
-
-        with (
-            patch("rfdetr.datasets.yolo.Path") as mock_path,
-            patch(f"rfdetr.datasets.yolo.{transform_fn}") as mock_transform,
-            patch("rfdetr.datasets.yolo.YoloDetection") as mock_dataset,
-        ):
-            mock_path.return_value.exists.return_value = True
-            mock_path.return_value.__truediv__ = lambda self, other: self
-            mock_path.return_value.__str__ = lambda self: "/fake/dataset"
-            mock_transform.return_value = MagicMock()
-            mock_dataset.return_value = MagicMock()
-
-            from rfdetr.datasets.yolo import build_roboflow_from_yolo
-
-            build_roboflow_from_yolo("train", args, resolution=640)
-
-        _, kwargs = mock_transform.call_args
-        assert kwargs.get("aug_config") is None

--- a/tests/datasets/test_yolo.py
+++ b/tests/datasets/test_yolo.py
@@ -4,6 +4,9 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
+import types
+from unittest.mock import MagicMock, patch
+
 import numpy as np
 import pytest
 import supervision as sv
@@ -265,3 +268,81 @@ class TestCocoLikeAPI:
         assert 0 in api.catToImgs[0]
         assert 1 in api.catToImgs[0]
         assert 0 in api.catToImgs[1]
+
+
+class TestBuildRoboflowFromYoloAugConfig:
+    """Regression tests for #769: aug_config forwarded to transform builders."""
+
+    def _make_args(self, square_resize_div_64: bool, aug_config=None) -> types.SimpleNamespace:
+        return types.SimpleNamespace(
+            dataset_dir="/fake/dataset",
+            square_resize_div_64=square_resize_div_64,
+            aug_config=aug_config,
+            segmentation_head=False,
+            multi_scale=False,
+            expanded_scales=None,
+            do_random_resize_via_padding=False,
+            patch_size=16,
+            num_windows=4,
+        )
+
+    @pytest.mark.parametrize(
+        "square_resize_div_64,transform_fn",
+        [
+            pytest.param(True, "make_coco_transforms_square_div_64", id="square_div_64"),
+            pytest.param(False, "make_coco_transforms", id="standard"),
+        ],
+    )
+    def test_aug_config_forwarded_to_transform(self, square_resize_div_64: bool, transform_fn: str) -> None:
+        """Regression test for #769: aug_config must be forwarded to transform builders."""
+        custom_aug_config = {"HorizontalFlip": {"p": 0.5}}
+        args = self._make_args(square_resize_div_64=square_resize_div_64, aug_config=custom_aug_config)
+
+        with (
+            patch("rfdetr.datasets.yolo.Path") as mock_path,
+            patch(f"rfdetr.datasets.yolo.{transform_fn}") as mock_transform,
+            patch("rfdetr.datasets.yolo.YoloDetection") as mock_dataset,
+        ):
+            mock_path.return_value.exists.return_value = True
+            mock_path.return_value.__truediv__ = lambda self, other: self
+            mock_path.return_value.__str__ = lambda self: "/fake/dataset"
+            mock_transform.return_value = MagicMock()
+            mock_dataset.return_value = MagicMock()
+
+            from rfdetr.datasets.yolo import build_roboflow_from_yolo
+
+            build_roboflow_from_yolo("train", args, resolution=640)
+
+        _, kwargs = mock_transform.call_args
+        assert kwargs.get("aug_config") == custom_aug_config, (
+            f"{transform_fn} was not called with aug_config; got {kwargs}"
+        )
+
+    @pytest.mark.parametrize(
+        "square_resize_div_64,transform_fn",
+        [
+            pytest.param(True, "make_coco_transforms_square_div_64", id="square_div_64"),
+            pytest.param(False, "make_coco_transforms", id="standard"),
+        ],
+    )
+    def test_none_aug_config_forwarded(self, square_resize_div_64: bool, transform_fn: str) -> None:
+        """When aug_config is None, transform builders receive None (use default)."""
+        args = self._make_args(square_resize_div_64=square_resize_div_64, aug_config=None)
+
+        with (
+            patch("rfdetr.datasets.yolo.Path") as mock_path,
+            patch(f"rfdetr.datasets.yolo.{transform_fn}") as mock_transform,
+            patch("rfdetr.datasets.yolo.YoloDetection") as mock_dataset,
+        ):
+            mock_path.return_value.exists.return_value = True
+            mock_path.return_value.__truediv__ = lambda self, other: self
+            mock_path.return_value.__str__ = lambda self: "/fake/dataset"
+            mock_transform.return_value = MagicMock()
+            mock_dataset.return_value = MagicMock()
+
+            from rfdetr.datasets.yolo import build_roboflow_from_yolo
+
+            build_roboflow_from_yolo("train", args, resolution=640)
+
+        _, kwargs = mock_transform.call_args
+        assert kwargs.get("aug_config") is None

--- a/tests/datasets/test_yolo.py
+++ b/tests/datasets/test_yolo.py
@@ -289,7 +289,12 @@ class TestBuildRoboflowFromYoloAugConfig:
     @pytest.mark.parametrize(
         "square_resize_div_64,transform_fn,aug_config",
         [
-            pytest.param(True, "make_coco_transforms_square_div_64", {"HorizontalFlip": {"p": 0.5}}, id="square_div_64_with_config"),
+            pytest.param(
+                True,
+                "make_coco_transforms_square_div_64",
+                {"HorizontalFlip": {"p": 0.5}},
+                id="square_div_64_with_config",
+            ),
             pytest.param(False, "make_coco_transforms", {"HorizontalFlip": {"p": 0.5}}, id="standard_with_config"),
             pytest.param(True, "make_coco_transforms_square_div_64", None, id="square_div_64_none"),
             pytest.param(False, "make_coco_transforms", None, id="standard_none"),

--- a/tests/datasets/test_yolo.py
+++ b/tests/datasets/test_yolo.py
@@ -307,8 +307,6 @@ class TestBuildRoboflowFromYoloAugConfig:
             patch("rfdetr.datasets.yolo.YoloDetection") as mock_dataset,
         ):
             mock_path.return_value.exists.return_value = True
-            mock_path.return_value.__truediv__ = lambda self, other: self
-            mock_path.return_value.__str__ = lambda self: "/fake/dataset"
             mock_transform.return_value = MagicMock()
             mock_dataset.return_value = MagicMock()
 


### PR DESCRIPTION
This pull request updates the `build_roboflow_from_yolo` function to support forwarding the `aug_config` argument to transformation builders, ensuring that custom augmentation configurations are properly handled. It also adds regression tests to verify this behavior and prevent future regressions.

**Enhancements to data pipeline configuration:**

* Updated `build_roboflow_from_yolo` in `src/rfdetr/datasets/yolo.py` to extract the `aug_config` attribute from `args` and forward it to the appropriate transformation builder functions (`make_coco_transforms` and `make_coco_transforms_square_div_64`). [[1]](diffhunk://#diff-d1e5ad158d1fc9bb75ca28e5f00118f0b7283ceb9bcaf6cbc8ff82b2216d8852R500) [[2]](diffhunk://#diff-d1e5ad158d1fc9bb75ca28e5f00118f0b7283ceb9bcaf6cbc8ff82b2216d8852R515) [[3]](diffhunk://#diff-d1e5ad158d1fc9bb75ca28e5f00118f0b7283ceb9bcaf6cbc8ff82b2216d8852R532)

**Testing and regression coverage:**

* Added a new test class `TestBuildRoboflowFromYoloAugConfig` in `tests/datasets/test_yolo.py` to provide regression tests ensuring that `aug_config` is correctly forwarded to transformation builders, both when set and when `None`.
* Imported `types`, `MagicMock`, and `patch` in `tests/datasets/test_yolo.py` to support mocking and testing of the new behavior.

---

closes #769