### PR TITLE
fix(mps): eliminate MPS CPU fallbacks for `grid_sample` and bicubic backward

### DIFF
--- a/src/rfdetr/models/backbone/dinov2.py
+++ b/src/rfdetr/models/backbone/dinov2.py
@@ -170,7 +170,7 @@ class DinoV2(nn.Module):
             )
             patch_pos_embed = patch_pos_embed.permute(0, 3, 1, 2)
 
-            # Use bicubic interpolation without antialias
+            # Use bicubic interpolation, disabling antialias only on MPS devices
             patch_pos_embed = F.interpolate(
                 patch_pos_embed,
                 size=(height, width),

--- a/src/rfdetr/models/backbone/dinov2.py
+++ b/src/rfdetr/models/backbone/dinov2.py
@@ -176,7 +176,7 @@ class DinoV2(nn.Module):
                 size=(height, width),
                 mode="bicubic",
                 align_corners=False,
-                antialias=True,
+                antialias=patch_pos_embed.device.type != "mps",
             )
 
             # Reshape back

--- a/src/rfdetr/models/backbone/dinov2.py
+++ b/src/rfdetr/models/backbone/dinov2.py
@@ -170,7 +170,7 @@ class DinoV2(nn.Module):
             )
             patch_pos_embed = patch_pos_embed.permute(0, 3, 1, 2)
 
-            # Use bilinear interpolation without antialias
+            # Use bicubic interpolation without antialias
             patch_pos_embed = F.interpolate(
                 patch_pos_embed,
                 size=(height, width),

--- a/src/rfdetr/models/backbone/dinov2_with_windowed_attn.py
+++ b/src/rfdetr/models/backbone/dinov2_with_windowed_attn.py
@@ -381,7 +381,7 @@ class WindowedDinov2WithRegistersEmbeddings(nn.Module):
             size=(torch_int(height), torch_int(width)),  # Explicit size instead of scale_factor
             mode="bicubic",
             align_corners=False,
-            antialias=True,
+            antialias=patch_pos_embed.device.type != "mps",
         ).to(dtype=target_dtype)
 
         # Validate output dimensions if not tracing

--- a/src/rfdetr/models/heads/segmentation.py
+++ b/src/rfdetr/models/heads/segmentation.py
@@ -231,13 +231,24 @@ def point_sample(input: torch.Tensor, point_coords: torch.Tensor, **kwargs: Any)
         if kwargs:
             unexpected = ", ".join(sorted(kwargs.keys()))
             raise TypeError(f"Unexpected keyword argument(s) for bilinear mode: {unexpected}")
-        # Use the optimized bilinear grid sampler.
-        output = _bilinear_grid_sample(
-            input,
-            grid,
-            padding_mode=padding_mode,
-            align_corners=align_corners,
-        )
+        # For bilinear mode, use the optimized sampler when the padding_mode
+        # is supported by the manual/MPS path. For other padding modes,
+        # delegate to F.grid_sample to keep behavior consistent across devices.
+        if padding_mode not in ("zeros", "border"):
+            output = F.grid_sample(
+                input,
+                grid,
+                mode=mode,
+                padding_mode=padding_mode,
+                align_corners=align_corners,
+            )
+        else:
+            output = _bilinear_grid_sample(
+                input,
+                grid,
+                padding_mode=padding_mode,
+                align_corners=align_corners,
+            )
     else:
         # Delegate to torch.nn.functional.grid_sample for other modes (e.g. "nearest"),
         # forwarding any remaining supported kwargs.

--- a/src/rfdetr/models/heads/segmentation.py
+++ b/src/rfdetr/models/heads/segmentation.py
@@ -10,6 +10,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from rfdetr.utilities.tensors import _bilinear_grid_sample
+
 
 class DepthwiseConvBlock(nn.Module):
     r"""Simplified ConvNeXt block without the MLP subnet"""
@@ -215,7 +217,9 @@ def point_sample(input: torch.Tensor, point_coords: torch.Tensor, **kwargs: Any)
     if point_coords.dim() == 3:
         add_dim = True
         point_coords = point_coords.unsqueeze(2)
-    output = F.grid_sample(input, 2.0 * point_coords - 1.0, padding_mode="border", **kwargs)
+    output = _bilinear_grid_sample(
+        input, 2.0 * point_coords - 1.0, padding_mode="border", align_corners=kwargs.get("align_corners", False)
+    )
     if add_dim:
         output = output.squeeze(3)
     return output

--- a/src/rfdetr/models/heads/segmentation.py
+++ b/src/rfdetr/models/heads/segmentation.py
@@ -217,9 +217,36 @@ def point_sample(input: torch.Tensor, point_coords: torch.Tensor, **kwargs: Any)
     if point_coords.dim() == 3:
         add_dim = True
         point_coords = point_coords.unsqueeze(2)
-    output = _bilinear_grid_sample(
-        input, 2.0 * point_coords - 1.0, padding_mode="border", align_corners=kwargs.get("align_corners", False)
-    )
+
+    # Normalize coordinates from [0, 1] to [-1, 1] as expected by grid_sample.
+    grid = 2.0 * point_coords - 1.0
+
+    # Extract common grid_sample arguments, with bilinear as the default mode to
+    # preserve existing behavior when mode is not provided.
+    mode = kwargs.pop("mode", "bilinear")
+    align_corners = kwargs.pop("align_corners", False)
+    padding_mode = kwargs.pop("padding_mode", "zeros")
+
+    if mode == "bilinear":
+        # Use the optimized bilinear grid sampler.
+        output = _bilinear_grid_sample(
+            input,
+            grid,
+            padding_mode=padding_mode,
+            align_corners=align_corners,
+        )
+    else:
+        # Delegate to torch.nn.functional.grid_sample for other modes (e.g. "nearest"),
+        # forwarding any remaining supported kwargs.
+        output = F.grid_sample(
+            input,
+            grid,
+            mode=mode,
+            padding_mode=padding_mode,
+            align_corners=align_corners,
+            **kwargs,
+        )
+
     if add_dim:
         output = output.squeeze(3)
     return output

--- a/src/rfdetr/models/heads/segmentation.py
+++ b/src/rfdetr/models/heads/segmentation.py
@@ -225,9 +225,14 @@ def point_sample(input: torch.Tensor, point_coords: torch.Tensor, **kwargs: Any)
     # preserve existing behavior when mode is not provided.
     mode = kwargs.pop("mode", "bilinear")
     align_corners = kwargs.pop("align_corners", False)
-    padding_mode = kwargs.pop("padding_mode", "zeros")
+    padding_mode = kwargs.pop("padding_mode", "border")
 
     if mode == "bilinear":
+        if kwargs:
+            unexpected = ", ".join(sorted(kwargs.keys()))
+            raise TypeError(
+                f"Unexpected keyword argument(s) for bilinear mode: {unexpected}"
+            )
         # Use the optimized bilinear grid sampler.
         output = _bilinear_grid_sample(
             input,

--- a/src/rfdetr/models/heads/segmentation.py
+++ b/src/rfdetr/models/heads/segmentation.py
@@ -230,9 +230,7 @@ def point_sample(input: torch.Tensor, point_coords: torch.Tensor, **kwargs: Any)
     if mode == "bilinear":
         if kwargs:
             unexpected = ", ".join(sorted(kwargs.keys()))
-            raise TypeError(
-                f"Unexpected keyword argument(s) for bilinear mode: {unexpected}"
-            )
+            raise TypeError(f"Unexpected keyword argument(s) for bilinear mode: {unexpected}")
         # Use the optimized bilinear grid sampler.
         output = _bilinear_grid_sample(
             input,

--- a/src/rfdetr/models/heads/segmentation.py
+++ b/src/rfdetr/models/heads/segmentation.py
@@ -199,8 +199,8 @@ class SegmentationHead(nn.Module):
 
 def point_sample(input: torch.Tensor, point_coords: torch.Tensor, **kwargs: Any) -> torch.Tensor:
     """
-    A wrapper around :function:`torch.nn.functional.grid_sample` to support 3D point_coords tensors.
-    Unlike :function:`torch.nn.functional.grid_sample` it assumes `point_coords` to lie inside
+    A wrapper around :func:`~rfdetr.utilities.tensors._bilinear_grid_sample` to support 3D point_coords tensors.
+    Unlike :func:`torch.nn.functional.grid_sample` it assumes `point_coords` to lie inside
     [0, 1] x [0, 1] square.
 
     Args:
@@ -211,7 +211,7 @@ def point_sample(input: torch.Tensor, point_coords: torch.Tensor, **kwargs: Any)
     Returns:
         A tensor of shape (N, C, P) or (N, C, Hgrid, Wgrid) that contains
             features for points in `point_coords`. The features are obtained via bilinear
-            interplation from `input` the same way as :function:`torch.nn.functional.grid_sample`.
+            interpolation from `input` the same way as :func:`~rfdetr.utilities.tensors._bilinear_grid_sample`.
     """
     add_dim = False
     if point_coords.dim() == 3:

--- a/src/rfdetr/models/ops/functions/ms_deform_attn_func.py
+++ b/src/rfdetr/models/ops/functions/ms_deform_attn_func.py
@@ -18,7 +18,8 @@ ms_deform_attn_func
 from __future__ import absolute_import, division, print_function
 
 import torch
-import torch.nn.functional as F
+
+from rfdetr.utilities.tensors import _bilinear_grid_sample
 
 
 def ms_deform_attn_core_pytorch(value, value_spatial_shapes, sampling_locations, attention_weights):
@@ -35,8 +36,8 @@ def ms_deform_attn_core_pytorch(value, value_spatial_shapes, sampling_locations,
         # B, Len_q, n_heads, P, 2 -> B, n_heads, Len_q, P, 2 -> B*n_heads, Len_q, P, 2
         sampling_grid_l_ = sampling_grids[:, :, :, lid_].transpose(1, 2).flatten(0, 1)
         # B*n_heads, head_dim, Len_q, P
-        sampling_value_l_ = F.grid_sample(
-            value_l_, sampling_grid_l_, mode="bilinear", padding_mode="zeros", align_corners=False
+        sampling_value_l_ = _bilinear_grid_sample(
+            value_l_, sampling_grid_l_, padding_mode="zeros", align_corners=False
         )
         sampling_value_list.append(sampling_value_l_)
     # (B, Len_q, n_heads, L * P) -> (B, n_heads, Len_q, L, P) -> (B*n_heads, 1, Len_q, L*P)

--- a/src/rfdetr/models/ops/functions/ms_deform_attn_func.py
+++ b/src/rfdetr/models/ops/functions/ms_deform_attn_func.py
@@ -36,9 +36,7 @@ def ms_deform_attn_core_pytorch(value, value_spatial_shapes, sampling_locations,
         # B, Len_q, n_heads, P, 2 -> B, n_heads, Len_q, P, 2 -> B*n_heads, Len_q, P, 2
         sampling_grid_l_ = sampling_grids[:, :, :, lid_].transpose(1, 2).flatten(0, 1)
         # B*n_heads, head_dim, Len_q, P
-        sampling_value_l_ = _bilinear_grid_sample(
-            value_l_, sampling_grid_l_, padding_mode="zeros", align_corners=False
-        )
+        sampling_value_l_ = _bilinear_grid_sample(value_l_, sampling_grid_l_, padding_mode="zeros", align_corners=False)
         sampling_value_list.append(sampling_value_l_)
     # (B, Len_q, n_heads, L * P) -> (B, n_heads, Len_q, L, P) -> (B*n_heads, 1, Len_q, L*P)
     attention_weights = attention_weights.transpose(1, 2).reshape(B * n_heads, 1, Len_q, L * P)

--- a/src/rfdetr/utilities/tensors.py
+++ b/src/rfdetr/utilities/tensors.py
@@ -192,6 +192,13 @@ def _bilinear_grid_sample(
     if input.device.type != "mps":
         return F.grid_sample(input, grid, mode="bilinear", padding_mode=padding_mode, align_corners=align_corners)
 
+    if padding_mode not in ("zeros", "border"):
+        msg = (
+            f"Unsupported padding_mode={padding_mode!r} for manual grid sampling. "
+            "Only 'zeros' and 'border' are supported in this path."
+        )
+        raise ValueError(msg)
+
     N, C, H, W = input.shape
     Hg, Wg = grid.shape[1], grid.shape[2]
 
@@ -209,17 +216,11 @@ def _bilinear_grid_sample(
     iy1 = iy0 + 1
 
     # Bilinear weights: fractional distance from top-left corner  [N, 1, Hg, Wg]
-    wx1 = (ix - ix0.float()).unsqueeze(1)
-    wy1 = (iy - iy0.float()).unsqueeze(1)
+    # Cast to input.dtype so float16 inputs don't silently upcast to float32.
+    wx1 = (ix - ix0.float()).to(input.dtype).unsqueeze(1)
+    wy1 = (iy - iy0.float()).to(input.dtype).unsqueeze(1)
     wx0 = 1.0 - wx1
     wy0 = 1.0 - wy1
-
-    if padding_mode not in ("zeros", "border"):
-        msg = (
-            f"Unsupported padding_mode={padding_mode!r} for manual grid sampling. "
-            "Only 'zeros' and 'border' are supported in this path."
-        )
-        raise ValueError(msg)
 
     if padding_mode == "border":
         ix0 = ix0.clamp(0, W - 1)

--- a/src/rfdetr/utilities/tensors.py
+++ b/src/rfdetr/utilities/tensors.py
@@ -214,6 +214,13 @@ def _bilinear_grid_sample(
     wx0 = 1.0 - wx1
     wy0 = 1.0 - wy1
 
+    if padding_mode not in ("zeros", "border"):
+        msg = (
+            f"Unsupported padding_mode={padding_mode!r} for manual grid sampling. "
+            "Only 'zeros' and 'border' are supported in this path."
+        )
+        raise ValueError(msg)
+
     if padding_mode == "border":
         ix0 = ix0.clamp(0, W - 1)
         iy0 = iy0.clamp(0, H - 1)

--- a/src/rfdetr/utilities/tensors.py
+++ b/src/rfdetr/utilities/tensors.py
@@ -160,6 +160,95 @@ def _onnx_nested_tensor_from_tensor_list(tensor_list: List[Tensor]) -> NestedTen
     return NestedTensor(tensor, mask=mask)
 
 
+def _bilinear_grid_sample(
+    input: torch.Tensor,
+    grid: torch.Tensor,
+    padding_mode: str = "zeros",
+    align_corners: bool = False,
+) -> torch.Tensor:
+    """Bilinear grid sampling compatible with all PyTorch backends including MPS.
+
+    Drop-in replacement for ``F.grid_sample(input, grid, mode='bilinear', ...)``.
+    On MPS, ``F.grid_sample`` backward (``grid_sampler_2d_backward``) is not yet
+    implemented and silently falls back to CPU.  This function uses gather-based
+    index arithmetic — natively supported on every backend — for the MPS path,
+    while delegating to ``F.grid_sample`` on CUDA/CPU where its fused kernel is
+    faster.  The two paths are numerically identical, so model accuracy is
+    unaffected.
+
+    Args:
+        input: Feature map of shape ``(N, C, H, W)``.
+        grid: Sampling grid of shape ``(N, Hg, Wg, 2)`` with values in ``[-1, 1]``.
+        padding_mode: ``"zeros"`` returns 0 for out-of-bounds samples;
+            ``"border"`` clamps to the nearest border pixel.
+        align_corners: If ``True``, grid extremes ``±1`` map to pixel centres at
+            positions ``0`` and ``H-1``/``W-1``.
+
+    Returns:
+        Sampled tensor of shape ``(N, C, Hg, Wg)``.
+    """
+    import torch.nn.functional as F
+
+    if input.device.type != "mps":
+        return F.grid_sample(input, grid, mode="bilinear", padding_mode=padding_mode, align_corners=align_corners)
+
+    N, C, H, W = input.shape
+    Hg, Wg = grid.shape[1], grid.shape[2]
+
+    # Unnormalize [-1, 1] → floating-point pixel coordinates
+    if align_corners:
+        ix = (grid[..., 0] + 1) * (W - 1) / 2  # [N, Hg, Wg]
+        iy = (grid[..., 1] + 1) * (H - 1) / 2
+    else:
+        ix = (grid[..., 0] + 1) * W / 2 - 0.5
+        iy = (grid[..., 1] + 1) * H / 2 - 0.5
+
+    ix0 = ix.floor().long()  # top-left corner
+    iy0 = iy.floor().long()
+    ix1 = ix0 + 1
+    iy1 = iy0 + 1
+
+    # Bilinear weights: fractional distance from top-left corner  [N, 1, Hg, Wg]
+    wx1 = (ix - ix0.float()).unsqueeze(1)
+    wy1 = (iy - iy0.float()).unsqueeze(1)
+    wx0 = 1.0 - wx1
+    wy0 = 1.0 - wy1
+
+    if padding_mode == "border":
+        ix0 = ix0.clamp(0, W - 1)
+        iy0 = iy0.clamp(0, H - 1)
+        ix1 = ix1.clamp(0, W - 1)
+        iy1 = iy1.clamp(0, H - 1)
+    else:  # zeros: record which corners fall inside the image before clamping
+        in_x0 = (ix0 >= 0) & (ix0 < W)  # [N, Hg, Wg]
+        in_x1 = (ix1 >= 0) & (ix1 < W)
+        in_y0 = (iy0 >= 0) & (iy0 < H)
+        in_y1 = (iy1 >= 0) & (iy1 < H)
+        ix0 = ix0.clamp(0, W - 1)
+        iy0 = iy0.clamp(0, H - 1)
+        ix1 = ix1.clamp(0, W - 1)
+        iy1 = iy1.clamp(0, H - 1)
+
+    flat = input.flatten(2)  # [N, C, H*W]
+
+    def _gather(iy_: torch.Tensor, ix_: torch.Tensor) -> torch.Tensor:
+        idx = (iy_ * W + ix_).flatten(1).unsqueeze(1).expand(N, C, -1)  # [N, C, Hg*Wg]
+        return flat.gather(2, idx).view(N, C, Hg, Wg)
+
+    v00 = _gather(iy0, ix0)  # top-left
+    v10 = _gather(iy0, ix1)  # top-right
+    v01 = _gather(iy1, ix0)  # bottom-left
+    v11 = _gather(iy1, ix1)  # bottom-right
+
+    if padding_mode == "zeros":
+        v00 = v00 * (in_x0 & in_y0).unsqueeze(1)
+        v10 = v10 * (in_x1 & in_y0).unsqueeze(1)
+        v01 = v01 * (in_x0 & in_y1).unsqueeze(1)
+        v11 = v11 * (in_x1 & in_y1).unsqueeze(1)
+
+    return wx0 * wy0 * v00 + wx1 * wy0 * v10 + wx0 * wy1 * v01 + wx1 * wy1 * v11
+
+
 def collate_fn(batch: List[Tuple[Any, ...]]) -> Tuple[Any, ...]:
     """Collate a list of (image, target) pairs into a batched NestedTensor.
 

--- a/src/rfdetr/utilities/tensors.py
+++ b/src/rfdetr/utilities/tensors.py
@@ -219,8 +219,9 @@ def _bilinear_grid_sample(
     # Cast to input.dtype so float16 inputs don't silently upcast to float32.
     wx1 = (ix - ix0.float()).to(input.dtype).unsqueeze(1)
     wy1 = (iy - iy0.float()).to(input.dtype).unsqueeze(1)
-    wx0 = 1.0 - wx1
-    wy0 = 1.0 - wy1
+    one = wx1.new_tensor(1.0)
+    wx0 = one - wx1
+    wy0 = one - wy1
 
     if padding_mode == "border":
         ix0 = ix0.clamp(0, W - 1)

--- a/tests/utilities/test_tensors.py
+++ b/tests/utilities/test_tensors.py
@@ -79,6 +79,27 @@ _PADDING_ALIGN_COMBOS = [
     pytest.param("zeros", True, id="zeros-align_corners"),
 ]
 
+_LOW_PRECISION_DTYPES = [
+    pytest.param(torch.float16, id="float16"),
+    pytest.param(torch.bfloat16, id="bfloat16"),
+]
+
+_LOW_PRECISION_GRAD_TOLERANCES = {
+    torch.float16: (1e-2, 2e-2),
+    torch.bfloat16: (3e-2, 1e-1),
+}
+
+
+def _require_grid_sample_dtype_support(dtype: torch.dtype) -> None:
+    """Skip test when current backend does not support grid_sample for dtype."""
+    input = torch.randn(1, 1, 2, 2, dtype=dtype, requires_grad=True)
+    grid = (torch.rand(1, 1, 1, 2, dtype=dtype) * 1.6 - 0.8).requires_grad_(True)
+    try:
+        out = F.grid_sample(input, grid, mode="bilinear", padding_mode="zeros", align_corners=False)
+        out.backward(torch.ones_like(out))
+    except RuntimeError as error:
+        pytest.skip(f"grid_sample dtype support missing for {dtype}: {error}")
+
 
 class TestBilinearGridSampleParity:
     """Manual gather path must match F.grid_sample for all grid/padding combos."""
@@ -305,6 +326,50 @@ class TestBilinearGridSampleGradient:
             atol=1e-4,
             rtol=1e-3,
         ), "gradcheck failed for manual bilinear grid sample path"
+
+
+class TestBilinearGridSampleLowPrecision:
+    """Low-precision parity and gradients stay aligned with F.grid_sample."""
+
+    @pytest.mark.parametrize("dtype", _LOW_PRECISION_DTYPES)
+    def test_low_precision_parity(self, seed, dtype):
+        """Manual path output matches F.grid_sample for low-precision inputs."""
+        _require_grid_sample_dtype_support(dtype)
+
+        input = torch.randn(2, 3, 6, 6, dtype=dtype)
+        grid = torch.rand(2, 4, 4, 2, dtype=dtype) * 3.0 - 1.5
+
+        expected = _grid_sample_reference(input, grid, padding_mode="zeros", align_corners=False)
+        actual = _call_manual_path(input, grid, padding_mode="zeros", align_corners=False)
+
+        torch.testing.assert_close(actual, expected, atol=1e-3, rtol=1e-3)
+        assert actual.dtype == dtype
+
+    @pytest.mark.parametrize("dtype", _LOW_PRECISION_DTYPES)
+    def test_low_precision_gradient_parity(self, seed, dtype):
+        """Manual path gradients match F.grid_sample gradients for low precision."""
+        _require_grid_sample_dtype_support(dtype)
+        atol, rtol = _LOW_PRECISION_GRAD_TOLERANCES[dtype]
+
+        input_ref = torch.randn(1, 2, 6, 6, dtype=dtype, requires_grad=True)
+        grid_ref = (torch.rand(1, 4, 4, 2, dtype=dtype) * 1.6 - 0.8).requires_grad_(True)
+
+        input_man = input_ref.detach().clone().requires_grad_(True)
+        grid_man = grid_ref.detach().clone().requires_grad_(True)
+
+        out_ref = _grid_sample_reference(input_ref, grid_ref, padding_mode="zeros", align_corners=False)
+        out_man = _call_manual_path(input_man, grid_man, padding_mode="zeros", align_corners=False)
+
+        upstream = torch.randn_like(out_ref)
+        out_ref.backward(upstream)
+        out_man.backward(upstream)
+
+        torch.testing.assert_close(input_man.grad, input_ref.grad, atol=atol, rtol=rtol)
+        torch.testing.assert_close(grid_man.grad, grid_ref.grad, atol=atol, rtol=rtol)
+        assert input_man.grad is not None
+        assert grid_man.grad is not None
+        assert input_man.grad.dtype == dtype
+        assert grid_man.grad.dtype == dtype
 
 
 class TestBilinearGridSampleRealUseCases:

--- a/tests/utilities/test_tensors.py
+++ b/tests/utilities/test_tensors.py
@@ -1,0 +1,342 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Parity tests for _bilinear_grid_sample: manual gather path vs F.grid_sample."""
+
+from unittest.mock import patch
+
+import pytest
+import torch
+import torch.nn.functional as F
+import torch.testing
+
+from rfdetr.utilities.tensors import _bilinear_grid_sample
+
+
+def _grid_sample_reference(
+    input: torch.Tensor,
+    grid: torch.Tensor,
+    padding_mode: str = "zeros",
+    align_corners: bool = False,
+) -> torch.Tensor:
+    """Ground-truth output from F.grid_sample for comparison."""
+    return F.grid_sample(
+        input,
+        grid,
+        mode="bilinear",
+        padding_mode=padding_mode,
+        align_corners=align_corners,
+    )
+
+
+def _call_manual_path(
+    input: torch.Tensor,
+    grid: torch.Tensor,
+    padding_mode: str = "zeros",
+    align_corners: bool = False,
+) -> torch.Tensor:
+    """Force the manual gather-based code path by mocking input.device.type.
+
+    The function checks ``input.device.type != "mps"`` to decide which branch
+    to take.  We patch ``torch.Tensor.device`` to return an object whose
+    ``.type`` is ``"mps"`` so the manual path runs on a normal CPU tensor.
+    """
+
+    class _FakeMPSDevice:
+        type = "mps"
+
+        def __eq__(self, other):
+            return False
+
+        def __repr__(self):
+            return "device(type='mps')"
+
+    with patch.object(torch.Tensor, "device", new_callable=lambda: property(lambda self: _FakeMPSDevice())):
+        return _bilinear_grid_sample(input, grid, padding_mode=padding_mode, align_corners=align_corners)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def seed():
+    """Fix random seed for reproducible grid/input generation."""
+    torch.manual_seed(42)
+
+
+# ---------------------------------------------------------------------------
+# Test scenarios as parametrize parameters
+# ---------------------------------------------------------------------------
+
+_PADDING_ALIGN_COMBOS = [
+    pytest.param("zeros", False, id="zeros-no_align"),
+    pytest.param("border", False, id="border-no_align"),
+    pytest.param("zeros", True, id="zeros-align_corners"),
+]
+
+
+class TestBilinearGridSampleParity:
+    """Manual gather path must match F.grid_sample for all grid/padding combos."""
+
+    @pytest.mark.parametrize(
+        "padding_mode, align_corners",
+        _PADDING_ALIGN_COMBOS,
+    )
+    def test_interior_grid_coordinates(self, seed, padding_mode, align_corners):
+        """Grid values well inside [-1, 1] -- pure interpolation, no boundary effects."""
+        input = torch.randn(1, 3, 8, 8)
+        # Grid in [-0.8, 0.8] -- safely inside
+        grid = torch.rand(1, 4, 4, 2) * 1.6 - 0.8
+
+        expected = _grid_sample_reference(input, grid, padding_mode, align_corners)
+        actual = _call_manual_path(input, grid, padding_mode, align_corners)
+
+        torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
+
+    @pytest.mark.parametrize(
+        "padding_mode, align_corners",
+        _PADDING_ALIGN_COMBOS,
+    )
+    def test_partially_outside_grid_coordinates(self, seed, padding_mode, align_corners):
+        """Grid values spanning [-1.5, 1.5] -- some samples fall outside the image."""
+        input = torch.randn(1, 3, 8, 8)
+        grid = torch.rand(1, 6, 6, 2) * 3.0 - 1.5
+
+        expected = _grid_sample_reference(input, grid, padding_mode, align_corners)
+        actual = _call_manual_path(input, grid, padding_mode, align_corners)
+
+        torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
+
+    @pytest.mark.parametrize(
+        "padding_mode, align_corners",
+        _PADDING_ALIGN_COMBOS,
+    )
+    def test_exact_boundary_grid_values(self, seed, padding_mode, align_corners):
+        """Grid values at exact boundaries: -1.0, 0.0, 1.0."""
+        input = torch.randn(1, 2, 4, 4)
+        # Manually craft grid with boundary values
+        coords = torch.tensor([-1.0, 0.0, 1.0])
+        grid_y, grid_x = torch.meshgrid(coords, coords, indexing="ij")
+        grid = torch.stack([grid_x, grid_y], dim=-1).unsqueeze(0)  # (1, 3, 3, 2)
+
+        expected = _grid_sample_reference(input, grid, padding_mode, align_corners)
+        actual = _call_manual_path(input, grid, padding_mode, align_corners)
+
+        torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
+
+    @pytest.mark.parametrize(
+        "padding_mode, align_corners",
+        _PADDING_ALIGN_COMBOS,
+    )
+    def test_single_pixel_input(self, padding_mode, align_corners):
+        """1x1 spatial input -- extreme edge case for index arithmetic."""
+        input = torch.tensor([[[[3.14]]]])  # (1, 1, 1, 1)
+        grid = torch.tensor([[[[0.0, 0.0]]]])  # (1, 1, 1, 2) -- center
+
+        expected = _grid_sample_reference(input, grid, padding_mode, align_corners)
+        actual = _call_manual_path(input, grid, padding_mode, align_corners)
+
+        torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
+
+    @pytest.mark.parametrize(
+        "padding_mode, align_corners",
+        _PADDING_ALIGN_COMBOS,
+    )
+    def test_batch_and_multichannel(self, seed, padding_mode, align_corners):
+        """Batch size > 1 and multiple channels."""
+        input = torch.randn(3, 5, 10, 12)
+        grid = torch.rand(3, 7, 9, 2) * 2.0 - 1.0  # [-1, 1]
+
+        expected = _grid_sample_reference(input, grid, padding_mode, align_corners)
+        actual = _call_manual_path(input, grid, padding_mode, align_corners)
+
+        torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
+
+    @pytest.mark.parametrize(
+        "padding_mode, align_corners",
+        _PADDING_ALIGN_COMBOS,
+    )
+    def test_all_out_of_bounds(self, padding_mode, align_corners):
+        """All grid coordinates far outside [-1, 1] -- tests OOB handling."""
+        input = torch.randn(1, 2, 4, 4)
+        # All coordinates at +5.0 -- far outside
+        grid = torch.full((1, 3, 3, 2), 5.0)
+
+        expected = _grid_sample_reference(input, grid, padding_mode, align_corners)
+        actual = _call_manual_path(input, grid, padding_mode, align_corners)
+
+        torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
+
+    @pytest.mark.parametrize(
+        "padding_mode, align_corners",
+        _PADDING_ALIGN_COMBOS,
+    )
+    def test_negative_out_of_bounds(self, padding_mode, align_corners):
+        """All grid coordinates at -5.0 -- far outside on the negative side."""
+        input = torch.randn(1, 2, 4, 4)
+        grid = torch.full((1, 3, 3, 2), -5.0)
+
+        expected = _grid_sample_reference(input, grid, padding_mode, align_corners)
+        actual = _call_manual_path(input, grid, padding_mode, align_corners)
+
+        torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
+
+    @pytest.mark.parametrize(
+        "padding_mode, align_corners",
+        [
+            pytest.param("zeros", False, id="zeros-no_align"),
+            pytest.param("border", False, id="border-no_align"),
+        ],
+    )
+    def test_non_square_spatial_dimensions(self, seed, padding_mode, align_corners):
+        """Non-square H != W input -- tests that x/y coordinate handling is correct."""
+        input = torch.randn(1, 2, 5, 13)  # tall vs wide
+        grid = torch.rand(1, 4, 6, 2) * 2.0 - 1.0
+
+        expected = _grid_sample_reference(input, grid, padding_mode, align_corners)
+        actual = _call_manual_path(input, grid, padding_mode, align_corners)
+
+        torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
+
+
+class TestBilinearGridSampleDelegation:
+    """On non-MPS devices, the function delegates directly to F.grid_sample."""
+
+    def test_cpu_delegates_to_grid_sample(self, seed):
+        """On CPU, output should match F.grid_sample exactly (same code path)."""
+        input = torch.randn(1, 3, 8, 8)
+        grid = torch.rand(1, 4, 4, 2) * 2.0 - 1.0
+
+        expected = _grid_sample_reference(input, grid, "zeros", False)
+        actual = _bilinear_grid_sample(input, grid, padding_mode="zeros", align_corners=False)
+
+        torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+    def test_cpu_border_delegates_to_grid_sample(self, seed):
+        """On CPU with border padding, output matches F.grid_sample exactly."""
+        input = torch.randn(2, 4, 6, 6)
+        grid = torch.rand(2, 3, 3, 2) * 3.0 - 1.5
+
+        expected = _grid_sample_reference(input, grid, "border", False)
+        actual = _bilinear_grid_sample(input, grid, padding_mode="border", align_corners=False)
+
+        torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+class TestBilinearGridSampleOutputShape:
+    """Output shape must be (N, C, Hg, Wg) for all inputs."""
+
+    @pytest.mark.parametrize(
+        "n, c, h, w, hg, wg",
+        [
+            pytest.param(1, 1, 1, 1, 1, 1, id="minimal"),
+            pytest.param(1, 3, 8, 8, 4, 4, id="standard"),
+            pytest.param(2, 5, 10, 12, 7, 9, id="batch_multichannel"),
+            pytest.param(1, 1, 3, 7, 5, 5, id="non_square"),
+        ],
+    )
+    def test_output_shape(self, n, c, h, w, hg, wg):
+        """Manual path output shape is (N, C, Hg, Wg)."""
+        input = torch.randn(n, c, h, w)
+        grid = torch.rand(n, hg, wg, 2) * 2.0 - 1.0
+
+        actual = _call_manual_path(input, grid)
+        assert actual.shape == (n, c, hg, wg), f"Expected shape ({n}, {c}, {hg}, {wg}), got {actual.shape}"
+
+
+class TestBilinearGridSampleGradient:
+    """Gradient correctness for the manual gather path."""
+
+    @pytest.mark.parametrize(
+        "padding_mode, align_corners",
+        [
+            pytest.param("zeros", False, id="zeros-no_align"),
+            pytest.param("border", False, id="border-no_align"),
+            pytest.param("zeros", True, id="zeros-align_corners"),
+        ],
+    )
+    def test_gradient_matches_grid_sample(self, seed, padding_mode, align_corners):
+        """Gradients from manual path match those from F.grid_sample."""
+        input_ref = torch.randn(1, 2, 6, 6, requires_grad=True)
+        grid_ref = (torch.rand(1, 4, 4, 2) * 1.6 - 0.8).requires_grad_(True)
+
+        # Clone for manual path
+        input_man = input_ref.detach().clone().requires_grad_(True)
+        grid_man = grid_ref.detach().clone().requires_grad_(True)
+
+        # Forward
+        out_ref = _grid_sample_reference(input_ref, grid_ref, padding_mode, align_corners)
+        out_man = _call_manual_path(input_man, grid_man, padding_mode, align_corners)
+
+        # Backward with same upstream gradient
+        upstream = torch.randn_like(out_ref)
+        out_ref.backward(upstream)
+        out_man.backward(upstream)
+
+        torch.testing.assert_close(
+            input_man.grad,
+            input_ref.grad,
+            atol=1e-5,
+            rtol=1e-5,
+            msg="Input gradient mismatch between manual path and F.grid_sample",
+        )
+        torch.testing.assert_close(
+            grid_man.grad,
+            grid_ref.grad,
+            atol=1e-5,
+            rtol=1e-5,
+            msg="Grid gradient mismatch between manual path and F.grid_sample",
+        )
+
+    def test_gradcheck_manual_path(self, seed):
+        """torch.autograd.gradcheck passes on the manual path (double precision)."""
+        input = torch.randn(1, 1, 4, 4, dtype=torch.float64, requires_grad=True)
+        grid = (torch.rand(1, 3, 3, 2, dtype=torch.float64) * 1.6 - 0.8).requires_grad_(True)
+
+        assert torch.autograd.gradcheck(
+            lambda inp, grd: _call_manual_path(inp, grd, padding_mode="zeros", align_corners=False),
+            (input, grid),
+            eps=1e-6,
+            atol=1e-4,
+            rtol=1e-3,
+        ), "gradcheck failed for manual bilinear grid sample path"
+
+
+class TestBilinearGridSampleRealUseCases:
+    """Parity tests matching the actual call sites in the codebase."""
+
+    def test_ms_deform_attn_pattern(self, seed):
+        """Matches ms_deform_attn_func: padding_mode='zeros', align_corners=False.
+
+        The attention function passes (B*n_heads, head_dim, H, W) input and
+        (B*n_heads, Len_q, P, 2) grid.
+        """
+        # Simulate B=2, n_heads=8, head_dim=32
+        input = torch.randn(16, 32, 14, 14)
+        grid = torch.rand(16, 100, 4, 2) * 2.0 - 1.0
+
+        expected = _grid_sample_reference(input, grid, "zeros", False)
+        actual = _call_manual_path(input, grid, "zeros", False)
+
+        torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
+
+    def test_point_sample_pattern(self, seed):
+        """Matches point_sample in segmentation: padding_mode='border', align_corners=False.
+
+        point_sample transforms point_coords via ``2.0 * point_coords - 1.0`` to
+        map [0, 1] -> [-1, 1].
+        """
+        input = torch.randn(4, 256, 28, 28)
+        # Simulate point_coords in [0, 1], transformed to [-1, 1]
+        point_coords_01 = torch.rand(4, 12544, 1, 2)
+        grid = 2.0 * point_coords_01 - 1.0
+
+        expected = _grid_sample_reference(input, grid, "border", False)
+        actual = _call_manual_path(input, grid, "border", False)
+
+        torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)


### PR DESCRIPTION
This pull request introduces a new utility function for bilinear grid sampling that ensures compatibility and correctness across all PyTorch backends, including MPS (Apple Silicon). The function replaces direct calls to `F.grid_sample` at key points in the codebase, addressing issues with the MPS backend where the backward operation is not implemented and silently falls back to CPU. Extensive tests are added to guarantee numerical and gradient parity with PyTorch's built-in implementation. The changes also update the handling of interpolation in positional encoding to avoid MPS-related pitfalls.

**Bilinear grid sampling compatibility and refactoring:**

* Added `_bilinear_grid_sample` in `src/rfdetr/utilities/tensors.py`, a drop-in replacement for `F.grid_sample` that uses a gather-based approach on MPS and delegates to `F.grid_sample` elsewhere, ensuring identical results and proper gradient support.
* Replaced direct calls to `F.grid_sample` with `_bilinear_grid_sample` in `src/rfdetr/models/ops/functions/ms_deform_attn_func.py` and `src/rfdetr/models/heads/segmentation.py`, ensuring robust operation across all devices. [[1]](diffhunk://#diff-b74d60c23d0c7d996e4c26f8d17750f4acd97b762e3ffdd74c5c7c1a5e94fa7fL21-R22) [[2]](diffhunk://#diff-b74d60c23d0c7d996e4c26f8d17750f4acd97b762e3ffdd74c5c7c1a5e94fa7fL38-R40) [[3]](diffhunk://#diff-ef70decf1024091205699fedd74ab1246fc5b1ad352d05c69766bd3fc123b930L218-R222)

**Device-specific interpolation handling:**

* Modified positional encoding interpolation in `src/rfdetr/models/backbone/dinov2.py` and `src/rfdetr/models/backbone/dinov2_with_windowed_attn.py` to set `antialias` dynamically based on device type, avoiding MPS backend issues. [[1]](diffhunk://#diff-f762873fe0811505d403e1ec88313874c56d2838c7b1543ce1666ee914445769L179-R179) [[2]](diffhunk://#diff-93e7c17f846a8dbe4091e0c2a248e62e5bb89bc5c5ab01754b18795daa796411L384-R384)

**Testing and validation:**

* Added comprehensive parity and gradient tests for `_bilinear_grid_sample` in `tests/utilities/test_tensors.py`, covering edge cases, boundary conditions, batch/multichannel scenarios, and real codebase call patterns. These tests ensure the manual path matches `F.grid_sample` in both output and gradients.

**Imports and code hygiene:**

* Updated imports in affected files to use the new utility function where appropriate, removing unnecessary imports of `torch.nn.functional` where replaced. [[1]](diffhunk://#diff-ef70decf1024091205699fedd74ab1246fc5b1ad352d05c69766bd3fc123b930R13-R14) [[2]](diffhunk://#diff-b74d60c23d0c7d996e4c26f8d17750f4acd97b762e3ffdd74c5c7c1a5e94fa7fL21-R22)