### PR TITLE
fix(datasets): add test split to make_coco_transforms, add PTL predict

### DIFF
--- a/src/rfdetr/datasets/coco.py
+++ b/src/rfdetr/datasets/coco.py
@@ -350,12 +350,12 @@ def make_coco_transforms(
     For the ``"train"`` split the pipeline uses a two-branch ``OneOf`` between a
     direct resize and a resize → random-crop → resize sequence (built via
     :func:`_build_train_resize_config`), followed by the augmentation stack and
-    normalisation.  For ``"val"`` and ``"val_speed"`` only resize and
-    normalisation are applied.
+    normalisation.  For ``"val"``, ``"test"``, and ``"val_speed"`` only resize and
+    normalisation are applied — no augmentation.
 
     Args:
-        image_set: Dataset split identifier — ``"train"``, ``"val"``, or
-            ``"val_speed"``.
+        image_set: Dataset split identifier — ``"train"``, ``"val"``, ``"test"``,
+            or ``"val_speed"``.
         resolution: Target short-side resolution in pixels.  During validation the
             longest side is capped at 1333 px to preserve aspect ratio.
         multi_scale: If ``True``, sample the resize target from a range of scales
@@ -401,7 +401,7 @@ def make_coco_transforms(
         aug_wrappers = AlbumentationsWrapper.from_config(resolved_aug_config)
         return Compose([*resize_wrappers, *aug_wrappers, to_image, to_float, normalize])
 
-    if image_set == "val":
+    if image_set in ("val", "test"):
         resize_wrappers = AlbumentationsWrapper.from_config(
             [
                 {"SmallestMaxSize": {"max_size": resolution}},

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -653,8 +653,8 @@ class RFDETR:
             orig_sizes.append((h, w))
 
             img_tensor = img_tensor.to(self.model.device)
-            img_tensor = F.normalize(img_tensor, self.means, self.stds)
             img_tensor = F.resize(img_tensor, (self.model.resolution, self.model.resolution))
+            img_tensor = F.normalize(img_tensor, self.means, self.stds)
 
             processed_images.append(img_tensor)
 

--- a/src/rfdetr/training/module_data.py
+++ b/src/rfdetr/training/module_data.py
@@ -90,6 +90,9 @@ class RFDETRDataModule(LightningDataModule):
             if self._dataset_test is None:
                 split = "test" if self.train_config.dataset_file == "roboflow" else "val"
                 self._dataset_test = build_dataset(split, ns, resolution)
+        elif stage == "predict":
+            if self._dataset_val is None:
+                self._dataset_val = build_dataset("val", ns, resolution)
 
     def train_dataloader(self) -> DataLoader:
         """Return the training DataLoader.
@@ -169,6 +172,24 @@ class RFDETRDataModule(LightningDataModule):
             self._dataset_test,
             batch_size=self.train_config.batch_size,
             sampler=torch.utils.data.SequentialSampler(self._dataset_test),
+            drop_last=False,
+            collate_fn=collate_fn,
+            num_workers=self.train_config.num_workers,
+            pin_memory=self._pin_memory,
+            persistent_workers=self._persistent_workers,
+            prefetch_factor=self._prefetch_factor,
+        )
+
+    def predict_dataloader(self) -> DataLoader:
+        """Return the predict DataLoader (reuses the validation dataset, no augmentation).
+
+        Returns:
+            DataLoader for the validation dataset with sequential sampling.
+        """
+        return DataLoader(
+            self._dataset_val,
+            batch_size=self.train_config.batch_size,
+            sampler=torch.utils.data.SequentialSampler(self._dataset_val),
             drop_last=False,
             collate_fn=collate_fn,
             num_workers=self.train_config.num_workers,

--- a/tests/datasets/test_augmentations.py
+++ b/tests/datasets/test_augmentations.py
@@ -1511,9 +1511,18 @@ class TestMakeCocoTransformsAugConfig:
 
         assert len(wrappers) == 1
 
-    def test_aug_config_not_applied_on_test(self):
-        """aug_config is ignored for the test split in make_coco_transforms_square_div_64."""
-        pipeline = make_coco_transforms_square_div_64("test", 640, aug_config={"HorizontalFlip": {"p": 1.0}})
+    @pytest.mark.parametrize(
+        "make_transforms,expected_resize_wrappers",
+        [
+            # make_coco_transforms test: SmallestMaxSize + LongestMaxSize = 2 wrappers
+            pytest.param(make_coco_transforms, 2, id="make_coco_transforms"),
+            # make_coco_transforms_square_div_64 test: Resize = 1 wrapper
+            pytest.param(make_coco_transforms_square_div_64, 1, id="make_coco_transforms_square_div_64"),
+        ],
+    )
+    def test_aug_config_not_applied_on_test(self, make_transforms, expected_resize_wrappers):
+        """aug_config is ignored for test splits — only resize wrappers are present."""
+        pipeline = make_transforms("test", 640, aug_config={"HorizontalFlip": {"p": 1.0}})
         wrappers = [t for t in pipeline.transforms if isinstance(t, AlbumentationsWrapper)]
 
-        assert len(wrappers) == 1
+        assert len(wrappers) == expected_resize_wrappers

--- a/tests/training/test_module_data.py
+++ b/tests/training/test_module_data.py
@@ -264,16 +264,28 @@ class TestSetup:
         assert dm._dataset_train is existing_train
         assert dm._dataset_val is existing_val
 
-    def test_predict_stage_builds_nothing(self, tmp_path):
-        """setup('predict') does not build any dataset."""
+    def test_predict_stage_builds_val_dataset(self, tmp_path):
+        """setup('predict') populates _dataset_val with the 'val' split."""
+        dm, _, fake_val, _ = self._setup_with_mock(tmp_path, "predict")
+        assert dm._dataset_val is fake_val
+        assert dm._dataset_train is None
+        assert dm._dataset_test is None
+
+    def test_predict_stage_does_not_rebuild_existing_val(self, tmp_path):
+        """setup('predict') skips building when _dataset_val is already set."""
         mc = _base_model_config()
         tc = _base_train_config(tmp_path)
         from rfdetr.training.module_data import RFDETRDataModule
 
         dm = RFDETRDataModule(mc, tc)
+        existing_val = _fake_dataset(20)
+        dm._dataset_val = existing_val
+
         with patch("rfdetr.training.module_data.build_dataset") as mock_build:
             dm.setup("predict")
             mock_build.assert_not_called()
+
+        assert dm._dataset_val is existing_val
 
 
 class TestTrainDataloader:
@@ -435,6 +447,49 @@ class TestTestDataloader:
         dm = self._setup_dm_with_test(tmp_path, batch_size=4)
         loader = dm.test_dataloader()
         assert loader.batch_size == 4
+
+
+class TestPredictDataloader:
+    """predict_dataloader() reuses the validation dataset with sequential sampling."""
+
+    def _setup_dm_with_val(self, tmp_path, dataset_length=50, batch_size=2, num_workers=0):
+        mc = _base_model_config()
+        tc = _base_train_config(tmp_path, batch_size=batch_size, num_workers=num_workers)
+        from rfdetr.training.module_data import RFDETRDataModule
+
+        dm = RFDETRDataModule(mc, tc)
+        dm._dataset_val = _fake_dataset(dataset_length)
+        return dm
+
+    def test_returns_dataloader(self, tmp_path):
+        """predict_dataloader() returns a DataLoader instance."""
+        dm = self._setup_dm_with_val(tmp_path)
+        loader = dm.predict_dataloader()
+        assert isinstance(loader, DataLoader)
+
+    def test_uses_sequential_sampler(self, tmp_path):
+        """predict_dataloader uses a SequentialSampler (deterministic ordering)."""
+        dm = self._setup_dm_with_val(tmp_path)
+        loader = dm.predict_dataloader()
+        assert isinstance(loader.sampler, torch.utils.data.SequentialSampler)
+
+    def test_drop_last_false(self, tmp_path):
+        """predict_dataloader does not drop the last incomplete batch."""
+        dm = self._setup_dm_with_val(tmp_path)
+        loader = dm.predict_dataloader()
+        assert loader.drop_last is False
+
+    def test_batch_size_forwarded(self, tmp_path):
+        """The DataLoader's batch size matches the train config."""
+        dm = self._setup_dm_with_val(tmp_path, batch_size=6)
+        loader = dm.predict_dataloader()
+        assert loader.batch_size == 6
+
+    def test_num_workers_forwarded(self, tmp_path):
+        """The DataLoader's num_workers matches the train config."""
+        dm = self._setup_dm_with_val(tmp_path, num_workers=0)
+        loader = dm.predict_dataloader()
+        assert loader.num_workers == 0
 
 
 class TestClassNames:


### PR DESCRIPTION
## What does this PR do?

- make_coco_transforms: handle "test" split (was raising ValueError); test now gets the same conservative pipeline as "val" (SmallestMaxSize + LongestMaxSize + normalize, no augmentation)
- RFDETRDataModule: add setup("predict") + predict_dataloader() so trainer.predict() works; reuses val dataset with SequentialSampler
- detr.predict(): swap normalize/resize order to match dataset pipeline (resize first, then normalize)

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
