### PR TITLE
chore: packaging pins + move peft to [lora] extra, fix eager backbone import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,17 +37,20 @@ keywords = ["machine-learning", "deep-learning", "vision", "ML", "DL", "AI", "DE
 dependencies = [
     "requests",                        # weight download from remote URLs
     "torch>=2.2.0",                    # core tensor ops and model forward pass
-    "torchvision>=0.14.0",             # image transforms and ops
+    "torchvision>=0.17.0",             # image transforms and ops (aligned with torch>=2.2.0)
     "tqdm",                            # progress bars during weight download
     "transformers>=5.1.0,<6.0.0",     # DINOv2 backbone loading
-    "peft",                            # LoRA backbone weight loading; TODO: consider moving to extras
-    "pydantic",                        # ModelConfig / TrainConfig validation
+    "pydantic>=2.0,<3",               # ModelConfig / TrainConfig validation
     "supervision",                     # inference output (Detections, Masks)
     "pyDeprecate>=0.3,<0.6",           # deprecation warnings for legacy APIs
 ]
 
 [project.optional-dependencies]
+lora = [
+    "peft",                            # LoRA backbone fine-tuning
+]
 train = [
+    "peft",                            # LoRA backbone fine-tuning (available during training)
     "pytorch_lightning>=2.6,<3",
     "torchmetrics[detection]>=1.2",
     "faster-coco-eval>=1.7.2",

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -167,7 +167,10 @@ def _apply_lora_to(nn_model: torch.nn.Module) -> None:
     Args:
         nn_model: LWDETR model whose backbone encoder will receive LoRA.
     """
-    from peft import LoraConfig, get_peft_model
+    try:
+        from peft import LoraConfig, get_peft_model
+    except ImportError as exc:
+        raise ImportError("LoRA requires peft: pip install 'rfdetr[lora]'") from exc
 
     lora_config = LoraConfig(
         r=16,

--- a/src/rfdetr/models/backbone/backbone.py
+++ b/src/rfdetr/models/backbone/backbone.py
@@ -119,8 +119,12 @@ class Backbone(BackboneBase):
 
         try:
             from peft import PeftModel
-        except ImportError:
+        except ModuleNotFoundError:
+            logger.warning("peft is not installed; skipping LoRA weight merging during export.")
             return
+        except ImportError as exc:
+            logger.warning("Failed to import PeftModel from peft during export: %s", exc)
+            raise
 
         if isinstance(self.encoder, PeftModel):
             logger.info("Merging and unloading LoRA weights")

--- a/src/rfdetr/models/backbone/backbone.py
+++ b/src/rfdetr/models/backbone/backbone.py
@@ -19,7 +19,6 @@ Backbone modules.
 
 import torch
 import torch.nn.functional as F
-from peft import PeftModel
 
 from rfdetr.models.backbone.base import BackboneBase
 from rfdetr.models.backbone.dinov2 import DinoV2
@@ -118,9 +117,14 @@ class Backbone(BackboneBase):
         self._forward_origin = self.forward
         self.forward = self.forward_export
 
+        try:
+            from peft import PeftModel
+        except ImportError:
+            return
+
         if isinstance(self.encoder, PeftModel):
             logger.info("Merging and unloading LoRA weights")
-            self.encoder.merge_and_unload()
+            self.encoder = self.encoder.merge_and_unload()
 
     def forward(self, tensor_list: NestedTensor):
         """ """

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -172,7 +172,10 @@ class RFDETRModelModule(LightningModule):
 
         Mirrors ``Model.__init__`` LoRA setup.
         """
-        from peft import LoraConfig, get_peft_model
+        try:
+            from peft import LoraConfig, get_peft_model
+        except ImportError as exc:
+            raise ImportError("LoRA requires peft: pip install 'rfdetr[lora]'") from exc
 
         lora_config = LoraConfig(
             r=16,

--- a/tests/models/backbone/test_backbone_export.py
+++ b/tests/models/backbone/test_backbone_export.py
@@ -1,0 +1,40 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Tests for backbone export behavior."""
+
+import sys
+from types import ModuleType
+
+from rfdetr.models.backbone.backbone import Backbone
+
+
+class TestBackboneExport:
+    """Tests for ``Backbone.export``."""
+
+    def test_export_replaces_peft_encoder_with_merged_encoder(self, monkeypatch) -> None:
+        """Export should replace PEFT wrapper with merged base encoder."""
+
+        class _MergedEncoder:
+            pass
+
+        class _FakePeftModel:
+            def __init__(self) -> None:
+                self._merged = _MergedEncoder()
+
+            def merge_and_unload(self):
+                return self._merged
+
+        peft_module = ModuleType("peft")
+        peft_module.PeftModel = _FakePeftModel
+        monkeypatch.setitem(sys.modules, "peft", peft_module)
+
+        backbone = object.__new__(Backbone)
+        backbone.encoder = _FakePeftModel()
+
+        backbone.export()
+
+        assert isinstance(backbone.encoder, _MergedEncoder)

--- a/tests/utilities/test_package.py
+++ b/tests/utilities/test_package.py
@@ -58,4 +58,9 @@ def test_peft_not_imported_eagerly_on_backbone_import_characterization() -> None
         text=True,
         check=False,
     )
-    assert result.returncode == 0, f"peft was eagerly imported by backbone.backbone.\nstderr: {result.stderr}"
+    assert result.returncode == 0, (
+        "Subprocess for backbone import failed:\n"
+        f"return code: {result.returncode}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )

--- a/tests/utilities/test_package.py
+++ b/tests/utilities/test_package.py
@@ -6,6 +6,8 @@
 
 """Tests for package metadata helpers."""
 
+import subprocess
+import sys
 from unittest.mock import patch
 
 from rfdetr.utilities.package import get_sha
@@ -32,3 +34,28 @@ def test_get_sha_marks_dirty_worktree_when_diff_command_returns_exit_code_1() ->
         sha = get_sha()
 
     assert sha == "sha: abc123, status: has uncommitted changes, branch: feature/test"
+
+
+def test_peft_not_imported_eagerly_on_backbone_import_characterization() -> None:
+    """Importing backbone.backbone must NOT pull peft into sys.modules (peft is optional).
+
+    This characterization test captures the invariant introduced in PR 1 (chore/packaging-peft-lora):
+    after the lazy-import refactor, importing backbone at module-load time must not trigger a
+    top-level ``from peft import PeftModel``.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "import rfdetr.models.backbone.backbone; "
+                "assert 'peft' not in sys.modules, "
+                "'peft was eagerly imported by backbone.backbone'"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"peft was eagerly imported by backbone.backbone.\nstderr: {result.stderr}"


### PR DESCRIPTION
## What does this PR do?

- Pin torchvision>=0.17.0 (aligns with torch>=2.2.0 floor)
- Pin pydantic>=2.0,<3 (formalises existing v2-only API usage)
- Move peft from core deps to [lora] and [train] optional extras
- Replace top-level `from peft import PeftModel` in backbone.py with lazy try/except import inside Backbone.export()
- Fix merge_and_unload() result not being assigned back to self.encoder
- Add ImportError hints in _apply_lora_to() and _apply_lora() pointing users to `pip install rfdetr[lora]`
- Add characterization test: importing backbone must not pull peft into sys.modules
- Add regression test: Backbone.export() replaces encoder with merged model

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)
- Refactoring (no functional changes)

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change


## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
