### PR TITLE
refactor: BuilderArgs Protocol + ModelConfig/TrainConfig field deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to RF-DETR are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `BuilderArgs` — a `@runtime_checkable` `typing.Protocol` documenting the minimum attribute set consumed by `build_model()`, `build_backbone()`, `build_transformer()`, and `build_criterion_and_postprocessors()`. Enables static type-checker support for custom builder integrations. Exported from `rfdetr.models`.
+
+### Deprecated
+
+The following fields are duplicated between `ModelConfig` and `TrainConfig`; clear ownership is being established for v1.9. Each field now emits `DeprecationWarning` when set on the wrong config object.  The fields continue to work as before — this is a warning-only Phase A change.
+
+- `TrainConfig.group_detr` — architecture decision; set on `ModelConfig` instead.
+- `TrainConfig.ia_bce_loss` — loss type tied to architecture family; set on `ModelConfig` instead.
+- `TrainConfig.segmentation_head` — architecture flag; set on `ModelConfig` instead.
+- `TrainConfig.num_select` — postprocessor count is an architecture decision; set on `ModelConfig` instead. `SegmentationTrainConfig` users: remove the `num_select` override — the model config value is always used.
+- `ModelConfig.cls_loss_coef` — training hyperparameter; set on `TrainConfig` instead.
+
+These fields will be **removed** in v1.9 after a full release cycle.
+
+### Fixed
+
+- Fixed `_namespace.py`: `num_select` in the builder namespace now always reads from `ModelConfig`, eliminating a regression where `TrainConfig.num_select` (default 300) silently overrode model-specific values of 100–200 for segmentation variants (`RFDETRSegNano`, `RFDETRSegSmall`, `RFDETRSegMedium`, `RFDETRSegLarge`, `RFDETRSegPreview`). Post-processing now uses the correct top-k count for each model.
+
+---
+
 ## [1.6.0] — 2026-03-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-The following fields are duplicated between `ModelConfig` and `TrainConfig`; clear ownership is being established for v1.9. Each field now emits `DeprecationWarning` when set on the wrong config object.  The fields continue to work as before — this is a warning-only Phase A change.
+The following fields are duplicated between `ModelConfig` and `TrainConfig`; clear ownership is being established for v1.9. Each field now emits `DeprecationWarning` when set on the wrong config object. The fields continue to work as before — this is a warning-only Phase A change.
 
 - `TrainConfig.group_detr` — architecture decision; set on `ModelConfig` instead.
 - `TrainConfig.ia_bce_loss` — loss type tied to architecture family; set on `ModelConfig` instead.

--- a/src/rfdetr/_namespace.py
+++ b/src/rfdetr/_namespace.py
@@ -37,7 +37,15 @@ def build_namespace(model_config: ModelConfig, train_config: TrainConfig) -> Any
     """
     mc = model_config
     tc = train_config
-    train_num_select = getattr(tc, "num_select", None)
+    train_fields_set = getattr(tc, "model_fields_set", set())
+    model_fields_set = getattr(mc, "model_fields_set", set())
+    # Transitional compatibility: during deprecation, preserve explicit
+    # ModelConfig.cls_loss_coef values when TrainConfig does not set one.
+    cls_loss_coef = (
+        tc.cls_loss_coef
+        if "cls_loss_coef" in train_fields_set or "cls_loss_coef" not in model_fields_set
+        else mc.cls_loss_coef
+    )
 
     return types.SimpleNamespace(
         # --- ModelConfig fields ---
@@ -66,11 +74,11 @@ def build_namespace(model_config: ModelConfig, train_config: TrainConfig) -> Any
         gradient_checkpointing=mc.gradient_checkpointing,
         positional_encoding_size=mc.positional_encoding_size,
         ia_bce_loss=mc.ia_bce_loss,
-        cls_loss_coef=mc.cls_loss_coef,
+        cls_loss_coef=cls_loss_coef,
         segmentation_head=mc.segmentation_head,
         mask_downsample_ratio=mc.mask_downsample_ratio,
         num_queries=mc.num_queries,
-        num_select=mc.num_select if train_num_select is None else train_num_select,
+        num_select=mc.num_select,
         # --- TrainConfig fields ---
         lr=tc.lr,
         lr_encoder=tc.lr_encoder,

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -6,6 +6,7 @@
 
 
 import os
+import warnings
 from typing import Any, ClassVar, Dict, List, Literal, Mapping, Optional, Union
 
 import torch
@@ -82,6 +83,26 @@ class ModelConfig(BaseConfig):
     backbone_lora: bool = False
     freeze_encoder: bool = False
     license: str = "Apache-2.0"
+
+    @model_validator(mode="after")
+    def _warn_deprecated_model_config_fields(self) -> "ModelConfig":
+        """Emit DeprecationWarning when cls_loss_coef is explicitly set on ModelConfig.
+
+        ``cls_loss_coef`` ownership is moving to ``TrainConfig`` (Item #3, v1.7). Setting
+        it on ``ModelConfig`` is deprecated.  Use ``TrainConfig(cls_loss_coef=...)`` instead.
+        """
+        if "cls_loss_coef" in self.model_fields_set:
+            # stacklevel=2 points into Pydantic internals rather than the user call
+            # site — this is unavoidable with @model_validator(mode="after") in
+            # Pydantic v2.  The warning still fires correctly; the origin frame is
+            # less precise than ideal.
+            warnings.warn(
+                "ModelConfig.cls_loss_coef is deprecated and will be removed in v1.9. "
+                "Set cls_loss_coef on TrainConfig instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return self
 
     @field_validator("pretrain_weights", mode="after")
     @classmethod
@@ -362,6 +383,32 @@ class TrainConfig(BaseModel):
     eval_interval: int = 1
     log_per_class_metrics: bool = True
     aug_config: Optional[Dict[str, Any]] = None
+
+    @model_validator(mode="after")
+    def _warn_deprecated_train_config_fields(self) -> "TrainConfig":
+        """Emit DeprecationWarning for fields whose ownership is moving to ModelConfig.
+
+        The following fields are duplicated between ``ModelConfig`` and ``TrainConfig``
+        but ``ModelConfig`` is the authoritative source (Item #3, v1.7).  Setting them
+        on ``TrainConfig`` is deprecated.  The fields will be removed in v1.9.
+
+        - ``group_detr``: query group count is an architecture decision → ``ModelConfig``
+        - ``ia_bce_loss``: loss type is tied to architecture family → ``ModelConfig``
+        - ``segmentation_head``: architecture flag → ``ModelConfig``
+        - ``num_select``: postprocessor count is an architecture decision → ``ModelConfig``
+        """
+        _deprecated = ("group_detr", "ia_bce_loss", "segmentation_head", "num_select")
+        for field in _deprecated:
+            if field in self.model_fields_set:
+                # stacklevel=2 points into Pydantic internals; unavoidable with
+                # @model_validator(mode="after") in Pydantic v2.
+                warnings.warn(
+                    f"TrainConfig.{field} is deprecated and will be removed in v1.9. "
+                    f"Set {field} on ModelConfig instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+        return self
 
     @field_validator("progress_bar", mode="before")
     @classmethod

--- a/src/rfdetr/models/__init__.py
+++ b/src/rfdetr/models/__init__.py
@@ -13,12 +13,14 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 # ------------------------------------------------------------------------
 
+from rfdetr.models._types import BuilderArgs
 from rfdetr.models.criterion import SetCriterion
 from rfdetr.models.lwdetr import build_model
 from rfdetr.models.math import MLP
 from rfdetr.models.postprocess import PostProcess
 
 __all__ = [
+    "BuilderArgs",
     "SetCriterion",
     "build_model",
     "MLP",

--- a/src/rfdetr/models/_types.py
+++ b/src/rfdetr/models/_types.py
@@ -78,6 +78,12 @@ class BuilderArgs(Protocol):
     backbone_only: bool
     encoder_only: bool
     # --- Criterion ---
+    # Note: `decoder_norm`, `dropout`, and `num_feature_levels` are consumed by
+    # `build_transformer()` (called inside `build_model()`) but are intentionally
+    # absent here.  They are hardcoded constants computed/assigned inside
+    # `build_namespace()` (e.g. `num_feature_levels = len(projector_scale)`) and
+    # are never read from external callers — exposing them in the Protocol would
+    # mislead consumers into thinking they must be supplied.
     aux_loss: bool
     focal_alpha: float
     bbox_loss_coef: float

--- a/src/rfdetr/models/_types.py
+++ b/src/rfdetr/models/_types.py
@@ -1,0 +1,93 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Shared type protocols for RF-DETR model builder functions.
+
+The ``BuilderArgs`` protocol documents the minimum attribute set consumed by
+``build_model()``, ``build_backbone()``, ``build_transformer()``, and
+``build_criterion_and_postprocessors()``.  It is satisfied structurally by any
+object that exposes the required attributes — including the ``SimpleNamespace``
+produced by :func:`rfdetr._namespace.build_namespace` and, after Item #1 is
+complete, by ``ModelConfig``/``TrainConfig`` directly.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class BuilderArgs(Protocol):
+    """Protocol satisfied by both ``ModelConfig``-based Namespaces and raw ``SimpleNamespace`` objects.
+
+    This documents the minimum attribute set consumed by ``build_model()``,
+    ``build_backbone()``, ``build_transformer()``, and
+    ``build_criterion_and_postprocessors()``.  All attributes that appear in
+    ``build_namespace()`` hardcoded defaults are included.
+
+    Note:
+        Python 3.10/3.11 runtime ``isinstance()`` checks with
+        ``@runtime_checkable`` only verify callable (method) presence, not
+        data-attribute presence.  Full structural enforcement requires Python
+        3.12+ or a static type checker (mypy / pyright).
+    """
+
+    # --- Architecture ---
+    encoder: str
+    out_feature_indexes: List[int]
+    dec_layers: int
+    freeze_encoder: bool
+    backbone_lora: bool
+    two_stage: bool
+    projector_scale: List[str]
+    hidden_dim: int
+    patch_size: int
+    num_windows: int
+    sa_nheads: int
+    ca_nheads: int
+    dec_n_points: int
+    bbox_reparam: bool
+    lite_refpoint_refine: bool
+    layer_norm: bool
+    amp: bool
+    num_classes: int
+    pretrain_weights: Optional[str]
+    device: str
+    resolution: int
+    group_detr: int
+    gradient_checkpointing: bool
+    positional_encoding_size: int
+    ia_bce_loss: bool
+    cls_loss_coef: float
+    segmentation_head: bool
+    mask_downsample_ratio: int
+    num_queries: int
+    num_select: int
+    # --- Legacy / hardcoded defaults (present on Namespace, absent on raw configs) ---
+    vit_encoder_num_layers: int
+    window_block_indexes: Optional[List[int]]
+    position_embedding: str
+    rms_norm: bool
+    force_no_pretrain: bool
+    dim_feedforward: int
+    use_cls_token: bool
+    pretrained_encoder: Optional[str]
+    backbone_only: bool
+    encoder_only: bool
+    # --- Criterion ---
+    aux_loss: bool
+    focal_alpha: float
+    bbox_loss_coef: float
+    giou_loss_coef: float
+    set_cost_class: float
+    set_cost_bbox: float
+    set_cost_giou: float
+    use_varifocal_loss: bool
+    use_position_supervised_loss: bool
+    sum_group_losses: bool
+    mask_ce_loss_coef: float
+    mask_dice_loss_coef: float
+    mask_point_sample_ratio: int

--- a/src/rfdetr/models/lwdetr.py
+++ b/src/rfdetr/models/lwdetr.py
@@ -27,6 +27,7 @@ from typing import Callable, Optional
 import torch
 from torch import nn
 
+from rfdetr.models._types import BuilderArgs
 from rfdetr.models.backbone import build_backbone
 
 # Backward-compat re-exports: loss functions that used to live in this module
@@ -348,7 +349,7 @@ class LWDETR(nn.Module):
                 module.p = drop_rate
 
 
-def build_model(args):
+def build_model(args: "BuilderArgs"):
     # the `num_classes` naming here is somewhat misleading.
     # it indeed corresponds to `max_obj_id + 1`, where max_obj_id
     # is the maximum id for a class in your dataset. For example,
@@ -421,7 +422,7 @@ def build_model(args):
     return model
 
 
-def build_criterion_and_postprocessors(args):
+def build_criterion_and_postprocessors(args: "BuilderArgs"):
     device = torch.device(args.device)
     matcher = build_matcher(args)
     weight_dict = {"loss_ce": args.cls_loss_coef, "loss_bbox": args.bbox_loss_coef}

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 
 from rfdetr.config import (
     ModelConfig,
+    RFDETRBaseConfig,
     RFDETRSeg2XLargeConfig,
     RFDETRSegLargeConfig,
     RFDETRSegMediumConfig,
@@ -60,7 +61,9 @@ class TestSegmentationTrainConfigNumSelect:
         assert config.num_select is None
 
     def test_explicit_value_is_accepted(self) -> None:
-        config = SegmentationTrainConfig(dataset_dir="/tmp", num_select=42)
+        # Explicitly setting num_select on SegmentationTrainConfig is deprecated (Item #3).
+        with pytest.warns(DeprecationWarning, match="TrainConfig.num_select is deprecated"):
+            config = SegmentationTrainConfig(dataset_dir="/tmp", num_select=42)
         assert config.num_select == 42
 
     @pytest.mark.parametrize(
@@ -280,3 +283,71 @@ class TestBuildTrainerUsesRealFields:
             build_trainer(self._tc(tmp_path, sync_bn=True), self._mc())
 
         assert captured_kwargs.get("sync_batchnorm") is True
+
+
+class TestDeprecatedTrainConfigFields:
+    """Item #3 Phase A: TrainConfig fields deprecated in favour of ModelConfig ownership."""
+
+    def _tc(self, **kwargs):
+        defaults = dict(dataset_dir="/tmp")
+        defaults.update(kwargs)
+        return TrainConfig(**defaults)
+
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            pytest.param("group_detr", 5, id="group_detr"),
+            pytest.param("ia_bce_loss", False, id="ia_bce_loss"),
+            pytest.param("segmentation_head", True, id="segmentation_head"),
+            pytest.param("num_select", 100, id="num_select"),
+        ],
+    )
+    def test_explicitly_set_deprecated_field_emits_warning(self, field, value) -> None:
+        """Setting a deprecated TrainConfig field explicitly must emit DeprecationWarning."""
+        with pytest.warns(DeprecationWarning, match=f"TrainConfig\\.{field} is deprecated"):
+            self._tc(**{field: value})
+
+    def test_default_group_detr_no_warning(self, recwarn) -> None:
+        """TrainConfig() without explicit group_detr must NOT warn."""
+        self._tc()
+        depr_warnings = [w for w in recwarn.list if issubclass(w.category, DeprecationWarning)]
+        assert not depr_warnings, f"Unexpected DeprecationWarning: {depr_warnings}"
+
+    def test_segmentation_train_config_no_warning_on_default_fields(self, recwarn) -> None:
+        """SegmentationTrainConfig() must NOT warn for its class-level defaults.
+
+        segmentation_head=True and num_select=None are SegmentationTrainConfig defaults,
+        not explicitly set by the user — they must not trigger DeprecationWarning.
+        """
+        SegmentationTrainConfig(dataset_dir="/tmp")
+        depr_warnings = [w for w in recwarn.list if issubclass(w.category, DeprecationWarning)]
+        assert not depr_warnings, f"Unexpected DeprecationWarning: {depr_warnings}"
+
+
+class TestDeprecatedModelConfigClsLossCoef:
+    """Item #3 Phase A: ModelConfig.cls_loss_coef deprecated in favour of TrainConfig ownership."""
+
+    def test_explicit_cls_loss_coef_emits_warning(self) -> None:
+        """Setting cls_loss_coef on ModelConfig explicitly must emit DeprecationWarning."""
+        sample = dict(
+            encoder="dinov2_windowed_small",
+            out_feature_indexes=[1, 2, 3],
+            dec_layers=3,
+            projector_scale=["P3"],
+            hidden_dim=256,
+            patch_size=14,
+            num_windows=2,
+            sa_nheads=8,
+            ca_nheads=8,
+            dec_n_points=4,
+            resolution=384,
+            positional_encoding_size=256,
+        )
+        with pytest.warns(DeprecationWarning, match="ModelConfig\\.cls_loss_coef is deprecated"):
+            ModelConfig(**sample, cls_loss_coef=2.0)
+
+    def test_default_cls_loss_coef_no_warning(self, recwarn) -> None:
+        """RFDETRBaseConfig() without explicit cls_loss_coef must NOT warn."""
+        RFDETRBaseConfig(pretrain_weights=None, device="cpu")
+        depr_warnings = [w for w in recwarn.list if issubclass(w.category, DeprecationWarning)]
+        assert not depr_warnings, f"Unexpected DeprecationWarning: {depr_warnings}"

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -6,10 +6,14 @@
 
 """Regression tests for build_namespace() config forwarding."""
 
+import sys
 from typing import Any
 
+import pytest
+
 from rfdetr._namespace import build_namespace
-from rfdetr.config import RFDETRBaseConfig, TrainConfig
+from rfdetr.config import RFDETRBaseConfig, RFDETRSegNanoConfig, SegmentationTrainConfig, TrainConfig
+from rfdetr.models._types import BuilderArgs
 
 
 class TestBuildNamespaceForwarding:
@@ -47,3 +51,95 @@ class TestBuildNamespaceForwarding:
     def test_early_stopping_use_ema_forwarded_false(self: "TestBuildNamespaceForwarding") -> None:
         ns = self._make_ns(early_stopping_use_ema=False)
         assert ns.early_stopping_use_ema is False
+
+
+class TestBuildNamespaceProtocol:
+    """build_namespace() output must satisfy the BuilderArgs Protocol."""
+
+    def _make_ns(self, mc=None, tc=None):
+        mc = mc or RFDETRBaseConfig(num_classes=80)
+        tc = tc or TrainConfig(dataset_dir="/tmp")
+        return build_namespace(mc, tc)
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 12),
+        reason="Runtime Protocol attribute checks require Python 3.12+",
+    )
+    def test_namespace_satisfies_builderargs_protocol_py312(self) -> None:
+        """On Python 3.12+, isinstance() verifies data-attribute presence."""
+        ns = self._make_ns()
+        assert isinstance(ns, BuilderArgs)
+
+    def test_namespace_is_builderargs_instance(self) -> None:
+        """isinstance() check passes on all supported Python versions.
+
+        On Python 3.10/3.11 this is a structural no-op (no method members to
+        check).  On 3.12+ it verifies attribute presence.  The test documents
+        the intent regardless of Python version.
+        """
+        ns = self._make_ns()
+        assert isinstance(ns, BuilderArgs)
+
+
+class TestBuildNamespaceFieldOwnership:
+    """Verify that the namespace reads each field from the authoritative owner."""
+
+    def _make_ns(self, mc=None, tc=None):
+        mc = mc or RFDETRBaseConfig(num_classes=80)
+        tc = tc or TrainConfig(dataset_dir="/tmp")
+        return build_namespace(mc, tc)
+
+    # --- cls_loss_coef must come from TrainConfig ---
+
+    def test_cls_loss_coef_from_train_config(self) -> None:
+        """ns.cls_loss_coef must reflect TrainConfig.cls_loss_coef, not ModelConfig."""
+        mc = RFDETRBaseConfig(num_classes=80)  # cls_loss_coef=1.0 (ModelConfig default)
+        tc = TrainConfig(dataset_dir="/tmp", cls_loss_coef=2.5)
+        ns = build_namespace(mc, tc)
+        assert ns.cls_loss_coef == pytest.approx(2.5)
+
+    def test_cls_loss_coef_segmentation_uses_train_config_value(self) -> None:
+        """SegmentationTrainConfig.cls_loss_coef=5.0 must propagate to namespace."""
+        mc = RFDETRSegNanoConfig()
+        tc = SegmentationTrainConfig(dataset_dir="/tmp")  # cls_loss_coef=5.0
+        ns = build_namespace(mc, tc)
+        assert ns.cls_loss_coef == pytest.approx(5.0)
+
+    def test_cls_loss_coef_train_config_wins_over_explicit_model_config(self) -> None:
+        """When both are explicitly set, TrainConfig.cls_loss_coef takes precedence."""
+        with pytest.warns(DeprecationWarning, match="ModelConfig\\.cls_loss_coef is deprecated"):
+            mc = RFDETRBaseConfig(num_classes=80, cls_loss_coef=0.5)
+        tc = TrainConfig(dataset_dir="/tmp", cls_loss_coef=3.0)
+        ns = build_namespace(mc, tc)
+        assert ns.cls_loss_coef == pytest.approx(3.0)
+
+    def test_cls_loss_coef_model_config_explicit_is_preserved_during_deprecation(self) -> None:
+        """Explicit ModelConfig.cls_loss_coef remains effective until removal."""
+        with pytest.warns(DeprecationWarning, match="ModelConfig\\.cls_loss_coef is deprecated"):
+            mc = RFDETRBaseConfig(num_classes=80, cls_loss_coef=2.5)
+        tc = TrainConfig(dataset_dir="/tmp")
+        ns = build_namespace(mc, tc)
+        assert ns.cls_loss_coef == pytest.approx(2.5)
+
+    # --- num_select must come from ModelConfig unconditionally ---
+
+    def test_num_select_from_model_config(self) -> None:
+        """ns.num_select must equal mc.num_select regardless of tc.num_select."""
+        mc = RFDETRSegNanoConfig()  # num_select=100
+        tc = TrainConfig(dataset_dir="/tmp")  # num_select=300 (default — was the bug)
+        ns = build_namespace(mc, tc)
+        assert ns.num_select == 100
+
+    @pytest.mark.parametrize(
+        "config_class, expected_num_select",
+        [
+            pytest.param(RFDETRSegNanoConfig, 100, id="seg_nano"),
+            pytest.param(RFDETRBaseConfig, 300, id="base"),
+        ],
+    )
+    def test_num_select_matches_model_config_variant(self, config_class, expected_num_select) -> None:
+        """ns.num_select must equal the model config's num_select for each variant."""
+        mc = config_class()
+        tc = TrainConfig(dataset_dir="/tmp")
+        ns = build_namespace(mc, tc)
+        assert ns.num_select == expected_num_select

--- a/tests/training/test_args.py
+++ b/tests/training/test_args.py
@@ -116,7 +116,9 @@ class TestBuildNamespace:
     def test_segmentation_num_select_none_falls_back_to_model_config(self, base_model_config, seg_train_config) -> None:
         """SegmentationTrainConfig(num_select=None) must not overwrite ModelConfig.num_select."""
         mc = base_model_config(segmentation_head=True, num_select=200)
-        tc = seg_train_config(num_select=None)
+        # Explicitly passing num_select=None triggers the deprecation warning (Item #3).
+        with pytest.warns(DeprecationWarning, match="TrainConfig.num_select is deprecated"):
+            tc = seg_train_config(num_select=None)
 
         args = build_namespace(mc, tc)
 


### PR DESCRIPTION
This pull request introduces a transitional phase for config field ownership in RF-DETR, clarifies the authoritative source for several key configuration fields, and improves type safety and static analysis support for model builder functions. It deprecates certain duplicated fields, adds runtime and static warnings for misplacement, and fixes a bug where the wrong config's value was being used for segmentation post-processing. The update also introduces the `BuilderArgs` protocol for better static type checking, and adds comprehensive tests to ensure correct field ownership and deprecation warnings.

**Deprecation and Field Ownership Changes:**

* Several fields previously duplicated between `ModelConfig` and `TrainConfig` now have clear ownership; setting them on the wrong config emits a `DeprecationWarning` and will be removed in v1.9. Specifically, `group_detr`, `ia_bce_loss`, `segmentation_head`, and `num_select` must be set on `ModelConfig`, while `cls_loss_coef` must be set on `TrainConfig`. (`src/rfdetr/config.py`, `CHANGELOG.md`, [[1]](diffhunk://#diff-8234f50bded952af8b2719bc9dc3bb60e36cce3e81c3c536b813696360577189R87-R106) [[2]](diffhunk://#diff-8234f50bded952af8b2719bc9dc3bb60e36cce3e81c3c536b813696360577189R387-R412) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R31)
* The `build_namespace()` function now always reads `num_select` from `ModelConfig` and ensures `cls_loss_coef` is taken from `TrainConfig` if set, otherwise from `ModelConfig` for backward compatibility. (`src/rfdetr/_namespace.py`, [[1]](diffhunk://#diff-d4c96d7bfae4d0e7b4d1f6bbd2806d07f3923be7f5b319ecb1f807528fdf2c77L40-R48) [[2]](diffhunk://#diff-d4c96d7bfae4d0e7b4d1f6bbd2806d07f3923be7f5b319ecb1f807528fdf2c77L69-R81)

**Type Safety and Static Analysis:**

* Introduced the `BuilderArgs` protocol (a runtime-checkable `typing.Protocol`) to document the required attributes for builder functions, improving static type checking and IDE support for custom builder integrations. Exported from `rfdetr.models`. (`src/rfdetr/models/_types.py`, `src/rfdetr/models/__init__.py`, [[1]](diffhunk://#diff-e41e4948ef2cb4cb9a7e456761e0d7d038f820227079bc5de2514beaef9456a9R16-R23) [[2]](diffhunk://#diff-b403fd16c69606cfdf986b63ea021054dcdd9e6274a983871f410d1d99557861R1-R99)
* Updated builder function signatures (`build_model`, `build_criterion_and_postprocessors`) to explicitly require `BuilderArgs`, enhancing type clarity. (`src/rfdetr/models/lwdetr.py`, [[1]](diffhunk://#diff-b785afd54616483f394a8cc0eec9df589ac585e3a5c7a062ff687f53166a5bc4R30) [[2]](diffhunk://#diff-b785afd54616483f394a8cc0eec9df589ac585e3a5c7a062ff687f53166a5bc4L351-R352) [[3]](diffhunk://#diff-b785afd54616483f394a8cc0eec9df589ac585e3a5c7a062ff687f53166a5bc4L424-R425)

**Bug Fixes:**

* Fixed a regression where `TrainConfig.num_select` (default 300) could override model-specific values for segmentation variants, ensuring post-processing uses the correct top-k count for each model. (`src/rfdetr/_namespace.py`, `CHANGELOG.md`, [[1]](diffhunk://#diff-d4c96d7bfae4d0e7b4d1f6bbd2806d07f3923be7f5b319ecb1f807528fdf2c77L69-R81) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R31)

**Testing Improvements:**

* Added and expanded tests to verify deprecation warnings, correct field ownership, and that the `build_namespace()` output satisfies the `BuilderArgs` protocol (including runtime checks on Python 3.12+). (`tests/models/test_config.py`, `tests/test_namespace.py`, [[1]](diffhunk://#diff-ca4ef592b17976c43de08d853fa142290fdebf0b704f39cfd37f4f679c9f898eR64-R65) [[2]](diffhunk://#diff-ca4ef592b17976c43de08d853fa142290fdebf0b704f39cfd37f4f679c9f898eR286-R353) [[3]](diffhunk://#diff-ae7aa567853d76dad64eae0880691405187f5ef64b38ce6177091d993f63089fR54-R145)

**Documentation and Changelog:**

* Updated `CHANGELOG.md` with detailed notes on the deprecation, bug fix, and new protocol for builder arguments. (`CHANGELOG.md`, [CHANGELOG.mdR8-R31](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R31))