### PR TITLE
test: add unit tests for distributed helpers & package metadata utils

### DIFF
--- a/tests/utilities/test_distributed.py
+++ b/tests/utilities/test_distributed.py
@@ -13,10 +13,8 @@ from rfdetr.utilities.distributed import all_gather
 
 def test_all_gather_supports_cpu_without_tensor_truthiness_error() -> None:
     """all_gather should work on CPU-only setups and return gathered objects."""
-    gathered_calls = {"count": 0}
 
     def _fake_all_gather(output_tensors, input_tensor) -> None:
-        gathered_calls["count"] += 1
         for out in output_tensors:
             out.copy_(input_tensor)
 
@@ -27,5 +25,4 @@ def test_all_gather_supports_cpu_without_tensor_truthiness_error() -> None:
     ):
         result = all_gather({"value": 7})
 
-    assert gathered_calls["count"] == 2
     assert result == [{"value": 7}, {"value": 7}]

--- a/tests/utilities/test_distributed.py
+++ b/tests/utilities/test_distributed.py
@@ -1,0 +1,33 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Tests for distributed utility helpers."""
+
+from unittest.mock import patch
+
+import torch
+
+from rfdetr.utilities.distributed import all_gather
+
+
+def test_all_gather_supports_cpu_without_tensor_truthiness_error() -> None:
+    """all_gather should work on CPU-only setups and return gathered objects."""
+    gathered_calls = {"count": 0}
+
+    def _fake_all_gather(output_tensors, input_tensor) -> None:
+        gathered_calls["count"] += 1
+        for out in output_tensors:
+            out.copy_(input_tensor)
+
+    with (
+        patch("rfdetr.utilities.distributed.get_world_size", return_value=2),
+        patch("rfdetr.utilities.distributed.dist.all_gather", side_effect=_fake_all_gather),
+        patch("rfdetr.utilities.distributed.torch.cuda.is_available", return_value=False),
+    ):
+        result = all_gather({"value": 7})
+
+    assert gathered_calls["count"] == 2
+    assert result == [{"value": 7}, {"value": 7}]

--- a/tests/utilities/test_distributed.py
+++ b/tests/utilities/test_distributed.py
@@ -8,8 +8,6 @@
 
 from unittest.mock import patch
 
-import torch
-
 from rfdetr.utilities.distributed import all_gather
 
 

--- a/tests/utilities/test_package.py
+++ b/tests/utilities/test_package.py
@@ -1,0 +1,34 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Tests for package metadata helpers."""
+
+from unittest.mock import patch
+
+from rfdetr.utilities.package import get_sha
+
+
+def test_get_sha_marks_dirty_worktree_when_diff_command_returns_non_zero() -> None:
+    """A non-zero diff exit code should report uncommitted changes, not unknown."""
+
+    def _fake_check_output(command, cwd=None):  # noqa: ANN001
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            return b"abc123\n"
+        if command[:4] == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+            return b"feature/test\n"
+        raise AssertionError(f"Unexpected command: {command!r}")
+
+    class _RunResult:
+        def __init__(self, returncode: int) -> None:
+            self.returncode = returncode
+
+    with (
+        patch("rfdetr.utilities.package.subprocess.check_output", side_effect=_fake_check_output),
+        patch("rfdetr.utilities.package.subprocess.run", return_value=_RunResult(returncode=1)),
+    ):
+        sha = get_sha()
+
+    assert sha == "sha: abc123, status: has uncommitted changes, branch: feature/test"

--- a/tests/utilities/test_package.py
+++ b/tests/utilities/test_package.py
@@ -11,10 +11,10 @@ from unittest.mock import patch
 from rfdetr.utilities.package import get_sha
 
 
-def test_get_sha_marks_dirty_worktree_when_diff_command_returns_non_zero() -> None:
-    """A non-zero diff exit code should report uncommitted changes, not unknown."""
+def test_get_sha_marks_dirty_worktree_when_diff_command_returns_exit_code_1() -> None:
+    """A diff exit code of 1 should report uncommitted changes, not unknown."""
 
-    def _fake_check_output(command, cwd=None):
+    def _fake_check_output(command: list[str], cwd: str | None = None) -> bytes:
         if command[:3] == ["git", "rev-parse", "HEAD"]:
             return b"abc123\n"
         if command[:4] == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:

--- a/tests/utilities/test_package.py
+++ b/tests/utilities/test_package.py
@@ -14,7 +14,7 @@ from rfdetr.utilities.package import get_sha
 def test_get_sha_marks_dirty_worktree_when_diff_command_returns_non_zero() -> None:
     """A non-zero diff exit code should report uncommitted changes, not unknown."""
 
-    def _fake_check_output(command, cwd=None):  # noqa: ANN001
+    def _fake_check_output(command, cwd=None):
         if command[:3] == ["git", "rev-parse", "HEAD"]:
             return b"abc123\n"
         if command[:4] == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:


### PR DESCRIPTION
This pull request adds new unit tests to improve coverage and reliability for utility functions in the project. The tests focus on verifying the behavior of distributed gathering and package metadata helpers, ensuring correctness in edge cases like CPU-only setups and dirty git worktrees.

Distributed utilities testing:

* Added `test_all_gather_supports_cpu_without_tensor_truthiness_error` to check that the `all_gather` function works correctly on CPU-only setups and returns gathered objects without errors related to tensor truthiness. (`tests/utilities/test_distributed.py`, [tests/utilities/test_distributed.pyR1-R33](diffhunk://#diff-def9280050d1ce05bb5969cf917f8c8c3c8d3dc24d46092718630bacc5273d90R1-R33))

Package metadata utilities testing:

* Added `test_get_sha_marks_dirty_worktree_when_diff_command_returns_non_zero` to verify that `get_sha` correctly reports uncommitted changes when the git diff command returns a non-zero exit code, rather than marking the status as unknown. (`tests/utilities/test_package.py`, [tests/utilities/test_package.pyR1-R34](diffhunk://#diff-c87e4d708a500e5706d17a75718df8e5df07074c9210b29ea9b3833c88424183R1-R34))