### PR TITLE
perf: defer supervision import to first use, not module load

### DIFF
--- a/src/rfdetr/datasets/yolo.py
+++ b/src/rfdetr/datasets/yolo.py
@@ -4,13 +4,17 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import os
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
-import supervision as sv
 import torch
+
+if TYPE_CHECKING:
+    import supervision as sv
 from PIL import Image
 from torchvision.datasets import VisionDataset
 
@@ -257,7 +261,8 @@ class CocoLikeAPI:
             if len(detections) == 0:
                 continue
             for i in range(len(detections)):
-                bbox_x, bbox_y, bbox_w, bbox_h = sv.xyxy_to_xywh(detections.xyxy[i : i + 1])[0]
+                x1, y1, x2, y2 = detections.xyxy[i]
+                bbox_x, bbox_y, bbox_w, bbox_h = float(x1), float(y1), float(x2 - x1), float(y2 - y1)
 
                 ann = {
                     "id": ann_id,
@@ -439,6 +444,8 @@ class YoloDetection(VisionDataset):
         self._transforms = transforms
         self.include_masks = include_masks
         self.prepare = ConvertYolo(include_masks=include_masks)
+
+        import supervision as sv
 
         # Load dataset using supervision's from_yolo method
         self.sv_dataset = sv.DetectionDataset.from_yolo(

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
+from __future__ import annotations
+
 import glob
 import json
 import os
@@ -10,12 +12,14 @@ import warnings
 from collections import defaultdict
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 import numpy as np
 import requests
-import supervision as sv
 import torch
+
+if TYPE_CHECKING:
+    import supervision as sv
 import torchvision.transforms.functional as F
 import yaml
 from PIL import Image
@@ -572,6 +576,8 @@ class RFDETR:
             A single or multiple Detections objects, each containing bounding box
             coordinates, confidence scores, and class IDs.
         """
+        import supervision as sv
+
         if not self._is_optimized_for_inference and not self._has_warned_about_not_being_optimized_for_inference:
             logger.warning(
                 "Model is not optimized for inference. Latency may be higher than expected."

--- a/src/rfdetr/evaluation/coco_eval.py
+++ b/src/rfdetr/evaluation/coco_eval.py
@@ -38,6 +38,14 @@ from rfdetr.utilities.logger import get_logger
 logger = get_logger()
 
 
+def _xyxy_to_xywh(boxes: np.ndarray) -> np.ndarray:
+    """Convert boxes from [x1, y1, x2, y2] to [x1, y1, w, h]."""
+    boxes = boxes.copy()
+    boxes[:, 2] -= boxes[:, 0]
+    boxes[:, 3] -= boxes[:, 1]
+    return boxes
+
+
 class CocoEvaluator:
     """COCO evaluator that works in distributed mode."""
 
@@ -138,11 +146,7 @@ class CocoEvaluator:
                 continue
 
             boxes = prediction["boxes"]
-            boxes_np = boxes.cpu().numpy()
-            boxes_np = boxes_np.copy()
-            boxes_np[:, 2] -= boxes_np[:, 0]
-            boxes_np[:, 3] -= boxes_np[:, 1]
-            boxes = boxes_np.tolist()
+            boxes = _xyxy_to_xywh(boxes.cpu().numpy()).tolist()
             scores = prediction["scores"].tolist()
             labels = prediction["labels"].tolist()
             use_raw_category_ids = self._should_use_raw_category_ids(labels)
@@ -206,11 +210,7 @@ class CocoEvaluator:
                 continue
 
             boxes = prediction["boxes"]
-            boxes_np = boxes.cpu().numpy()
-            boxes_np = boxes_np.copy()
-            boxes_np[:, 2] -= boxes_np[:, 0]
-            boxes_np[:, 3] -= boxes_np[:, 1]
-            boxes = boxes_np.tolist()
+            boxes = _xyxy_to_xywh(boxes.cpu().numpy()).tolist()
             scores = prediction["scores"].tolist()
             labels = prediction["labels"].tolist()
             keypoints = prediction["keypoints"]

--- a/src/rfdetr/evaluation/coco_eval.py
+++ b/src/rfdetr/evaluation/coco_eval.py
@@ -29,7 +29,6 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import pycocotools.mask as mask_util
-import supervision as sv
 from pycocotools.coco import COCO
 from pycocotools.cocoeval import COCOeval
 
@@ -139,7 +138,11 @@ class CocoEvaluator:
                 continue
 
             boxes = prediction["boxes"]
-            boxes = sv.xyxy_to_xywh(boxes.cpu().numpy()).tolist()
+            boxes_np = boxes.cpu().numpy()
+            boxes_np = boxes_np.copy()
+            boxes_np[:, 2] -= boxes_np[:, 0]
+            boxes_np[:, 3] -= boxes_np[:, 1]
+            boxes = boxes_np.tolist()
             scores = prediction["scores"].tolist()
             labels = prediction["labels"].tolist()
             use_raw_category_ids = self._should_use_raw_category_ids(labels)
@@ -203,7 +206,11 @@ class CocoEvaluator:
                 continue
 
             boxes = prediction["boxes"]
-            boxes = sv.xyxy_to_xywh(boxes.cpu().numpy()).tolist()
+            boxes_np = boxes.cpu().numpy()
+            boxes_np = boxes_np.copy()
+            boxes_np[:, 2] -= boxes_np[:, 0]
+            boxes_np[:, 3] -= boxes_np[:, 1]
+            boxes = boxes_np.tolist()
             scores = prediction["scores"].tolist()
             labels = prediction["labels"].tolist()
             keypoints = prediction["keypoints"]

--- a/src/rfdetr/visualize/data.py
+++ b/src/rfdetr/visualize/data.py
@@ -7,7 +7,6 @@
 from pathlib import Path
 
 import numpy as np
-import supervision as sv
 from PIL import Image
 
 from rfdetr.utilities.logger import get_logger
@@ -33,6 +32,8 @@ def save_gt_predictions_visualization(
     Boxes are labeled with class ID and confidence (for predictions).
     For predictions with known IoU, the IoU value is also shown.
     """
+    import supervision as sv
+
     save_dir.mkdir(exist_ok=True)
 
     top_padding = 60


### PR DESCRIPTION
This pull request refactors several files to reduce unnecessary imports and improve compatibility with static type checking. The main change is to move the import of the `supervision` library inside functions and methods where it is actually used, and to use `TYPE_CHECKING` for type hints. Additionally, direct calls to `sv.xyxy_to_xywh` are replaced with manual bounding box conversion logic, which removes the dependency on `supervision` for those operations.

Refactoring imports and type checking:

* Moved the `supervision` import inside functions and methods in `src/rfdetr/datasets/yolo.py`, `src/rfdetr/detr.py`, and `src/rfdetr/visualize/data.py`, and used `TYPE_CHECKING` to allow type hints without requiring the library at runtime. [[1]](diffhunk://#diff-d1e5ad158d1fc9bb75ca28e5f00118f0b7283ceb9bcaf6cbc8ff82b2216d8852R7-R17) [[2]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86R6-R22) [[3]](diffhunk://#diff-bcaee63a6b2d378ee191b622e7a7eaf3f897f50c2d8eb8beaf152aad0c8251ecL10)

Bounding box conversion logic:

* Replaced calls to `sv.xyxy_to_xywh` with manual conversion of bounding box coordinates in `src/rfdetr/datasets/yolo.py` and `src/rfdetr/evaluation/coco_eval.py`, ensuring that the conversion does not depend on `supervision`. [[1]](diffhunk://#diff-d1e5ad158d1fc9bb75ca28e5f00118f0b7283ceb9bcaf6cbc8ff82b2216d8852L260-R265) [[2]](diffhunk://#diff-c9847aadcf2c0be75e4359b795f7bbd8c976cf022247370321640f55eb263797L142-R145) [[3]](diffhunk://#diff-c9847aadcf2c0be75e4359b795f7bbd8c976cf022247370321640f55eb263797L206-R213)

On-demand imports for efficiency:

* Added on-demand imports of `supervision` inside relevant methods and functions in `src/rfdetr/datasets/yolo.py`, `src/rfdetr/detr.py`, and `src/rfdetr/visualize/data.py` to avoid unnecessary global imports. [[1]](diffhunk://#diff-d1e5ad158d1fc9bb75ca28e5f00118f0b7283ceb9bcaf6cbc8ff82b2216d8852R448-R449) [[2]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86R579-R580) [[3]](diffhunk://#diff-bcaee63a6b2d378ee191b622e7a7eaf3f897f50c2d8eb8beaf152aad0c8251ecR35-R36)

Cleanup of unused imports:

* Removed unused global imports of `supervision` from `src/rfdetr/evaluation/coco_eval.py` and `src/rfdetr/visualize/data.py`. [[1]](diffhunk://#diff-c9847aadcf2c0be75e4359b795f7bbd8c976cf022247370321640f55eb263797L32) [[2]](diffhunk://#diff-bcaee63a6b2d378ee191b622e7a7eaf3f897f50c2d8eb8beaf152aad0c8251ecL10)