### PR TITLE
fix: API surface cleanup — class_names, ModelContext, ModelConfig, migration artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/adr/
 
 # PyBuilder
 .pybuilder/

--- a/src/rfdetr/__init__.py
+++ b/src/rfdetr/__init__.py
@@ -5,6 +5,7 @@
 # ------------------------------------------------------------------------
 
 from rfdetr.detr import (
+    ModelContext,
     RFDETRBase,  # DEPRECATED # noqa: F401
     RFDETRLarge,
     RFDETRLargeDeprecated,  # DEPRECATED # noqa: F401
@@ -21,6 +22,7 @@ from rfdetr.detr import (
 )
 
 __all__ = [
+    "ModelContext",
     "RFDETRNano",
     "RFDETRSmall",
     "RFDETRMedium",

--- a/src/rfdetr/_namespace.py
+++ b/src/rfdetr/_namespace.py
@@ -37,6 +37,7 @@ def build_namespace(model_config: ModelConfig, train_config: TrainConfig) -> Any
     """
     mc = model_config
     tc = train_config
+    train_num_select = getattr(tc, "num_select", None)
 
     return types.SimpleNamespace(
         # --- ModelConfig fields ---
@@ -69,7 +70,7 @@ def build_namespace(model_config: ModelConfig, train_config: TrainConfig) -> Any
         segmentation_head=mc.segmentation_head,
         mask_downsample_ratio=mc.mask_downsample_ratio,
         num_queries=mc.num_queries,
-        num_select=getattr(tc, "num_select", mc.num_select),
+        num_select=mc.num_select if train_num_select is None else train_num_select,
         # --- TrainConfig fields ---
         lr=tc.lr,
         lr_encoder=tc.lr_encoder,

--- a/src/rfdetr/_namespace.py
+++ b/src/rfdetr/_namespace.py
@@ -69,7 +69,7 @@ def build_namespace(model_config: ModelConfig, train_config: TrainConfig) -> Any
         segmentation_head=mc.segmentation_head,
         mask_downsample_ratio=mc.mask_downsample_ratio,
         num_queries=mc.num_queries,
-        num_select=mc.num_select,
+        num_select=getattr(tc, "num_select", mc.num_select),
         # --- TrainConfig fields ---
         lr=tc.lr,
         lr_encoder=tc.lr_encoder,

--- a/src/rfdetr/_namespace.py
+++ b/src/rfdetr/_namespace.py
@@ -68,9 +68,8 @@ def build_namespace(model_config: ModelConfig, train_config: TrainConfig) -> Any
         cls_loss_coef=mc.cls_loss_coef,
         segmentation_head=mc.segmentation_head,
         mask_downsample_ratio=mc.mask_downsample_ratio,
-        # num_queries / num_select live on subclass configs.
-        num_queries=getattr(mc, "num_queries", 300),
-        num_select=getattr(mc, "num_select", tc.num_select),
+        num_queries=mc.num_queries,
+        num_select=mc.num_select,
         # --- TrainConfig fields ---
         lr=tc.lr,
         lr_encoder=tc.lr_encoder,
@@ -155,9 +154,9 @@ def build_namespace(model_config: ModelConfig, train_config: TrainConfig) -> Any
         use_cls_token=False,
         lr_scheduler="step",
         lr_min_factor=0.0,
-        early_stopping=True,
-        early_stopping_patience=10,
-        early_stopping_min_delta=0.001,
+        early_stopping=tc.early_stopping,
+        early_stopping_patience=tc.early_stopping_patience,
+        early_stopping_min_delta=tc.early_stopping_min_delta,
         early_stopping_use_ema=tc.early_stopping_use_ema,
         subcommand=None,
     )

--- a/src/rfdetr/assets/coco_classes.py
+++ b/src/rfdetr/assets/coco_classes.py
@@ -4,7 +4,7 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
-"""COCO class ID to name mapping."""
+"""COCO class ID to name mapping and flat class name list."""
 
 COCO_CLASSES = {
     1: "person",
@@ -88,3 +88,5 @@ COCO_CLASSES = {
     89: "hair drier",
     90: "toothbrush",
 }
+
+COCO_CLASS_NAMES: list[str] = [name for _, name in sorted(COCO_CLASSES.items())]

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -58,6 +58,9 @@ class ModelConfig(BaseConfig):
     ca_nheads: int
     dec_n_points: int
     num_queries: int = 300
+    # NOTE:
+    # - ModelConfig is the authoritative source of `num_select` for PTL/inference; it is read via `build_namespace`.
+    # - Any `num_select` field on TrainConfig / SegmentationTrainConfig is deprecated and ignored by PTL/inference.
     num_select: int = 300
     bbox_reparam: bool = True
     lite_refpoint_refine: bool = True

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -57,6 +57,8 @@ class ModelConfig(BaseConfig):
     sa_nheads: int
     ca_nheads: int
     dec_n_points: int
+    num_queries: int = 300
+    num_select: int = 300
     bbox_reparam: bool = True
     lite_refpoint_refine: bool = True
     layer_norm: bool = True
@@ -347,7 +349,7 @@ class TrainConfig(BaseModel):
     tensorboard: bool = True
     wandb: bool = False
     mlflow: bool = False
-    clearml: bool = False
+    clearml: bool = False  # Not yet implemented — reserved for future use.
     project: Optional[str] = None
     run: Optional[str] = None
     class_names: List[str] = None

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -585,7 +585,7 @@ class RFDETR:
             COCO class names.
         """
         if hasattr(self.model, "class_names") and self.model.class_names is not None:
-            return self.model.class_names
+            return list(self.model.class_names)
 
         return COCO_CLASS_NAMES
 

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -12,7 +12,7 @@ import warnings
 from collections import defaultdict
 from copy import deepcopy
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 import numpy as np
 import requests
@@ -24,7 +24,7 @@ import torchvision.transforms.functional as F
 import yaml
 from PIL import Image
 
-from rfdetr.assets.coco_classes import COCO_CLASSES
+from rfdetr.assets.coco_classes import COCO_CLASS_NAMES
 from rfdetr.assets.model_weights import download_pretrain_weights, validate_pretrain_weights
 from rfdetr.config import (
     ModelConfig,
@@ -58,7 +58,7 @@ except Exception:
 logger = get_logger()
 
 
-class _ModelContext:
+class ModelContext:
     """Lightweight model wrapper returned by RFDETR.get_model().
 
     Provides the same attribute interface as the legacy ``main.py:Model`` but
@@ -98,6 +98,9 @@ class _ModelContext:
         """
         self.model.reinitialize_detection_head(num_classes)
         self.args.num_classes = num_classes
+
+
+_ModelContext = ModelContext  # backward compat alias
 
 
 def _load_pretrain_weights_into(nn_model: torch.nn.Module, args: Any) -> List[str]:
@@ -185,8 +188,8 @@ def _apply_lora_to(nn_model: torch.nn.Module) -> None:
     nn_model.backbone[0].encoder = get_peft_model(nn_model.backbone[0].encoder, lora_config)
 
 
-def _build_model_context(model_config: ModelConfig) -> "_ModelContext":
-    """Build a _ModelContext from ModelConfig without using legacy main.py:Model.
+def _build_model_context(model_config: ModelConfig) -> "ModelContext":
+    """Build a ModelContext from ModelConfig without using legacy main.py:Model.
 
     Replicates ``Model.__init__`` logic: builds the nn.Module, optionally loads
     pretrain weights and applies LoRA, then moves the model to the target device.
@@ -195,7 +198,7 @@ def _build_model_context(model_config: ModelConfig) -> "_ModelContext":
         model_config: Architecture configuration.
 
     Returns:
-        Fully initialised _ModelContext ready for inference or training.
+        Fully initialised ModelContext ready for inference or training.
     """
     from rfdetr._namespace import build_namespace
 
@@ -215,7 +218,7 @@ def _build_model_context(model_config: ModelConfig) -> "_ModelContext":
     nn_model = nn_model.to(device)
     postprocess = PostProcess(num_select=args.num_select)
 
-    return _ModelContext(
+    return ModelContext(
         model=nn_model,
         postprocess=postprocess,
         device=device,
@@ -560,34 +563,31 @@ class RFDETR:
         """
         return self._train_config_class(**kwargs)
 
-    def get_model(self, config: ModelConfig) -> "_ModelContext":
+    def get_model(self, config: ModelConfig) -> "ModelContext":
         """Retrieve a model context from the provided architecture configuration.
 
         Args:
             config: Architecture configuration.
 
         Returns:
-            _ModelContext with model, postprocess, device, resolution, args,
+            ModelContext with model, postprocess, device, resolution, args,
             and class_names attributes.
         """
         return _build_model_context(config)
 
-    # Get class_names from the model
     @property
-    def class_names(self) -> Dict[int, str]:
+    def class_names(self) -> List[str]:
         """Retrieve the class names supported by the loaded model.
 
         Returns:
-            A dictionary mapping integer class IDs to class name strings.
-            IDs are 1-indexed and may be non-contiguous (e.g. COCO category
-            IDs have gaps such as 11→13 and 25→27).  When no custom class
-            names are embedded in the checkpoint, returns the standard COCO
-            classes dict.
+            A list of class name strings, 0-indexed.  When no custom class
+            names are embedded in the checkpoint, returns the standard 80
+            COCO class names.
         """
         if hasattr(self.model, "class_names") and self.model.class_names is not None:
-            return {i + 1: name for i, name in enumerate(self.model.class_names)}
+            return self.model.class_names
 
-        return COCO_CLASSES
+        return COCO_CLASS_NAMES
 
     def predict(
         self,

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -110,7 +110,7 @@ class BestModelCallback(ModelCheckpoint):
 
         Args:
             trainer: The Lightning Trainer instance.
-            pl_module: The ``RFDETRModule`` being trained.
+            pl_module: The ``RFDETRModelModule`` being trained.
 
         Returns:
             EMA model state dict when available, otherwise the live model state dict.
@@ -185,7 +185,7 @@ class BestModelCallback(ModelCheckpoint):
 
         Args:
             trainer: The Lightning Trainer instance.
-            pl_module: The ``RFDETRModule`` being trained.
+            pl_module: The ``RFDETRModelModule`` being trained.
         """
         # Stash for use inside _save_checkpoint (which has no pl_module param).
         self._current_pl_module = pl_module
@@ -231,7 +231,7 @@ class BestModelCallback(ModelCheckpoint):
 
         Args:
             trainer: The Lightning Trainer instance.
-            pl_module: The ``RFDETRModule`` being trained.
+            pl_module: The ``RFDETRModelModule`` being trained.
         """
         if not trainer.is_global_zero:
             return
@@ -331,7 +331,7 @@ class RFDETREarlyStopping(EarlyStopping):
 
         Args:
             trainer: The Lightning Trainer instance.
-            pl_module: The ``RFDETRModule`` being trained.
+            pl_module: The ``RFDETRModelModule`` being trained.
         """
         metrics = trainer.callback_metrics
         regular_tensor = metrics.get(self._monitor_regular)

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -4,7 +4,7 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
-"""COCOEvalCallback — torchmetrics-based mAP and F1 evaluation (Phase 3)."""
+"""COCOEvalCallback — torchmetrics-based mAP and F1 evaluation."""
 
 import contextlib
 from typing import Any
@@ -146,7 +146,7 @@ class COCOEvalCallback(Callback):
         """Accumulate predictions and matching data for one validation batch.
 
         Expects ``outputs`` to be the dict returned by
-        ``RFDETRModule.validation_step``:
+        ``RFDETRModelModule.validation_step``:
         ``{"results": list[dict], "targets": list[dict]}``.
 
         When an EMA callback is present the EMA model is run on the same batch

--- a/src/rfdetr/training/module_data.py
+++ b/src/rfdetr/training/module_data.py
@@ -4,7 +4,7 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
-"""LightningDataModule for RF-DETR dataset construction and loaders (Phase 2)."""
+"""LightningDataModule for RF-DETR dataset construction and loaders."""
 
 from typing import List, Optional, Tuple
 
@@ -26,10 +26,6 @@ _MIN_TRAIN_BATCHES = 5
 
 class RFDETRDataModule(LightningDataModule):
     """LightningDataModule wrapping RF-DETR dataset construction and data loading.
-
-    Migrates ``Model.train()`` dataset construction and DataLoader setup from
-    ``main.py`` into PTL lifecycle hooks.  Coexists with the existing code until
-    Chapter 4 removes the legacy path.
 
     Args:
         model_config: Architecture configuration (used for resolution, patch_size, etc.).

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -4,7 +4,7 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
-"""LightningModule for RF-DETR training and validation (Phase 1)."""
+"""LightningModule for RF-DETR training and validation."""
 
 from __future__ import annotations
 
@@ -25,17 +25,13 @@ from rfdetr.datasets.coco import compute_multi_scale_scales
 from rfdetr.models.lwdetr import build_criterion_and_postprocessors, build_model
 from rfdetr.training.param_groups import get_param_dict
 from rfdetr.utilities.logger import get_logger
-from rfdetr.utilities.state_dict import _ckpt_args_get, validate_checkpoint_compatibility
+from rfdetr.utilities.state_dict import validate_checkpoint_compatibility
 
 logger = get_logger()
 
 
 class RFDETRModelModule(LightningModule):
     """LightningModule wrapping the RF-DETR model and training loop.
-
-    Migrates ``Model.__init__``, ``train_one_epoch``, ``evaluate``, and
-    optimizer setup from ``main.py`` / ``engine.py`` into PTL lifecycle hooks.
-    Coexists with the existing code until Chapter 4 removes the legacy path.
 
     Args:
         model_config: Architecture configuration.
@@ -123,9 +119,6 @@ class RFDETRModelModule(LightningModule):
             download_pretrain_weights(pretrain_weights, redownload=True, validate_md5=False)
             checkpoint = torch.load(pretrain_weights, map_location="cpu", weights_only=False)
 
-        if "args" in checkpoint:
-            self._pretrain_class_names = _ckpt_args_get(checkpoint["args"], "class_names")
-
         ns = build_namespace(mc, self.train_config)
         validate_checkpoint_compatibility(checkpoint, ns)
 
@@ -156,7 +149,7 @@ class RFDETRModelModule(LightningModule):
             self.model.reinitialize_detection_head(checkpoint_num_classes)
 
         # Trim query embeddings to the configured query count.
-        num_desired_queries = getattr(mc, "num_queries", 300) * getattr(mc, "group_detr", 13)
+        num_desired_queries = mc.num_queries * mc.group_detr
         query_param_names = ["refpoint_embed.weight", "query_feat.weight"]
         for name in list(checkpoint["model"].keys()):
             if any(name.endswith(x) for x in query_param_names):

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -189,9 +189,7 @@ def build_trainer(
             _logger.warning("MLflow logging disabled: %s. Install with: pip install mlflow", exc)
 
     if tc.clearml:
-        raise NotImplementedError(
-            "ClearML logging is not yet supported. Remove clearml=True from TrainConfig."
-        )
+        raise NotImplementedError("ClearML logging is not yet supported. Remove clearml=True from TrainConfig.")
 
     # --- Promoted config fields (T4-2 added these to TrainConfig) ---
     clip_max_norm: float = tc.clip_max_norm

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -189,12 +189,8 @@ def build_trainer(
             _logger.warning("MLflow logging disabled: %s. Install with: pip install mlflow", exc)
 
     if tc.clearml:
-        warnings.warn(
-            "ClearML logging is not supported via a native PTL logger in this version."
-            " Metrics will not be logged to ClearML. Use the ClearML SDK callback directly"
-            " or wait for a dedicated ClearML PTL logger integration.",
-            UserWarning,
-            stacklevel=2,
+        raise NotImplementedError(
+            "ClearML logging is not yet supported. Remove clearml=True from TrainConfig."
         )
 
     # --- Promoted config fields (T4-2 added these to TrainConfig) ---

--- a/tests/training/test_args.py
+++ b/tests/training/test_args.py
@@ -113,6 +113,15 @@ class TestBuildNamespace:
         assert args.mask_ce_loss_coef == pytest.approx(5.0)
         assert args.mask_dice_loss_coef == pytest.approx(5.0)
 
+    def test_segmentation_num_select_none_falls_back_to_model_config(self, base_model_config, seg_train_config) -> None:
+        """SegmentationTrainConfig(num_select=None) must not overwrite ModelConfig.num_select."""
+        mc = base_model_config(segmentation_head=True, num_select=200)
+        tc = seg_train_config(num_select=None)
+
+        args = build_namespace(mc, tc)
+
+        assert args.num_select == 200
+
     def test_segmentation_extras_default_for_plain_config(self, base_model_config, base_train_config):
         """mask_* attributes default to 5.0 for a plain TrainConfig (not segmentation)."""
         args = build_namespace(base_model_config(), base_train_config())

--- a/tests/training/test_build_trainer.py
+++ b/tests/training/test_build_trainer.py
@@ -332,16 +332,13 @@ class TestBuildTrainerLoggers:
         assert all(not isinstance(lg, TensorBoardLogger) for lg in trainer.loggers)
         assert any(isinstance(lg, CSVLogger) for lg in trainer.loggers)
 
-    def test_clearml_flag_emits_warning(self, tmp_path):
-        """clearml=True must emit a UserWarning (no native PTL logger)."""
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
+    def test_clearml_flag_raises_not_implemented(self, tmp_path):
+        """clearml=True must raise NotImplementedError (not yet supported)."""
+        with pytest.raises(NotImplementedError, match="ClearML"):
             build_trainer(
                 _tc(tmp_path, clearml=True, use_ema=False),
                 _mc(),
             )
-        user_warns = [w for w in caught if issubclass(w.category, UserWarning)]
-        assert any("ClearML" in str(w.message) for w in user_warns)
 
     def test_multiple_loggers_combined(self, tmp_path):
         """Multiple loggers can be wired simultaneously."""

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -987,3 +987,14 @@ class TestClassNamesProperty:
         result = RFDETR.class_names.fget(mock_self)
 
         assert result == ["cat", "dog"]
+
+    def test_custom_class_names_returns_shallow_copy(self):
+        """Mutating the returned class_names list must not mutate model state."""
+        mock_self = MagicMock()
+        mock_self.model.class_names = ["cat", "dog"]
+
+        result = RFDETR.class_names.fget(mock_self)
+        result.append("bird")
+
+        assert result == ["cat", "dog", "bird"]
+        assert mock_self.model.class_names == ["cat", "dog"]

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -951,39 +951,39 @@ class TestLoadPretrainWeightsInto:
 
 
 class TestClassNamesProperty:
-    """RFDETR.class_names property uses is-None identity, not truthiness, for empty lists."""
+    """RFDETR.class_names property returns List[str] (0-indexed)."""
 
-    def test_empty_class_names_returns_empty_dict_not_coco(self):
-        """class_names property returns {} when model.class_names is [], NOT COCO_CLASSES.
+    def test_empty_class_names_returns_empty_list_not_coco(self):
+        """class_names property returns [] when model.class_names is [], NOT COCO fallback.
 
         Regression test for #509: the truthiness check `and self.model.class_names:`
         treated [] as falsy and fell through to return COCO_CLASSES, defeating the
         detr.py sync-back even after training on a dataset that reports empty names.
-        The fix uses `is not None` so that [] is preserved as an empty mapping.
+        The fix uses `is not None` so that [] is preserved.
         """
         mock_self = MagicMock()
         mock_self.model.class_names = []
 
         result = RFDETR.class_names.fget(mock_self)
 
-        assert result == {}, "class_names=[] must return {} (empty dict), not COCO_CLASSES"
+        assert result == [], "class_names=[] must return [] (empty list), not COCO fallback"
 
     def test_none_class_names_returns_coco(self):
-        """class_names property falls back to COCO_CLASSES when model.class_names is None."""
-        from rfdetr.assets.coco_classes import COCO_CLASSES
+        """class_names property falls back to COCO_CLASS_NAMES when model.class_names is None."""
+        from rfdetr.assets.coco_classes import COCO_CLASS_NAMES
 
         mock_self = MagicMock()
         mock_self.model.class_names = None
 
         result = RFDETR.class_names.fget(mock_self)
 
-        assert result is COCO_CLASSES
+        assert result is COCO_CLASS_NAMES
 
-    def test_custom_class_names_returned_as_one_indexed_dict(self):
-        """Non-empty class_names are returned as a 1-indexed dict."""
+    def test_custom_class_names_returned_as_list(self):
+        """Non-empty class_names are returned as a 0-indexed list."""
         mock_self = MagicMock()
         mock_self.model.class_names = ["cat", "dog"]
 
         result = RFDETR.class_names.fget(mock_self)
 
-        assert result == {1: "cat", 2: "dog"}
+        assert result == ["cat", "dog"]

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -349,24 +349,6 @@ class TestLoadPretrainWeights:
 
     @patch("rfdetr.training.module_model.torch.load")
     @patch("rfdetr.training.module_model.validate_pretrain_weights")
-    def test_pretrain_class_names_stored_when_present(
-        self, mock_validate, mock_torch_load, base_model_config, build_module
-    ):
-        """Class names from checkpoint args must be saved for transfer learning use."""
-        mc = base_model_config(num_classes=90)
-        ckpt_args = SimpleNamespace(class_names=["cat", "dog"])
-        checkpoint = self._make_checkpoint(num_classes_in_ckpt=91)
-        checkpoint["args"] = ckpt_args
-        mock_torch_load.return_value = checkpoint
-
-        module, _, _, _ = build_module(model_config=mc)
-        module.model_config = module.model_config.model_copy(update={"pretrain_weights": "/fake/weights.pth"})
-        module._load_pretrain_weights()
-
-        assert module._pretrain_class_names == ["cat", "dog"]
-
-    @patch("rfdetr.training.module_model.torch.load")
-    @patch("rfdetr.training.module_model.validate_pretrain_weights")
     def test_seg_checkpoint_into_detection_model_raises(
         self, mock_validate, mock_torch_load, base_model_config, build_module
     ):


### PR DESCRIPTION
## What does this PR do?

- Standardise class_names to List[str] across RFDETR, RFDETRDataModule, and BestModelCallback (was Dict[int,str] on the public property); add COCO_CLASS_NAMES flat list to assets/coco_classes.py as fallback
- Remove dead self._pretrain_class_names assignment in RFDETRModelModule._load_pretrain_weights() and the corresponding test
- Rename _ModelContext → ModelContext (public); export from __init__; keep _ModelContext = ModelContext backward-compat alias
- Add num_queries/num_select fields to ModelConfig base class; replace getattr(mc, "num_queries", 300) silent fallbacks with direct mc.num_queries in _namespace.py and module_model.py
- Fix _namespace.py early_stopping hardcoded True → reads tc.early_stopping, tc.early_stopping_patience, tc.early_stopping_min_delta
- Raise NotImplementedError when TrainConfig.clearml=True (was silent no-op UserWarning); update test accordingly
- Fix stale RFDETRModule → RFDETRModelModule references in docstrings (best_model.py, coco_eval.py)
- Remove empty src/rfdetr/lit/ migration artifact tree
- Scrub stale "Phase N / Chapter N / coexists with existing code" migration scaffolding comments from module_model.py, module_data.py, coco_eval.py

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)
- Refactoring (no functional changes)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
