### PR TITLE
fix: sync `class_names` from dataset after training so `predict()` returns correct labels

### DIFF
--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -330,10 +330,11 @@ class RFDETR:
         # Sync the trained weights back so predict() / export() see the updated model.
         self.model.model = module.model
         # Sync class names: prefer explicit config.class_names, otherwise fall back to dataset (#509).
-        if config.class_names is not None:
-            self.model.class_names = config.class_names
+        config_class_names = getattr(config, "class_names", None)
+        if config_class_names is not None:
+            self.model.class_names = config_class_names
         else:
-            dataset_class_names = datamodule.class_names
+            dataset_class_names = getattr(datamodule, "class_names", None)
             if dataset_class_names is not None:
                 self.model.class_names = dataset_class_names
 

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -331,7 +331,7 @@ class RFDETR:
         self.model.model = module.model
         # Sync class names from the dataset so predict() returns the correct labels (#509).
         dataset_class_names = datamodule.class_names
-        if dataset_class_names:
+        if dataset_class_names is not None:
             self.model.class_names = dataset_class_names
 
     def optimize_for_inference(self, compile=True, batch_size=1, dtype=torch.float32):

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -329,6 +329,10 @@ class RFDETR:
 
         # Sync the trained weights back so predict() / export() see the updated model.
         self.model.model = module.model
+        # Sync class names from the dataset so predict() returns the correct labels (#509).
+        dataset_class_names = datamodule.class_names
+        if dataset_class_names:
+            self.model.class_names = dataset_class_names
 
     def optimize_for_inference(self, compile=True, batch_size=1, dtype=torch.float32):
         self.remove_optimized_model()

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -549,7 +549,7 @@ class RFDETR:
         Returns:
             dict: A dictionary mapping class IDs to class names. The keys are integers starting from
         """
-        if hasattr(self.model, "class_names") and self.model.class_names:
+        if hasattr(self.model, "class_names") and self.model.class_names is not None:
             return {i + 1: name for i, name in enumerate(self.model.class_names)}
 
         return COCO_CLASSES

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -329,10 +329,13 @@ class RFDETR:
 
         # Sync the trained weights back so predict() / export() see the updated model.
         self.model.model = module.model
-        # Sync class names from the dataset so predict() returns the correct labels (#509).
-        dataset_class_names = datamodule.class_names
-        if dataset_class_names is not None:
-            self.model.class_names = dataset_class_names
+        # Sync class names: prefer explicit config.class_names, otherwise fall back to dataset (#509).
+        if config.class_names is not None:
+            self.model.class_names = config.class_names
+        else:
+            dataset_class_names = datamodule.class_names
+            if dataset_class_names is not None:
+                self.model.class_names = dataset_class_names
 
     def optimize_for_inference(self, compile=True, batch_size=1, dtype=torch.float32):
         self.remove_optimized_model()

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -127,10 +127,20 @@ class BestModelCallback(ModelCheckpoint):
             _orig = getattr(pl_module.model, "_orig_mod", None)
             raw = _orig if isinstance(_orig, torch.nn.Module) else pl_module.model
             model_state_dict = raw.state_dict()
+        # Enrich train_config with dataset class names so reloaded checkpoints
+        # return the correct labels, not COCO defaults (#509).
+        train_config = pl_module.train_config
+        dataset_class_names = getattr(trainer.datamodule, "class_names", None)
+        if (
+            dataset_class_names
+            and hasattr(train_config, "model_copy")
+            and not getattr(train_config, "class_names", None)
+        ):
+            train_config = train_config.model_copy(update={"class_names": dataset_class_names})
         torch.save(
             {
                 "model": model_state_dict,
-                "args": pl_module.train_config,
+                "args": train_config,
                 "epoch": trainer.current_epoch,
             },
             pth_path,
@@ -162,10 +172,20 @@ class BestModelCallback(ModelCheckpoint):
             self._best_ema = ema_val
             self._output_dir.mkdir(parents=True, exist_ok=True)
             ema_state_dict = self._get_ema_model_state_dict(trainer, pl_module)
+            # Enrich train_config with dataset class names so reloaded checkpoints
+            # return the correct labels, not COCO defaults (#509).
+            ema_train_config = pl_module.train_config
+            dataset_class_names = getattr(trainer.datamodule, "class_names", None)
+            if (
+                dataset_class_names
+                and hasattr(ema_train_config, "model_copy")
+                and not getattr(ema_train_config, "class_names", None)
+            ):
+                ema_train_config = ema_train_config.model_copy(update={"class_names": dataset_class_names})
             torch.save(
                 {
                     "model": ema_state_dict,
-                    "args": pl_module.train_config,
+                    "args": ema_train_config,
                     "epoch": trainer.current_epoch,
                 },
                 self._output_dir / "checkpoint_best_ema.pth",

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -134,7 +134,7 @@ class BestModelCallback(ModelCheckpoint):
         if (
             dataset_class_names is not None
             and hasattr(train_config, "model_copy")
-            and not getattr(train_config, "class_names", None)
+            and getattr(train_config, "class_names", None) is None
         ):
             train_config = train_config.model_copy(update={"class_names": dataset_class_names})
         torch.save(
@@ -179,7 +179,7 @@ class BestModelCallback(ModelCheckpoint):
             if (
                 dataset_class_names is not None
                 and hasattr(ema_train_config, "model_copy")
-                and not getattr(ema_train_config, "class_names", None)
+                and getattr(ema_train_config, "class_names", None) is None
             ):
                 ema_train_config = ema_train_config.model_copy(update={"class_names": dataset_class_names})
             torch.save(

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -132,7 +132,7 @@ class BestModelCallback(ModelCheckpoint):
         train_config = pl_module.train_config
         dataset_class_names = getattr(trainer.datamodule, "class_names", None)
         if (
-            dataset_class_names
+            dataset_class_names is not None
             and hasattr(train_config, "model_copy")
             and not getattr(train_config, "class_names", None)
         ):
@@ -177,7 +177,7 @@ class BestModelCallback(ModelCheckpoint):
             ema_train_config = pl_module.train_config
             dataset_class_names = getattr(trainer.datamodule, "class_names", None)
             if (
-                dataset_class_names
+                dataset_class_names is not None
                 and hasattr(ema_train_config, "model_copy")
                 and not getattr(ema_train_config, "class_names", None)
             ):

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -322,6 +322,88 @@ class TestBestModelCallback:
 
         trainer.test.assert_not_called()
 
+    def test_checkpoint_class_names_populated_from_datamodule(self, tmp_path: Path) -> None:
+        """Saved checkpoint args.class_names reflects dataset class names.
+
+        Regression test for #509: checkpoints were saved with class_names=None
+        when the user did not pass class_names explicitly, causing reloaded-model
+        inference to fall through to COCO labels instead of dataset labels.
+        """
+        from rfdetr.config import TrainConfig
+
+        cb = BestModelCallback(output_dir=str(tmp_path))
+        custom_names = ["cat", "dog"]
+        trainer = _make_trainer({"val/mAP_50_95": 0.5})
+        trainer.datamodule.class_names = custom_names
+
+        pl_module = _make_pl_module()
+        # Real TrainConfig with class_names unset — the bug scenario.
+        pl_module.train_config = TrainConfig(dataset_dir=str(tmp_path / "ds"), tensorboard=False)
+
+        cb.on_validation_end(trainer, pl_module)
+
+        checkpoint = torch.load(
+            tmp_path / "checkpoint_best_regular.pth",
+            map_location="cpu",
+            weights_only=False,
+        )
+        assert checkpoint["args"].class_names == custom_names
+
+    def test_ema_checkpoint_class_names_populated_from_datamodule(self, tmp_path: Path) -> None:
+        """EMA checkpoint args.class_names also reflects dataset class names.
+
+        Regression test for #509: EMA checkpoint path was not enriched with
+        class names, so EMA-selected runs would still return COCO labels after reload.
+        """
+        from rfdetr.config import TrainConfig
+
+        cb = BestModelCallback(
+            output_dir=str(tmp_path),
+            monitor_ema="val/ema_mAP_50_95",
+        )
+        custom_names = ["cat", "dog"]
+        trainer = _make_trainer({"val/mAP_50_95": 0.4, "val/ema_mAP_50_95": 0.6})
+        trainer.datamodule.class_names = custom_names
+
+        pl_module = _make_pl_module()
+        pl_module.train_config = TrainConfig(dataset_dir=str(tmp_path / "ds"), tensorboard=False)
+
+        cb.on_validation_end(trainer, pl_module)
+
+        checkpoint = torch.load(
+            tmp_path / "checkpoint_best_ema.pth",
+            map_location="cpu",
+            weights_only=False,
+        )
+        assert checkpoint["args"].class_names == custom_names
+
+    def test_checkpoint_class_names_not_overwritten_when_already_set(self, tmp_path: Path) -> None:
+        """Explicitly-set class_names in TrainConfig are preserved in the checkpoint.
+
+        When the user passes class_names=['defect'] to TrainConfig, the saved
+        checkpoint must keep that value even if the datamodule reports different names.
+        """
+        from rfdetr.config import TrainConfig
+
+        cb = BestModelCallback(output_dir=str(tmp_path))
+        trainer = _make_trainer({"val/mAP_50_95": 0.5})
+        trainer.datamodule.class_names = ["other_class"]  # would overwrite if bug exists
+
+        pl_module = _make_pl_module()
+        explicit_names = ["defect"]
+        pl_module.train_config = TrainConfig(
+            dataset_dir=str(tmp_path / "ds"), tensorboard=False, class_names=explicit_names
+        )
+
+        cb.on_validation_end(trainer, pl_module)
+
+        checkpoint = torch.load(
+            tmp_path / "checkpoint_best_regular.pth",
+            map_location="cpu",
+            weights_only=False,
+        )
+        assert checkpoint["args"].class_names == explicit_names
+
     def test_not_global_zero_does_not_save(self, tmp_path: Path) -> None:
         """Non-main process (is_global_zero=False) must not write any files."""
         cb = BestModelCallback(

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -418,9 +418,7 @@ class TestBestModelCallback:
         trainer.datamodule.class_names = ["cat", "dog"]  # would overwrite if bug exists
 
         pl_module = _make_pl_module()
-        pl_module.train_config = TrainConfig(
-            dataset_dir=str(tmp_path / "ds"), tensorboard=False, class_names=[]
-        )
+        pl_module.train_config = TrainConfig(dataset_dir=str(tmp_path / "ds"), tensorboard=False, class_names=[])
 
         cb.on_validation_end(trainer, pl_module)
 
@@ -433,9 +431,7 @@ class TestBestModelCallback:
             "Explicit class_names=[] in TrainConfig must not be overwritten by datamodule names"
         )
 
-    def test_ema_checkpoint_explicit_empty_class_names_not_overwritten_by_datamodule(
-        self, tmp_path: Path
-    ) -> None:
+    def test_ema_checkpoint_explicit_empty_class_names_not_overwritten_by_datamodule(self, tmp_path: Path) -> None:
         """EMA path: TrainConfig(class_names=[]) is preserved even when datamodule has non-empty names.
 
         Mirrors the regular checkpoint guard-bypass regression test for the EMA path.
@@ -450,9 +446,7 @@ class TestBestModelCallback:
         trainer.datamodule.class_names = ["cat", "dog"]  # would overwrite if bug exists
 
         pl_module = _make_pl_module()
-        pl_module.train_config = TrainConfig(
-            dataset_dir=str(tmp_path / "ds"), tensorboard=False, class_names=[]
-        )
+        pl_module.train_config = TrainConfig(dataset_dir=str(tmp_path / "ds"), tensorboard=False, class_names=[])
 
         cb.on_validation_end(trainer, pl_module)
 

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -404,6 +404,67 @@ class TestBestModelCallback:
         )
         assert checkpoint["args"].class_names == explicit_names
 
+    def test_checkpoint_explicit_empty_class_names_not_overwritten_by_datamodule(self, tmp_path: Path) -> None:
+        """TrainConfig(class_names=[]) is preserved even when datamodule has non-empty names.
+
+        Guard-bypass regression: the truthiness check `not getattr(..., "class_names", None)`
+        treated an explicit empty list the same as None (both falsy), silently overwriting
+        the user's intent with the datamodule's names. The fix uses `is None` identity.
+        """
+        from rfdetr.config import TrainConfig
+
+        cb = BestModelCallback(output_dir=str(tmp_path))
+        trainer = _make_trainer({"val/mAP_50_95": 0.5})
+        trainer.datamodule.class_names = ["cat", "dog"]  # would overwrite if bug exists
+
+        pl_module = _make_pl_module()
+        pl_module.train_config = TrainConfig(
+            dataset_dir=str(tmp_path / "ds"), tensorboard=False, class_names=[]
+        )
+
+        cb.on_validation_end(trainer, pl_module)
+
+        checkpoint = torch.load(
+            tmp_path / "checkpoint_best_regular.pth",
+            map_location="cpu",
+            weights_only=False,
+        )
+        assert checkpoint["args"].class_names == [], (
+            "Explicit class_names=[] in TrainConfig must not be overwritten by datamodule names"
+        )
+
+    def test_ema_checkpoint_explicit_empty_class_names_not_overwritten_by_datamodule(
+        self, tmp_path: Path
+    ) -> None:
+        """EMA path: TrainConfig(class_names=[]) is preserved even when datamodule has non-empty names.
+
+        Mirrors the regular checkpoint guard-bypass regression test for the EMA path.
+        """
+        from rfdetr.config import TrainConfig
+
+        cb = BestModelCallback(
+            output_dir=str(tmp_path),
+            monitor_ema="val/ema_mAP_50_95",
+        )
+        trainer = _make_trainer({"val/mAP_50_95": 0.4, "val/ema_mAP_50_95": 0.6})
+        trainer.datamodule.class_names = ["cat", "dog"]  # would overwrite if bug exists
+
+        pl_module = _make_pl_module()
+        pl_module.train_config = TrainConfig(
+            dataset_dir=str(tmp_path / "ds"), tensorboard=False, class_names=[]
+        )
+
+        cb.on_validation_end(trainer, pl_module)
+
+        checkpoint = torch.load(
+            tmp_path / "checkpoint_best_ema.pth",
+            map_location="cpu",
+            weights_only=False,
+        )
+        assert checkpoint["args"].class_names == [], (
+            "Explicit class_names=[] in TrainConfig must not be overwritten by datamodule names (EMA path)"
+        )
+
     def test_checkpoint_empty_class_names_populated_from_datamodule(self, tmp_path: Path) -> None:
         """Checkpoint preserves explicitly-empty dataset class names.
 

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -404,6 +404,52 @@ class TestBestModelCallback:
         )
         assert checkpoint["args"].class_names == explicit_names
 
+    def test_checkpoint_empty_class_names_populated_from_datamodule(self, tmp_path: Path) -> None:
+        """Checkpoint preserves explicitly-empty dataset class names.
+
+        Empty list should be treated as a provided value, not as missing.
+        """
+        from rfdetr.config import TrainConfig
+
+        cb = BestModelCallback(output_dir=str(tmp_path))
+        trainer = _make_trainer({"val/mAP_50_95": 0.5})
+        trainer.datamodule.class_names = []
+
+        pl_module = _make_pl_module()
+        pl_module.train_config = TrainConfig(dataset_dir=str(tmp_path / "ds"), tensorboard=False)
+
+        cb.on_validation_end(trainer, pl_module)
+
+        checkpoint = torch.load(
+            tmp_path / "checkpoint_best_regular.pth",
+            map_location="cpu",
+            weights_only=False,
+        )
+        assert checkpoint["args"].class_names == []
+
+    def test_ema_checkpoint_empty_class_names_populated_from_datamodule(self, tmp_path: Path) -> None:
+        """EMA checkpoint preserves explicitly-empty dataset class names."""
+        from rfdetr.config import TrainConfig
+
+        cb = BestModelCallback(
+            output_dir=str(tmp_path),
+            monitor_ema="val/ema_mAP_50_95",
+        )
+        trainer = _make_trainer({"val/mAP_50_95": 0.4, "val/ema_mAP_50_95": 0.6})
+        trainer.datamodule.class_names = []
+
+        pl_module = _make_pl_module()
+        pl_module.train_config = TrainConfig(dataset_dir=str(tmp_path / "ds"), tensorboard=False)
+
+        cb.on_validation_end(trainer, pl_module)
+
+        checkpoint = torch.load(
+            tmp_path / "checkpoint_best_ema.pth",
+            map_location="cpu",
+            weights_only=False,
+        )
+        assert checkpoint["args"].class_names == []
+
     def test_not_global_zero_does_not_save(self, tmp_path: Path) -> None:
         """Non-main process (is_global_zero=False) must not write any files."""
         cb = BestModelCallback(

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -837,3 +837,49 @@ class TestLoadPretrainWeightsInto:
 
         with pytest.raises(ValueError, match=r"patch_size"):
             _load_pretrain_weights_into(fake_model, args)
+
+
+# ---------------------------------------------------------------------------
+# 7. RFDETR.class_names property — empty-list identity check
+# ---------------------------------------------------------------------------
+
+
+class TestClassNamesProperty:
+    """RFDETR.class_names property uses is-None identity, not truthiness, for empty lists."""
+
+    def test_empty_class_names_returns_empty_dict_not_coco(self):
+        """class_names property returns {} when model.class_names is [], NOT COCO_CLASSES.
+
+        Regression test for #509: the truthiness check `and self.model.class_names:`
+        treated [] as falsy and fell through to return COCO_CLASSES, defeating the
+        detr.py sync-back even after training on a dataset that reports empty names.
+        The fix uses `is not None` so that [] is preserved as an empty mapping.
+        """
+        mock_self = MagicMock()
+        mock_self.model.class_names = []
+
+        result = RFDETR.class_names.fget(mock_self)
+
+        assert result == {}, (
+            "class_names=[] must return {} (empty dict), not COCO_CLASSES"
+        )
+
+    def test_none_class_names_returns_coco(self):
+        """class_names property falls back to COCO_CLASSES when model.class_names is None."""
+        from rfdetr.assets.coco_classes import COCO_CLASSES
+
+        mock_self = MagicMock()
+        mock_self.model.class_names = None
+
+        result = RFDETR.class_names.fget(mock_self)
+
+        assert result is COCO_CLASSES
+
+    def test_custom_class_names_returned_as_one_indexed_dict(self):
+        """Non-empty class_names are returned as a 1-indexed dict."""
+        mock_self = MagicMock()
+        mock_self.model.class_names = ["cat", "dog"]
+
+        result = RFDETR.class_names.fget(mock_self)
+
+        assert result == {1: "cat", 2: "dog"}

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -860,9 +860,7 @@ class TestClassNamesProperty:
 
         result = RFDETR.class_names.fget(mock_self)
 
-        assert result == {}, (
-            "class_names=[] must return {} (empty dict), not COCO_CLASSES"
-        )
+        assert result == {}, "class_names=[] must return {} (empty dict), not COCO_CLASSES"
 
     def test_none_class_names_returns_coco(self):
         """class_names property falls back to COCO_CLASSES when model.class_names is None."""

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -199,6 +199,22 @@ class TestRFDETRTrainPTL:
 
         assert mock_self.model.class_names == sentinel_names
 
+    def test_empty_class_names_synced_from_datamodule_after_training(self, tmp_path):
+        """Empty class name lists are synced and overwrite stale model labels.
+
+        Empty list is a valid explicit value and should not be treated as missing.
+        """
+        mock_self = _make_rfdetr_self(tmp_path)
+        sentinel_names = ["stale_label"]
+        mock_self.model.class_names = sentinel_names
+        p_mod, p_dm, p_bt, _mcls, dmcls, _mock_bt = _patch_lit()
+        dmcls.return_value.class_names = []
+
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self)
+
+        assert mock_self.model.class_names == []
+
     def test_device_kwarg_silently_dropped(self, tmp_path):
         """device= is consumed without error or warning."""
         mock_self = _make_rfdetr_self(tmp_path)

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -165,6 +165,40 @@ class TestRFDETRTrainPTL:
             result = RFDETR.train(mock_self)
         assert result is None
 
+    def test_class_names_synced_from_datamodule_after_training(self, tmp_path):
+        """self.model.class_names is set from RFDETRDataModule.class_names after train().
+
+        Regression test for #509: custom class names were not synced back from
+        RFDETRDataModule after training, causing predict() to return COCO labels
+        instead of the dataset's class labels.
+        """
+        mock_self = _make_rfdetr_self(tmp_path)
+        p_mod, p_dm, p_bt, _mcls, dmcls, _mock_bt = _patch_lit()
+        custom_class_names = ["cat", "dog", "bird"]
+        dmcls.return_value.class_names = custom_class_names
+
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self)
+
+        assert mock_self.model.class_names == custom_class_names
+
+    def test_class_names_not_synced_when_datamodule_returns_none(self, tmp_path):
+        """self.model.class_names is NOT overwritten when datamodule.class_names is None.
+
+        Ensures the sync-back guard does not clobber existing class names
+        when the datamodule has no class information (e.g. custom dataset format).
+        """
+        mock_self = _make_rfdetr_self(tmp_path)
+        sentinel_names = ["existing_class"]
+        mock_self.model.class_names = sentinel_names
+        p_mod, p_dm, p_bt, _mcls, dmcls, _mock_bt = _patch_lit()
+        dmcls.return_value.class_names = None  # datamodule has no class names
+
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self)
+
+        assert mock_self.model.class_names == sentinel_names
+
     def test_device_kwarg_silently_dropped(self, tmp_path):
         """device= is consumed without error or warning."""
         mock_self = _make_rfdetr_self(tmp_path)


### PR DESCRIPTION

This pull request addresses a regression where custom dataset class names were not correctly propagated and preserved throughout the training, checkpointing, and inference process, causing models to default to COCO labels instead of dataset-specific labels. The changes ensure that class names are properly synced from the dataset, saved in checkpoints, and handled correctly during inference, including edge cases like empty lists and explicit user-provided values.

Class name synchronization and checkpoint enrichment:

* Ensured that `self.model.class_names` is synced from the dataset (`datamodule.class_names`) after training, so `predict()` returns the correct labels.
* Modified checkpoint saving logic in `BestModelCallback` to enrich the saved `TrainConfig` with dataset class names, preventing fallback to COCO defaults on reload. This includes both regular and EMA checkpoints, and preserves explicit user-provided values (including empty lists) without overwriting them. [[1]](diffhunk://#diff-f2dc71e7284ba0e8b92f7bfdace93fb82896f8be4de1c2a69ae9e3973bb6ccd4R130-R143) [[2]](diffhunk://#diff-f2dc71e7284ba0e8b92f7bfdace93fb82896f8be4de1c2a69ae9e3973bb6ccd4R175-R188)

Inference and property handling improvements:

* Updated the `class_names` property to distinguish between `None` (fall back to COCO labels) and empty lists (return empty dict), fixing the truthiness bug that treated empty lists as missing.

Testing and regression coverage:

* Added comprehensive tests to ensure checkpoint class names are correctly populated from the datamodule, preserved when explicitly set or empty, and not overwritten unintentionally. Tests cover both regular and EMA checkpoint paths.
* Added tests verifying correct syncing of class names after training and proper property behavior for empty lists, `None`, and custom values. [[1]](diffhunk://#diff-6b1d80c3cb1bad19362f3974e085ec0eec262356a56dfbac555707b8b0cc0cb8R168-R217) [[2]](diffhunk://#diff-6b1d80c3cb1bad19362f3974e085ec0eec262356a56dfbac555707b8b0cc0cb8R840-R885)

These changes collectively ensure robust handling of dataset class names, preventing accidental fallback to COCO labels and respecting explicit user intent.

--- 

closes #509