### PR TITLE
chore: replace `utils.all_gather` with `utilities.all_gather`, remove `RFDETRLargeNew`

### DIFF
--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -827,16 +827,6 @@ class RFDETRMedium(RFDETR):
         return TrainConfig(**kwargs)
 
 
-class RFDETRLargeNew(RFDETR):
-    size = "rfdetr-large"
-
-    def get_model_config(self, **kwargs):
-        return RFDETRLargeConfig(**kwargs)
-
-    def get_train_config(self, **kwargs):
-        return TrainConfig(**kwargs)
-
-
 class RFDETRLargeDeprecated(RFDETR):
     """
     Train an RF-DETR Large model.

--- a/src/rfdetr/evaluation/matching.py
+++ b/src/rfdetr/evaluation/matching.py
@@ -23,7 +23,7 @@ import torch
 import torch.nn.functional as F
 from torchvision.ops import box_iou
 
-import rfdetr.util.misc as utils
+from rfdetr.utilities import all_gather
 
 
 def _compute_mask_iou(pred_masks: torch.Tensor, gt_masks: torch.Tensor) -> torch.Tensor:
@@ -300,7 +300,7 @@ def distributed_merge_matching_data(
     Returns:
         Merged accumulator containing contributions from all ranks.
     """
-    gathered: List[dict[int, dict[str, Any]]] = utils.all_gather(local_data)
+    gathered: List[dict[int, dict[str, Any]]] = all_gather(local_data)
     merged: dict[int, dict[str, Any]] = {}
     for rank_data in gathered:
         merge_matching_data(merged, rank_data)

--- a/src/rfdetr/evaluation/matching.py
+++ b/src/rfdetr/evaluation/matching.py
@@ -290,7 +290,7 @@ def distributed_merge_matching_data(
 ) -> dict[int, dict[str, Any]]:
     """Gather per-rank matching data from all DDP ranks and merge into one dict.
 
-    Uses ``utils.all_gather`` (pickle-based) so the data need not be a tensor.
+    Uses ``rfdetr.utilities.all_gather`` (pickle-based) so the data need not be a tensor.
     In single-process (non-distributed) mode, returns a merged copy of *local_data*
     unchanged.
 

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -449,7 +449,7 @@ class TestDistributedMergeMatchingData:
         """Two ranks with disjoint classes -> merged result contains both."""
         rank0 = {0: _make_matching_entry([0.9], [1], [False], 1)}
         rank1 = {1: _make_matching_entry([0.7], [0], [False], 2)}
-        with patch("rfdetr.evaluation.matching.utils.all_gather", return_value=[rank0, rank1]):
+        with patch("rfdetr.evaluation.matching.all_gather", return_value=[rank0, rank1]):
             result = distributed_merge_matching_data(rank0)
         assert set(result.keys()) == {0, 1}
         assert result[0]["total_gt"] == 1
@@ -459,7 +459,7 @@ class TestDistributedMergeMatchingData:
         """Two ranks sharing class 0 -> arrays concatenated, total_gt summed."""
         rank0 = {0: _make_matching_entry([0.9], [1], [False], 2)}
         rank1 = {0: _make_matching_entry([0.7, 0.5], [0, 1], [False, False], 3)}
-        with patch("rfdetr.evaluation.matching.utils.all_gather", return_value=[rank0, rank1]):
+        with patch("rfdetr.evaluation.matching.all_gather", return_value=[rank0, rank1]):
             result = distributed_merge_matching_data(rank0)
         np.testing.assert_allclose(result[0]["scores"], [0.9, 0.7, 0.5], rtol=1e-6)
         assert result[0]["total_gt"] == 5


### PR DESCRIPTION
This pull request makes a few targeted improvements to the codebase, primarily focused on refactoring and simplifying class definitions and utility imports. The most significant changes are the removal of an unused model variant class and the consolidation of utility imports in the evaluation module.

### Model class cleanup

* Removed the `RFDETRLargeNew` class from `src/rfdetr/detr.py` as it was redundant or unused, streamlining the model class hierarchy.

### Utility import refactor

* Replaced the import of `utils.all_gather` with a direct import from `rfdetr.utilities` in `src/rfdetr/evaluation/matching.py`, and updated its usage accordingly for clarity and consistency. [[1]](diffhunk://#diff-221c0cfe8e5c2cab205bd35313af279d1fcdf110e7988d8c5fa766efbab92cccL26-R26) [[2]](diffhunk://#diff-221c0cfe8e5c2cab205bd35313af279d1fcdf110e7988d8c5fa766efbab92cccL303-R303)