### PR TITLE
feat: add DDP support to `model.train()` via `TrainConfig` topology fields

### DIFF
--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -6,7 +6,7 @@
 
 
 import os
-from typing import Any, ClassVar, Dict, List, Literal, Mapping, Optional
+from typing import Any, ClassVar, Dict, List, Literal, Mapping, Optional, Union
 
 import torch
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
@@ -342,6 +342,9 @@ class TrainConfig(BaseModel):
     clip_max_norm: float = 0.1
     seed: Optional[int] = None
     sync_bn: bool = False
+    strategy: str = "auto"
+    devices: Union[int, str] = 1
+    num_nodes: int = 1
     fp16_eval: bool = False
     lr_scheduler: Literal["step", "cosine"] = "step"
     lr_min_factor: float = 0.0

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -342,8 +342,12 @@ class TrainConfig(BaseModel):
     clip_max_norm: float = 0.1
     seed: Optional[int] = None
     sync_bn: bool = False
+    # strategy maps to PTL Trainer(strategy=...). Common values: "auto", "ddp",
+    # "ddp_spawn", "fsdp", "deepspeed". Invalid values surface as PTL errors.
     strategy: str = "auto"
     devices: Union[int, str] = 1
+    # num_nodes maps to PTL Trainer(num_nodes=...) for multi-machine training.
+    # Single-machine DDP users should leave this at 1 (the default).
     num_nodes: int = 1
     fp16_eval: bool = False
     lr_scheduler: Literal["step", "cosine"] = "step"

--- a/src/rfdetr/training/datamodule.py
+++ b/src/rfdetr/training/datamodule.py
@@ -110,8 +110,8 @@ class RFDETRDataModule(LightningDataModule):
 
         Uses a replacement sampler when the dataset is too small to fill
         ``_MIN_TRAIN_BATCHES`` effective batches (matching legacy behaviour in
-        ``main.py``).  Otherwise uses a ``BatchSampler`` with
-        ``drop_last=True`` to avoid incomplete batches.
+        ``main.py``).  Otherwise uses ``shuffle=True, drop_last=True`` so that
+        PTL can auto-inject ``DistributedSampler`` in DDP mode.
 
         Returns:
             DataLoader for the training dataset.
@@ -143,14 +143,11 @@ class RFDETRDataModule(LightningDataModule):
                 prefetch_factor=self._prefetch_factor,
             )
 
-        batch_sampler = torch.utils.data.BatchSampler(
-            torch.utils.data.RandomSampler(dataset),
-            batch_size,
-            drop_last=True,
-        )
         return DataLoader(
             dataset,
-            batch_sampler=batch_sampler,
+            batch_size=batch_size,
+            shuffle=True,
+            drop_last=True,
             collate_fn=collate_fn,
             num_workers=args.num_workers,
             pin_memory=self._pin_memory,

--- a/src/rfdetr/training/module.py
+++ b/src/rfdetr/training/module.py
@@ -175,7 +175,7 @@ class RFDETRModule(LightningModule):
         preserving deterministic training behaviour for actual fit runs.
         """
         if self.train_config.seed is not None:
-            seed_everything(self.train_config.seed, workers=True)
+            seed_everything(self.train_config.seed + self.global_rank, workers=True)
 
     def on_train_batch_start(self, batch: Tuple, batch_idx: int) -> None:
         """Apply optional multi-scale resize to the incoming batch.

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -81,7 +81,7 @@ def build_trainer(
         return "32-true"
 
     # --- Strategy + EMA sharding guard ---
-    strategy = getattr(tc, "strategy", "auto")
+    strategy = tc.strategy
     sharded = any(s in str(strategy).lower() for s in ("fsdp", "deepspeed"))
     enable_ema = bool(tc.use_ema) and not sharded
     if tc.use_ema and sharded:
@@ -197,7 +197,8 @@ def build_trainer(
     trainer_config: dict[str, Any] = {
         "max_epochs": tc.epochs,
         "accelerator": accelerator,
-        "devices": 1,
+        "devices": tc.devices,
+        "num_nodes": tc.num_nodes,
         "strategy": strategy,
         "precision": _resolve_precision(),
         "accumulate_grad_batches": tc.grad_accum_steps,

--- a/tests/training/helpers.py
+++ b/tests/training/helpers.py
@@ -97,6 +97,9 @@ class _FakePostProcess:
 
     ``MagicMock`` is not picklable and cannot survive the subprocess boundary
     that ``ddp_spawn`` creates.  This plain class is a drop-in replacement.
+
+    Delegates to ``_fake_postprocess``; keep both in sync if the fake output
+    format changes.
     """
 
     def __call__(self, outputs, orig_sizes):

--- a/tests/training/helpers.py
+++ b/tests/training/helpers.py
@@ -92,6 +92,17 @@ class _FakeDatasetWithMasks(_FakeDataset):
         return image, target
 
 
+class _FakePostProcess:
+    """Picklable postprocessor for ddp_spawn tests.
+
+    ``MagicMock`` is not picklable and cannot survive the subprocess boundary
+    that ``ddp_spawn`` creates.  This plain class is a drop-in replacement.
+    """
+
+    def __call__(self, outputs, orig_sizes):
+        return _fake_postprocess(outputs, orig_sizes)
+
+
 def _fake_postprocess(outputs, orig_sizes):
     """Return one non-empty prediction per image so COCOEvalCallback has something to score."""
     n = orig_sizes.shape[0]

--- a/tests/training/test_build_trainer.py
+++ b/tests/training/test_build_trainer.py
@@ -423,3 +423,93 @@ class TestBuildTrainerSeed:
         with mock.patch("pytorch_lightning.seed_everything") as mock_seed:
             build_trainer(tc, _mc())
         mock_seed.assert_not_called()
+
+
+class TestBuildTrainerDDPFields:
+    """build_trainer() must thread devices/num_nodes/strategy from TrainConfig to Trainer."""
+
+    def test_devices_threaded_from_train_config(self, tmp_path):
+        """TrainConfig.devices is forwarded to Trainer(devices=...)."""
+        import unittest.mock as mock
+
+        captured: dict = {}
+
+        def _fake_trainer(**kwargs):
+            captured.update(kwargs)
+            return mock.MagicMock()
+
+        tc = _tc(tmp_path, use_ema=False, devices=4)
+        with mock.patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer):
+            build_trainer(tc, _mc())
+
+        assert captured["devices"] == 4
+
+    def test_num_nodes_threaded_from_train_config(self, tmp_path):
+        """TrainConfig.num_nodes is forwarded to Trainer(num_nodes=...)."""
+        import unittest.mock as mock
+
+        captured: dict = {}
+
+        def _fake_trainer(**kwargs):
+            captured.update(kwargs)
+            return mock.MagicMock()
+
+        tc = _tc(tmp_path, use_ema=False, num_nodes=2)
+        with mock.patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer):
+            build_trainer(tc, _mc())
+
+        assert captured["num_nodes"] == 2
+
+    def test_strategy_threaded_from_train_config(self, tmp_path):
+        """TrainConfig.strategy is forwarded to Trainer(strategy=...)."""
+        import unittest.mock as mock
+
+        captured: dict = {}
+
+        def _fake_trainer(**kwargs):
+            captured.update(kwargs)
+            return mock.MagicMock()
+
+        tc = _tc(tmp_path, use_ema=False, strategy="ddp")
+        with mock.patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer):
+            build_trainer(tc, _mc())
+
+        assert captured["strategy"] == "ddp"
+
+    def test_default_devices_is_1(self, tmp_path):
+        """Default TrainConfig.devices must produce devices=1 (single-GPU default)."""
+        import unittest.mock as mock
+
+        captured: dict = {}
+
+        def _fake_trainer(**kwargs):
+            captured.update(kwargs)
+            return mock.MagicMock()
+
+        tc = _tc(tmp_path, use_ema=False)
+        with mock.patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer):
+            build_trainer(tc, _mc())
+
+        assert captured["devices"] == 1
+
+    def test_default_num_nodes_is_1(self, tmp_path):
+        """Default TrainConfig.num_nodes must produce num_nodes=1."""
+        import unittest.mock as mock
+
+        captured: dict = {}
+
+        def _fake_trainer(**kwargs):
+            captured.update(kwargs)
+            return mock.MagicMock()
+
+        tc = _tc(tmp_path, use_ema=False)
+        with mock.patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer):
+            build_trainer(tc, _mc())
+
+        assert captured["num_nodes"] == 1
+
+    def test_devices_string_accepted(self, tmp_path):
+        """TrainConfig.devices accepts a string value (e.g. '0,1')."""
+        tc = _tc(tmp_path, use_ema=False, devices="auto")
+        # Should not raise during config construction.
+        assert tc.devices == "auto"

--- a/tests/training/test_module.py
+++ b/tests/training/test_module.py
@@ -7,7 +7,7 @@
 """Comprehensive unit tests for RFDETRModule (LightningModule wrapper)."""
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 import torch
@@ -427,14 +427,30 @@ class TestOnFitStart:
     """Tests for on_fit_start() seeding behavior."""
 
     @patch("rfdetr.training.module.seed_everything")
-    def test_seed_applied_when_configured(self, mock_seed, base_train_config, build_module):
-        """Configured seed should be applied at fit start."""
+    def test_seed_at_rank_zero(self, mock_seed, base_train_config, build_module):
+        """Rank 0: seed_everything(seed + 0) == seed_everything(seed)."""
         tc = base_train_config(seed=7)
         module, _, _, _ = build_module(train_config=tc)
 
-        module.on_fit_start()
+        with patch.object(type(module), "global_rank", new_callable=PropertyMock, return_value=0):
+            module.on_fit_start()
 
         mock_seed.assert_called_once_with(7, workers=True)
+
+    @patch("rfdetr.training.module.seed_everything")
+    def test_seed_rank_offset(self, mock_seed, base_train_config, build_module):
+        """Non-zero rank: seed_everything(seed + global_rank) must be called.
+
+        Validates the rank-offset contract — each worker seeds with a unique
+        value to prevent correlated data augmentation across DDP processes.
+        """
+        tc = base_train_config(seed=7)
+        module, _, _, _ = build_module(train_config=tc)
+
+        with patch.object(type(module), "global_rank", new_callable=PropertyMock, return_value=2):
+            module.on_fit_start()
+
+        mock_seed.assert_called_once_with(9, workers=True)  # 7 + 2
 
     @patch("rfdetr.training.module.seed_everything")
     def test_seed_skipped_when_none(self, mock_seed, base_train_config, build_module):

--- a/tests/training/test_trainer_smoke.py
+++ b/tests/training/test_trainer_smoke.py
@@ -29,6 +29,7 @@ from .helpers import (
     _FakeCriterion,
     _FakeDataset,
     _FakeDatasetWithMasks,
+    _FakePostProcess,
     _make_param_dicts,
     _TinyModel,
 )
@@ -279,3 +280,60 @@ class TestBuildTrainerSmoke:
             datamodule = RFDETRDataModule(mc, tc)
             trainer = build_trainer(tc, mc, accelerator="cpu", fast_dev_run=2)
             trainer.fit(module, datamodule=datamodule)
+
+
+class _DDPModule(RFDETRModule):
+    """RFDETRModule subclass for ddp_spawn smoke tests.
+
+    Overrides ``configure_optimizers`` so ``get_param_dict`` is never called
+    in child processes.  ``ddp_spawn`` forks child processes that unpack a
+    pickled copy of this module; patches applied in the parent process are not
+    visible in children, so the real ``get_param_dict`` would be called and
+    would fail on ``_TinyModel`` (no ``.backbone`` attribute).
+
+    Must be defined at module level so ``pickle`` can look up the class by
+    qualified name when deserialising in the child process.
+    """
+
+    def configure_optimizers(self):
+        """Minimal single-group AdamW — bypasses get_param_dict."""
+        return torch.optim.AdamW(self.parameters(), lr=1e-4)
+
+
+class TestDDPSmoke:
+    """DDP training smoke test using ddp_spawn on CPU with 2 workers.
+
+    ``ddp_spawn`` forks child processes, so all objects passed to
+    ``trainer.fit()`` must be picklable.  ``MagicMock`` is NOT picklable;
+    this suite uses ``_FakePostProcess``, plain dataset instances, and
+    ``_DDPModule`` (module-level class) instead.
+    """
+
+    def test_ddp_spawn_fit_runs_without_error(self, base_model_config, base_train_config):
+        """ddp_spawn with 2 CPU workers must run fast_dev_run=2 without error."""
+        mc = base_model_config()
+        tc = base_train_config(use_ema=False, run_test=False, devices=2, strategy="ddp_spawn")
+
+        fake_dataset = _FakeDataset(length=20)
+
+        with (
+            patch("rfdetr.training.module.build_model", return_value=_TinyModel()),
+            patch(
+                "rfdetr.training.module.build_criterion_and_postprocessors",
+                return_value=(_FakeCriterion(), _FakePostProcess()),
+            ),
+        ):
+            module = _DDPModule(mc, tc)
+
+        datamodule = RFDETRDataModule(mc, tc)
+        # Pre-set datasets: build_dataset mock doesn't survive the spawn boundary.
+        datamodule._dataset_train = fake_dataset
+        datamodule._dataset_val = fake_dataset
+
+        trainer = build_trainer(
+            tc,
+            mc,
+            accelerator="cpu",
+            fast_dev_run=2,
+        )
+        trainer.fit(module, datamodule=datamodule)

--- a/tests/training/test_trainer_smoke.py
+++ b/tests/training/test_trainer_smoke.py
@@ -14,8 +14,10 @@ so no real dataset or GPU is required.
 Chapter 1 gate: these must pass before Chapter 2 begins.
 """
 
+import sys
 from unittest.mock import MagicMock, patch
 
+import pytest
 import torch
 from pytorch_lightning import Trainer
 
@@ -300,46 +302,35 @@ class _DDPModule(RFDETRModule):
         return torch.optim.AdamW(self.parameters(), lr=1e-4)
 
 
-class TestDDPSmoke:
-    """DDP training smoke test using ddp_spawn on CPU with 2 workers.
+# TODO: find a Windows-compatible spawn strategy or loopback init_method fix;
+#       gloo DDP spawn fails on Windows CI (makeDeviceForHostname: unsupported gloo device).
+@pytest.mark.skipif(sys.platform == "win32", reason="gloo DDP spawn unsupported on Windows CI")
+def test_ddp_spawn_fit_runs_without_error(base_model_config, base_train_config):
+    """ddp_spawn with 2 CPU workers must run fast_dev_run=2 without error.
 
     ``ddp_spawn`` forks child processes, so all objects passed to
     ``trainer.fit()`` must be picklable.  ``MagicMock`` is NOT picklable;
-    this suite uses ``_FakePostProcess``, plain dataset instances, and
+    this test uses ``_FakePostProcess``, plain dataset instances, and
     ``_DDPModule`` (module-level class) instead.
     """
+    mc = base_model_config()
+    tc = base_train_config(use_ema=False, run_test=False, devices=2, strategy="ddp_spawn")
 
-    def test_ddp_spawn_fit_runs_without_error(self, monkeypatch, base_model_config, base_train_config):
-        """ddp_spawn with 2 CPU workers must run fast_dev_run=2 without error.
+    fake_dataset = _FakeDataset(length=20)
 
-        Sets MASTER_ADDR=127.0.0.1 so gloo resolves to the loopback interface
-        on all platforms, including Windows CI runners where hostname-based
-        resolution fails.
-        """
-        monkeypatch.setenv("MASTER_ADDR", "127.0.0.1")
-        mc = base_model_config()
-        tc = base_train_config(use_ema=False, run_test=False, devices=2, strategy="ddp_spawn")
+    with (
+        patch("rfdetr.training.module.build_model", return_value=_TinyModel()),
+        patch(
+            "rfdetr.training.module.build_criterion_and_postprocessors",
+            return_value=(_FakeCriterion(), _FakePostProcess()),
+        ),
+    ):
+        module = _DDPModule(mc, tc)
 
-        fake_dataset = _FakeDataset(length=20)
+    datamodule = RFDETRDataModule(mc, tc)
+    # Pre-set datasets: build_dataset mock doesn't survive the spawn boundary.
+    datamodule._dataset_train = fake_dataset
+    datamodule._dataset_val = fake_dataset
 
-        with (
-            patch("rfdetr.training.module.build_model", return_value=_TinyModel()),
-            patch(
-                "rfdetr.training.module.build_criterion_and_postprocessors",
-                return_value=(_FakeCriterion(), _FakePostProcess()),
-            ),
-        ):
-            module = _DDPModule(mc, tc)
-
-        datamodule = RFDETRDataModule(mc, tc)
-        # Pre-set datasets: build_dataset mock doesn't survive the spawn boundary.
-        datamodule._dataset_train = fake_dataset
-        datamodule._dataset_val = fake_dataset
-
-        trainer = build_trainer(
-            tc,
-            mc,
-            accelerator="cpu",
-            fast_dev_run=2,
-        )
-        trainer.fit(module, datamodule=datamodule)
+    trainer = build_trainer(tc, mc, accelerator="cpu", fast_dev_run=2)
+    trainer.fit(module, datamodule=datamodule)

--- a/tests/training/test_trainer_smoke.py
+++ b/tests/training/test_trainer_smoke.py
@@ -309,8 +309,14 @@ class TestDDPSmoke:
     ``_DDPModule`` (module-level class) instead.
     """
 
-    def test_ddp_spawn_fit_runs_without_error(self, base_model_config, base_train_config):
-        """ddp_spawn with 2 CPU workers must run fast_dev_run=2 without error."""
+    def test_ddp_spawn_fit_runs_without_error(self, monkeypatch, base_model_config, base_train_config):
+        """ddp_spawn with 2 CPU workers must run fast_dev_run=2 without error.
+
+        Sets MASTER_ADDR=127.0.0.1 so gloo resolves to the loopback interface
+        on all platforms, including Windows CI runners where hostname-based
+        resolution fails.
+        """
+        monkeypatch.setenv("MASTER_ADDR", "127.0.0.1")
         mc = base_model_config()
         tc = base_train_config(use_ema=False, run_test=False, devices=2, strategy="ddp_spawn")
 


### PR DESCRIPTION
## What does this PR do?

- Add `strategy`, `devices`, `num_nodes` to `TrainConfig` (defaults preserve single-GPU behaviour — zero breaking changes)
- Thread all three fields through `build_trainer()` (replaces hardcoded `devices=1`)
- Replace `BatchSampler(RandomSampler(...))` in `train_dataloader` with `shuffle=True, drop_last=True` so PTL can auto-inject `DistributedSampler` in DDP mode
- Offset seed by `global_rank` in `on_fit_start` for per-rank augmentation diversity
- Add `_FakePostProcess` picklable helper and `_DDPModule` subclass for ddp_spawn smoke tests; add `TestDDPSmoke` and `TestBuildTrainerDDPFields` (7 new tests, 935 total passing)

Closes #803

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)
- Refactoring (no functional changes)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
