### PR TITLE
chore: add __getattr__ hook for rfdetr.util/rfdetr.deploy removal

### DIFF
--- a/src/rfdetr/__init__.py
+++ b/src/rfdetr/__init__.py
@@ -3,6 +3,28 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
+"""RF-DETR public package initialiser.
+
+Two-phase legacy-module deprecation
+------------------------------------
+Some sub-packages were relocated in v1.6 and are scheduled for removal in v1.7.
+The migration is handled in two phases so users get a full release cycle to update
+their imports:
+
+**Phase 1 — v1.6 (current):** the old packages (``rfdetr.util``, ``rfdetr.deploy``)
+still exist on disk and work normally, but emit a ``DeprecationWarning`` on import.
+``_RemovedModuleFinder`` is installed in ``sys.meta_path`` but stays dormant: its
+``find_spec`` returns ``None`` whenever ``importlib.machinery.PathFinder`` can
+resolve the name (i.e. while the shim directories are present).
+
+**Phase 2 — v1.7:** the shim directories are deleted.  ``PathFinder`` can no longer
+resolve ``rfdetr.util`` / ``rfdetr.deploy``, so ``_RemovedModuleFinder`` intercepts
+the import and raises a descriptive ``ImportError`` (migration hint) instead of the
+cryptic default ``ModuleNotFoundError: No module named 'rfdetr.util'``.
+
+To complete Phase 2, delete ``src/rfdetr/util/`` and ``src/rfdetr/deploy/`` and bump
+``_REMOVED_IN_V17`` (or rename it) to reflect the new version boundary.
+"""
 
 import importlib
 import importlib.abc

--- a/src/rfdetr/__init__.py
+++ b/src/rfdetr/__init__.py
@@ -80,6 +80,8 @@ class _RemovedModuleFinder(importlib.abc.MetaPathFinder):
         target: object | None = None,
     ) -> importlib.machinery.ModuleSpec | None:
         """Return a failing spec with a migration hint for removed legacy modules."""
+        if not fullname.startswith(f"{__name__}."):
+            return None
         root, _, _ = fullname.removeprefix(f"{__name__}.").partition(".")
         if root not in _REMOVED_IN_V17:
             return None
@@ -94,8 +96,9 @@ class _RemovedModuleFinder(importlib.abc.MetaPathFinder):
 
 _REMOVED_MODULE_FINDER = _RemovedModuleFinder()
 
-if not any(type(finder) is _RemovedModuleFinder for finder in sys.meta_path):
+if not getattr(sys, "_rfdetr_removed_finder", False):
     sys.meta_path.insert(0, _REMOVED_MODULE_FINDER)
+    sys._rfdetr_removed_finder = True
 
 
 def __getattr__(name: str):

--- a/src/rfdetr/__init__.py
+++ b/src/rfdetr/__init__.py
@@ -5,6 +5,10 @@
 # ------------------------------------------------------------------------
 
 import importlib
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import sys
 
 from rfdetr.detr import (
     ModelContext,
@@ -41,11 +45,57 @@ __all__ = [
 _LAZY_TRAINING = frozenset({"RFDETRModelModule", "RFDETRDataModule", "build_trainer"})
 _PLUS_EXPORTS = frozenset({"RFDETR2XLarge", "RFDETRXLarge"})
 
-# Modules removed in v1.7 — hook fires once the shim files are deleted at release time.
+# Legacy module aliases delegate to shim packages while they still exist, then raise
+# migration-hint ImportError messages once those shims are removed in v1.7+.
 _REMOVED_IN_V17 = {
     "util": "rfdetr.util was removed in v1.7. Use rfdetr.utilities instead.",
     "deploy": "rfdetr.deploy was removed in v1.7. Use rfdetr.export instead.",
 }
+
+
+class _RemovedModuleLoader(importlib.abc.Loader):
+    """Raise a migration hint when a removed legacy module import is attempted."""
+
+    def __init__(self, message: str) -> None:
+        self._message = message
+
+    def create_module(self, spec: importlib.machinery.ModuleSpec) -> None:
+        """Use the default module creation path."""
+        return None
+
+    def exec_module(self, module: object) -> None:
+        """Abort import with a migration hint instead of bare ModuleNotFoundError."""
+        raise ImportError(self._message) from None
+
+
+class _RemovedModuleFinder(importlib.abc.MetaPathFinder):
+    """Intercept removed legacy dotted imports after their shim packages are deleted."""
+
+    _PATH_FINDER = importlib.machinery.PathFinder
+
+    def find_spec(
+        self,
+        fullname: str,
+        path: list[str] | None,
+        target: object | None = None,
+    ) -> importlib.machinery.ModuleSpec | None:
+        """Return a failing spec with a migration hint for removed legacy modules."""
+        root, _, _ = fullname.removeprefix(f"{__name__}.").partition(".")
+        if root not in _REMOVED_IN_V17:
+            return None
+
+        if self._PATH_FINDER.find_spec(fullname, path) is not None:
+            return None
+
+        is_package = fullname == f"{__name__}.{root}"
+        loader = _RemovedModuleLoader(_REMOVED_IN_V17[root])
+        return importlib.util.spec_from_loader(fullname, loader, is_package=is_package)
+
+
+_REMOVED_MODULE_FINDER = _RemovedModuleFinder()
+
+if not any(type(finder) is _RemovedModuleFinder for finder in sys.meta_path):
+    sys.meta_path.insert(0, _REMOVED_MODULE_FINDER)
 
 
 def __getattr__(name: str):

--- a/src/rfdetr/__init__.py
+++ b/src/rfdetr/__init__.py
@@ -49,7 +49,21 @@ _REMOVED_IN_V17 = {
 
 
 def __getattr__(name: str):
-    """Resolve PTL and plus-only exports lazily, raising only on explicit access."""
+    """Lazily resolve training/PTL and plus-only exports and handle removed-module aliases.
+
+    This hook is only invoked on explicit attribute access (e.g. ``rfdetr.RFDETRModelModule``)
+    and supports three behaviors:
+
+    * Training/PTL exports (names in ``_LAZY_TRAINING``) are imported from ``rfdetr.training``
+      on first use to avoid importing PyTorch Lightning at ``import rfdetr`` time.
+    * Plus-only exports (names in ``_PLUS_EXPORTS``) are imported from ``rfdetr.platform.models``,
+      and a descriptive ``ImportError`` is raised with an installation hint if the model is
+      not available.
+    * Removed-module aliases (keys in ``_REMOVED_IN_V17``, such as ``util`` and ``deploy``)
+      are first attempted via a shim submodule (e.g. ``rfdetr.util``); once the shim files
+      are removed, a migration-hint ``ImportError`` is raised instead of silently masking
+      unrelated nested import errors.
+    """
     if name in _REMOVED_IN_V17:
         module_name = f"{__name__}.{name}"
         try:

--- a/src/rfdetr/__init__.py
+++ b/src/rfdetr/__init__.py
@@ -4,6 +4,8 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
+import importlib
+
 from rfdetr.detr import (
     ModelContext,
     RFDETRBase,  # DEPRECATED # noqa: F401
@@ -39,9 +41,27 @@ __all__ = [
 _LAZY_TRAINING = frozenset({"RFDETRModelModule", "RFDETRDataModule", "build_trainer"})
 _PLUS_EXPORTS = frozenset({"RFDETR2XLarge", "RFDETRXLarge"})
 
+# Modules removed in v1.7 — hook fires once the shim files are deleted at release time.
+_REMOVED_IN_V17 = {
+    "util": "rfdetr.util was removed in v1.7. Use rfdetr.utilities instead.",
+    "deploy": "rfdetr.deploy was removed in v1.7. Use rfdetr.export instead.",
+}
+
 
 def __getattr__(name: str):
     """Resolve PTL and plus-only exports lazily, raising only on explicit access."""
+    if name in _REMOVED_IN_V17:
+        module_name = f"{__name__}.{name}"
+        try:
+            value = importlib.import_module(module_name)
+            globals()[name] = value
+            return value
+        except ModuleNotFoundError as exc:
+            # Avoid masking nested import errors from within the shim itself.
+            if exc.name != module_name:
+                raise
+            raise ImportError(_REMOVED_IN_V17[name]) from None
+
     if name in _LAZY_TRAINING:
         from rfdetr import training as _training
 

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -14,6 +14,8 @@
 """
 
 import argparse
+import importlib
+import sys
 import warnings
 from collections import defaultdict
 from types import SimpleNamespace
@@ -811,6 +813,90 @@ class TestPublicAPIExports:
 
         # It is NOT directly on rfdetr (Phase 7.7 spec lists only the three PTL exports)
         assert not hasattr(rfdetr, "convert_legacy_checkpoint")
+
+
+class TestRemovedLegacyModuleAliases:
+    """Removed legacy modules resolve via shims today and via migration hints after removal."""
+
+    @staticmethod
+    def _simulate_missing_removed_module_specs(monkeypatch: pytest.MonkeyPatch, *names: str) -> None:
+        """Force the removed-module finder to behave as if shim files no longer exist."""
+        import rfdetr
+
+        path_finder = rfdetr._RemovedModuleFinder._PATH_FINDER
+        original_find_spec = path_finder.find_spec
+
+        def _fake_find_spec(fullname: str, path: list[str] | None = None, target: object | None = None) -> object:
+            if fullname in names:
+                return None
+            return original_find_spec(fullname, path, target)
+
+        monkeypatch.setattr(path_finder, "find_spec", _fake_find_spec)
+        for name in names:
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+        root_names = {name.removeprefix("rfdetr.").split(".", maxsplit=1)[0] for name in names}
+        for root_name in root_names:
+            monkeypatch.delitem(rfdetr.__dict__, root_name, raising=False)
+
+    def test_removed_util_alias_resolves_via_package_attribute(self) -> None:
+        """PEP 562 lookup resolves rfdetr.util while the shim package exists."""
+        import rfdetr
+
+        assert getattr(rfdetr, "util").__name__ == "rfdetr.util"
+
+    def test_removed_deploy_alias_resolves_via_package_attribute(self) -> None:
+        """PEP 562 lookup resolves rfdetr.deploy while the shim package exists."""
+        import rfdetr
+
+        assert rfdetr.deploy.__name__ == "rfdetr.deploy"
+
+    def test_removed_shim_missing_raises_importerror_with_getattr(self) -> None:
+        """Missing removed shim should raise ImportError with migration hint."""
+        import rfdetr
+
+        missing_name = "rfdetr.missing_removed_shim"
+        missing_exc = ModuleNotFoundError(f"No module named '{missing_name}'", name=missing_name)
+        with (
+            patch.dict(rfdetr._REMOVED_IN_V17, {"missing_removed_shim": "migration hint"}),
+            patch("rfdetr.importlib.import_module", side_effect=missing_exc),
+            pytest.raises(ImportError, match="migration hint"),
+        ):
+            getattr(rfdetr, "missing_removed_shim")
+
+    def test_nested_module_not_found_is_not_masked_for_package_attribute(self) -> None:
+        """Nested ModuleNotFoundError from inside a shim import should propagate."""
+        import rfdetr
+
+        with (
+            patch.dict(rfdetr._REMOVED_IN_V17, {"missing_dep_shim": "migration hint"}),
+            patch(
+                "rfdetr.importlib.import_module",
+                side_effect=ModuleNotFoundError("No module named 'torchvision_ops'", name="torchvision_ops"),
+            ),
+            pytest.raises(ModuleNotFoundError, match="torchvision_ops"),
+        ):
+            getattr(rfdetr, "missing_dep_shim")
+
+    def test_removed_util_import_raises_migration_hint_when_shim_is_deleted(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Dotted legacy imports get a migration hint once the util shim package is removed."""
+        self._simulate_missing_removed_module_specs(monkeypatch, "rfdetr.util")
+
+        with pytest.raises(ImportError, match=r"rfdetr\.util was removed in v1\.7"):
+            importlib.import_module("rfdetr.util")
+
+    def test_removed_deploy_submodule_import_raises_migration_hint_when_shim_is_deleted(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Dotted legacy submodule imports get a migration hint once the deploy shim is removed."""
+        self._simulate_missing_removed_module_specs(monkeypatch, "rfdetr.deploy", "rfdetr.deploy.benchmark")
+
+        with pytest.raises(ImportError, match=r"rfdetr\.deploy was removed in v1\.7"):
+            importlib.import_module("rfdetr.deploy.benchmark")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -898,6 +898,26 @@ class TestRemovedLegacyModuleAliases:
         with pytest.raises(ImportError, match=r"rfdetr\.deploy was removed in v1\.7"):
             importlib.import_module("rfdetr.deploy.benchmark")
 
+    def test_find_spec_ignores_non_rfdetr_top_level_imports(self) -> None:
+        """find_spec must not intercept bare top-level imports like 'util' or 'deploy'."""
+        import rfdetr
+
+        finder = rfdetr._RemovedModuleFinder()
+        assert finder.find_spec("util", None) is None
+        assert finder.find_spec("deploy", None) is None
+        assert finder.find_spec("os", None) is None
+
+    def test_meta_path_insertion_is_idempotent_across_reload(self) -> None:
+        """importlib.reload(rfdetr) must not insert a second finder into sys.meta_path."""
+        import rfdetr
+
+        count_before = sum(type(f).__name__ == "_RemovedModuleFinder" for f in sys.meta_path)
+        importlib.reload(rfdetr)
+        count_after = sum(type(f).__name__ == "_RemovedModuleFinder" for f in sys.meta_path)
+        assert count_after == count_before, (
+            f"reload added {count_after - count_before} extra finder(s) to sys.meta_path"
+        )
+
 
 # ---------------------------------------------------------------------------
 # 6. RFDETRLarge deprecated-config fallback behaviour

--- a/tests/utilities/test_package.py
+++ b/tests/utilities/test_package.py
@@ -8,6 +8,9 @@
 
 from unittest.mock import patch
 
+import pytest
+
+import rfdetr
 from rfdetr.utilities.package import get_sha
 
 
@@ -32,3 +35,40 @@ def test_get_sha_marks_dirty_worktree_when_diff_command_returns_exit_code_1() ->
         sha = get_sha()
 
     assert sha == "sha: abc123, status: has uncommitted changes, branch: feature/test"
+
+
+def test_getattr_hook_resolves_removed_util_module_while_shim_exists() -> None:
+    """Removed-name aliases should still resolve while shim modules exist."""
+    util_module = rfdetr.__getattr__("util")
+    assert util_module.__name__ == "rfdetr.util"
+
+
+def test_getattr_hook_resolves_removed_deploy_module_while_shim_exists() -> None:
+    """Removed-name aliases should still resolve while shim modules exist."""
+    deploy_module = rfdetr.__getattr__("deploy")
+    assert deploy_module.__name__ == "rfdetr.deploy"
+
+
+def test_getattr_hook_raises_importerror_when_removed_shim_is_missing() -> None:
+    """Missing removed shim should raise ImportError with migration hint."""
+    missing_name = "rfdetr.missing_removed_shim"
+    missing_exc = ModuleNotFoundError(f"No module named '{missing_name}'", name=missing_name)
+    with (
+        patch.dict(rfdetr._REMOVED_IN_V17, {"missing_removed_shim": "migration hint"}),
+        patch("rfdetr.importlib.import_module", side_effect=missing_exc),
+        pytest.raises(ImportError, match="migration hint"),
+    ):
+        rfdetr.__getattr__("missing_removed_shim")
+
+
+def test_getattr_hook_does_not_mask_nested_module_not_found_error() -> None:
+    """Nested ModuleNotFoundError from inside shim import should propagate."""
+    with (
+        patch.dict(rfdetr._REMOVED_IN_V17, {"missing_dep_shim": "migration hint"}),
+        patch(
+            "rfdetr.importlib.import_module",
+            side_effect=ModuleNotFoundError("No module named 'torchvision_ops'", name="torchvision_ops"),
+        ),
+        pytest.raises(ModuleNotFoundError, match="torchvision_ops"),
+    ):
+        rfdetr.__getattr__("missing_dep_shim")

--- a/tests/utilities/test_package.py
+++ b/tests/utilities/test_package.py
@@ -10,9 +10,6 @@ import subprocess
 import sys
 from unittest.mock import patch
 
-import pytest
-
-import rfdetr
 from rfdetr.utilities.package import get_sha
 
 
@@ -67,40 +64,3 @@ def test_peft_not_imported_eagerly_on_backbone_import_characterization() -> None
         f"stdout:\n{result.stdout}\n"
         f"stderr:\n{result.stderr}"
     )
-
-
-def test_getattr_hook_resolves_removed_util_module_while_shim_exists() -> None:
-    """Removed-name aliases should still resolve while shim modules exist."""
-    util_module = rfdetr.__getattr__("util")
-    assert util_module.__name__ == "rfdetr.util"
-
-
-def test_getattr_hook_resolves_removed_deploy_module_while_shim_exists() -> None:
-    """Removed-name aliases should still resolve while shim modules exist."""
-    deploy_module = rfdetr.__getattr__("deploy")
-    assert deploy_module.__name__ == "rfdetr.deploy"
-
-
-def test_getattr_hook_raises_importerror_when_removed_shim_is_missing() -> None:
-    """Missing removed shim should raise ImportError with migration hint."""
-    missing_name = "rfdetr.missing_removed_shim"
-    missing_exc = ModuleNotFoundError(f"No module named '{missing_name}'", name=missing_name)
-    with (
-        patch.dict(rfdetr._REMOVED_IN_V17, {"missing_removed_shim": "migration hint"}),
-        patch("rfdetr.importlib.import_module", side_effect=missing_exc),
-        pytest.raises(ImportError, match="migration hint"),
-    ):
-        rfdetr.__getattr__("missing_removed_shim")
-
-
-def test_getattr_hook_does_not_mask_nested_module_not_found_error() -> None:
-    """Nested ModuleNotFoundError from inside shim import should propagate."""
-    with (
-        patch.dict(rfdetr._REMOVED_IN_V17, {"missing_dep_shim": "migration hint"}),
-        patch(
-            "rfdetr.importlib.import_module",
-            side_effect=ModuleNotFoundError("No module named 'torchvision_ops'", name="torchvision_ops"),
-        ),
-        pytest.raises(ModuleNotFoundError, match="torchvision_ops"),
-    ):
-        rfdetr.__getattr__("missing_dep_shim")


### PR DESCRIPTION
## What does this PR do?

Extends rfdetr/__init__.__getattr__ with a _REMOVED_IN_V17 mapping so that when the util/ and deploy/ shim directories are deleted at the v1.7 release, users get a clear ImportError with a migration hint instead of an opaque ModuleNotFoundError.

While the shim files still exist the hook transparently delegates to importlib.import_module(), preserving backward compatibility. A guard on ModuleNotFoundError.name prevents the hook from masking genuine nested import failures inside the shim.

Adds 4 tests: shim-exists resolution for util and deploy, migration hint on missing shim (mocked), and nested-error propagation.

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)
- Refactoring (no functional changes)

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have tested this change locally
- [x] I have added/updated tests for this change

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
