### PR TITLE
fix(datasets): silently drop degenerate `bboxes` before Alb. val

### DIFF
--- a/src/rfdetr/datasets/transforms.py
+++ b/src/rfdetr/datasets/transforms.py
@@ -529,8 +529,6 @@ class AlbumentationsWrapper:
                 # idxs carries original indices so downstream _filter_per_instance_fields
                 # can correctly slice fields from the un-filtered target.
                 idxs = [idxs[i] for i in valid_positions]
-                if masks_list is not None:
-                    masks_list = [masks_list[i] for i in valid_positions]
         # Apply transform
         transform_kwargs = {"image": image_np, "bboxes": boxes_np, "category_ids": labels, "idxs": idxs}
         if masks_list is not None and len(masks_list) > 0:

--- a/src/rfdetr/datasets/transforms.py
+++ b/src/rfdetr/datasets/transforms.py
@@ -516,6 +516,21 @@ class AlbumentationsWrapper:
                 raise ValueError(f"masks must have shape (N, H, W), got {masks_np.shape}")
             masks_np = masks_np.astype(np.uint8, copy=False)
             masks_list = [mask for mask in masks_np]
+        # Filter out degenerate boxes (zero-width or zero-height) before passing to
+        # Albumentations. Such boxes arise when an annotation sits exactly on or beyond
+        # the image boundary so that x_min == x_max (or y_min == y_max) after clipping.
+        # Albumentations' check_bboxes would raise ValueError for these inputs.
+        if num_boxes > 0:
+            valid_mask = (boxes_np[:, 2] > boxes_np[:, 0]) & (boxes_np[:, 3] > boxes_np[:, 1])
+            if not valid_mask.all():
+                valid_positions = np.where(valid_mask)[0].tolist()
+                boxes_np = boxes_np[valid_mask]
+                labels = [labels[i] for i in valid_positions]
+                # idxs carries original indices so downstream _filter_per_instance_fields
+                # can correctly slice fields from the un-filtered target.
+                idxs = [idxs[i] for i in valid_positions]
+                if masks_list is not None:
+                    masks_list = [masks_list[i] for i in valid_positions]
         # Apply transform
         transform_kwargs = {"image": image_np, "bboxes": boxes_np, "category_ids": labels, "idxs": idxs}
         if masks_list is not None and len(masks_list) > 0:

--- a/tests/datasets/test_augmentations.py
+++ b/tests/datasets/test_augmentations.py
@@ -565,7 +565,7 @@ class TestAlbumentationsWrapper:
             # box 2: y_min==y_max (bottom edge)
             "boxes": torch.tensor(
                 [
-                    [10.0, 20.0, 50.0, 60.0],   # valid — should survive
+                    [10.0, 20.0, 50.0, 60.0],  # valid — should survive
                     [100.0, 14.0, 100.0, 17.0],  # degenerate: x_min == x_max
                     [10.0, 100.0, 50.0, 100.0],  # degenerate: y_min == y_max
                 ]
@@ -579,9 +579,7 @@ class TestAlbumentationsWrapper:
 
         assert isinstance(aug_image, Image.Image)
         # Only the valid box survives
-        assert aug_target["boxes"].shape[0] == 1, (
-            f"Expected 1 valid box, got {aug_target['boxes'].shape[0]}"
-        )
+        assert aug_target["boxes"].shape[0] == 1, f"Expected 1 valid box, got {aug_target['boxes'].shape[0]}"
         assert aug_target["labels"].tolist() == [1]
         assert aug_target["area"].shape[0] == 1
 
@@ -599,7 +597,7 @@ class TestAlbumentationsWrapper:
         target = {
             "boxes": torch.tensor(
                 [
-                    [10.0, 20.0, 50.0, 60.0],   # valid
+                    [10.0, 20.0, 50.0, 60.0],  # valid
                     [100.0, 14.0, 100.0, 17.0],  # degenerate: x_min == x_max
                 ]
             ),

--- a/tests/datasets/test_augmentations.py
+++ b/tests/datasets/test_augmentations.py
@@ -546,6 +546,73 @@ class TestAlbumentationsWrapper:
         assert len(aug_target["masks"]) == 1
         assert aug_target["masks"].shape == (1, 50, 50)
 
+    def test_degenerate_bbox_at_image_boundary_is_silently_dropped(self):
+        """Degenerate boxes (x_min == x_max or y_min == y_max) must not raise ValueError.
+
+        Regression test: COCO annotations sometimes place a box exactly on the image
+        boundary so that both x coordinates equal the image width (normalized: 1.0).
+        Albumentations' check_bboxes rejects these with
+        "x_max is less than or equal to x_min", crashing the DataLoader worker.
+        """
+        transform = A.HorizontalFlip(p=1.0)
+        wrapper = AlbumentationsWrapper(transform)
+
+        width, height = 100, 100
+        image = Image.new("RGB", (width, height))
+
+        target = {
+            # box 0: valid                box 1: x_min==x_max (right edge)
+            # box 2: y_min==y_max (bottom edge)
+            "boxes": torch.tensor(
+                [
+                    [10.0, 20.0, 50.0, 60.0],   # valid — should survive
+                    [100.0, 14.0, 100.0, 17.0],  # degenerate: x_min == x_max
+                    [10.0, 100.0, 50.0, 100.0],  # degenerate: y_min == y_max
+                ]
+            ),
+            "labels": torch.tensor([1, 2, 3]),
+            "area": torch.tensor([1600.0, 0.0, 0.0]),
+        }
+
+        # Must not raise ValueError
+        aug_image, aug_target = wrapper(image, target)
+
+        assert isinstance(aug_image, Image.Image)
+        # Only the valid box survives
+        assert aug_target["boxes"].shape[0] == 1, (
+            f"Expected 1 valid box, got {aug_target['boxes'].shape[0]}"
+        )
+        assert aug_target["labels"].tolist() == [1]
+        assert aug_target["area"].shape[0] == 1
+
+    def test_degenerate_bbox_mixed_with_masks(self):
+        """Degenerate boxes are dropped together with their corresponding masks."""
+        transform = A.HorizontalFlip(p=1.0)
+        wrapper = AlbumentationsWrapper(transform)
+
+        width, height = 100, 100
+        image = Image.new("RGB", (width, height))
+
+        masks = torch.zeros((2, height, width), dtype=torch.uint8)
+        masks[0, 20:60, 10:50] = 1  # valid mask
+
+        target = {
+            "boxes": torch.tensor(
+                [
+                    [10.0, 20.0, 50.0, 60.0],   # valid
+                    [100.0, 14.0, 100.0, 17.0],  # degenerate: x_min == x_max
+                ]
+            ),
+            "labels": torch.tensor([1, 2]),
+            "masks": masks,
+        }
+
+        aug_image, aug_target = wrapper(image, target)
+
+        assert aug_target["boxes"].shape[0] == 1
+        assert aug_target["labels"].tolist() == [1]
+        assert aug_target["masks"].shape[0] == 1
+
 
 class TestAlbumentationsWrapperFromConfig:
     """Tests for AlbumentationsWrapper.from_config() static method."""

--- a/tests/training/test_coco_eval_callback.py
+++ b/tests/training/test_coco_eval_callback.py
@@ -185,11 +185,6 @@ class TestOnFitStart:
         assert cb._cat_id_to_name == {1: "fish", 2: "shark"}
 
 
-# ---------------------------------------------------------------------------
-# Batch-end — shared behaviour for both validation and test loops
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.parametrize(
     "hook,stage",
     [
@@ -265,11 +260,6 @@ class TestOnTestBatchEnd:
 
         # Must not raise with explicit dataloader_idx=0
         cb.on_test_batch_end(_make_trainer(), _make_pl_module(), outputs, None, 0, dataloader_idx=0)
-
-
-# ---------------------------------------------------------------------------
-# Epoch-end — shared behaviour for both validation and test loops
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -404,11 +394,6 @@ class TestEpochEndCommon:
 
         logged_keys = {c.args[0] for c in module.log.call_args_list}
         assert f"{prefix}AP/3" in logged_keys
-
-
-# ---------------------------------------------------------------------------
-# Validation-epoch-end-only behaviour
-# ---------------------------------------------------------------------------
 
 
 class TestOnValidationEpochEnd:
@@ -591,9 +576,62 @@ class TestOnTestEpochEnd:
         assert not any(k.startswith("val/") for k in logged_keys)
 
 
-# ---------------------------------------------------------------------------
-# Target conversion
-# ---------------------------------------------------------------------------
+class TestConvertPreds:
+    """_convert_preds() normalizes prediction dicts for metric consumers."""
+
+    @pytest.mark.parametrize(
+        ("boxes", "expected_kept_idxs"),
+        [
+            pytest.param(
+                # Degenerate first -> keep original index 1 (non-zero keep idx).
+                [[2.0, 2.0, 2.0, 4.0], [0.0, 0.0, 3.0, 3.0], [5.0, 5.0, 5.0, 7.0]],
+                [1],
+                id="degenerate-first-keeps-index-1",
+            ),
+            pytest.param(
+                # Degenerate between valid boxes -> keep non-contiguous original indices.
+                [[0.0, 0.0, 3.0, 3.0], [2.0, 2.0, 2.0, 4.0], [4.0, 4.0, 6.0, 6.0]],
+                [0, 2],
+                id="degenerate-middle-keeps-noncontiguous",
+            ),
+        ],
+    )
+    def test_masks_remain_aligned_with_original_indices_after_degenerate_filtering(
+        self,
+        boxes: list[list[float]],
+        expected_kept_idxs: list[int],
+    ) -> None:
+        """Filtering degenerate boxes must preserve mask alignment via original indices.
+
+        Regression context: when a degenerate box is not last, keep indices are
+        non-zero/non-contiguous. Downstream filtering must keep masks from the
+        same original prediction indices.
+        """
+        cb = COCOEvalCallback()
+
+        # Distinct one-hot masks so index/mask misalignment is easy to detect.
+        masks = torch.zeros(3, 1, 2, 2, dtype=torch.bool)
+        masks[0, 0, 0, 0] = True
+        masks[1, 0, 0, 1] = True
+        masks[2, 0, 1, 0] = True
+
+        preds = [
+            {
+                "boxes": torch.tensor(boxes, dtype=torch.float32),
+                "scores": torch.tensor([0.9, 0.8, 0.7], dtype=torch.float32),
+                "labels": torch.tensor([0, 0, 0], dtype=torch.int64),
+                "masks": masks,
+            }
+        ]
+
+        out = cb._convert_preds(preds)
+        out_boxes = out[0]["boxes"]
+        out_masks = out[0]["masks"]
+        assert out_masks.shape == (3, 2, 2)
+
+        keep = torch.where((out_boxes[:, 2] > out_boxes[:, 0]) & (out_boxes[:, 3] > out_boxes[:, 1]))[0]
+        assert keep.tolist() == expected_kept_idxs
+        assert torch.equal(out_masks[keep], masks.squeeze(1)[keep])
 
 
 class TestConvertTargets:


### PR DESCRIPTION
## What does this PR do?

COCO annotations sometimes place a bounding box exactly on the image boundary, resulting in x_min == x_max (or y_min == y_max) after coordinate clipping. Albumentations' check_bboxes rejects these with "x_max is less than or equal to x_min", crashing DataLoader workers.

Filter out zero-width/zero-height boxes in _apply_geometric_transform before passing to Albumentations. Labels, idxs, and masks are updated in lockstep; because idxs carries original indices, downstream _filter_per_instance_fields still slices per-instance fields correctly from the un-filtered target.

Adds two regression tests covering the bbox-only and bbox+masks cases.

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
