### PR TITLE
fix: use static normalized_shape in projector LayerNorm for ONNX export compatibility

### DIFF
--- a/src/rfdetr/models/backbone/projector.py
+++ b/src/rfdetr/models/backbone/projector.py
@@ -40,7 +40,7 @@ class LayerNorm(nn.Module):
         TODO: this is a hack to avoid overflow when using fp16
         """
         x = x.permute(0, 2, 3, 1)
-        x = F.layer_norm(x, (x.size(3),), self.weight, self.bias, self.eps)
+        x = F.layer_norm(x, self.normalized_shape, self.weight, self.bias, self.eps)
         x = x.permute(0, 3, 1, 2)
         return x
 

--- a/tests/models/backbone/test_projector.py
+++ b/tests/models/backbone/test_projector.py
@@ -26,48 +26,47 @@ import torch
 from rfdetr.models.backbone.projector import LayerNorm
 
 
-def test_layernorm_forward_preserves_shape():
-    """LayerNorm should preserve input shape (B, C, H, W)."""
-    channels = 64
-    ln = LayerNorm(channels)
-    x = torch.randn(2, channels, 8, 8)
-    out = ln(x)
-    assert out.shape == x.shape
+class TestProjectorLayerNorm:
+    def test_layernorm_forward_preserves_shape(self) -> None:
+        """LayerNorm should preserve input shape (B, C, H, W)."""
+        channels = 64
+        ln = LayerNorm(channels)
+        x = torch.randn(2, channels, 8, 8)
+        out = ln(x)
+        assert out.shape == x.shape
 
+    def test_layernorm_normalized_shape_is_static(self) -> None:
+        """normalized_shape must be a plain tuple (not derived from a tensor)
+        so that ONNX exporters see it as a constant."""
+        channels = 128
+        ln = LayerNorm(channels)
+        assert ln.normalized_shape == (channels,)
+        assert isinstance(ln.normalized_shape, tuple)
 
-def test_layernorm_normalized_shape_is_static():
-    """normalized_shape must be a plain tuple (not derived from a tensor)
-    so that ONNX exporters see it as a constant."""
-    channels = 128
-    ln = LayerNorm(channels)
-    assert ln.normalized_shape == (channels,)
-    assert isinstance(ln.normalized_shape, tuple)
-
-
-@pytest.mark.skipif(
-    importlib.util.find_spec("onnx") is None,
-    reason="onnx not installed, run: pip install rfdetr[onnxexport]",
-)
-def test_layernorm_onnx_export(tmp_path: Path):
-    """The LayerNorm module should be exportable to ONNX without errors.
-
-    This is the regression test for the fix: prior to the change, PyTorch 2.9+
-    raised ``SymbolicValueError`` because ``(x.size(3),)`` was treated as a
-    non-constant shape during tracing.
-    """
-    channels = 64
-    ln = LayerNorm(channels)
-    ln.train(False)
-    dummy = torch.randn(1, channels, 8, 8)
-
-    onnx_path = str(tmp_path / "layernorm.onnx")
-    torch.onnx.export(
-        ln,
-        (dummy,),
-        onnx_path,
-        input_names=["input"],
-        output_names=["output"],
-        dynamic_axes={"input": {0: "batch", 2: "height", 3: "width"}},
-        opset_version=17,
+    @pytest.mark.skipif(
+        importlib.util.find_spec("onnx") is None,
+        reason="onnx not installed, run: pip install rfdetr[onnxexport]",
     )
-    assert Path(onnx_path).stat().st_size > 0, "ONNX export should produce non-empty file"
+    def test_layernorm_onnx_export(self, tmp_path: Path) -> None:
+        """The LayerNorm module should be exportable to ONNX without errors.
+
+        This is the regression test for the fix: prior to the change, PyTorch 2.9+
+        raised ``SymbolicValueError`` because ``(x.size(3),)`` was treated as a
+        non-constant shape during tracing.
+        """
+        channels = 64
+        ln = LayerNorm(channels)
+        ln.train(False)
+        dummy = torch.randn(1, channels, 8, 8)
+
+        onnx_path = str(tmp_path / "layernorm.onnx")
+        torch.onnx.export(
+            ln,
+            (dummy,),
+            onnx_path,
+            input_names=["input"],
+            output_names=["output"],
+            dynamic_axes={"input": {0: "batch", 2: "height", 3: "width"}},
+            opset_version=17,
+        )
+        assert Path(onnx_path).stat().st_size > 0, "ONNX export should produce non-empty file"

--- a/tests/models/backbone/test_projector.py
+++ b/tests/models/backbone/test_projector.py
@@ -1,0 +1,73 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""
+Tests for the projector LayerNorm ONNX export fix.
+
+The custom LayerNorm in projector.py performs channel-wise normalization on
+(B, C, H, W) inputs. The original implementation passed ``(x.size(3),)`` as
+``normalized_shape`` to ``F.layer_norm``, which worked at runtime but caused
+ONNX export failures on PyTorch 2.9+ because the exporter treats dynamic
+tensor dimensions as symbolic (non-constant) values.
+
+The fix replaces the dynamic ``(x.size(3),)`` with the static attribute
+``self.normalized_shape``, which is set once in ``__init__``.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import torch
+
+from rfdetr.models.backbone.projector import LayerNorm
+
+
+def test_layernorm_forward_preserves_shape():
+    """LayerNorm should preserve input shape (B, C, H, W)."""
+    channels = 64
+    ln = LayerNorm(channels)
+    x = torch.randn(2, channels, 8, 8)
+    out = ln(x)
+    assert out.shape == x.shape
+
+
+def test_layernorm_normalized_shape_is_static():
+    """normalized_shape must be a plain tuple (not derived from a tensor)
+    so that ONNX exporters see it as a constant."""
+    channels = 128
+    ln = LayerNorm(channels)
+    assert ln.normalized_shape == (channels,)
+    assert isinstance(ln.normalized_shape, tuple)
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("onnx") is None,
+    reason="onnx not installed, run: pip install rfdetr[onnxexport]",
+)
+def test_layernorm_onnx_export(tmp_path: Path):
+    """The LayerNorm module should be exportable to ONNX without errors.
+
+    This is the regression test for the fix: prior to the change, PyTorch 2.9+
+    raised ``SymbolicValueError`` because ``(x.size(3),)`` was treated as a
+    non-constant shape during tracing.
+    """
+    channels = 64
+    ln = LayerNorm(channels)
+    ln.train(False)
+    dummy = torch.randn(1, channels, 8, 8)
+
+    onnx_path = str(tmp_path / "layernorm.onnx")
+    torch.onnx.export(
+        ln,
+        (dummy,),
+        onnx_path,
+        input_names=["input"],
+        output_names=["output"],
+        dynamic_axes={"input": {0: "batch", 2: "height", 3: "width"}},
+        opset_version=17,
+    )
+    assert Path(onnx_path).stat().st_size > 0, "ONNX export should produce non-empty file"


### PR DESCRIPTION
## Summary

Replace `(x.size(3),)` with `self.normalized_shape` in the projector's
`LayerNorm.forward()`. This is functionally identical — `self.normalized_shape`
is set to `(channel_dim,)` in `__init__`, which always equals `x.size(3)` at
runtime — but makes the ONNX export succeed on PyTorch 2.9+.

## Problem

Starting with PyTorch 2.9, `torch.onnx.export` defaults to the new
dynamo-based exporter (`dynamo=True`). This exporter treats `x.size(3)` as
a symbolic value that could vary across inputs, and refuses to use it where
a static shape is required (the `normalized_shape` argument to
`F.layer_norm`).

Falling back to the legacy TorchScript exporter (`dynamo=False`) also fails
on PyTorch 2.9 because the tracer is now stricter about `prim::ListConstruct`
nodes with non-constant inputs.

On PyTorch < 2.9, the legacy tracer evaluated `x.size(3)` eagerly during
tracing and embedded the result as a constant, so the export succeeded.
This is most likely why the issue was not previously reported.

The error:

```
torch.onnx.errors.SymbolicValueError: Failed to export a node ... because
it is not constant. Please try to make things (e.g. kernel sizes) static
if possible.
```

at `rfdetr/models/backbone/projector.py:43`.

## Fix

```diff
- x = F.layer_norm(x, (x.size(3),), self.weight, self.bias, self.eps)
+ x = F.layer_norm(x, self.normalized_shape, self.weight, self.bias, self.eps)
```

`self.normalized_shape` is a tuple `(channel_dim,)` assigned in `__init__`
and never changes. Both the dynamo and legacy exporters see it as a constant.

## Impact

- Fixes ONNX export for all RF-DETR variants (detection and segmentation,
  all sizes) on PyTorch 2.9+
- No behavioral change at inference time
- Related: #406 (this removes one of several obstacles to `torch.export` compat)