### PR TITLE
fix(training): make BestModelCallback save PTL-compatible checkpoints

### DIFF
--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -48,7 +48,7 @@ from rfdetr.datasets.coco import is_valid_coco_dataset
 from rfdetr.datasets.yolo import is_valid_yolo_dataset
 from rfdetr.models import PostProcess, build_model
 from rfdetr.utilities.logger import get_logger
-from rfdetr.utilities.state_dict import validate_checkpoint_compatibility
+from rfdetr.utilities.state_dict import _ckpt_args_get, validate_checkpoint_compatibility
 
 try:
     torch.set_float32_matmul_precision("high")
@@ -130,8 +130,8 @@ def _load_pretrain_weights_into(nn_model: torch.nn.Module, args: Any) -> List[st
         download_pretrain_weights(args.pretrain_weights, redownload=True, validate_md5=False)
         checkpoint = torch.load(args.pretrain_weights, map_location="cpu", weights_only=False)
 
-    if "args" in checkpoint and hasattr(checkpoint["args"], "class_names"):
-        class_names = checkpoint["args"].class_names or []
+    if "args" in checkpoint:
+        class_names = _ckpt_args_get(checkpoint["args"], "class_names") or []
 
     validate_checkpoint_compatibility(checkpoint, args)
 

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -12,9 +12,8 @@ import shutil
 from pathlib import Path
 from typing import Optional
 
-import pytorch_lightning as pl
 import torch
-from pytorch_lightning import LightningModule, Trainer
+from pytorch_lightning import LightningModule, Trainer, __version__
 from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint
 
 from rfdetr.utilities.logger import get_logger
@@ -147,7 +146,7 @@ class BestModelCallback(ModelCheckpoint):
                 # PTL-compatible keys so trainer.fit(ckpt_path=...) works directly.
                 "state_dict": {f"model.{k}": v for k, v in model_state_dict.items()},
                 "global_step": trainer.global_step,
-                "pytorch-lightning_version": pl.__version__,
+                "pytorch-lightning_version": __version__,
                 "loops": {"fit_loop": _make_fit_loop_state(trainer.current_epoch)},
                 # Keep keys present with empty values so PTL resume paths that
                 # expect them can proceed without loading optimizer state.
@@ -204,7 +203,7 @@ class BestModelCallback(ModelCheckpoint):
                     # PTL-compatible keys so trainer.fit(ckpt_path=...) works directly.
                     "state_dict": {f"model.{k}": v for k, v in ema_state_dict.items()},
                     "global_step": trainer.global_step,
-                    "pytorch-lightning_version": pl.__version__,
+                    "pytorch-lightning_version": __version__,
                     "loops": {"fit_loop": _make_fit_loop_state(trainer.current_epoch)},
                     # Keep keys present with empty values so PTL resume paths
                     # can proceed while still starting a fresh optimizer.

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -12,12 +12,13 @@ import shutil
 from pathlib import Path
 from typing import Optional
 
+import pytorch_lightning as pl
 import torch
 from pytorch_lightning import LightningModule, Trainer
 from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint
 
 from rfdetr.utilities.logger import get_logger
-from rfdetr.utilities.state_dict import strip_checkpoint
+from rfdetr.utilities.state_dict import _make_fit_loop_state, strip_checkpoint
 
 logger = get_logger()
 
@@ -137,11 +138,17 @@ class BestModelCallback(ModelCheckpoint):
             and getattr(train_config, "class_names", None) is None
         ):
             train_config = train_config.model_copy(update={"class_names": dataset_class_names})
+        args_dict = train_config.model_dump() if hasattr(train_config, "model_dump") else train_config
         torch.save(
             {
                 "model": model_state_dict,
-                "args": train_config,
+                "args": args_dict,
                 "epoch": trainer.current_epoch,
+                # PTL-compatible keys so trainer.fit(ckpt_path=...) works directly.
+                "state_dict": {f"model.{k}": v for k, v in model_state_dict.items()},
+                "global_step": trainer.global_step,
+                "pytorch-lightning_version": pl.__version__,
+                "loops": {"fit_loop": _make_fit_loop_state(trainer.current_epoch)},
             },
             pth_path,
         )
@@ -182,11 +189,19 @@ class BestModelCallback(ModelCheckpoint):
                 and getattr(ema_train_config, "class_names", None) is None
             ):
                 ema_train_config = ema_train_config.model_copy(update={"class_names": dataset_class_names})
+            ema_args_dict = (
+                ema_train_config.model_dump() if hasattr(ema_train_config, "model_dump") else ema_train_config
+            )
             torch.save(
                 {
                     "model": ema_state_dict,
-                    "args": ema_train_config,
+                    "args": ema_args_dict,
                     "epoch": trainer.current_epoch,
+                    # PTL-compatible keys so trainer.fit(ckpt_path=...) works directly.
+                    "state_dict": {f"model.{k}": v for k, v in ema_state_dict.items()},
+                    "global_step": trainer.global_step,
+                    "pytorch-lightning_version": pl.__version__,
+                    "loops": {"fit_loop": _make_fit_loop_state(trainer.current_epoch)},
                 },
                 self._output_dir / "checkpoint_best_ema.pth",
             )

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -13,7 +13,8 @@ from pathlib import Path
 from typing import Optional
 
 import torch
-from pytorch_lightning import LightningModule, Trainer, __version__ as ptl_version
+from pytorch_lightning import LightningModule, Trainer
+from pytorch_lightning import __version__ as ptl_version
 from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint
 
 from rfdetr.utilities.logger import get_logger

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Optional
 
 import torch
-from pytorch_lightning import LightningModule, Trainer, __version__
+from pytorch_lightning import LightningModule, Trainer, __version__ as ptl_version
 from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint
 
 from rfdetr.utilities.logger import get_logger
@@ -146,7 +146,7 @@ class BestModelCallback(ModelCheckpoint):
                 # PTL-compatible keys so trainer.fit(ckpt_path=...) works directly.
                 "state_dict": {f"model.{k}": v for k, v in model_state_dict.items()},
                 "global_step": trainer.global_step,
-                "pytorch-lightning_version": __version__,
+                "pytorch-lightning_version": ptl_version,
                 "loops": {"fit_loop": _make_fit_loop_state(trainer.current_epoch)},
                 # Keep keys present with empty values so PTL resume paths that
                 # expect them can proceed without loading optimizer state.
@@ -203,7 +203,7 @@ class BestModelCallback(ModelCheckpoint):
                     # PTL-compatible keys so trainer.fit(ckpt_path=...) works directly.
                     "state_dict": {f"model.{k}": v for k, v in ema_state_dict.items()},
                     "global_step": trainer.global_step,
-                    "pytorch-lightning_version": __version__,
+                    "pytorch-lightning_version": ptl_version,
                     "loops": {"fit_loop": _make_fit_loop_state(trainer.current_epoch)},
                     # Keep keys present with empty values so PTL resume paths
                     # can proceed while still starting a fresh optimizer.

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -149,6 +149,10 @@ class BestModelCallback(ModelCheckpoint):
                 "global_step": trainer.global_step,
                 "pytorch-lightning_version": pl.__version__,
                 "loops": {"fit_loop": _make_fit_loop_state(trainer.current_epoch)},
+                # Keep keys present with empty values so PTL resume paths that
+                # expect them can proceed without loading optimizer state.
+                "optimizer_states": [],
+                "lr_schedulers": [],
             },
             pth_path,
         )
@@ -202,6 +206,10 @@ class BestModelCallback(ModelCheckpoint):
                     "global_step": trainer.global_step,
                     "pytorch-lightning_version": pl.__version__,
                     "loops": {"fit_loop": _make_fit_loop_state(trainer.current_epoch)},
+                    # Keep keys present with empty values so PTL resume paths
+                    # can proceed while still starting a fresh optimizer.
+                    "optimizer_states": [],
+                    "lr_schedulers": [],
                 },
                 self._output_dir / "checkpoint_best_ema.pth",
             )

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -13,7 +13,8 @@ from pathlib import Path
 from typing import Optional
 
 import torch
-from pytorch_lightning import LightningModule, Trainer, __version__ as ptl_version
+from pytorch_lightning import LightningModule, Trainer
+from pytorch_lightning import __version__ as ptl_version
 from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint
 
 from rfdetr.utilities.logger import get_logger
@@ -68,8 +69,40 @@ class BestModelCallback(ModelCheckpoint):
         # Stash current pl_module so _save_checkpoint (no pl_module param) can access it.
         self._current_pl_module: Optional[LightningModule] = None
 
+    @staticmethod
+    def _build_checkpoint_payload(
+        model_state_dict: dict[str, torch.Tensor],
+        args_dict: object,
+        trainer: Trainer,
+    ) -> dict[str, object]:
+        """Build a PTL-compatible RF-DETR checkpoint payload.
+
+        Args:
+            model_state_dict: Model weights with raw (non-prefixed) keys.
+            args_dict: Serialized training args/config payload.
+            trainer: Active Lightning trainer providing epoch/step counters.
+
+        Returns:
+            Checkpoint dictionary that supports ``Trainer.fit(ckpt_path=...)``
+            while intentionally omitting optimizer/scheduler states.
+        """
+        return {
+            "model": model_state_dict,
+            "args": args_dict,
+            "epoch": trainer.current_epoch,
+            # PTL-compatible keys so trainer.fit(ckpt_path=...) works directly.
+            "state_dict": {f"model.{k}": v for k, v in model_state_dict.items()},
+            "global_step": trainer.global_step,
+            "pytorch-lightning_version": ptl_version,
+            "loops": {"fit_loop": _make_fit_loop_state(trainer.current_epoch)},
+            # Keep keys present with empty values so PTL resume paths that
+            # expect them can proceed without loading optimizer state.
+            "optimizer_states": [],
+            "lr_schedulers": [],
+        }
+
+    @staticmethod
     def _get_ema_model_state_dict(
-        self,
         trainer: Trainer,
         pl_module: LightningModule,
     ) -> dict[str, torch.Tensor]:
@@ -138,23 +171,7 @@ class BestModelCallback(ModelCheckpoint):
         ):
             train_config = train_config.model_copy(update={"class_names": dataset_class_names})
         args_dict = train_config.model_dump() if hasattr(train_config, "model_dump") else train_config
-        torch.save(
-            {
-                "model": model_state_dict,
-                "args": args_dict,
-                "epoch": trainer.current_epoch,
-                # PTL-compatible keys so trainer.fit(ckpt_path=...) works directly.
-                "state_dict": {f"model.{k}": v for k, v in model_state_dict.items()},
-                "global_step": trainer.global_step,
-                "pytorch-lightning_version": ptl_version,
-                "loops": {"fit_loop": _make_fit_loop_state(trainer.current_epoch)},
-                # Keep keys present with empty values so PTL resume paths that
-                # expect them can proceed without loading optimizer state.
-                "optimizer_states": [],
-                "lr_schedulers": [],
-            },
-            pth_path,
-        )
+        torch.save(self._build_checkpoint_payload(model_state_dict, args_dict, trainer), pth_path)
         self._last_global_step_saved = trainer.global_step
         logger.info("Best regular mAP saved to %s (epoch %d)", pth_path, trainer.current_epoch)
 
@@ -196,20 +213,7 @@ class BestModelCallback(ModelCheckpoint):
                 ema_train_config.model_dump() if hasattr(ema_train_config, "model_dump") else ema_train_config
             )
             torch.save(
-                {
-                    "model": ema_state_dict,
-                    "args": ema_args_dict,
-                    "epoch": trainer.current_epoch,
-                    # PTL-compatible keys so trainer.fit(ckpt_path=...) works directly.
-                    "state_dict": {f"model.{k}": v for k, v in ema_state_dict.items()},
-                    "global_step": trainer.global_step,
-                    "pytorch-lightning_version": ptl_version,
-                    "loops": {"fit_loop": _make_fit_loop_state(trainer.current_epoch)},
-                    # Keep keys present with empty values so PTL resume paths
-                    # can proceed while still starting a fresh optimizer.
-                    "optimizer_states": [],
-                    "lr_schedulers": [],
-                },
+                self._build_checkpoint_payload(ema_state_dict, ema_args_dict, trainer),
                 self._output_dir / "checkpoint_best_ema.pth",
             )
             logger.info(

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -24,7 +24,7 @@ from rfdetr.datasets.coco import compute_multi_scale_scales
 from rfdetr.models.lwdetr import build_criterion_and_postprocessors, build_model
 from rfdetr.training.param_groups import get_param_dict
 from rfdetr.utilities.logger import get_logger
-from rfdetr.utilities.state_dict import validate_checkpoint_compatibility
+from rfdetr.utilities.state_dict import _ckpt_args_get, validate_checkpoint_compatibility
 
 logger = get_logger()
 
@@ -45,6 +45,9 @@ class RFDETRModelModule(LightningModule):
         super().__init__()
         self.model_config = model_config
         self.train_config = train_config
+        # Allow partial state-dict loading when resuming from a .pth checkpoint
+        # (which contains only model weights, not criterion/postprocess state).
+        self.strict_loading = False
 
         # Build a local namespace for the legacy builder functions.
         ns = build_namespace(model_config, train_config)
@@ -119,8 +122,8 @@ class RFDETRModelModule(LightningModule):
             download_pretrain_weights(pretrain_weights, redownload=True, validate_md5=False)
             checkpoint = torch.load(pretrain_weights, map_location="cpu", weights_only=False)
 
-        if "args" in checkpoint and hasattr(checkpoint["args"], "class_names"):
-            self._pretrain_class_names = checkpoint["args"].class_names
+        if "args" in checkpoint:
+            self._pretrain_class_names = _ckpt_args_get(checkpoint["args"], "class_names")
 
         ns = build_namespace(mc, self.train_config)
         validate_checkpoint_compatibility(checkpoint, ns)

--- a/src/rfdetr/utilities/state_dict.py
+++ b/src/rfdetr/utilities/state_dict.py
@@ -121,8 +121,9 @@ def strip_checkpoint(checkpoint: str | os.PathLike[str]) -> None:
     """Strip a checkpoint file down to ``model``, ``args``, and PTL-compatible keys.
 
     Preserves ``state_dict``, ``global_step``, ``pytorch-lightning_version``,
-    and ``loops`` when present so the stripped checkpoint can still be used
-    directly with ``trainer.fit(ckpt_path=...)``.
+    ``loops``, ``optimizer_states``, and ``lr_schedulers`` when present so the
+    stripped checkpoint can still be used directly with
+    ``trainer.fit(ckpt_path=...)``.
 
     Overwrites the file atomically so a partial write cannot corrupt it.
 

--- a/src/rfdetr/utilities/state_dict.py
+++ b/src/rfdetr/utilities/state_dict.py
@@ -15,9 +15,107 @@ from rfdetr.utilities.logger import get_logger
 
 logger = get_logger()
 
+# PTL-compatible keys written by BestModelCallback; preserved by strip_checkpoint so
+# checkpoint_best_total.pth can be used directly with trainer.fit(ckpt_path=...).
+_PTL_COMPAT_KEYS = ("state_dict", "global_step", "pytorch-lightning_version", "loops")
+
+
+def _ckpt_args_get(args: Any, field: str, default: Any = None) -> Any:
+    """Get a field from checkpoint ``"args"``, handling both dict and attribute access.
+
+    New checkpoints (PTL training stack) store ``"args"`` as a plain ``dict``
+    (via ``TrainConfig.model_dump()``).  Legacy checkpoints (pre-PTL engine or
+    the pre-release PTL code) stored it as a ``Namespace``-like object.  This
+    helper abstracts both so callers do not need to branch on the type.
+
+    Args:
+        args: The ``checkpoint["args"]`` value.
+        field: Field name to retrieve.
+        default: Value returned when the field is absent.
+
+    Returns:
+        The field value, or ``default`` if not found.
+    """
+    if isinstance(args, dict):
+        return args.get(field, default)
+    return getattr(args, field, default)
+
+
+def _make_fit_loop_state(epoch: int) -> dict:
+    """Build a minimal ``fit_loop`` state dict that restores the epoch counter.
+
+    ``BestModelCallback`` stores ``trainer.current_epoch`` as ``"epoch"`` in
+    the checkpoint.  That value is captured during ``on_validation_end``, which
+    fires *before* the loop's epoch-end hooks increment the counter.  To resume
+    training *after* that epoch, PTL's epoch-progress counter must be set to
+    ``epoch + 1`` so that ``trainer.current_epoch == epoch + 1`` when the new
+    ``trainer.fit()`` call begins.
+
+    Optimizer and scheduler states are intentionally omitted — loading a
+    ``.pth`` file starts a fresh optimizer for the new training phase.
+
+    Args:
+        epoch: The ``"epoch"`` value from the checkpoint (``trainer.current_epoch``
+            at the time of ``on_validation_end``).
+
+    Returns:
+        A ``fit_loop`` state dict compatible with
+        :meth:`pytorch_lightning.loops._FitLoop.load_state_dict`.
+    """
+    n = epoch + 1  # number of epochs fully completed after epoch `epoch` finishes
+    zero4 = {"ready": 0, "started": 0, "processed": 0, "completed": 0}
+    zero3 = {"ready": 0, "started": 0, "completed": 0}
+    zero2 = {"ready": 0, "completed": 0}
+    n4 = {"ready": n, "started": n, "processed": n, "completed": n}
+    return {
+        "state_dict": {},
+        "epoch_loop.state_dict": {"_batches_that_stepped": 0},
+        "epoch_loop.batch_progress": {
+            "total": {**zero4},
+            "current": {**zero4},
+            "is_last_batch": False,
+        },
+        "epoch_loop.scheduler_progress": {
+            "total": {**zero2},
+            "current": {**zero2},
+        },
+        "epoch_loop.automatic_optimization.state_dict": {},
+        "epoch_loop.automatic_optimization.optim_progress": {
+            "optimizer": {
+                "step": {
+                    "total": {**zero2},
+                    "current": {**zero2},
+                },
+                "zero_grad": {
+                    "total": {**zero3},
+                    "current": {**zero3},
+                },
+            }
+        },
+        "epoch_loop.manual_optimization.state_dict": {},
+        "epoch_loop.manual_optimization.optim_step_progress": {
+            "total": {**zero2},
+            "current": {**zero2},
+        },
+        "epoch_loop.val_loop.state_dict": {},
+        "epoch_loop.val_loop.batch_progress": {
+            "total": {**zero4},
+            "current": {**zero4},
+            "is_last_batch": False,
+        },
+        "epoch_progress": {
+            "total": {**n4},
+            "current": {**n4},
+        },
+    }
+
 
 def strip_checkpoint(checkpoint: str | os.PathLike[str]) -> None:
-    """Strip a checkpoint file down to ``model`` and ``args`` keys only.
+    """Strip a checkpoint file down to ``model``, ``args``, and PTL-compatible keys.
+
+    Preserves ``state_dict``, ``global_step``, ``pytorch-lightning_version``,
+    and ``loops`` when present so the stripped checkpoint can still be used
+    directly with ``trainer.fit(ckpt_path=...)``.
 
     Overwrites the file atomically so a partial write cannot corrupt it.
 
@@ -26,11 +124,15 @@ def strip_checkpoint(checkpoint: str | os.PathLike[str]) -> None:
     """
     import torch
 
-    state_dict = torch.load(checkpoint, map_location="cpu", weights_only=False)
+    state_dict = torch.load(checkpoint, map_location="cpu", weights_only=True)
     new_state_dict = {
         "model": state_dict["model"],
         "args": state_dict["args"],
     }
+    # Preserve PTL-compatible keys when present (written by BestModelCallback).
+    for key in _PTL_COMPAT_KEYS:
+        if key in state_dict:
+            new_state_dict[key] = state_dict[key]
     # Create the temp file in the destination directory so os.replace stays on the same filesystem (atomic).
     checkpoint_dir = os.path.dirname(os.path.abspath(os.fspath(checkpoint)))
     with tempfile.NamedTemporaryFile(dir=checkpoint_dir, delete=False) as tmp_file:
@@ -77,7 +179,7 @@ def validate_checkpoint_compatibility(checkpoint: Dict[str, Any], model_args: An
 
     Args:
         checkpoint: Loaded checkpoint dictionary, expected to contain an optional
-            ``"args"`` key with training namespace attributes.
+            ``"args"`` key with training namespace attributes or a plain dict.
         model_args: Namespace (e.g. ``types.SimpleNamespace``) with at least
             ``segmentation_head`` and ``patch_size`` attributes describing the
             current model.
@@ -135,7 +237,7 @@ def validate_checkpoint_compatibility(checkpoint: Dict[str, Any], model_args: An
         return
 
     ckpt_args = checkpoint["args"]
-    ckpt_segmentation_head: Optional[bool] = getattr(ckpt_args, "segmentation_head", None)
+    ckpt_segmentation_head: Optional[bool] = _ckpt_args_get(ckpt_args, "segmentation_head")
     model_segmentation_head: Optional[bool] = getattr(model_args, "segmentation_head", None)
 
     if ckpt_segmentation_head is not None and model_segmentation_head is not None:
@@ -151,7 +253,7 @@ def validate_checkpoint_compatibility(checkpoint: Dict[str, Any], model_args: An
                     "Load the weights into a detection model (e.g. RFDETRNano) instead of a segmentation model."
                 )
 
-    ckpt_patch_size: Optional[int] = getattr(ckpt_args, "patch_size", None)
+    ckpt_patch_size: Optional[int] = _ckpt_args_get(ckpt_args, "patch_size")
     model_patch_size: Optional[int] = getattr(model_args, "patch_size", None)
     if ckpt_patch_size is not None and model_patch_size is not None and ckpt_patch_size != model_patch_size:
         raise ValueError(

--- a/src/rfdetr/utilities/state_dict.py
+++ b/src/rfdetr/utilities/state_dict.py
@@ -124,7 +124,11 @@ def strip_checkpoint(checkpoint: str | os.PathLike[str]) -> None:
     """
     import torch
 
-    state_dict = torch.load(checkpoint, map_location="cpu", weights_only=True)
+    # `checkpoint_best_total.pth` is produced by local RF-DETR training and can
+    # contain non-tensor metadata under "args" (e.g. `types.SimpleNamespace`).
+    # PyTorch 2.6 changed `torch.load` default `weights_only=True`, which rejects
+    # these objects. This utility intentionally operates on trusted checkpoints.
+    state_dict = torch.load(checkpoint, map_location="cpu", weights_only=False)
     new_state_dict = {
         "model": state_dict["model"],
         "args": state_dict["args"],

--- a/src/rfdetr/utilities/state_dict.py
+++ b/src/rfdetr/utilities/state_dict.py
@@ -17,7 +17,14 @@ logger = get_logger()
 
 # PTL-compatible keys written by BestModelCallback; preserved by strip_checkpoint so
 # checkpoint_best_total.pth can be used directly with trainer.fit(ckpt_path=...).
-_PTL_COMPAT_KEYS = ("state_dict", "global_step", "pytorch-lightning_version", "loops")
+_PTL_COMPAT_KEYS = (
+    "state_dict",
+    "global_step",
+    "pytorch-lightning_version",
+    "loops",
+    "optimizer_states",
+    "lr_schedulers",
+)
 
 
 def _ckpt_args_get(args: Any, field: str, default: Any = None) -> Any:

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -12,8 +12,8 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-import pytorch_lightning as pl
 import torch
+from pytorch_lightning import Callback, LightningModule, Trainer, __version__
 from pytorch_lightning.trainer.states import TrainerFn
 from torch.utils.data import DataLoader, TensorDataset
 
@@ -64,7 +64,7 @@ def _make_pl_module() -> MagicMock:
     return pl_module
 
 
-class _ResumeTinyModule(pl.LightningModule):
+class _ResumeTinyModule(LightningModule):
     """Tiny LightningModule used to validate real ckpt_path resume behavior."""
 
     def __init__(self) -> None:
@@ -85,7 +85,7 @@ class _ResumeTinyModule(pl.LightningModule):
         return torch.optim.SGD(self.model.parameters(), lr=0.01)
 
 
-class _ResumeProbeCallback(pl.Callback):
+class _ResumeProbeCallback(Callback):
     """Capture restored epoch/step at fit start for resume assertions."""
 
     def __init__(self) -> None:
@@ -605,7 +605,7 @@ class TestBestModelCallback:
         cb.on_validation_end(trainer, pl_module)
 
         ckpt = torch.load(tmp_path / "checkpoint_best_regular.pth", map_location="cpu", weights_only=False)
-        assert ckpt.get("pytorch-lightning_version") == pl.__version__
+        assert ckpt.get("pytorch-lightning_version") == __version__
 
     def test_ema_checkpoint_has_ptl_state_dict_key(self, tmp_path: Path) -> None:
         """Saved EMA checkpoint must include 'state_dict' with model. prefix."""
@@ -690,7 +690,7 @@ class TestBestModelCallback:
         val_loader = DataLoader(TensorDataset(x, y), batch_size=2)
 
         save_cb = BestModelCallback(output_dir=str(tmp_path), run_test=False)
-        trainer_first = pl.Trainer(
+        trainer_first = Trainer(
             max_epochs=1,
             accelerator="cpu",
             enable_progress_bar=False,
@@ -712,7 +712,7 @@ class TestBestModelCallback:
         assert ckpt_data["global_step"] == first_phase_global_step
 
         resume_probe = _ResumeProbeCallback()
-        trainer_second = pl.Trainer(
+        trainer_second = Trainer(
             max_epochs=2,
             accelerator="cpu",
             enable_progress_bar=False,

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -596,8 +596,6 @@ class TestBestModelCallback:
 
     def test_regular_checkpoint_has_ptl_version_key(self, tmp_path: Path) -> None:
         """Saved regular checkpoint must include 'pytorch-lightning_version'."""
-        import pytorch_lightning as pl
-
         cb = BestModelCallback(output_dir=str(tmp_path))
         trainer = _make_trainer({"val/mAP_50_95": 0.5})
         pl_module = _make_pl_module()

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -730,9 +730,16 @@ class TestBestModelCallback:
             ckpt_path=str(ckpt_path),
         )
 
+        # Assert that epoch and global_step were correctly restored at fit start.
+        assert resume_probe.fit_start_epoch == 1
+        assert resume_probe.fit_start_global_step == 2
+        # The first training epoch after resume should also see the restored step.
         assert resume_probe.first_train_epoch == 1
+        assert resume_probe.first_train_global_step == 2
+        # With max_epochs=2 and limit_train_batches=2, the resumed run should
+        # perform 2 additional optimizer steps (epoch 2), ending at step 4.
         assert trainer_second.current_epoch == 2
-        assert trainer_second.global_step == 2
+        assert trainer_second.global_step == 4
 
 
 # ---------------------------------------------------------------------------

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -87,25 +87,16 @@ class _ResumeTinyModule(LightningModule):
 
 
 class _ResumeProbeCallback(Callback):
-    """Capture restored epoch/step at fit start for resume assertions."""
+    """Capture the first train epoch index for resume assertions."""
 
     def __init__(self) -> None:
         super().__init__()
-        self.fit_start_epoch: int | None = None
-        self.fit_start_global_step: int | None = None
         self.first_train_epoch: int | None = None
-        self.first_train_global_step: int | None = None
-
-    def on_fit_start(self, trainer, pl_module):
-        del pl_module
-        self.fit_start_epoch = trainer.current_epoch
-        self.fit_start_global_step = trainer.global_step
 
     def on_train_epoch_start(self, trainer, pl_module):
         del pl_module
         if self.first_train_epoch is None:
             self.first_train_epoch = trainer.current_epoch
-            self.first_train_global_step = trainer.global_step
 
 
 # ---------------------------------------------------------------------------
@@ -730,16 +721,12 @@ class TestBestModelCallback:
             ckpt_path=str(ckpt_path),
         )
 
-        # Assert that epoch and global_step were correctly restored at fit start.
-        assert resume_probe.fit_start_epoch == 1
-        assert resume_probe.fit_start_global_step == 2
         # PTL applies loop restoration by the first train epoch start.
         assert resume_probe.first_train_epoch == 1
-        assert resume_probe.first_train_global_step == 2
         # In the stripped-checkpoint resume path, optimizer state is intentionally
-        # fresh; this resumed phase contributes 2 steps (limit_train_batches=2).
+        # fresh; this resumed phase contributes exactly one epoch with 2 steps.
         assert trainer_second.current_epoch == 2
-        assert trainer_second.global_step == 4
+        assert trainer_second.global_step == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -48,6 +48,8 @@ def _make_trainer(
     trainer.world_size = 1
     # Required by ModelCheckpoint.check_monitor_top_k and EarlyStopping (DDP reduce)
     trainer.strategy.reduce_boolean_decision.side_effect = lambda x, **kwargs: x
+    # Prevent MagicMock auto-attribute from triggering class_names enrichment.
+    trainer.datamodule.class_names = None
     return trainer
 
 
@@ -347,7 +349,7 @@ class TestBestModelCallback:
             map_location="cpu",
             weights_only=False,
         )
-        assert checkpoint["args"].class_names == custom_names
+        assert checkpoint["args"]["class_names"] == custom_names
 
     def test_ema_checkpoint_class_names_populated_from_datamodule(self, tmp_path: Path) -> None:
         """EMA checkpoint args.class_names also reflects dataset class names.
@@ -375,7 +377,7 @@ class TestBestModelCallback:
             map_location="cpu",
             weights_only=False,
         )
-        assert checkpoint["args"].class_names == custom_names
+        assert checkpoint["args"]["class_names"] == custom_names
 
     def test_checkpoint_class_names_not_overwritten_when_already_set(self, tmp_path: Path) -> None:
         """Explicitly-set class_names in TrainConfig are preserved in the checkpoint.
@@ -402,7 +404,7 @@ class TestBestModelCallback:
             map_location="cpu",
             weights_only=False,
         )
-        assert checkpoint["args"].class_names == explicit_names
+        assert checkpoint["args"]["class_names"] == explicit_names
 
     def test_checkpoint_explicit_empty_class_names_not_overwritten_by_datamodule(self, tmp_path: Path) -> None:
         """TrainConfig(class_names=[]) is preserved even when datamodule has non-empty names.
@@ -427,7 +429,7 @@ class TestBestModelCallback:
             map_location="cpu",
             weights_only=False,
         )
-        assert checkpoint["args"].class_names == [], (
+        assert checkpoint["args"]["class_names"] == [], (
             "Explicit class_names=[] in TrainConfig must not be overwritten by datamodule names"
         )
 
@@ -455,7 +457,7 @@ class TestBestModelCallback:
             map_location="cpu",
             weights_only=False,
         )
-        assert checkpoint["args"].class_names == [], (
+        assert checkpoint["args"]["class_names"] == [], (
             "Explicit class_names=[] in TrainConfig must not be overwritten by datamodule names (EMA path)"
         )
 
@@ -480,7 +482,7 @@ class TestBestModelCallback:
             map_location="cpu",
             weights_only=False,
         )
-        assert checkpoint["args"].class_names == []
+        assert checkpoint["args"]["class_names"] == []
 
     def test_ema_checkpoint_empty_class_names_populated_from_datamodule(self, tmp_path: Path) -> None:
         """EMA checkpoint preserves explicitly-empty dataset class names."""
@@ -503,7 +505,115 @@ class TestBestModelCallback:
             map_location="cpu",
             weights_only=False,
         )
-        assert checkpoint["args"].class_names == []
+        assert checkpoint["args"]["class_names"] == []
+
+    # --- PTL-compatible format tests ---
+
+    def test_regular_checkpoint_args_is_dict(self, tmp_path: Path) -> None:
+        """Saved args must be a plain dict (not a Pydantic object) for weights_only=True compat."""
+        from rfdetr.config import TrainConfig
+
+        cb = BestModelCallback(output_dir=str(tmp_path))
+        trainer = _make_trainer({"val/mAP_50_95": 0.5})
+        pl_module = _make_pl_module()
+        pl_module.train_config = TrainConfig(dataset_dir=str(tmp_path / "ds"), tensorboard=False)
+
+        cb.on_validation_end(trainer, pl_module)
+
+        # weights_only=True must succeed now that args is a plain dict.
+        ckpt = torch.load(tmp_path / "checkpoint_best_regular.pth", map_location="cpu", weights_only=True)
+        assert isinstance(ckpt["args"], dict)
+
+    def test_regular_checkpoint_has_ptl_state_dict_key(self, tmp_path: Path) -> None:
+        """Saved regular checkpoint must include 'state_dict' with model. prefix."""
+        cb = BestModelCallback(output_dir=str(tmp_path))
+        trainer = _make_trainer({"val/mAP_50_95": 0.5})
+        pl_module = _make_pl_module()
+
+        cb.on_validation_end(trainer, pl_module)
+
+        ckpt = torch.load(tmp_path / "checkpoint_best_regular.pth", map_location="cpu", weights_only=False)
+        assert "state_dict" in ckpt
+        assert all(k.startswith("model.") for k in ckpt["state_dict"])
+
+    def test_regular_checkpoint_has_loops_key(self, tmp_path: Path) -> None:
+        """Saved regular checkpoint must include 'loops' with fit_loop epoch counter."""
+        cb = BestModelCallback(output_dir=str(tmp_path))
+        trainer = _make_trainer({"val/mAP_50_95": 0.5}, current_epoch=3)
+        pl_module = _make_pl_module()
+
+        cb.on_validation_end(trainer, pl_module)
+
+        ckpt = torch.load(tmp_path / "checkpoint_best_regular.pth", map_location="cpu", weights_only=False)
+        assert "loops" in ckpt
+        ep = ckpt["loops"]["fit_loop"]["epoch_progress"]
+        assert ep["current"]["completed"] == 4  # epoch 3 + 1
+
+    def test_regular_checkpoint_has_ptl_version_key(self, tmp_path: Path) -> None:
+        """Saved regular checkpoint must include 'pytorch-lightning_version'."""
+        import pytorch_lightning as pl
+
+        cb = BestModelCallback(output_dir=str(tmp_path))
+        trainer = _make_trainer({"val/mAP_50_95": 0.5})
+        pl_module = _make_pl_module()
+
+        cb.on_validation_end(trainer, pl_module)
+
+        ckpt = torch.load(tmp_path / "checkpoint_best_regular.pth", map_location="cpu", weights_only=False)
+        assert ckpt.get("pytorch-lightning_version") == pl.__version__
+
+    def test_ema_checkpoint_has_ptl_state_dict_key(self, tmp_path: Path) -> None:
+        """Saved EMA checkpoint must include 'state_dict' with model. prefix."""
+        cb = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
+        trainer = _make_trainer({"val/mAP_50_95": 0.4, "val/ema_mAP_50_95": 0.6})
+        pl_module = _make_pl_module()
+
+        cb.on_validation_end(trainer, pl_module)
+
+        ckpt = torch.load(tmp_path / "checkpoint_best_ema.pth", map_location="cpu", weights_only=False)
+        assert "state_dict" in ckpt
+        assert all(k.startswith("model.") for k in ckpt["state_dict"])
+
+    def test_ema_checkpoint_has_loops_key(self, tmp_path: Path) -> None:
+        """Saved EMA checkpoint must include 'loops' with fit_loop epoch counter."""
+        cb = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
+        trainer = _make_trainer({"val/mAP_50_95": 0.4, "val/ema_mAP_50_95": 0.6}, current_epoch=5)
+        pl_module = _make_pl_module()
+
+        cb.on_validation_end(trainer, pl_module)
+
+        ckpt = torch.load(tmp_path / "checkpoint_best_ema.pth", map_location="cpu", weights_only=False)
+        assert "loops" in ckpt
+        ep = ckpt["loops"]["fit_loop"]["epoch_progress"]
+        assert ep["current"]["completed"] == 6  # epoch 5 + 1
+
+    def test_state_dict_values_match_model_weights(self, tmp_path: Path) -> None:
+        """state_dict values must be identical to the original model weights."""
+        cb = BestModelCallback(output_dir=str(tmp_path))
+        trainer = _make_trainer({"val/mAP_50_95": 0.5})
+        pl_module = _make_pl_module()
+        weights = {"w": torch.randn(3, 3)}
+        pl_module.model.state_dict.return_value = weights
+
+        cb.on_validation_end(trainer, pl_module)
+
+        ckpt = torch.load(tmp_path / "checkpoint_best_regular.pth", map_location="cpu", weights_only=False)
+        assert torch.equal(ckpt["state_dict"]["model.w"], weights["w"])
+
+    def test_best_total_preserves_ptl_keys_after_strip(self, tmp_path: Path) -> None:
+        """strip_checkpoint must preserve state_dict and loops in the final file."""
+        cb = BestModelCallback(output_dir=str(tmp_path), run_test=False)
+        trainer = _make_trainer({"val/mAP_50_95": 0.5})
+        pl_module = _make_pl_module()
+
+        cb.on_validation_end(trainer, pl_module)
+        cb.on_fit_end(trainer, pl_module)
+
+        total = tmp_path / "checkpoint_best_total.pth"
+        data = torch.load(total, map_location="cpu", weights_only=False)
+        assert "state_dict" in data, "strip_checkpoint must preserve 'state_dict'"
+        assert "loops" in data, "strip_checkpoint must preserve 'loops'"
+        assert "pytorch-lightning_version" in data, "strip_checkpoint must preserve 'pytorch-lightning_version'"
 
     def test_not_global_zero_does_not_save(self, tmp_path: Path) -> None:
         """Non-main process (is_global_zero=False) must not write any files."""

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock
 
 import pytest
 import torch
-from pytorch_lightning import Callback, LightningModule, Trainer, __version__
+from pytorch_lightning import Callback, LightningModule, Trainer, __version__ as ptl_version
 from pytorch_lightning.trainer.states import TrainerFn
 from torch.utils.data import DataLoader, TensorDataset
 
@@ -603,7 +603,7 @@ class TestBestModelCallback:
         cb.on_validation_end(trainer, pl_module)
 
         ckpt = torch.load(tmp_path / "checkpoint_best_regular.pth", map_location="cpu", weights_only=False)
-        assert ckpt.get("pytorch-lightning_version") == __version__
+        assert ckpt.get("pytorch-lightning_version") == ptl_version
 
     def test_ema_checkpoint_has_ptl_state_dict_key(self, tmp_path: Path) -> None:
         """Saved EMA checkpoint must include 'state_dict' with model. prefix."""

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -12,8 +12,10 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+import pytorch_lightning as pl
 import torch
 from pytorch_lightning.trainer.states import TrainerFn
+from torch.utils.data import DataLoader, TensorDataset
 
 from rfdetr.training.callbacks.best_model import BestModelCallback, RFDETREarlyStopping
 
@@ -60,6 +62,49 @@ def _make_pl_module() -> MagicMock:
     # Use a real dict so torch.save can pickle it (MagicMock is not picklable).
     pl_module.train_config = {"lr": 0.001}
     return pl_module
+
+
+class _ResumeTinyModule(pl.LightningModule):
+    """Tiny LightningModule used to validate real ckpt_path resume behavior."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.model = torch.nn.Linear(4, 1)
+        self.train_config = {"lr": 0.01}
+
+    def training_step(self, batch, batch_idx):
+        x, y = batch
+        pred = self.model(x)
+        return torch.nn.functional.mse_loss(pred, y)
+
+    def validation_step(self, batch, batch_idx):
+        del batch, batch_idx
+        self.log("val/mAP_50_95", torch.tensor(0.5), on_step=False, on_epoch=True, prog_bar=False)
+
+    def configure_optimizers(self):
+        return torch.optim.SGD(self.model.parameters(), lr=0.01)
+
+
+class _ResumeProbeCallback(pl.Callback):
+    """Capture restored epoch/step at fit start for resume assertions."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.fit_start_epoch: int | None = None
+        self.fit_start_global_step: int | None = None
+        self.first_train_epoch: int | None = None
+        self.first_train_global_step: int | None = None
+
+    def on_fit_start(self, trainer, pl_module):
+        del pl_module
+        self.fit_start_epoch = trainer.current_epoch
+        self.fit_start_global_step = trainer.global_step
+
+    def on_train_epoch_start(self, trainer, pl_module):
+        del pl_module
+        if self.first_train_epoch is None:
+            self.first_train_epoch = trainer.current_epoch
+            self.first_train_global_step = trainer.global_step
 
 
 # ---------------------------------------------------------------------------
@@ -614,6 +659,8 @@ class TestBestModelCallback:
         assert "state_dict" in data, "strip_checkpoint must preserve 'state_dict'"
         assert "loops" in data, "strip_checkpoint must preserve 'loops'"
         assert "pytorch-lightning_version" in data, "strip_checkpoint must preserve 'pytorch-lightning_version'"
+        assert "optimizer_states" in data, "strip_checkpoint must preserve 'optimizer_states'"
+        assert "lr_schedulers" in data, "strip_checkpoint must preserve 'lr_schedulers'"
 
     def test_not_global_zero_does_not_save(self, tmp_path: Path) -> None:
         """Non-main process (is_global_zero=False) must not write any files."""
@@ -633,6 +680,60 @@ class TestBestModelCallback:
         assert not (tmp_path / "checkpoint_best_regular.pth").exists()
         assert not (tmp_path / "checkpoint_best_ema.pth").exists()
         assert not (tmp_path / "checkpoint_best_total.pth").exists()
+
+    def test_best_total_checkpoint_resumes_via_trainer_fit_ckpt_path(self, tmp_path: Path) -> None:
+        """checkpoint_best_total.pth must restore epoch/step when passed to Trainer.fit(ckpt_path=...)."""
+        torch.manual_seed(0)
+        x = torch.randn(8, 4)
+        y = torch.randn(8, 1)
+        train_loader = DataLoader(TensorDataset(x, y), batch_size=2)
+        val_loader = DataLoader(TensorDataset(x, y), batch_size=2)
+
+        save_cb = BestModelCallback(output_dir=str(tmp_path), run_test=False)
+        trainer_first = pl.Trainer(
+            max_epochs=1,
+            accelerator="cpu",
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            logger=False,
+            num_sanity_val_steps=0,
+            limit_train_batches=2,
+            limit_val_batches=1,
+            callbacks=[save_cb],
+            default_root_dir=str(tmp_path),
+        )
+        trainer_first.fit(_ResumeTinyModule(), train_dataloaders=train_loader, val_dataloaders=val_loader)
+
+        ckpt_path = tmp_path / "checkpoint_best_total.pth"
+        assert ckpt_path.exists()
+        first_phase_global_step = trainer_first.global_step
+        assert first_phase_global_step == 2
+        ckpt_data = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+        assert ckpt_data["global_step"] == first_phase_global_step
+
+        resume_probe = _ResumeProbeCallback()
+        trainer_second = pl.Trainer(
+            max_epochs=2,
+            accelerator="cpu",
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            logger=False,
+            num_sanity_val_steps=0,
+            limit_train_batches=2,
+            limit_val_batches=1,
+            callbacks=[resume_probe],
+            default_root_dir=str(tmp_path),
+        )
+        trainer_second.fit(
+            _ResumeTinyModule(),
+            train_dataloaders=train_loader,
+            val_dataloaders=val_loader,
+            ckpt_path=str(ckpt_path),
+        )
+
+        assert resume_probe.first_train_epoch == 1
+        assert trainer_second.current_epoch == 2
+        assert trainer_second.global_step == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -596,7 +596,6 @@ class TestBestModelCallback:
 
     def test_regular_checkpoint_has_ptl_version_key(self, tmp_path: Path) -> None:
         """Saved regular checkpoint must include 'pytorch-lightning_version'."""
-        import pytorch_lightning as pl
 
         cb = BestModelCallback(output_dir=str(tmp_path))
         trainer = _make_trainer({"val/mAP_50_95": 0.5})

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -13,7 +13,8 @@ from unittest.mock import MagicMock
 
 import pytest
 import torch
-from pytorch_lightning import Callback, LightningModule, Trainer, __version__ as ptl_version
+from pytorch_lightning import Callback, LightningModule, Trainer
+from pytorch_lightning import __version__ as ptl_version
 from pytorch_lightning.trainer.states import TrainerFn
 from torch.utils.data import DataLoader, TensorDataset
 

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -730,8 +730,11 @@ class TestBestModelCallback:
             ckpt_path=str(ckpt_path),
         )
 
+        # PTL applies loop restoration by the first train epoch start.
         assert resume_probe.first_train_epoch == 1
         assert trainer_second.current_epoch == 2
+        # In the stripped-checkpoint resume path, optimizer state is intentionally
+        # fresh; this resumed phase contributes 2 steps (limit_train_batches=2).
         assert trainer_second.global_step == 2
 
 

--- a/tests/utilities/test_state_dict.py
+++ b/tests/utilities/test_state_dict.py
@@ -10,8 +10,8 @@ import logging
 from types import SimpleNamespace
 
 import pytest
-import pytorch_lightning as pl
 import torch
+from pytorch_lightning import LightningModule, Trainer
 
 from rfdetr.utilities.state_dict import _make_fit_loop_state, validate_checkpoint_compatibility
 
@@ -62,14 +62,14 @@ class TestMakeFitLoopState:
     def test_ptl_accepts_fit_loop_state(self) -> None:
         """PTL's _FitLoop.load_state_dict must not raise with our synthesised state dict."""
 
-        class _DummyModule(pl.LightningModule):
+        class _DummyModule(LightningModule):
             def training_step(self, batch, idx):
                 return torch.tensor(0.0, requires_grad=True)
 
             def configure_optimizers(self):
                 return torch.optim.SGD(self.parameters(), lr=1e-3)
 
-        trainer = pl.Trainer(max_epochs=10, accelerator="cpu", enable_progress_bar=False, logger=False)
+        trainer = Trainer(max_epochs=10, accelerator="cpu", enable_progress_bar=False, logger=False)
         trainer.strategy.connect(_DummyModule())
 
         epoch = 4

--- a/tests/utilities/test_state_dict.py
+++ b/tests/utilities/test_state_dict.py
@@ -4,15 +4,102 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
-"""Unit tests for validate_checkpoint_compatibility in rfdetr.utilities.state_dict."""
+"""Unit tests for rfdetr.utilities.state_dict."""
 
 import logging
 from types import SimpleNamespace
 
 import pytest
+import pytorch_lightning as pl
 import torch
 
-from rfdetr.utilities.state_dict import validate_checkpoint_compatibility
+from rfdetr.utilities.state_dict import _make_fit_loop_state, validate_checkpoint_compatibility
+
+# ---------------------------------------------------------------------------
+# _make_fit_loop_state
+# ---------------------------------------------------------------------------
+
+
+class TestMakeFitLoopState:
+    """Tests for _make_fit_loop_state epoch counter encoding."""
+
+    @pytest.mark.parametrize(
+        "epoch,expected_n",
+        [
+            pytest.param(0, 1, id="epoch_0"),
+            pytest.param(4, 5, id="epoch_4"),
+            pytest.param(9, 10, id="epoch_9"),
+        ],
+    )
+    def test_epoch_progress_completed_is_epoch_plus_one(self, epoch: int, expected_n: int) -> None:
+        """epoch_progress.current.completed == epoch + 1 so PTL sets current_epoch correctly."""
+        state = _make_fit_loop_state(epoch)
+        assert state["epoch_progress"]["current"]["completed"] == expected_n
+        assert state["epoch_progress"]["total"]["completed"] == expected_n
+
+    def test_epoch_progress_all_counters_equal(self) -> None:
+        """All four counters in epoch_progress should be equal (epoch fully completed)."""
+        state = _make_fit_loop_state(7)
+        for scope in ("total", "current"):
+            ep = state["epoch_progress"][scope]
+            vals = [ep["ready"], ep["started"], ep["processed"], ep["completed"]]
+            assert len(set(vals)) == 1, f"epoch_progress.{scope} counters differ: {ep}"
+
+    def test_batches_that_stepped_is_zero(self) -> None:
+        """Optimizer/scheduler state should start fresh; _batches_that_stepped must be 0."""
+        state = _make_fit_loop_state(3)
+        assert state["epoch_loop.state_dict"]["_batches_that_stepped"] == 0
+
+    def test_batch_progress_is_zero(self) -> None:
+        """Batch progress counters should be zeroed out (not mid-batch resume)."""
+        state = _make_fit_loop_state(5)
+        for key in ("epoch_loop.batch_progress", "epoch_loop.val_loop.batch_progress"):
+            bp = state[key]
+            assert bp["is_last_batch"] is False
+            for scope in ("total", "current"):
+                assert all(v == 0 for v in bp[scope].values()), f"{key}.{scope} not zero: {bp[scope]}"
+
+    def test_ptl_accepts_fit_loop_state(self) -> None:
+        """PTL's _FitLoop.load_state_dict must not raise with our synthesised state dict."""
+
+        class _DummyModule(pl.LightningModule):
+            def training_step(self, batch, idx):
+                return torch.tensor(0.0, requires_grad=True)
+
+            def configure_optimizers(self):
+                return torch.optim.SGD(self.parameters(), lr=1e-3)
+
+        trainer = pl.Trainer(max_epochs=10, accelerator="cpu", enable_progress_bar=False, logger=False)
+        trainer.strategy.connect(_DummyModule())
+
+        epoch = 4
+        state = _make_fit_loop_state(epoch)
+        trainer.fit_loop.load_state_dict(state)
+        assert trainer.current_epoch == epoch + 1
+
+    def test_required_top_level_keys_present(self) -> None:
+        """State dict must contain all keys the FitLoop accesses during load."""
+        required = {
+            "state_dict",
+            "epoch_loop.state_dict",
+            "epoch_loop.batch_progress",
+            "epoch_loop.scheduler_progress",
+            "epoch_loop.automatic_optimization.state_dict",
+            "epoch_loop.automatic_optimization.optim_progress",
+            "epoch_loop.manual_optimization.state_dict",
+            "epoch_loop.manual_optimization.optim_step_progress",
+            "epoch_loop.val_loop.state_dict",
+            "epoch_loop.val_loop.batch_progress",
+            "epoch_progress",
+        }
+        state = _make_fit_loop_state(0)
+        missing = required - set(state.keys())
+        assert not missing, f"Missing keys: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# validate_checkpoint_compatibility
+# ---------------------------------------------------------------------------
 
 
 class TestValidateCheckpointCompatibility:


### PR DESCRIPTION
## What does this PR do?

Fixes two-phase training resume via trainer.fit(ckpt_path=...).

Previously, checkpoint_best_total.pth could not be loaded via PTL's ckpt_path parameter because:
1. The file lacked the state_dict and loops keys PTL expects.
2. PyTorch >=2.6 defaulted torch.load to weights_only=True, rejecting the pickled TrainConfig Pydantic object stored under "args".

Source fix (no adapter needed):
- BestModelCallback now saves args as a plain dict (model_dump()) so weights_only=True works without registering safe globals.
- Adds PTL-compatible keys to every saved .pth: state_dict (model. prefixed), loops (epoch counter via _make_fit_loop_state), global_step, and pytorch-lightning_version.
- strip_checkpoint preserves these PTL keys so checkpoint_best_total.pth also works with ckpt_path.
- _make_fit_loop_state and _ckpt_args_get helpers moved/added to state_dict.py; readers (detr.py, module_model.py) use _ckpt_args_get to handle both dict (new) and namespace/object (legacy) args.
- checkpoint_io.py removed (no longer needed).

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

## Additional Context

needed for #824
