### PR TITLE
refactor: extract load_pretrain_weights + apply_lora into models/weights.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,17 +37,20 @@ keywords = ["machine-learning", "deep-learning", "vision", "ML", "DL", "AI", "DE
 dependencies = [
     "requests",                        # weight download from remote URLs
     "torch>=2.2.0",                    # core tensor ops and model forward pass
-    "torchvision>=0.14.0",             # image transforms and ops
+    "torchvision>=0.17.0",             # image transforms and ops (aligned with torch>=2.2.0)
     "tqdm",                            # progress bars during weight download
     "transformers>=5.1.0,<6.0.0",     # DINOv2 backbone loading
-    "peft",                            # LoRA backbone weight loading; TODO: consider moving to extras
-    "pydantic",                        # ModelConfig / TrainConfig validation
+    "pydantic>=2.0,<3",               # ModelConfig / TrainConfig validation
     "supervision",                     # inference output (Detections, Masks)
     "pyDeprecate>=0.3,<0.6",           # deprecation warnings for legacy APIs
 ]
 
 [project.optional-dependencies]
+lora = [
+    "peft",                            # LoRA backbone fine-tuning
+]
 train = [
+    "peft",                            # LoRA backbone fine-tuning (available during training)
     "pytorch_lightning>=2.6,<3",
     "torchmetrics[detection]>=1.2",
     "faster-coco-eval>=1.7.2",

--- a/src/rfdetr/__init__.py
+++ b/src/rfdetr/__init__.py
@@ -3,6 +3,34 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
+"""RF-DETR public package initialiser.
+
+Two-phase legacy-module deprecation
+------------------------------------
+Some sub-packages were relocated in v1.6 and are scheduled for removal in v1.7.
+The migration is handled in two phases so users get a full release cycle to update
+their imports:
+
+**Phase 1 — v1.6 (current):** the old packages (``rfdetr.util``, ``rfdetr.deploy``)
+still exist on disk and work normally, but emit a ``DeprecationWarning`` on import.
+``_RemovedModuleFinder`` is installed in ``sys.meta_path`` but stays dormant: its
+``find_spec`` returns ``None`` whenever ``importlib.machinery.PathFinder`` can
+resolve the name (i.e. while the shim directories are present).
+
+**Phase 2 — v1.7:** the shim directories are deleted.  ``PathFinder`` can no longer
+resolve ``rfdetr.util`` / ``rfdetr.deploy``, so ``_RemovedModuleFinder`` intercepts
+the import and raises a descriptive ``ImportError`` (migration hint) instead of the
+cryptic default ``ModuleNotFoundError: No module named 'rfdetr.util'``.
+
+To complete Phase 2, delete ``src/rfdetr/util/`` and ``src/rfdetr/deploy/`` and bump
+``_REMOVED_IN_V17`` (or rename it) to reflect the new version boundary.
+"""
+
+import importlib
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import sys
 
 from rfdetr.detr import (
     ModelContext,
@@ -39,9 +67,90 @@ __all__ = [
 _LAZY_TRAINING = frozenset({"RFDETRModelModule", "RFDETRDataModule", "build_trainer"})
 _PLUS_EXPORTS = frozenset({"RFDETR2XLarge", "RFDETRXLarge"})
 
+# Legacy module aliases delegate to shim packages while they still exist, then raise
+# migration-hint ImportError messages once those shims are removed in v1.7+.
+_REMOVED_IN_V17 = {
+    "util": "rfdetr.util was removed in v1.7. Use rfdetr.utilities instead.",
+    "deploy": "rfdetr.deploy was removed in v1.7. Use rfdetr.export instead.",
+}
+
+
+class _RemovedModuleLoader(importlib.abc.Loader):
+    """Raise a migration hint when a removed legacy module import is attempted."""
+
+    def __init__(self, message: str) -> None:
+        self._message = message
+
+    def create_module(self, spec: importlib.machinery.ModuleSpec) -> None:
+        """Use the default module creation path."""
+        return None
+
+    def exec_module(self, module: object) -> None:
+        """Abort import with a migration hint instead of bare ModuleNotFoundError."""
+        raise ImportError(self._message) from None
+
+
+class _RemovedModuleFinder(importlib.abc.MetaPathFinder):
+    """Intercept removed legacy dotted imports after their shim packages are deleted."""
+
+    _PATH_FINDER = importlib.machinery.PathFinder
+
+    def find_spec(
+        self,
+        fullname: str,
+        path: list[str] | None,
+        target: object | None = None,
+    ) -> importlib.machinery.ModuleSpec | None:
+        """Return a failing spec with a migration hint for removed legacy modules."""
+        if not fullname.startswith(f"{__name__}."):
+            return None
+        root, _, _ = fullname.removeprefix(f"{__name__}.").partition(".")
+        if root not in _REMOVED_IN_V17:
+            return None
+
+        if self._PATH_FINDER.find_spec(fullname, path) is not None:
+            return None
+
+        is_package = fullname == f"{__name__}.{root}"
+        loader = _RemovedModuleLoader(_REMOVED_IN_V17[root])
+        return importlib.util.spec_from_loader(fullname, loader, is_package=is_package)
+
+
+_REMOVED_MODULE_FINDER = _RemovedModuleFinder()
+
+if not getattr(sys, "_rfdetr_removed_finder", False):
+    sys.meta_path.insert(0, _REMOVED_MODULE_FINDER)
+    sys._rfdetr_removed_finder = True
+
 
 def __getattr__(name: str):
-    """Resolve PTL and plus-only exports lazily, raising only on explicit access."""
+    """Lazily resolve training/PTL and plus-only exports and handle removed-module aliases.
+
+    This hook is only invoked on explicit attribute access (e.g. ``rfdetr.RFDETRModelModule``)
+    and supports three behaviors:
+
+    * Training/PTL exports (names in ``_LAZY_TRAINING``) are imported from ``rfdetr.training``
+      on first use to avoid importing PyTorch Lightning at ``import rfdetr`` time.
+    * Plus-only exports (names in ``_PLUS_EXPORTS``) are imported from ``rfdetr.platform.models``,
+      and a descriptive ``ImportError`` is raised with an installation hint if the model is
+      not available.
+    * Removed-module aliases (keys in ``_REMOVED_IN_V17``, such as ``util`` and ``deploy``)
+      are first attempted via a shim submodule (e.g. ``rfdetr.util``); once the shim files
+      are removed, a migration-hint ``ImportError`` is raised instead of silently masking
+      unrelated nested import errors.
+    """
+    if name in _REMOVED_IN_V17:
+        module_name = f"{__name__}.{name}"
+        try:
+            value = importlib.import_module(module_name)
+            globals()[name] = value
+            return value
+        except ModuleNotFoundError as exc:
+            # Avoid masking nested import errors from within the shim itself.
+            if exc.name != module_name:
+                raise
+            raise ImportError(_REMOVED_IN_V17[name]) from None
+
     if name in _LAZY_TRAINING:
         from rfdetr import training as _training
 

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -167,7 +167,10 @@ def _apply_lora_to(nn_model: torch.nn.Module) -> None:
     Args:
         nn_model: LWDETR model whose backbone encoder will receive LoRA.
     """
-    from peft import LoraConfig, get_peft_model
+    try:
+        from peft import LoraConfig, get_peft_model
+    except ImportError as exc:
+        raise ImportError("LoRA requires peft: pip install 'rfdetr[lora]'") from exc
 
     lora_config = LoraConfig(
         r=16,

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -126,6 +126,10 @@ def _build_model_context(model_config: ModelConfig) -> "ModelContext":
     class_names: List[str] = []
     if model_config.pretrain_weights is not None:
         class_names = load_pretrain_weights(nn_model, model_config, dummy_train_config)
+        # ``load_pretrain_weights`` can mutate ``model_config.num_classes`` when
+        # aligning to checkpoint heads. Keep the derived namespace in sync.
+        if hasattr(args, "num_classes") and getattr(args, "num_classes") != model_config.num_classes:
+            args.num_classes = model_config.num_classes
 
     if model_config.backbone_lora:
         apply_lora(nn_model)

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -25,7 +25,7 @@ import yaml
 from PIL import Image
 
 from rfdetr.assets.coco_classes import COCO_CLASS_NAMES
-from rfdetr.assets.model_weights import download_pretrain_weights, validate_pretrain_weights
+from rfdetr.assets.model_weights import download_pretrain_weights
 from rfdetr.config import (
     ModelConfig,
     RFDETRBaseConfig,  # DEPRECATED
@@ -47,8 +47,8 @@ from rfdetr.config import (
 from rfdetr.datasets.coco import is_valid_coco_dataset
 from rfdetr.datasets.yolo import is_valid_yolo_dataset
 from rfdetr.models import PostProcess, build_model
+from rfdetr.models.weights import apply_lora, load_pretrain_weights
 from rfdetr.utilities.logger import get_logger
-from rfdetr.utilities.state_dict import _ckpt_args_get, validate_checkpoint_compatibility
 
 try:
     torch.set_float32_matmul_precision("high")
@@ -103,91 +103,6 @@ class ModelContext:
 _ModelContext = ModelContext  # backward compat alias
 
 
-def _load_pretrain_weights_into(nn_model: torch.nn.Module, args: Any) -> List[str]:
-    """Load pretrained checkpoint weights into *nn_model* in-place.
-
-    Mirrors ``Model.__init__`` and ``RFDETRModelModule._load_pretrain_weights``
-    checkpoint loading logic: validates hash, re-downloads on corruption, and
-    trims query embeddings to match the configured query count.
-
-    Args:
-        nn_model: The model to load weights into.
-        args: Namespace with ``pretrain_weights``, ``num_classes``,
-            ``num_queries``, and ``group_detr`` attributes.
-
-    Returns:
-        List of class names extracted from the checkpoint, or empty list.
-    """
-    class_names: List[str] = []
-
-    download_pretrain_weights(args.pretrain_weights)
-    if not os.path.isfile(args.pretrain_weights):
-        logger.warning("Pretrain weights not found after initial download; retrying without MD5 validation.")
-        download_pretrain_weights(args.pretrain_weights, redownload=True, validate_md5=False)
-    validate_pretrain_weights(args.pretrain_weights, strict=False)
-
-    try:
-        checkpoint = torch.load(args.pretrain_weights, map_location="cpu", weights_only=False)
-    except Exception:
-        logger.info("Failed to load pretrain weights, re-downloading")
-        download_pretrain_weights(args.pretrain_weights, redownload=True, validate_md5=False)
-        checkpoint = torch.load(args.pretrain_weights, map_location="cpu", weights_only=False)
-
-    if "args" in checkpoint:
-        class_names = _ckpt_args_get(checkpoint["args"], "class_names") or []
-
-    validate_checkpoint_compatibility(checkpoint, args)
-
-    checkpoint_num_classes = checkpoint["model"]["class_embed.bias"].shape[0]
-    if checkpoint_num_classes != args.num_classes + 1:
-        # Temporarily align the detection head size with the checkpoint so
-        # that state_dict loading succeeds even when the configured
-        # num_classes differs from the checkpoint.
-        nn_model.reinitialize_detection_head(checkpoint_num_classes)
-
-    num_desired_queries = args.num_queries * args.group_detr
-    query_param_names = ["refpoint_embed.weight", "query_feat.weight"]
-    for name in list(checkpoint["model"].keys()):
-        if any(name.endswith(x) for x in query_param_names):
-            checkpoint["model"][name] = checkpoint["model"][name][:num_desired_queries]
-
-    nn_model.load_state_dict(checkpoint["model"], strict=False)
-
-    # Only reinitialize back to configured size when intentionally reducing a
-    # larger pretrain checkpoint to fewer task-specific classes.
-    if args.num_classes + 1 < checkpoint_num_classes:
-        nn_model.reinitialize_detection_head(args.num_classes + 1)
-
-    return class_names
-
-
-def _apply_lora_to(nn_model: torch.nn.Module) -> None:
-    """Apply LoRA adapters to the backbone encoder of *nn_model*.
-
-    Args:
-        nn_model: LWDETR model whose backbone encoder will receive LoRA.
-    """
-    from peft import LoraConfig, get_peft_model
-
-    lora_config = LoraConfig(
-        r=16,
-        lora_alpha=16,
-        use_dora=True,
-        target_modules=[
-            "q_proj",
-            "v_proj",
-            "k_proj",
-            "qkv",
-            "query",
-            "key",
-            "value",
-            "cls_token",
-            "register_tokens",
-        ],
-    )
-    nn_model.backbone[0].encoder = get_peft_model(nn_model.backbone[0].encoder, lora_config)
-
-
 def _build_model_context(model_config: ModelConfig) -> "ModelContext":
     """Build a ModelContext from ModelConfig without using legacy main.py:Model.
 
@@ -204,15 +119,16 @@ def _build_model_context(model_config: ModelConfig) -> "ModelContext":
 
     # A dummy TrainConfig is needed only for build_namespace's required fields;
     # dataset_dir/output_dir are unused during model construction.
-    args = build_namespace(model_config, TrainConfig(dataset_dir=".", output_dir="."))
+    dummy_train_config = TrainConfig(dataset_dir=".", output_dir=".")
+    args = build_namespace(model_config, dummy_train_config)
     nn_model = build_model(args)
 
     class_names: List[str] = []
-    if args.pretrain_weights is not None:
-        class_names = _load_pretrain_weights_into(nn_model, args)
+    if model_config.pretrain_weights is not None:
+        class_names = load_pretrain_weights(nn_model, model_config, dummy_train_config)
 
-    if args.backbone_lora:
-        _apply_lora_to(nn_model)
+    if model_config.backbone_lora:
+        apply_lora(nn_model)
 
     device = torch.device(args.device)
     nn_model = nn_model.to(device)
@@ -587,7 +503,7 @@ class RFDETR:
         if hasattr(self.model, "class_names") and self.model.class_names is not None:
             return list(self.model.class_names)
 
-        return COCO_CLASS_NAMES
+        return list(COCO_CLASS_NAMES)
 
     def predict(
         self,

--- a/src/rfdetr/models/__init__.py
+++ b/src/rfdetr/models/__init__.py
@@ -17,10 +17,13 @@ from rfdetr.models.criterion import SetCriterion
 from rfdetr.models.lwdetr import build_model
 from rfdetr.models.math import MLP
 from rfdetr.models.postprocess import PostProcess
+from rfdetr.models.weights import apply_lora, load_pretrain_weights
 
 __all__ = [
     "SetCriterion",
     "build_model",
     "MLP",
     "PostProcess",
+    "load_pretrain_weights",
+    "apply_lora",
 ]

--- a/src/rfdetr/models/backbone/backbone.py
+++ b/src/rfdetr/models/backbone/backbone.py
@@ -19,7 +19,6 @@ Backbone modules.
 
 import torch
 import torch.nn.functional as F
-from peft import PeftModel
 
 from rfdetr.models.backbone.base import BackboneBase
 from rfdetr.models.backbone.dinov2 import DinoV2
@@ -118,9 +117,18 @@ class Backbone(BackboneBase):
         self._forward_origin = self.forward
         self.forward = self.forward_export
 
+        try:
+            from peft import PeftModel
+        except ModuleNotFoundError:
+            logger.warning("peft is not installed; skipping LoRA weight merging during export.")
+            return
+        except ImportError as exc:
+            logger.warning("Failed to import PeftModel from peft during export: %s", exc)
+            raise
+
         if isinstance(self.encoder, PeftModel):
             logger.info("Merging and unloading LoRA weights")
-            self.encoder.merge_and_unload()
+            self.encoder = self.encoder.merge_and_unload()
 
     def forward(self, tensor_list: NestedTensor):
         """ """

--- a/src/rfdetr/models/backbone/backbone.py
+++ b/src/rfdetr/models/backbone/backbone.py
@@ -117,6 +117,9 @@ class Backbone(BackboneBase):
         self._forward_origin = self.forward
         self.forward = self.forward_export
 
+        if not hasattr(self.encoder, "merge_and_unload"):
+            return
+
         try:
             from peft import PeftModel
         except ModuleNotFoundError:

--- a/src/rfdetr/models/weights.py
+++ b/src/rfdetr/models/weights.py
@@ -1,0 +1,187 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Shared weight-loading and LoRA application utilities.
+
+Provides the canonical implementations of pretrained checkpoint loading and
+LoRA adapter injection, used by both the L1 inference facade (``rfdetr.detr``)
+and the L2 LightningModule (``rfdetr.training.module_model``).
+
+The weight-loading logic is taken from ``RFDETRModelModule._load_pretrain_weights``
+in ``module_model.py`` (more complete: Pydantic-aware user-override detection,
+auto-alignment for fine-tuned checkpoints) and augmented with class-name
+extraction from ``detr.py:_load_pretrain_weights_into``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import List
+
+import torch
+
+from rfdetr._namespace import build_namespace
+from rfdetr.assets.model_weights import download_pretrain_weights, validate_pretrain_weights
+from rfdetr.config import ModelConfig, TrainConfig
+from rfdetr.utilities.logger import get_logger
+from rfdetr.utilities.state_dict import _ckpt_args_get, validate_checkpoint_compatibility
+
+logger = get_logger()
+
+__all__ = ["load_pretrain_weights", "apply_lora"]
+
+
+def load_pretrain_weights(
+    nn_model: torch.nn.Module,
+    model_config: ModelConfig,
+    train_config: TrainConfig,
+) -> List[str]:
+    """Load pretrained checkpoint weights into *nn_model* in-place.
+
+    Canonical implementation shared by the L1 facade (``_build_model_context``
+    in ``rfdetr.detr``) and the L2 LightningModule (``RFDETRModelModule.__init__``
+    in ``rfdetr.training.module_model``).
+
+    Uses the Pydantic-aware logic from ``module_model.py``:
+
+    - When the user did **not** explicitly override ``num_classes`` (left at the
+      ModelConfig default), the checkpoint class count is treated as authoritative
+      and the model head is auto-aligned to it.
+    - When the user **did** explicitly override ``num_classes`` to a value larger
+      than the checkpoint provides, the head is temporarily aligned to the
+      checkpoint for loading, then expanded back to the configured size.
+    - When the checkpoint has more classes than configured (backbone-pretrain
+      scenario), both reinitializations are applied: expand to checkpoint size for
+      loading, then trim to configured size.
+
+    Class names stored in the checkpoint ``args`` are extracted and returned.
+
+    Args:
+        nn_model: The model whose weights will be updated in-place.
+        model_config: Pydantic ``ModelConfig`` instance. Must have
+            ``pretrain_weights``, ``num_classes``, ``num_queries``, and
+            ``group_detr`` attributes.
+        train_config: ``TrainConfig`` used to build the namespace for checkpoint
+            compatibility validation.
+
+    Returns:
+        List of class name strings from the checkpoint, or an empty list if none
+        are present.
+
+    Raises:
+        RuntimeError: If the checkpoint file cannot be loaded after a re-download.
+    """
+    mc = model_config
+    pretrain_weights = mc.pretrain_weights
+    class_names: List[str] = []
+
+    # Download first (no-op if already present and hash is valid).
+    download_pretrain_weights(pretrain_weights)
+    # If the first download attempt didn't produce the file (e.g. stale MD5
+    # caused an earlier ValueError that was silently swallowed), retry with
+    # MD5 validation disabled so a stale registry hash can't block training.
+    if not os.path.isfile(pretrain_weights):
+        logger.warning("Pretrain weights not found after initial download; retrying without MD5 validation.")
+        download_pretrain_weights(pretrain_weights, redownload=True, validate_md5=False)
+    validate_pretrain_weights(pretrain_weights, strict=False)
+
+    try:
+        checkpoint = torch.load(pretrain_weights, map_location="cpu", weights_only=False)
+    except Exception:
+        logger.info("Failed to load pretrain weights, re-downloading")
+        download_pretrain_weights(pretrain_weights, redownload=True, validate_md5=False)
+        checkpoint = torch.load(pretrain_weights, map_location="cpu", weights_only=False)
+
+    # Extract class_names from the checkpoint if available (ported from detr.py).
+    if "args" in checkpoint:
+        class_names = _ckpt_args_get(checkpoint["args"], "class_names") or []
+
+    ns = build_namespace(mc, train_config)
+    validate_checkpoint_compatibility(checkpoint, ns)
+
+    # Determine whether the user explicitly set num_classes on the ModelConfig,
+    # and whether that explicit value differs from the model default.
+    user_set_num_classes = False
+    if hasattr(mc, "model_fields_set"):
+        user_set_num_classes = "num_classes" in getattr(mc, "model_fields_set", set())
+    default_num_classes = type(mc).model_fields["num_classes"].default
+    num_classes = mc.num_classes
+    # True only when the user explicitly set num_classes to a non-default value.
+    user_overrode_default_num_classes = user_set_num_classes and num_classes != default_num_classes
+
+    checkpoint_num_classes = checkpoint["model"]["class_embed.bias"].shape[0]
+    configured_num_classes_plus_bg = num_classes + 1
+    if checkpoint_num_classes != configured_num_classes_plus_bg:
+        # Align model head size before loading checkpoint weights.
+        if checkpoint_num_classes < configured_num_classes_plus_bg:
+            # Checkpoint has FEWER classes than configured.
+            if not user_overrode_default_num_classes:
+                # Auto-align to the checkpoint when the user did NOT provide a
+                # non-default override for num_classes (i.e., left it at the
+                # ModelConfig default): treat the checkpoint as authoritative.
+                num_classes = checkpoint_num_classes - 1
+                configured_num_classes_plus_bg = checkpoint_num_classes
+        # In all mismatch cases we need the head to match the checkpoint's
+        # class count so load_state_dict succeeds without size mismatches.
+        nn_model.reinitialize_detection_head(checkpoint_num_classes)
+
+    # Trim query embeddings to the configured query count.
+    num_desired_queries = mc.num_queries * mc.group_detr
+    query_param_names = ["refpoint_embed.weight", "query_feat.weight"]
+    for name in list(checkpoint["model"].keys()):
+        if any(name.endswith(x) for x in query_param_names):
+            checkpoint["model"][name] = checkpoint["model"][name][:num_desired_queries]
+
+    nn_model.load_state_dict(checkpoint["model"], strict=False)
+
+    # If the user explicitly set a class count larger than the checkpoint,
+    # expand/reinitialize the head back to the configured size after load.
+    if checkpoint_num_classes < configured_num_classes_plus_bg and user_overrode_default_num_classes:
+        nn_model.reinitialize_detection_head(configured_num_classes_plus_bg)
+
+    # Only trim back down when loading a larger pretrain checkpoint into a
+    # smaller configured task-specific class count.
+    if num_classes + 1 < checkpoint_num_classes:
+        nn_model.reinitialize_detection_head(num_classes + 1)
+
+    return class_names
+
+
+def apply_lora(nn_model: torch.nn.Module) -> None:
+    """Apply LoRA adapters to the backbone encoder of *nn_model*.
+
+    Replaces ``nn_model.backbone[0].encoder`` in-place with a PEFT-wrapped
+    encoder using DoRA with rank 16 and alpha 16.
+
+    Args:
+        nn_model: LWDETR model whose backbone encoder will receive LoRA adapters.
+
+    Raises:
+        ImportError: If ``peft`` is not installed.
+            Install with ``pip install peft``.
+    """
+    try:
+        from peft import LoraConfig, get_peft_model
+    except ImportError as exc:
+        raise ImportError("LoRA requires peft: pip install peft") from exc
+
+    lora_config = LoraConfig(
+        r=16,
+        lora_alpha=16,
+        use_dora=True,
+        target_modules=[
+            "q_proj",
+            "v_proj",
+            "k_proj",
+            "qkv",
+            "query",
+            "key",
+            "value",
+            "cls_token",
+            "register_tokens",
+        ],
+    )
+    nn_model.backbone[0].encoder = get_peft_model(nn_model.backbone[0].encoder, lora_config)

--- a/src/rfdetr/models/weights.py
+++ b/src/rfdetr/models/weights.py
@@ -139,8 +139,6 @@ def load_pretrain_weights(
                 # ModelConfig default): treat the checkpoint as authoritative.
                 num_classes = checkpoint_num_classes - 1
                 configured_num_classes_plus_bg = checkpoint_num_classes
-                # Keep the ModelConfig in sync with the effective class count.
-                mc.num_classes = num_classes
         # In all mismatch cases we need the head to match the checkpoint's
         # class count so load_state_dict succeeds without size mismatches.
         nn_model.reinitialize_detection_head(checkpoint_num_classes)
@@ -178,12 +176,20 @@ def apply_lora(nn_model: torch.nn.Module) -> None:
 
     Raises:
         ImportError: If ``peft`` is not installed.
-            Install with ``pip install peft``.
+            Install via the RF-DETR extras, for example::
+
+                pip install "rfdetr[lora]"
+                # or
+                pip install "rfdetr[train]"
     """
     try:
         from peft import LoraConfig, get_peft_model
     except ImportError as exc:
-        raise ImportError("LoRA requires peft: pip install peft") from exc
+        raise ImportError(
+            "LoRA requires the 'peft' dependency. "
+            'Install it via RF-DETR extras, e.g.: '
+            'pip install "rfdetr[lora]" or pip install "rfdetr[train]".'
+        ) from exc
 
     lora_config = LoraConfig(
         r=16,

--- a/src/rfdetr/models/weights.py
+++ b/src/rfdetr/models/weights.py
@@ -72,7 +72,7 @@ def load_pretrain_weights(
         are present.
 
     Raises:
-        RuntimeError: If the checkpoint file cannot be loaded after a re-download.
+        Exception: If the checkpoint file cannot be loaded even after a re-download.
     """
     mc = model_config
     pretrain_weights = mc.pretrain_weights
@@ -97,7 +97,20 @@ def load_pretrain_weights(
 
     # Extract class_names from the checkpoint if available (ported from detr.py).
     if "args" in checkpoint:
-        class_names = _ckpt_args_get(checkpoint["args"], "class_names") or []
+        raw_class_names = _ckpt_args_get(checkpoint["args"], "class_names")
+        if raw_class_names:
+            # Normalize to a new List[str] to avoid leaking mutable references and
+            # to respect the annotated return type.
+            if isinstance(raw_class_names, str):
+                class_names = [raw_class_names]
+            else:
+                try:
+                    iterator = iter(raw_class_names)
+                except TypeError:
+                    # Non-iterable, ignore and keep the default empty list.
+                    class_names = []
+                else:
+                    class_names = [name for name in iterator if isinstance(name, str)]
 
     ns = build_namespace(mc, train_config)
     validate_checkpoint_compatibility(checkpoint, ns)
@@ -124,6 +137,8 @@ def load_pretrain_weights(
                 # ModelConfig default): treat the checkpoint as authoritative.
                 num_classes = checkpoint_num_classes - 1
                 configured_num_classes_plus_bg = checkpoint_num_classes
+                # Keep the ModelConfig in sync with the effective class count.
+                mc.num_classes = num_classes
         # In all mismatch cases we need the head to match the checkpoint's
         # class count so load_state_dict succeeds without size mismatches.
         nn_model.reinitialize_detection_head(checkpoint_num_classes)

--- a/src/rfdetr/models/weights.py
+++ b/src/rfdetr/models/weights.py
@@ -69,13 +69,15 @@ def load_pretrain_weights(
 
     Returns:
         List of class name strings from the checkpoint, or an empty list if none
-        are present.
+        are present or if ``model_config.pretrain_weights`` is ``None``.
 
     Raises:
         Exception: If the checkpoint file cannot be loaded even after a re-download.
     """
     mc = model_config
     pretrain_weights = mc.pretrain_weights
+    if pretrain_weights is None:
+        return []
     class_names: List[str] = []
 
     # Download first (no-op if already present and hash is valid).

--- a/src/rfdetr/models/weights.py
+++ b/src/rfdetr/models/weights.py
@@ -187,7 +187,7 @@ def apply_lora(nn_model: torch.nn.Module) -> None:
     except ImportError as exc:
         raise ImportError(
             "LoRA requires the 'peft' dependency. "
-            'Install it via RF-DETR extras, e.g.: '
+            "Install it via RF-DETR extras, e.g.: "
             'pip install "rfdetr[lora]" or pip install "rfdetr[train]".'
         ) from exc
 

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -172,7 +172,10 @@ class RFDETRModelModule(LightningModule):
 
         Mirrors ``Model.__init__`` LoRA setup.
         """
-        from peft import LoraConfig, get_peft_model
+        try:
+            from peft import LoraConfig, get_peft_model
+        except ImportError as exc:
+            raise ImportError("LoRA requires peft: pip install 'rfdetr[lora]'") from exc
 
         lora_config = LoraConfig(
             r=16,

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -9,7 +9,6 @@
 from __future__ import annotations
 
 import math
-import os
 import random
 import warnings
 from typing import Any, Dict, Optional, Tuple
@@ -19,13 +18,12 @@ import torch.nn.functional as F
 from pytorch_lightning import LightningModule, seed_everything
 
 from rfdetr._namespace import build_namespace
-from rfdetr.assets.model_weights import download_pretrain_weights, validate_pretrain_weights
 from rfdetr.config import ModelConfig, TrainConfig
 from rfdetr.datasets.coco import compute_multi_scale_scales
 from rfdetr.models.lwdetr import build_criterion_and_postprocessors, build_model
+from rfdetr.models.weights import apply_lora, load_pretrain_weights
 from rfdetr.training.param_groups import get_param_dict
 from rfdetr.utilities.logger import get_logger
-from rfdetr.utilities.state_dict import validate_checkpoint_compatibility
 
 logger = get_logger()
 
@@ -55,7 +53,7 @@ class RFDETRModelModule(LightningModule):
             # Capture the configured class count before loading weights so we can
             # detect any automatic alignment to the checkpoint.
             prev_num_classes = self.model_config.num_classes
-            self._load_pretrain_weights()
+            load_pretrain_weights(self.model, self.model_config, self.train_config)
             # If the loaded checkpoint changed the model's effective number of
             # classes (e.g. to match a fine-tuned head), persist that back onto
             # the model_config so downstream components see the aligned value.
@@ -64,7 +62,7 @@ class RFDETRModelModule(LightningModule):
                 if model_num_classes is not None and model_num_classes != prev_num_classes:
                     self.model_config.num_classes = model_num_classes
         if model_config.backbone_lora:
-            self._apply_lora()
+            apply_lora(self.model)
 
         # Rebuild the namespace after potential num_classes alignment so that
         # the criterion and postprocessors are constructed with a config that
@@ -90,107 +88,6 @@ class RFDETRModelModule(LightningModule):
             torch._dynamo.config.suppress_errors = True
             torch._dynamo.config.capture_scalar_outputs = True
             self.model = torch.compile(self.model, dynamic=True)
-
-    # ------------------------------------------------------------------
-    # Helpers
-    # ------------------------------------------------------------------
-
-    def _load_pretrain_weights(self) -> None:
-        """Load pretrained checkpoint into ``self.model``.
-
-        Mirrors ``Model.__init__`` checkpoint loading logic: validates hash,
-        re-downloads on corruption, trims query embeddings to match config.
-        """
-        mc = self.model_config
-        pretrain_weights = mc.pretrain_weights
-        # Download first (no-op if already present and hash is valid).
-        download_pretrain_weights(pretrain_weights)
-        # If the first download attempt didn't produce the file (e.g. stale MD5
-        # caused an earlier ValueError that was silently swallowed), retry with
-        # MD5 validation disabled so a stale registry hash can't block training.
-        if not os.path.isfile(pretrain_weights):
-            logger.warning("Pretrain weights not found after initial download; retrying without MD5 validation.")
-            download_pretrain_weights(pretrain_weights, redownload=True, validate_md5=False)
-        validate_pretrain_weights(pretrain_weights, strict=False)
-        try:
-            checkpoint = torch.load(pretrain_weights, map_location="cpu", weights_only=False)
-        except Exception:
-            logger.info("Failed to load pretrain weights, re-downloading")
-            download_pretrain_weights(pretrain_weights, redownload=True, validate_md5=False)
-            checkpoint = torch.load(pretrain_weights, map_location="cpu", weights_only=False)
-
-        ns = build_namespace(mc, self.train_config)
-        validate_checkpoint_compatibility(checkpoint, ns)
-
-        # Determine whether the user explicitly set num_classes on the ModelConfig,
-        # and whether that explicit value differs from the model default.
-        user_set_num_classes = False
-        if hasattr(mc, "model_fields_set"):
-            user_set_num_classes = "num_classes" in getattr(mc, "model_fields_set", set())
-        default_num_classes = type(mc).model_fields["num_classes"].default
-        num_classes = mc.num_classes
-        # True only when the user explicitly set num_classes to a non-default value.
-        user_overrode_default_num_classes = user_set_num_classes and num_classes != default_num_classes
-
-        checkpoint_num_classes = checkpoint["model"]["class_embed.bias"].shape[0]
-        configured_num_classes_plus_bg = num_classes + 1
-        if checkpoint_num_classes != configured_num_classes_plus_bg:
-            # Align model head size before loading checkpoint weights.
-            if checkpoint_num_classes < configured_num_classes_plus_bg:
-                # Checkpoint has FEWER classes than configured.
-                if not user_overrode_default_num_classes:
-                    # Auto-align to the checkpoint when the user did NOT provide a
-                    # non-default override for num_classes (i.e., left it at the
-                    # ModelConfig default): treat the checkpoint as authoritative.
-                    num_classes = checkpoint_num_classes - 1
-                    configured_num_classes_plus_bg = checkpoint_num_classes
-            # In all mismatch cases we need the head to match the checkpoint's
-            # class count so load_state_dict succeeds without size mismatches.
-            self.model.reinitialize_detection_head(checkpoint_num_classes)
-
-        # Trim query embeddings to the configured query count.
-        num_desired_queries = mc.num_queries * mc.group_detr
-        query_param_names = ["refpoint_embed.weight", "query_feat.weight"]
-        for name in list(checkpoint["model"].keys()):
-            if any(name.endswith(x) for x in query_param_names):
-                checkpoint["model"][name] = checkpoint["model"][name][:num_desired_queries]
-
-        self.model.load_state_dict(checkpoint["model"], strict=False)
-
-        # If the user explicitly set a class count larger than the checkpoint,
-        # expand/reinitialize the head back to the configured size after load.
-        if checkpoint_num_classes < configured_num_classes_plus_bg and user_overrode_default_num_classes:
-            self.model.reinitialize_detection_head(configured_num_classes_plus_bg)
-
-        # Only trim back down when loading a larger pretrain checkpoint into a
-        # smaller configured task-specific class count.
-        if num_classes + 1 < checkpoint_num_classes:
-            self.model.reinitialize_detection_head(num_classes + 1)
-
-    def _apply_lora(self) -> None:
-        """Apply LoRA adapters to the backbone encoder.
-
-        Mirrors ``Model.__init__`` LoRA setup.
-        """
-        from peft import LoraConfig, get_peft_model
-
-        lora_config = LoraConfig(
-            r=16,
-            lora_alpha=16,
-            use_dora=True,
-            target_modules=[
-                "q_proj",
-                "v_proj",
-                "k_proj",
-                "qkv",
-                "query",
-                "key",
-                "value",
-                "cls_token",
-                "register_tokens",
-            ],
-        )
-        self.model.backbone[0].encoder = get_peft_model(self.model.backbone[0].encoder, lora_config)
 
     # ------------------------------------------------------------------
     # PTL lifecycle hooks

--- a/tests/models/backbone/test_backbone_export.py
+++ b/tests/models/backbone/test_backbone_export.py
@@ -1,0 +1,40 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Tests for backbone export behavior."""
+
+import sys
+from types import ModuleType
+
+from rfdetr.models.backbone.backbone import Backbone
+
+
+class TestBackboneExport:
+    """Tests for ``Backbone.export``."""
+
+    def test_export_replaces_peft_encoder_with_merged_encoder(self, monkeypatch) -> None:
+        """Export should replace PEFT wrapper with merged base encoder."""
+
+        class _MergedEncoder:
+            pass
+
+        class _FakePeftModel:
+            def __init__(self) -> None:
+                self._merged = _MergedEncoder()
+
+            def merge_and_unload(self):
+                return self._merged
+
+        peft_module = ModuleType("peft")
+        peft_module.PeftModel = _FakePeftModel
+        monkeypatch.setitem(sys.modules, "peft", peft_module)
+
+        backbone = object.__new__(Backbone)
+        backbone.encoder = _FakePeftModel()
+
+        backbone.export()
+
+        assert isinstance(backbone.encoder, _MergedEncoder)

--- a/tests/models/backbone/test_backbone_export.py
+++ b/tests/models/backbone/test_backbone_export.py
@@ -15,6 +15,19 @@ from rfdetr.models.backbone.backbone import Backbone
 class TestBackboneExport:
     """Tests for ``Backbone.export``."""
 
+    def test_export_without_lora_encoder_skips_peft_import_and_warning(self, monkeypatch) -> None:
+        """Non-LoRA exports should not warn just because peft is unavailable."""
+        backbone = object.__new__(Backbone)
+        backbone.encoder = object()
+        warning_messages: list[str] = []
+
+        monkeypatch.delitem(sys.modules, "peft", raising=False)
+        monkeypatch.setattr("rfdetr.models.backbone.backbone.logger.warning", warning_messages.append)
+
+        backbone.export()
+
+        assert warning_messages == []
+
     def test_export_replaces_peft_encoder_with_merged_encoder(self, monkeypatch) -> None:
         """Export should replace PEFT wrapper with merged base encoder."""
 

--- a/tests/models/test_weights.py
+++ b/tests/models/test_weights.py
@@ -229,6 +229,20 @@ class TestLoadPretrainWeightsClassNames:
 
         assert result == [], f"Expected empty list when checkpoint has no class_names, got {result!r}"
 
+    def test_none_pretrain_weights_returns_empty_list_immediately(self, tmp_path):
+        """load_pretrain_weights returns [] without any I/O when pretrain_weights is None."""
+        from rfdetr.models.weights import load_pretrain_weights
+
+        mc = RFDETRBaseConfig(pretrain_weights=None, device="cpu")
+        tc = _make_train_config(tmp_path)
+        nn_model = _fake_nn_model()
+
+        result = load_pretrain_weights(nn_model, mc, tc)
+
+        assert result == [], f"Expected [] for None pretrain_weights, got {result!r}"
+        nn_model.load_state_dict.assert_not_called()
+        nn_model.reinitialize_detection_head.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # apply_lora

--- a/tests/models/test_weights.py
+++ b/tests/models/test_weights.py
@@ -1,0 +1,292 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Unit tests for ``rfdetr.models.weights`` — the unified weight-loading and LoRA module.
+
+These tests cover ``load_pretrain_weights`` and ``apply_lora`` directly,
+exercising the unified logic extracted from ``detr.py`` and ``module_model.py``.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+import torch
+
+from rfdetr.config import RFDETRBaseConfig, TrainConfig
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_checkpoint(num_classes: int = 91, num_queries: int = 300, group_detr: int = 13) -> dict:
+    """Build a minimal checkpoint dict with the given class count.
+
+    Args:
+        num_classes: Total classes including background (bias shape).
+        num_queries: Number of object queries per group.
+        group_detr: Number of groups.
+    """
+    total_queries = num_queries * group_detr
+    state = {
+        "class_embed.weight": torch.randn(num_classes, 256),
+        "class_embed.bias": torch.randn(num_classes),
+        "refpoint_embed.weight": torch.randn(total_queries, 4),
+        "query_feat.weight": torch.randn(total_queries, 256),
+        "other_layer.weight": torch.randn(10, 10),
+    }
+    ckpt_args = SimpleNamespace(
+        segmentation_head=False,
+        patch_size=14,
+        class_names=["cat", "dog"],
+    )
+    return {"model": state, "args": ckpt_args}
+
+
+def _make_train_config(tmp_path=None) -> TrainConfig:
+    """Return a minimal TrainConfig for use in load_pretrain_weights.
+
+    Args:
+        tmp_path: Optional pytest tmp_path fixture value.
+    """
+    return TrainConfig(
+        dataset_dir=str(tmp_path / "dataset") if tmp_path else "/nonexistent/dataset",
+        output_dir=str(tmp_path / "output") if tmp_path else "/nonexistent/output",
+        epochs=10,
+        lr=1e-4,
+        lr_encoder=1.5e-4,
+        batch_size=2,
+        weight_decay=1e-4,
+        lr_drop=8,
+        warmup_epochs=1.0,
+        drop_path=0.0,
+        multi_scale=False,
+        expanded_scales=False,
+        do_random_resize_via_padding=False,
+        grad_accum_steps=1,
+        tensorboard=False,
+    )
+
+
+def _fake_nn_model() -> MagicMock:
+    """Return a MagicMock that behaves enough like an LWDETR nn.Module.
+
+    Returns:
+        MagicMock with reinitialize_detection_head and load_state_dict stubs.
+    """
+    model = MagicMock()
+    model.reinitialize_detection_head = MagicMock()
+    model.load_state_dict = MagicMock()
+    return model
+
+
+# ---------------------------------------------------------------------------
+# load_pretrain_weights — reinit scenarios
+# ---------------------------------------------------------------------------
+
+
+class TestLoadPretrainWeightsReinitScenarios:
+    """Verify reinitialize_detection_head call patterns for all class-count scenarios."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_io(self, monkeypatch):
+        """Suppress all download, file-existence, and validation side effects."""
+        monkeypatch.setattr("rfdetr.models.weights.download_pretrain_weights", lambda *a, **kw: None)
+        monkeypatch.setattr("rfdetr.models.weights.validate_pretrain_weights", lambda *a, **kw: None)
+        monkeypatch.setattr("rfdetr.models.weights.validate_checkpoint_compatibility", lambda *a, **kw: None)
+        monkeypatch.setattr("rfdetr.models.weights.os.path.isfile", lambda _: True)
+
+    def test_characterization_fine_tuned_checkpoint_auto_aligns_default_num_classes(self, monkeypatch, tmp_path):
+        """Fine-tuned checkpoint (fewer classes) + default num_classes → 1 reinit to ckpt size.
+
+        When the user did NOT explicitly set num_classes (default=90), the loader
+        auto-aligns to the checkpoint's class count (3 classes = bias shape [3]).
+        Only one reinit fires; no second reinit back to 91.
+        """
+        from rfdetr.models.weights import load_pretrain_weights
+
+        mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu")
+        tc = _make_train_config(tmp_path)
+        checkpoint = _make_checkpoint(num_classes=3)
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
+
+        nn_model = _fake_nn_model()
+        load_pretrain_weights(nn_model, mc, tc)
+
+        calls = nn_model.reinitialize_detection_head.call_args_list
+        assert calls[0] == call(3), f"First reinit must resize to checkpoint size 3, got {calls[0]}"
+        assert len(calls) == 1, (
+            f"Expected exactly 1 reinit call; got {len(calls)}: {calls}. "
+            "A second reinit to 91 would destroy loaded fine-tuned weights."
+        )
+
+    def test_characterization_backbone_pretrain_two_reinits(self, monkeypatch, tmp_path):
+        """Backbone pretrain (more classes in checkpoint) + explicit small num_classes → 2 reinits.
+
+        Scenario: 91-class COCO checkpoint, user explicitly requested num_classes=2.
+        First reinit to 91 so load_state_dict works; second reinit to 3 to match config.
+        """
+        from rfdetr.models.weights import load_pretrain_weights
+
+        mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu", num_classes=2)
+        tc = _make_train_config(tmp_path)
+        checkpoint = _make_checkpoint(num_classes=91)
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
+
+        nn_model = _fake_nn_model()
+        load_pretrain_weights(nn_model, mc, tc)
+
+        calls = nn_model.reinitialize_detection_head.call_args_list
+        assert calls == [call(91), call(3)], f"Expected reinit to [91, 3] (expand then trim), got {calls}"
+
+    def test_characterization_user_override_larger_than_checkpoint_reexpands(self, monkeypatch, tmp_path):
+        """Explicit num_classes larger than checkpoint → 2 reinits (load then expand back).
+
+        Scenario: 91-class checkpoint, user explicitly set num_classes=93.
+        The head must temporarily align to 91 for loading, then expand back to 94.
+        """
+        from rfdetr.models.weights import load_pretrain_weights
+
+        mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu", num_classes=93)
+        tc = _make_train_config(tmp_path)
+        checkpoint = _make_checkpoint(num_classes=91)
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
+
+        nn_model = _fake_nn_model()
+        load_pretrain_weights(nn_model, mc, tc)
+
+        calls = nn_model.reinitialize_detection_head.call_args_list
+        assert calls == [call(91), call(94)], f"Expected reinit to [91, 94] (load then expand), got {calls}"
+
+    def test_characterization_no_mismatch_no_reinit(self, monkeypatch, tmp_path):
+        """Checkpoint class count matches config → no reinit.
+
+        Scenario: 91-class checkpoint with num_classes=90. 91 == 90 + 1 → no reinit.
+        """
+        from rfdetr.models.weights import load_pretrain_weights
+
+        mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu", num_classes=90)
+        tc = _make_train_config(tmp_path)
+        checkpoint = _make_checkpoint(num_classes=91)
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
+
+        nn_model = _fake_nn_model()
+        load_pretrain_weights(nn_model, mc, tc)
+
+        nn_model.reinitialize_detection_head.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# load_pretrain_weights — class_names extraction
+# ---------------------------------------------------------------------------
+
+
+class TestLoadPretrainWeightsClassNames:
+    """Verify that class_names are extracted from checkpoint and returned."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_io(self, monkeypatch):
+        monkeypatch.setattr("rfdetr.models.weights.download_pretrain_weights", lambda *a, **kw: None)
+        monkeypatch.setattr("rfdetr.models.weights.validate_pretrain_weights", lambda *a, **kw: None)
+        monkeypatch.setattr("rfdetr.models.weights.validate_checkpoint_compatibility", lambda *a, **kw: None)
+        monkeypatch.setattr("rfdetr.models.weights.os.path.isfile", lambda _: True)
+
+    def test_characterization_class_names_extracted_from_checkpoint(self, monkeypatch, tmp_path):
+        """class_names stored in checkpoint args are returned as a list of strings."""
+        from rfdetr.models.weights import load_pretrain_weights
+
+        mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu", num_classes=90)
+        tc = _make_train_config(tmp_path)
+        checkpoint = _make_checkpoint(num_classes=91)
+        checkpoint["args"] = SimpleNamespace(
+            segmentation_head=False,
+            patch_size=14,
+            class_names=["cat", "dog", "bird"],
+        )
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
+
+        nn_model = _fake_nn_model()
+        result = load_pretrain_weights(nn_model, mc, tc)
+
+        assert result == ["cat", "dog", "bird"], f"Expected class names from checkpoint, got {result!r}"
+
+    def test_characterization_empty_class_names_when_absent_from_checkpoint(self, monkeypatch, tmp_path):
+        """Empty list returned when checkpoint has no args or no class_names key."""
+        from rfdetr.models.weights import load_pretrain_weights
+
+        mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu", num_classes=90)
+        tc = _make_train_config(tmp_path)
+        checkpoint = _make_checkpoint(num_classes=91)
+        checkpoint.pop("args", None)  # no args key at all
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
+
+        nn_model = _fake_nn_model()
+        result = load_pretrain_weights(nn_model, mc, tc)
+
+        assert result == [], f"Expected empty list when checkpoint has no class_names, got {result!r}"
+
+
+# ---------------------------------------------------------------------------
+# apply_lora
+# ---------------------------------------------------------------------------
+
+
+class TestApplyLora:
+    """Verify that apply_lora applies LoRA adapters to the backbone encoder.
+
+    ``apply_lora`` lazily imports ``peft`` inside the function body, so we use
+    ``patch.dict("sys.modules", ...)`` to intercept the import rather than
+    patching a module-level name.
+    """
+
+    def test_characterization_apply_lora_wraps_backbone_encoder(self):
+        """apply_lora must call get_peft_model on nn_model.backbone[0].encoder."""
+        from rfdetr.models.weights import apply_lora
+
+        nn_model = MagicMock()
+        fake_peft_model = MagicMock()
+
+        mock_peft = MagicMock()
+        mock_peft.get_peft_model.return_value = fake_peft_model
+
+        with patch.dict("sys.modules", {"peft": mock_peft}):
+            apply_lora(nn_model)
+
+        mock_peft.LoraConfig.assert_called_once()
+        lora_kwargs = mock_peft.LoraConfig.call_args.kwargs
+        assert lora_kwargs.get("r") == 16, "LoRA rank must be 16"
+        assert lora_kwargs.get("lora_alpha") == 16, "LoRA alpha must be 16"
+        assert lora_kwargs.get("use_dora") is True, "DoRA must be enabled"
+
+        assert mock_peft.get_peft_model.call_count == 1, "get_peft_model must be called exactly once"
+        assert nn_model.backbone[0].encoder is fake_peft_model, "backbone encoder must be replaced with the peft model"
+
+    def test_characterization_apply_lora_target_modules(self):
+        """apply_lora must target exactly the 9 expected module names."""
+        from rfdetr.models.weights import apply_lora
+
+        nn_model = MagicMock()
+        mock_peft = MagicMock()
+
+        with patch.dict("sys.modules", {"peft": mock_peft}):
+            apply_lora(nn_model)
+
+        expected_targets = {
+            "q_proj",
+            "v_proj",
+            "k_proj",
+            "qkv",
+            "query",
+            "key",
+            "value",
+            "cls_token",
+            "register_tokens",
+        }
+        actual_targets = set(mock_peft.LoraConfig.call_args.kwargs.get("target_modules", []))
+        assert actual_targets == expected_targets, (
+            f"LoRA target_modules mismatch.\nExpected: {expected_targets}\nGot: {actual_targets}"
+        )

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -14,6 +14,8 @@
 """
 
 import argparse
+import importlib
+import sys
 import warnings
 from collections import defaultdict
 from types import SimpleNamespace
@@ -811,6 +813,110 @@ class TestPublicAPIExports:
 
         # It is NOT directly on rfdetr (Phase 7.7 spec lists only the three PTL exports)
         assert not hasattr(rfdetr, "convert_legacy_checkpoint")
+
+
+class TestRemovedLegacyModuleAliases:
+    """Removed legacy modules resolve via shims today and via migration hints after removal."""
+
+    @staticmethod
+    def _simulate_missing_removed_module_specs(monkeypatch: pytest.MonkeyPatch, *names: str) -> None:
+        """Force the removed-module finder to behave as if shim files no longer exist."""
+        import rfdetr
+
+        path_finder = rfdetr._RemovedModuleFinder._PATH_FINDER
+        original_find_spec = path_finder.find_spec
+
+        def _fake_find_spec(fullname: str, path: list[str] | None = None, target: object | None = None) -> object:
+            if fullname in names:
+                return None
+            return original_find_spec(fullname, path, target)
+
+        monkeypatch.setattr(path_finder, "find_spec", _fake_find_spec)
+        for name in names:
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+        root_names = {name.removeprefix("rfdetr.").split(".", maxsplit=1)[0] for name in names}
+        for root_name in root_names:
+            monkeypatch.delitem(rfdetr.__dict__, root_name, raising=False)
+
+    def test_removed_util_alias_resolves_via_package_attribute(self) -> None:
+        """PEP 562 lookup resolves rfdetr.util while the shim package exists."""
+        import rfdetr
+
+        assert getattr(rfdetr, "util").__name__ == "rfdetr.util"
+
+    def test_removed_deploy_alias_resolves_via_package_attribute(self) -> None:
+        """PEP 562 lookup resolves rfdetr.deploy while the shim package exists."""
+        import rfdetr
+
+        assert rfdetr.deploy.__name__ == "rfdetr.deploy"
+
+    def test_removed_shim_missing_raises_importerror_with_getattr(self) -> None:
+        """Missing removed shim should raise ImportError with migration hint."""
+        import rfdetr
+
+        missing_name = "rfdetr.missing_removed_shim"
+        missing_exc = ModuleNotFoundError(f"No module named '{missing_name}'", name=missing_name)
+        with (
+            patch.dict(rfdetr._REMOVED_IN_V17, {"missing_removed_shim": "migration hint"}),
+            patch("rfdetr.importlib.import_module", side_effect=missing_exc),
+            pytest.raises(ImportError, match="migration hint"),
+        ):
+            getattr(rfdetr, "missing_removed_shim")
+
+    def test_nested_module_not_found_is_not_masked_for_package_attribute(self) -> None:
+        """Nested ModuleNotFoundError from inside a shim import should propagate."""
+        import rfdetr
+
+        with (
+            patch.dict(rfdetr._REMOVED_IN_V17, {"missing_dep_shim": "migration hint"}),
+            patch(
+                "rfdetr.importlib.import_module",
+                side_effect=ModuleNotFoundError("No module named 'torchvision_ops'", name="torchvision_ops"),
+            ),
+            pytest.raises(ModuleNotFoundError, match="torchvision_ops"),
+        ):
+            getattr(rfdetr, "missing_dep_shim")
+
+    def test_removed_util_import_raises_migration_hint_when_shim_is_deleted(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Dotted legacy imports get a migration hint once the util shim package is removed."""
+        self._simulate_missing_removed_module_specs(monkeypatch, "rfdetr.util")
+
+        with pytest.raises(ImportError, match=r"rfdetr\.util was removed in v1\.7"):
+            importlib.import_module("rfdetr.util")
+
+    def test_removed_deploy_submodule_import_raises_migration_hint_when_shim_is_deleted(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Dotted legacy submodule imports get a migration hint once the deploy shim is removed."""
+        self._simulate_missing_removed_module_specs(monkeypatch, "rfdetr.deploy", "rfdetr.deploy.benchmark")
+
+        with pytest.raises(ImportError, match=r"rfdetr\.deploy was removed in v1\.7"):
+            importlib.import_module("rfdetr.deploy.benchmark")
+
+    def test_find_spec_ignores_non_rfdetr_top_level_imports(self) -> None:
+        """find_spec must not intercept bare top-level imports like 'util' or 'deploy'."""
+        import rfdetr
+
+        finder = rfdetr._RemovedModuleFinder()
+        assert finder.find_spec("util", None) is None
+        assert finder.find_spec("deploy", None) is None
+        assert finder.find_spec("os", None) is None
+
+    def test_meta_path_insertion_is_idempotent_across_reload(self) -> None:
+        """importlib.reload(rfdetr) must not insert a second finder into sys.meta_path."""
+        import rfdetr
+
+        count_before = sum(type(f).__name__ == "_RemovedModuleFinder" for f in sys.meta_path)
+        importlib.reload(rfdetr)
+        count_after = sum(type(f).__name__ == "_RemovedModuleFinder" for f in sys.meta_path)
+        assert count_after == count_before, (
+            f"reload added {count_after - count_before} extra finder(s) to sys.meta_path"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -908,41 +908,43 @@ def _make_detr_checkpoint(
 
 
 class TestLoadPretrainWeightsInto:
-    """Tests for _load_pretrain_weights_into (detr.py path) — the non-PTL code path
-    exercised when RFDETRNano(pretrain_weights=...) is called directly (issue #806)."""
+    """Tests for load_pretrain_weights (models/weights.py) — checkpoint compatibility
+    validation exercised when RFDETRNano(pretrain_weights=...) is called (issue #806)."""
 
     @pytest.fixture(autouse=True)
     def _patch_download(self, monkeypatch):
         """Suppress all download and file-existence side effects."""
-        monkeypatch.setattr("rfdetr.detr.download_pretrain_weights", lambda *a, **kw: None)
-        monkeypatch.setattr("rfdetr.detr.validate_pretrain_weights", lambda *a, **kw: None)
-        monkeypatch.setattr("os.path.isfile", lambda _: True)
+        monkeypatch.setattr("rfdetr.models.weights.download_pretrain_weights", lambda *a, **kw: None)
+        monkeypatch.setattr("rfdetr.models.weights.validate_pretrain_weights", lambda *a, **kw: None)
+        monkeypatch.setattr("rfdetr.models.weights.os.path.isfile", lambda _: True)
 
-    def test_seg_ckpt_into_detection_model_raises_via_detr_path(self, monkeypatch):
-        """Segmentation checkpoint loaded via _load_pretrain_weights_into must raise ValueError."""
-        from rfdetr.detr import _load_pretrain_weights_into
+    def test_seg_ckpt_into_detection_model_raises_via_detr_path(self, monkeypatch, tmp_path):
+        """Segmentation checkpoint must raise ValueError when loaded into a detection model."""
+        from rfdetr.models.weights import load_pretrain_weights
 
         checkpoint = _make_detr_checkpoint(segmentation_head=True, patch_size=14)
-        monkeypatch.setattr("rfdetr.detr.torch.load", lambda *a, **kw: checkpoint)
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
 
         fake_model = MagicMock()
-        args = _make_detr_args(segmentation_head=False, patch_size=14)
+        mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu", segmentation_head=False)
+        tc = _make_train_config(tmp_path)
 
         with pytest.raises(ValueError, match="segmentation head"):
-            _load_pretrain_weights_into(fake_model, args)
+            load_pretrain_weights(fake_model, mc, tc)
 
-    def test_patch_size_mismatch_raises_via_detr_path(self, monkeypatch):
-        """patch_size mismatch raised by _load_pretrain_weights_into via the detr.py path."""
-        from rfdetr.detr import _load_pretrain_weights_into
+    def test_patch_size_mismatch_raises_via_detr_path(self, monkeypatch, tmp_path):
+        """patch_size mismatch must raise ValueError via the load_pretrain_weights path."""
+        from rfdetr.models.weights import load_pretrain_weights
 
         checkpoint = _make_detr_checkpoint(segmentation_head=False, patch_size=12)
-        monkeypatch.setattr("rfdetr.detr.torch.load", lambda *a, **kw: checkpoint)
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
 
         fake_model = MagicMock()
-        args = _make_detr_args(segmentation_head=False, patch_size=16)
+        mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu", patch_size=16)
+        tc = _make_train_config(tmp_path)
 
         with pytest.raises(ValueError, match=r"patch_size"):
-            _load_pretrain_weights_into(fake_model, args)
+            load_pretrain_weights(fake_model, mc, tc)
 
 
 # ---------------------------------------------------------------------------
@@ -977,7 +979,8 @@ class TestClassNamesProperty:
 
         result = RFDETR.class_names.fget(mock_self)
 
-        assert result is COCO_CLASS_NAMES
+        assert result == COCO_CLASS_NAMES
+        assert result is not COCO_CLASS_NAMES, "COCO fallback must return a copy, not the mutable global"
 
     def test_custom_class_names_returned_as_list(self):
         """Non-empty class_names are returned as a 0-indexed list."""

--- a/tests/training/test_load_pretrain_weights.py
+++ b/tests/training/test_load_pretrain_weights.py
@@ -7,27 +7,23 @@
 """Regression tests for fine-tuned checkpoint weight destruction.
 
 When a user loads a fine-tuned N-class checkpoint but has ``num_classes``
-configured to a LARGER value (e.g. default 90), the second reinit in both
-``_load_pretrain_weights_into`` (detr.py) and ``_load_pretrain_weights``
-(training/module_model.py) erroneously resizes the detection head to
-``args.num_classes + 1``, destroying the loaded weights.
+configured to a LARGER value (e.g. default 90), the second reinit in
+``load_pretrain_weights`` (models/weights.py) must NOT erroneously resize the
+detection head to ``num_classes + 1``, destroying the loaded weights.
 
 The fix changes the second reinit condition from:
     ``checkpoint_num_classes != args.num_classes + 1``
-to:
-    ``args.num_classes + 1 < checkpoint_num_classes``
+to the user-override-aware logic that auto-aligns to the checkpoint when the
+user did not explicitly set ``num_classes``.
 
-This preserves the "backbone pretrain" scenario (checkpoint has MORE classes
-than configured, e.g. COCO 91-class pretrain to fine-tune on 2 classes) while
-no longer clobbering loaded weights when the checkpoint has fewer classes.
-
-Each scenario is tested for both code paths:
-  - Path 1: ``_load_pretrain_weights_into`` in ``src/rfdetr/detr.py``
-  - Path 2: ``_load_pretrain_weights`` in ``src/rfdetr/training/module_model.py``
+These tests exercise ``rfdetr.models.weights.load_pretrain_weights`` directly,
+which is the unified function that replaced the two prior separate implementations
+(``detr.py:_load_pretrain_weights_into`` and
+``module_model.py:RFDETRModelModule._load_pretrain_weights``).
 """
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, call
 
 import pytest
 import torch
@@ -63,130 +59,15 @@ def _make_checkpoint(num_classes=91, num_queries=300, group_detr=13):
     return {"model": state, "args": ckpt_args}
 
 
-# ---------------------------------------------------------------------------
-# Path 1: _load_pretrain_weights_into (detr.py)
-# ---------------------------------------------------------------------------
+def _make_train_config():
+    """Return a minimal TrainConfig for use in load_pretrain_weights.
 
-
-def _make_detr_args(num_classes=90, num_queries=300, group_detr=13):
-    """Return a SimpleNamespace shaped like the args for _load_pretrain_weights_into."""
-    return SimpleNamespace(
-        pretrain_weights="/fake/weights.pth",
-        num_classes=num_classes,
-        num_queries=num_queries,
-        group_detr=group_detr,
-        segmentation_head=False,
-        patch_size=14,
-    )
-
-
-class TestLoadPretrainWeightsIntoSecondReinit:
-    """Regression tests for _load_pretrain_weights_into (detr.py path).
-
-    Validates that the second reinitialize_detection_head call only fires when
-    the checkpoint has MORE classes than configured (backbone pretrain scenario),
-    not when it has fewer (fine-tuned checkpoint scenario).
+    Returns:
+        Minimal TrainConfig with placeholder dataset and output dirs.
     """
-
-    @pytest.fixture(autouse=True)
-    def _patch_download(self, monkeypatch):
-        """Suppress all download and file-existence side effects."""
-        monkeypatch.setattr("rfdetr.detr.download_pretrain_weights", lambda *a, **kw: None)
-        monkeypatch.setattr("rfdetr.detr.validate_pretrain_weights", lambda *a, **kw: None)
-        monkeypatch.setattr("rfdetr.detr.validate_checkpoint_compatibility", lambda *a, **kw: None)
-        monkeypatch.setattr("rfdetr.detr.os.path.isfile", lambda _: True)
-
-    def test_finetune_checkpoint_preserves_weights(self, monkeypatch):
-        """Fine-tuned checkpoint (fewer classes) must NOT trigger second reinit.
-
-        Scenario: 2-class fine-tuned checkpoint (bias shape [3]) loaded with
-        num_classes=90 (the default). The first reinit correctly resizes the
-        head to 3 so load_state_dict works. The second reinit must NOT resize
-        to 91 — that would destroy the loaded fine-tuned weights.
-        """
-        from rfdetr.detr import _load_pretrain_weights_into
-
-        checkpoint = _make_checkpoint(num_classes=3)  # 2-class fine-tuned
-        monkeypatch.setattr("rfdetr.detr.torch.load", lambda *a, **kw: checkpoint)
-
-        fake_model = MagicMock()
-        args = _make_detr_args(num_classes=90)
-
-        _load_pretrain_weights_into(fake_model, args)
-
-        # First reinit to checkpoint size (3) must happen.
-        # Second reinit to 91 must NOT happen — that is the bug.
-        calls = fake_model.reinitialize_detection_head.call_args_list
-        assert calls[0] == call(3), f"First reinit should resize to checkpoint size 3, got {calls[0]}"
-        assert len(calls) == 1, (
-            f"Expected exactly 1 reinit call (to checkpoint size), but got {len(calls)}: "
-            f"{calls}. The second reinit to {args.num_classes + 1} destroys loaded weights."
-        )
-
-    def test_no_mismatch_no_reinit(self, monkeypatch):
-        """Checkpoint class count matches config — no reinit at all.
-
-        Scenario: COCO checkpoint (91 classes) with num_classes=90.
-        91 == 90 + 1, so no reinit should fire.
-        """
-        from rfdetr.detr import _load_pretrain_weights_into
-
-        checkpoint = _make_checkpoint(num_classes=91)
-        monkeypatch.setattr("rfdetr.detr.torch.load", lambda *a, **kw: checkpoint)
-
-        fake_model = MagicMock()
-        args = _make_detr_args(num_classes=90)
-
-        _load_pretrain_weights_into(fake_model, args)
-
-        fake_model.reinitialize_detection_head.assert_not_called()
-
-    def test_backbone_pretrain_still_reinits(self, monkeypatch):
-        """Backbone pretrain (more classes in checkpoint) must still reinit.
-
-        Scenario: COCO 91-class checkpoint loaded for 2-class fine-tuning
-        (num_classes=2). Both reinits are correct here: first to 91 for
-        load_state_dict, second to 3 for the configured class count.
-        """
-        from rfdetr.detr import _load_pretrain_weights_into
-
-        checkpoint = _make_checkpoint(num_classes=91)
-        monkeypatch.setattr("rfdetr.detr.torch.load", lambda *a, **kw: checkpoint)
-
-        fake_model = MagicMock()
-        args = _make_detr_args(num_classes=2)
-
-        _load_pretrain_weights_into(fake_model, args)
-
-        calls = fake_model.reinitialize_detection_head.call_args_list
-        assert calls == [call(91), call(3)], f"Expected reinit to [91, 3] (expand then trim), got {calls}"
-
-
-# ---------------------------------------------------------------------------
-# Path 2: RFDETRModelModule._load_pretrain_weights (training/module_model.py)
-# ---------------------------------------------------------------------------
-
-
-def _fake_model():
-    """Return a MagicMock that behaves enough like an LWDETR model."""
-    from torch import nn
-
-    model = MagicMock(spec=nn.Module)
-    real_param = nn.Parameter(torch.randn(4, 4))
-    model.parameters.return_value = iter([real_param])
-    model.named_parameters.return_value = iter([("weight", real_param)])
-    model.update_drop_path = MagicMock()
-    model.update_dropout = MagicMock()
-    model.reinitialize_detection_head = MagicMock()
-    return model
-
-
-def _build_module(model_config=None, train_config=None, tmp_path=None):
-    """Construct RFDETRModelModule with build_model and build_criterion_and_postprocessors mocked."""
-    mc = model_config or RFDETRBaseConfig(pretrain_weights=None, device="cpu", num_classes=5)
-    tc = train_config or TrainConfig(
-        dataset_dir=str(tmp_path / "dataset") if tmp_path else "/nonexistent/dataset",
-        output_dir=str(tmp_path / "output") if tmp_path else "/nonexistent/output",
+    return TrainConfig(
+        dataset_dir="/nonexistent/dataset",
+        output_dir="/nonexistent/output",
         epochs=10,
         lr=1e-4,
         lr_encoder=1.5e-4,
@@ -201,25 +82,15 @@ def _build_module(model_config=None, train_config=None, tmp_path=None):
         grad_accum_steps=1,
         tensorboard=False,
     )
-    fake = _fake_model()
-    fake_criterion = MagicMock()
-    fake_criterion.weight_dict = {"loss_ce": 1.0, "loss_bbox": 5.0, "loss_giou": 2.0}
-    fake_postprocess = MagicMock()
-    with (
-        patch("rfdetr.training.module_model.build_model", return_value=fake),
-        patch(
-            "rfdetr.training.module_model.build_criterion_and_postprocessors",
-            return_value=(fake_criterion, fake_postprocess),
-        ),
-    ):
-        from rfdetr.training.module_model import RFDETRModelModule
-
-        module = RFDETRModelModule(mc, tc)
-    return module, fake
 
 
-class TestModuleLoadPretrainWeightsSecondReinit:
-    """Regression tests for RFDETRModelModule._load_pretrain_weights (module_model.py path).
+# ---------------------------------------------------------------------------
+# Regression tests: load_pretrain_weights (models/weights.py)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadPretrainWeightsSecondReinit:
+    """Regression tests for ``load_pretrain_weights`` in ``rfdetr.models.weights``.
 
     Validates that the second reinitialize_detection_head call only fires when
     the checkpoint has MORE classes than configured (backbone pretrain scenario),
@@ -229,90 +100,91 @@ class TestModuleLoadPretrainWeightsSecondReinit:
     @pytest.fixture(autouse=True)
     def _patch_download(self, monkeypatch):
         """Suppress all download and file-existence side effects."""
-        monkeypatch.setattr("rfdetr.training.module_model.download_pretrain_weights", lambda *a, **kw: None)
-        monkeypatch.setattr("rfdetr.training.module_model.validate_pretrain_weights", lambda *a, **kw: None)
-        monkeypatch.setattr("rfdetr.training.module_model.validate_checkpoint_compatibility", lambda *a, **kw: None)
-        monkeypatch.setattr("rfdetr.training.module_model.os.path.isfile", lambda _: True)
+        monkeypatch.setattr("rfdetr.models.weights.download_pretrain_weights", lambda *a, **kw: None)
+        monkeypatch.setattr("rfdetr.models.weights.validate_pretrain_weights", lambda *a, **kw: None)
+        monkeypatch.setattr("rfdetr.models.weights.validate_checkpoint_compatibility", lambda *a, **kw: None)
+        monkeypatch.setattr("rfdetr.models.weights.os.path.isfile", lambda _: True)
 
-    @patch("rfdetr.training.module_model.torch.load")
-    def test_finetune_checkpoint_preserves_weights(self, mock_torch_load, tmp_path):
+    def test_finetune_checkpoint_preserves_weights(self, monkeypatch):
         """Fine-tuned checkpoint (fewer classes) must NOT trigger second reinit.
 
         Scenario: 2-class fine-tuned checkpoint (bias shape [3]) loaded with
-        default num_classes=90. The first reinit correctly resizes the head to 3 so
-        load_state_dict works. The second reinit must NOT resize to 91.
+        default num_classes=90. The first reinit correctly resizes the head to 3
+        so load_state_dict works. The second reinit must NOT resize to 91 —
+        that would destroy the loaded fine-tuned weights.
         """
-        mc = RFDETRBaseConfig(pretrain_weights=None, device="cpu")
-        module, fake_model = _build_module(model_config=mc, tmp_path=tmp_path)
+        from rfdetr.models.weights import load_pretrain_weights
 
-        checkpoint = _make_checkpoint(num_classes=3)  # 2-class fine-tuned
-        mock_torch_load.return_value = checkpoint
-        module.model_config = module.model_config.model_copy(update={"pretrain_weights": "/fake/weights.pth"})
+        mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu")
+        tc = _make_train_config()
+        checkpoint = _make_checkpoint(num_classes=3)
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
 
-        module._load_pretrain_weights()
+        fake_model = MagicMock()
+        load_pretrain_weights(fake_model, mc, tc)
 
         calls = fake_model.reinitialize_detection_head.call_args_list
         assert calls[0] == call(3), f"First reinit should resize to checkpoint size 3, got {calls[0]}"
         assert len(calls) == 1, (
             f"Expected exactly 1 reinit call (to checkpoint size), but got {len(calls)}: "
-            f"{calls}. A second reinit would destroy loaded weights."
+            f"{calls}. The second reinit to 91 destroys loaded weights."
         )
 
-    @patch("rfdetr.training.module_model.torch.load")
-    def test_user_override_larger_than_checkpoint_reexpands_head(self, mock_torch_load, tmp_path):
-        """Explicit larger num_classes must be restored after checkpoint load.
-
-        Scenario: 91-class checkpoint loaded with explicit num_classes=93.
-        Loader must temporarily match checkpoint size for load_state_dict, then
-        expand to 94 logits and keep args.num_classes unchanged.
-        """
-        mc = RFDETRBaseConfig(pretrain_weights=None, device="cpu", num_classes=93)
-        module, fake_model = _build_module(model_config=mc, tmp_path=tmp_path)
-
-        checkpoint = _make_checkpoint(num_classes=91)
-        mock_torch_load.return_value = checkpoint
-        module.model_config = module.model_config.model_copy(update={"pretrain_weights": "/fake/weights.pth"})
-
-        module._load_pretrain_weights()
-
-        calls = fake_model.reinitialize_detection_head.call_args_list
-        assert calls == [call(91), call(94)], f"Expected reinit to [91, 94] (load then expand), got {calls}"
-        assert module.model_config.num_classes == 93, "Explicitly configured num_classes must not be overwritten."
-
-    @patch("rfdetr.training.module_model.torch.load")
-    def test_no_mismatch_no_reinit(self, mock_torch_load, tmp_path):
+    def test_no_mismatch_no_reinit(self, monkeypatch):
         """Checkpoint class count matches config — no reinit at all.
 
         Scenario: COCO checkpoint (91 classes) with num_classes=90.
         91 == 90 + 1, so no reinit should fire.
         """
-        mc = RFDETRBaseConfig(pretrain_weights=None, device="cpu", num_classes=90)
-        module, fake_model = _build_module(model_config=mc, tmp_path=tmp_path)
+        from rfdetr.models.weights import load_pretrain_weights
 
+        mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu", num_classes=90)
+        tc = _make_train_config()
         checkpoint = _make_checkpoint(num_classes=91)
-        mock_torch_load.return_value = checkpoint
-        module.model_config = module.model_config.model_copy(update={"pretrain_weights": "/fake/weights.pth"})
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
 
-        module._load_pretrain_weights()
+        fake_model = MagicMock()
+        load_pretrain_weights(fake_model, mc, tc)
 
         fake_model.reinitialize_detection_head.assert_not_called()
 
-    @patch("rfdetr.training.module_model.torch.load")
-    def test_backbone_pretrain_still_reinits(self, mock_torch_load, tmp_path):
+    def test_backbone_pretrain_still_reinits(self, monkeypatch):
         """Backbone pretrain (more classes in checkpoint) must still reinit.
 
         Scenario: COCO 91-class checkpoint loaded for 2-class fine-tuning
         (num_classes=2). Both reinits are correct here: first to 91 for
         load_state_dict, second to 3 for the configured class count.
         """
-        mc = RFDETRBaseConfig(pretrain_weights=None, device="cpu", num_classes=2)
-        module, fake_model = _build_module(model_config=mc, tmp_path=tmp_path)
+        from rfdetr.models.weights import load_pretrain_weights
 
+        mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu", num_classes=2)
+        tc = _make_train_config()
         checkpoint = _make_checkpoint(num_classes=91)
-        mock_torch_load.return_value = checkpoint
-        module.model_config = module.model_config.model_copy(update={"pretrain_weights": "/fake/weights.pth"})
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
 
-        module._load_pretrain_weights()
+        fake_model = MagicMock()
+        load_pretrain_weights(fake_model, mc, tc)
 
         calls = fake_model.reinitialize_detection_head.call_args_list
         assert calls == [call(91), call(3)], f"Expected reinit to [91, 3] (expand then trim), got {calls}"
+
+    def test_user_override_larger_than_checkpoint_reexpands_head(self, monkeypatch):
+        """Explicit larger num_classes must be restored after checkpoint load.
+
+        Scenario: 91-class checkpoint loaded with explicit num_classes=93.
+        Loader must temporarily match checkpoint size for load_state_dict, then
+        expand to 94 logits and keep args.num_classes unchanged.
+        """
+        from rfdetr.models.weights import load_pretrain_weights
+
+        mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu", num_classes=93)
+        tc = _make_train_config()
+        checkpoint = _make_checkpoint(num_classes=91)
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
+
+        fake_model = MagicMock()
+        load_pretrain_weights(fake_model, mc, tc)
+
+        calls = fake_model.reinitialize_detection_head.call_args_list
+        assert calls == [call(91), call(94)], f"Expected reinit to [91, 94] (load then expand), got {calls}"
+        assert mc.num_classes == 93, "Explicitly configured num_classes must not be overwritten."

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -14,6 +14,7 @@ import torch
 from torch import nn
 
 from rfdetr.config import RFDETRBaseConfig, TrainConfig
+from rfdetr.models.weights import apply_lora, load_pretrain_weights
 from rfdetr.utilities.tensors import NestedTensor
 
 # ---------------------------------------------------------------------------
@@ -209,8 +210,8 @@ class TestLoadPretrainWeights:
             }
         }
 
-    @patch("rfdetr.training.module_model.torch.load")
-    @patch("rfdetr.training.module_model.validate_pretrain_weights")
+    @patch("rfdetr.models.weights.torch.load")
+    @patch("rfdetr.models.weights.validate_pretrain_weights")
     def test_loads_checkpoint_successfully(self, mock_validate, mock_torch_load, base_model_config, build_module):
         """A valid checkpoint must be validated, loaded, and applied to the model."""
         mc = base_model_config(num_classes=90)
@@ -219,13 +220,13 @@ class TestLoadPretrainWeights:
 
         module, _, _, _ = build_module(model_config=mc)
         module.model_config = module.model_config.model_copy(update={"pretrain_weights": "/fake/weights.pth"})
-        module._load_pretrain_weights()
+        load_pretrain_weights(module.model, module.model_config, module.train_config)
 
         mock_validate.assert_called_once_with("/fake/weights.pth", strict=False)
         module.model.load_state_dict.assert_called_once()
 
-    @patch("rfdetr.training.module_model.torch.load")
-    @patch("rfdetr.training.module_model.validate_pretrain_weights")
+    @patch("rfdetr.models.weights.torch.load")
+    @patch("rfdetr.models.weights.validate_pretrain_weights")
     def test_class_count_mismatch_triggers_reinitialize(
         self, mock_validate, mock_torch_load, base_model_config, build_module
     ):
@@ -236,7 +237,7 @@ class TestLoadPretrainWeights:
 
         module, fake_model, _, _ = build_module(model_config=mc)
         module.model_config = module.model_config.model_copy(update={"pretrain_weights": "/fake/weights.pth"})
-        module._load_pretrain_weights()
+        load_pretrain_weights(module.model, module.model_config, module.train_config)
 
         # First call: expand to checkpoint size so load_state_dict shapes match.
         # Second call: trim back to configured num_classes + 1 (background class).
@@ -245,8 +246,8 @@ class TestLoadPretrainWeights:
         fake_model.reinitialize_detection_head.assert_has_calls([call(91), call(6)])
         assert fake_model.reinitialize_detection_head.call_count == 2
 
-    @patch("rfdetr.training.module_model.torch.load")
-    @patch("rfdetr.training.module_model.validate_pretrain_weights")
+    @patch("rfdetr.models.weights.torch.load")
+    @patch("rfdetr.models.weights.validate_pretrain_weights")
     def test_class_count_match_does_not_reinitialize(
         self, mock_validate, mock_torch_load, base_model_config, build_module
     ):
@@ -257,12 +258,12 @@ class TestLoadPretrainWeights:
 
         module, fake_model, _, _ = build_module(model_config=mc)
         module.model_config = module.model_config.model_copy(update={"pretrain_weights": "/fake/weights.pth"})
-        module._load_pretrain_weights()
+        load_pretrain_weights(module.model, module.model_config, module.train_config)
 
         fake_model.reinitialize_detection_head.assert_not_called()
 
-    @patch("rfdetr.training.module_model.torch.load")
-    @patch("rfdetr.training.module_model.validate_pretrain_weights")
+    @patch("rfdetr.models.weights.torch.load")
+    @patch("rfdetr.models.weights.validate_pretrain_weights")
     def test_query_embedding_trimmed_to_configured_count(
         self, mock_validate, mock_torch_load, base_model_config, build_module
     ):
@@ -286,14 +287,14 @@ class TestLoadPretrainWeights:
         mock_torch_load.return_value = checkpoint
 
         module.model_config = module.model_config.model_copy(update={"pretrain_weights": "/fake/weights.pth"})
-        module._load_pretrain_weights()
+        load_pretrain_weights(module.model, module.model_config, module.train_config)
 
         assert checkpoint["model"]["refpoint_embed.weight"].shape[0] == desired
         assert checkpoint["model"]["query_feat.weight"].shape[0] == desired
 
-    @patch("rfdetr.training.module_model.os.path.isfile", return_value=True)
-    @patch("rfdetr.training.module_model.download_pretrain_weights")
-    @patch("rfdetr.training.module_model.validate_pretrain_weights")
+    @patch("rfdetr.models.weights.os.path.isfile", return_value=True)
+    @patch("rfdetr.models.weights.download_pretrain_weights")
+    @patch("rfdetr.models.weights.validate_pretrain_weights")
     def test_redownloads_on_load_failure(
         self, mock_validate, mock_download, mock_isfile, base_model_config, build_module
     ):
@@ -311,8 +312,8 @@ class TestLoadPretrainWeights:
                 raise RuntimeError("corrupted file")
             return checkpoint
 
-        with patch("rfdetr.training.module_model.torch.load", side_effect=fake_torch_load):
-            module._load_pretrain_weights()
+        with patch("rfdetr.models.weights.torch.load", side_effect=fake_torch_load):
+            load_pretrain_weights(module.model, module.model_config, module.train_config)
 
         # Verify a redownload with validate_md5=False was triggered after load failure.
         redownload_calls = [c for c in mock_download.call_args_list if c.kwargs.get("redownload") is True]
@@ -320,10 +321,10 @@ class TestLoadPretrainWeights:
         assert all(c.kwargs.get("validate_md5") is False for c in redownload_calls)
         assert load_calls[0] == 2
 
-    @patch("rfdetr.training.module_model.os.path.isfile", return_value=False)
-    @patch("rfdetr.training.module_model.download_pretrain_weights")
-    @patch("rfdetr.training.module_model.validate_pretrain_weights")
-    @patch("rfdetr.training.module_model.torch.load")
+    @patch("rfdetr.models.weights.os.path.isfile", return_value=False)
+    @patch("rfdetr.models.weights.download_pretrain_weights")
+    @patch("rfdetr.models.weights.validate_pretrain_weights")
+    @patch("rfdetr.models.weights.torch.load")
     def test_download_before_load_when_weights_absent(
         self, mock_torch_load, mock_validate, mock_download, mock_isfile, base_model_config, build_module
     ):
@@ -340,15 +341,15 @@ class TestLoadPretrainWeights:
 
         module, _, _, _ = build_module(model_config=mc)
         module.model_config = module.model_config.model_copy(update={"pretrain_weights": "/content/rf-detr-base.pth"})
-        module._load_pretrain_weights()
+        load_pretrain_weights(module.model, module.model_config, module.train_config)
 
         # download_pretrain_weights must have been called at least once before any load
         assert mock_download.call_count >= 1
         first_call = mock_download.call_args_list[0]
         assert first_call.args[0] == "/content/rf-detr-base.pth"
 
-    @patch("rfdetr.training.module_model.torch.load")
-    @patch("rfdetr.training.module_model.validate_pretrain_weights")
+    @patch("rfdetr.models.weights.torch.load")
+    @patch("rfdetr.models.weights.validate_pretrain_weights")
     def test_seg_checkpoint_into_detection_model_raises(
         self, mock_validate, mock_torch_load, base_model_config, build_module
     ):
@@ -365,10 +366,10 @@ class TestLoadPretrainWeights:
         )
 
         with pytest.raises(ValueError, match="segmentation head"):
-            module._load_pretrain_weights()
+            load_pretrain_weights(module.model, module.model_config, module.train_config)
 
-    @patch("rfdetr.training.module_model.torch.load")
-    @patch("rfdetr.training.module_model.validate_pretrain_weights")
+    @patch("rfdetr.models.weights.torch.load")
+    @patch("rfdetr.models.weights.validate_pretrain_weights")
     def test_detection_checkpoint_into_seg_model_raises(
         self, mock_validate, mock_torch_load, base_model_config, build_module
     ):
@@ -385,10 +386,10 @@ class TestLoadPretrainWeights:
         )
 
         with pytest.raises(ValueError, match="segmentation head"):
-            module._load_pretrain_weights()
+            load_pretrain_weights(module.model, module.model_config, module.train_config)
 
-    @patch("rfdetr.training.module_model.torch.load")
-    @patch("rfdetr.training.module_model.validate_pretrain_weights")
+    @patch("rfdetr.models.weights.torch.load")
+    @patch("rfdetr.models.weights.validate_pretrain_weights")
     def test_patch_size_mismatch_raises(self, mock_validate, mock_torch_load, base_model_config, build_module):
         """Loading a checkpoint with a different patch_size must raise ValueError."""
         mc = base_model_config(num_classes=90)
@@ -403,10 +404,10 @@ class TestLoadPretrainWeights:
         )
 
         with pytest.raises(ValueError, match="patch_size"):
-            module._load_pretrain_weights()
+            load_pretrain_weights(module.model, module.model_config, module.train_config)
 
-    @patch("rfdetr.training.module_model.torch.load")
-    @patch("rfdetr.training.module_model.validate_pretrain_weights")
+    @patch("rfdetr.models.weights.torch.load")
+    @patch("rfdetr.models.weights.validate_pretrain_weights")
     def test_compatible_checkpoint_does_not_raise(
         self, mock_validate, mock_torch_load, base_model_config, build_module
     ):
@@ -423,7 +424,7 @@ class TestLoadPretrainWeights:
         )
 
         # Should not raise.
-        module._load_pretrain_weights()
+        load_pretrain_weights(module.model, module.model_config, module.train_config)
 
 
 class TestApplyLora:
@@ -463,7 +464,7 @@ class TestApplyLora:
         module, _, _, _ = self._build_module_with_backbone(tmp_path)
         mock_get_peft.return_value = MagicMock()
 
-        module._apply_lora()
+        apply_lora(module.model)
 
         mock_lora_cfg_class.assert_called_once()
         target_modules = mock_lora_cfg_class.call_args.kwargs.get("target_modules")
@@ -478,7 +479,7 @@ class TestApplyLora:
         peft_wrapped = MagicMock()
         mock_get_peft.return_value = peft_wrapped
 
-        module._apply_lora()
+        apply_lora(module.model)
 
         assert mock_get_peft.call_args[0][0] is fake_encoder
         assert fake_backbone_0.encoder is peft_wrapped

--- a/tests/utilities/test_package.py
+++ b/tests/utilities/test_package.py
@@ -6,6 +6,8 @@
 
 """Tests for package metadata helpers."""
 
+import subprocess
+import sys
 from unittest.mock import patch
 
 from rfdetr.utilities.package import get_sha
@@ -32,3 +34,33 @@ def test_get_sha_marks_dirty_worktree_when_diff_command_returns_exit_code_1() ->
         sha = get_sha()
 
     assert sha == "sha: abc123, status: has uncommitted changes, branch: feature/test"
+
+
+def test_peft_not_imported_eagerly_on_backbone_import_characterization() -> None:
+    """Importing backbone.backbone must NOT pull peft into sys.modules (peft is optional).
+
+    This characterization test captures the invariant introduced in PR 1 (chore/packaging-peft-lora):
+    after the lazy-import refactor, importing backbone at module-load time must not trigger a
+    top-level ``from peft import PeftModel``.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "import rfdetr.models.backbone.backbone; "
+                "assert 'peft' not in sys.modules, "
+                "'peft was eagerly imported by backbone.backbone'"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        "Subprocess for backbone import failed:\n"
+        f"return code: {result.returncode}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
## What does this PR do?

Eliminates duplicated weight-loading and LoRA application logic between detr.py (_load_pretrain_weights_into, _apply_lora_to) and module_model.py (_load_pretrain_weights, _apply_lora). The canonical unified implementation lives in the new src/rfdetr/models/weights.py and both callers delegate to it.

Key changes:
- New src/rfdetr/models/weights.py: load_pretrain_weights() uses the more complete module_model.py logic (Pydantic model_fields_set for user-override detection, auto-align to fine-tuned checkpoints, expand-back for explicit num_classes) plus class_names extraction from detr.py. apply_lora() is the unified LoRA application function.
- detr.py: removes ~80 lines of private weight/LoRA methods; delegates to weights.py; fixes mutable COCO_CLASS_NAMES returned directly from class_names property (now returns list copy).
- module_model.py: removes ~95 lines of private weight/LoRA methods; delegates to weights.py.
- Top-level package compatibility: documents and tests the v1.7 legacy-module migration path for removed namespaces such as rfdetr.util and rfdetr.deploy, including dotted-import behavior after shim removal.
- Packaging/dependency behavior: export now skips LoRA merge noise unless the backbone encoder is actually PEFT-wrapped, and LoRA install guidance remains centralized in the shared helper.
- tests/models/test_weights.py: characterization coverage for reinit scenarios, class_names extraction, and LoRA application.
- tests/models/backbone/test_backbone_export.py, test_load_pretrain_weights.py, test_module_model.py, test_detr_shim.py: migrated patch targets and added regression coverage for export and package compatibility behavior.

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)
- Refactoring (no functional changes)

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
