### PR TITLE
refactor: config-native `build_{model|criterion}_from_config`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `BuilderArgs` — a `@runtime_checkable` `typing.Protocol` documenting the minimum attribute set consumed by `build_model()`, `build_backbone()`, `build_transformer()`, and `build_criterion_and_postprocessors()`. Enables static type-checker support for custom builder integrations. Exported from `rfdetr.models`.
+- `build_model_from_config(model_config, train_config=None, defaults=MODEL_DEFAULTS)` — config-native alternative to `build_model(build_namespace(mc, tc))`; accepts Pydantic config objects directly and constructs the internal namespace automatically. Exported from `rfdetr.models`.
+- `build_criterion_from_config(model_config, train_config, defaults=MODEL_DEFAULTS)` — config-native alternative to `build_criterion_and_postprocessors(build_namespace(mc, tc))`; returns a `(SetCriterion, PostProcess)` tuple. Exported from `rfdetr.models`.
+- `ModelDefaults` dataclass — exposes the 35 hardcoded architectural constants previously buried inside `build_namespace()`. Pass a `dataclasses.replace(MODEL_DEFAULTS, ...)` override to the new config-native builders to customise individual constants. **Note:** fields may be promoted to `ModelConfig`/`TrainConfig` in future phases. Exported from `rfdetr.models`.
+- `MODEL_DEFAULTS` — the canonical `ModelDefaults` singleton with production defaults. Exported from `rfdetr.models`.
 
 ### Deprecated
 
@@ -26,6 +30,7 @@ These fields will be **removed** in v1.9 after a full release cycle.
 ### Fixed
 
 - Fixed `_namespace.py`: `num_select` in the builder namespace now always reads from `ModelConfig`, eliminating a regression where `TrainConfig.num_select` (default 300) silently overrode model-specific values of 100–200 for segmentation variants (`RFDETRSegNano`, `RFDETRSegSmall`, `RFDETRSegMedium`, `RFDETRSegLarge`, `RFDETRSegPreview`). Post-processing now uses the correct top-k count for each model.
+- Fixed `models/weights.py`: `load_pretrain_weights` now correctly auto-aligns the model head when the checkpoint has fewer classes than the configured default, preventing a silent mismatch when `num_classes` was not explicitly set by the caller.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-- `build_namespace(model_config, train_config)` — no longer used internally; use `build_model_from_config`, `build_criterion_from_config`, or `_namespace_from_configs` directly. Will be formally deprecated in v1.9.
+- `build_namespace(model_config, train_config)` — no longer used internally and deprecated in this release; use `build_model_from_config`, `build_criterion_from_config`, or `_namespace_from_configs` directly. It will be removed in v1.9 and currently emits a `DeprecationWarning` on use.
 - `load_pretrain_weights(nn_model, model_config, train_config)` — the `train_config` positional argument is deprecated and will be removed in v1.9; it is no longer used internally. Omit it: `load_pretrain_weights(nn_model, model_config)`. Passing a non-`None` value emits a `DeprecationWarning`.
 
 The following fields are duplicated between `ModelConfig` and `TrainConfig`; clear ownership is being established for v1.9. Each field now emits `DeprecationWarning` when set on the wrong config object. The fields continue to work as before — this is a warning-only Phase A change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+- `build_namespace(model_config, train_config)` — no longer used internally; use `build_model_from_config`, `build_criterion_from_config`, or `_namespace_from_configs` directly. Will be formally deprecated in v1.9.
+
 The following fields are duplicated between `ModelConfig` and `TrainConfig`; clear ownership is being established for v1.9. Each field now emits `DeprecationWarning` when set on the wrong config object. The fields continue to work as before — this is a warning-only Phase A change.
 
 - `TrainConfig.group_detr` — architecture decision; set on `ModelConfig` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - `build_namespace(model_config, train_config)` — no longer used internally; use `build_model_from_config`, `build_criterion_from_config`, or `_namespace_from_configs` directly. Will be formally deprecated in v1.9.
+- `load_pretrain_weights(nn_model, model_config, train_config)` — the `train_config` positional argument is deprecated and will be removed in v1.9; it is no longer used internally. Omit it: `load_pretrain_weights(nn_model, model_config)`. Passing a non-`None` value emits a `DeprecationWarning`.
 
 The following fields are duplicated between `ModelConfig` and `TrainConfig`; clear ownership is being established for v1.9. Each field now emits `DeprecationWarning` when set on the wrong config object. The fields continue to work as before — this is a warning-only Phase A change.
 

--- a/src/rfdetr/_namespace.py
+++ b/src/rfdetr/_namespace.py
@@ -11,11 +11,95 @@ Replaces the previous shim in ``_args.py`` that called the deprecated
 on ``main.py`` and can survive its deletion.
 """
 
+import dataclasses
 import types
 import warnings
 
 from rfdetr.config import ModelConfig, TrainConfig
 from rfdetr.models._defaults import MODEL_DEFAULTS, ModelDefaults
+
+# Fields forwarded from ModelConfig into the namespace.
+# Excludes cls_loss_coef (handled by transitional override logic below).
+_MC_NAMESPACE_FIELDS = {
+    "amp",
+    "backbone_lora",
+    "bbox_reparam",
+    "ca_nheads",
+    "dec_layers",
+    "dec_n_points",
+    "device",
+    "encoder",
+    "freeze_encoder",
+    "gradient_checkpointing",
+    "group_detr",
+    "hidden_dim",
+    "ia_bce_loss",
+    "layer_norm",
+    "lite_refpoint_refine",
+    "mask_downsample_ratio",
+    "num_classes",
+    "num_queries",
+    "num_select",
+    "num_windows",
+    "out_feature_indexes",
+    "patch_size",
+    "positional_encoding_size",
+    "pretrain_weights",
+    "projector_scale",
+    "resolution",
+    "sa_nheads",
+    "segmentation_head",
+    "two_stage",
+}
+
+# TrainConfig fields NOT forwarded to the legacy namespace.
+# _TC_NAMESPACE_FIELDS is derived as: all TrainConfig fields minus this set.
+#
+# Excluded categories:
+#   - Explicit transformations: handled with custom logic in _namespace_from_configs.
+#   - Deprecated TC architecture copies: ModelConfig wins (see _MC_NAMESPACE_FIELDS).
+#   - PTL Trainer / DDP, logger flags, auto-batch probe, DataModule knobs:
+#     not consumed by legacy builders.
+_TC_NON_NAMESPACE_FIELDS = {
+    # Explicit transformations.
+    "resume",
+    "seed",
+    "cls_loss_coef",
+    # Deprecated TC architecture copies — ModelConfig wins.
+    "group_detr",
+    "ia_bce_loss",
+    "segmentation_head",
+    "num_select",
+    # PTL Trainer / DDP.
+    "accelerator",
+    "strategy",
+    "devices",
+    "num_nodes",
+    # Logger flags.
+    "tensorboard",
+    "wandb",
+    "mlflow",
+    "clearml",
+    "project",
+    "run",
+    # Auto-batch probe.
+    "auto_batch_target_effective",
+    "auto_batch_max_targets_per_image",
+    "auto_batch_ema_headroom",
+    # PTL-only Trainer / DataModule / LR-scheduler knobs.
+    "progress_bar",
+    "run_test",
+    "dont_save_weights",
+    "pin_memory",
+    "persistent_workers",
+    "lr_scheduler",
+    "lr_min_factor",
+    # Dataset class labels.
+    "class_names",
+}
+
+# Derived: all TrainConfig fields not in _TC_NON_NAMESPACE_FIELDS.
+_TC_NAMESPACE_FIELDS = set(TrainConfig.model_fields) - _TC_NON_NAMESPACE_FIELDS
 
 
 def _namespace_from_configs(
@@ -60,126 +144,25 @@ def _namespace_from_configs(
     )
 
     return types.SimpleNamespace(
-        # --- ModelConfig fields ---
-        encoder=mc.encoder,
-        out_feature_indexes=mc.out_feature_indexes,
-        dec_layers=mc.dec_layers,
-        freeze_encoder=mc.freeze_encoder,
-        backbone_lora=mc.backbone_lora,
-        two_stage=mc.two_stage,
-        projector_scale=mc.projector_scale,
-        hidden_dim=mc.hidden_dim,
-        patch_size=mc.patch_size,
-        num_windows=mc.num_windows,
-        sa_nheads=mc.sa_nheads,
-        ca_nheads=mc.ca_nheads,
-        dec_n_points=mc.dec_n_points,
-        bbox_reparam=mc.bbox_reparam,
-        lite_refpoint_refine=mc.lite_refpoint_refine,
-        layer_norm=mc.layer_norm,
-        amp=mc.amp,
-        num_classes=mc.num_classes,
-        pretrain_weights=mc.pretrain_weights,
-        device=mc.device,
-        resolution=mc.resolution,
-        group_detr=mc.group_detr,
-        gradient_checkpointing=mc.gradient_checkpointing,
-        positional_encoding_size=mc.positional_encoding_size,
-        ia_bce_loss=mc.ia_bce_loss,
-        cls_loss_coef=cls_loss_coef,
-        segmentation_head=mc.segmentation_head,
-        mask_downsample_ratio=mc.mask_downsample_ratio,
-        num_queries=mc.num_queries,
-        num_select=mc.num_select,
-        # --- TrainConfig fields ---
-        lr=tc.lr,
-        lr_encoder=tc.lr_encoder,
-        batch_size=tc.batch_size,
-        grad_accum_steps=tc.grad_accum_steps,
-        epochs=tc.epochs,
-        resume=tc.resume or "",
-        ema_decay=tc.ema_decay,
-        ema_tau=tc.ema_tau,
-        lr_drop=tc.lr_drop,
-        checkpoint_interval=tc.checkpoint_interval,
-        warmup_epochs=tc.warmup_epochs,
-        lr_vit_layer_decay=tc.lr_vit_layer_decay,
-        lr_component_decay=tc.lr_component_decay,
-        drop_path=tc.drop_path,
-        weight_decay=tc.weight_decay,
-        multi_scale=tc.multi_scale,
-        expanded_scales=tc.expanded_scales,
-        do_random_resize_via_padding=tc.do_random_resize_via_padding,
-        square_resize_div_64=tc.square_resize_div_64,
-        num_workers=tc.num_workers,
-        dataset_file=tc.dataset_file,
-        dataset_dir=tc.dataset_dir,
-        output_dir=tc.output_dir,
-        # Segmentation extras (present on SegmentationTrainConfig only).
-        mask_ce_loss_coef=getattr(tc, "mask_ce_loss_coef", 5.0),
-        mask_dice_loss_coef=getattr(tc, "mask_dice_loss_coef", 5.0),
-        mask_point_sample_ratio=getattr(tc, "mask_point_sample_ratio", 16),
-        # Evaluation extras forwarded via extra_kwargs in the legacy shim.
-        eval_max_dets=tc.eval_max_dets,
-        eval_interval=tc.eval_interval,
-        log_per_class_metrics=tc.log_per_class_metrics,
-        compute_val_loss=tc.compute_val_loss,
-        compute_test_loss=tc.compute_test_loss,
-        ema_update_interval=tc.ema_update_interval,
-        train_log_sync_dist=tc.train_log_sync_dist,
-        train_log_on_step=tc.train_log_on_step,
-        prefetch_factor=tc.prefetch_factor,
-        # --- Hardcoded defaults (from ModelDefaults) ---
-        print_freq=d.print_freq,
-        clip_max_norm=tc.clip_max_norm,
-        do_benchmark=d.do_benchmark,
-        dropout=d.dropout,
-        drop_mode=d.drop_mode,
-        drop_schedule=d.drop_schedule,
-        cutoff_epoch=d.cutoff_epoch,
-        pretrained_encoder=d.pretrained_encoder,
-        pretrain_exclude_keys=d.pretrain_exclude_keys,
-        pretrain_keys_modify_to_load=d.pretrain_keys_modify_to_load,
-        pretrained_distiller=d.pretrained_distiller,
-        vit_encoder_num_layers=d.vit_encoder_num_layers,
-        window_block_indexes=d.window_block_indexes,
-        position_embedding=d.position_embedding,
-        rms_norm=d.rms_norm,
-        force_no_pretrain=d.force_no_pretrain,
-        dim_feedforward=d.dim_feedforward,
-        decoder_norm=d.decoder_norm,
-        freeze_batch_norm=d.freeze_batch_norm,
-        set_cost_class=d.set_cost_class,
-        set_cost_bbox=d.set_cost_bbox,
-        set_cost_giou=d.set_cost_giou,
-        bbox_loss_coef=d.bbox_loss_coef,
-        giou_loss_coef=d.giou_loss_coef,
-        focal_alpha=d.focal_alpha,
-        aux_loss=d.aux_loss,
-        sum_group_losses=d.sum_group_losses,
-        use_varifocal_loss=d.use_varifocal_loss,
-        use_position_supervised_loss=d.use_position_supervised_loss,
-        coco_path=d.coco_path,
-        aug_config=tc.aug_config,
-        dont_save_weights=d.dont_save_weights,
-        seed=tc.seed if tc.seed is not None else 42,
-        start_epoch=d.start_epoch,
-        eval=d.eval,
-        use_ema=tc.use_ema,
-        world_size=d.world_size,
-        dist_url=d.dist_url,
-        sync_bn=tc.sync_bn,
-        fp16_eval=tc.fp16_eval,
-        encoder_only=d.encoder_only,
-        backbone_only=d.backbone_only,
-        use_cls_token=d.use_cls_token,
-        lr_scheduler=d.lr_scheduler,
-        lr_min_factor=d.lr_min_factor,
-        early_stopping=tc.early_stopping,
-        early_stopping_patience=tc.early_stopping_patience,
-        early_stopping_min_delta=tc.early_stopping_min_delta,
-        early_stopping_use_ema=tc.early_stopping_use_ema,
-        subcommand=d.subcommand,
+        **{
+            # Architectural defaults — 35 constants not exposed in ModelConfig/TrainConfig.
+            **dataclasses.asdict(d),
+            # TrainConfig: fields consumed by legacy builders (PTL, logger, auto-batch
+            # fields excluded; see _TC_NAMESPACE_FIELDS).  Architecture copies
+            # (group_detr, num_select, …) are intentionally absent — mc wins below.
+            **tc.model_dump(include=set(_TC_NAMESPACE_FIELDS)),
+            # ModelConfig: wins over tc for overlapping architecture params
+            # (group_detr, ia_bce_loss, segmentation_head, num_select).
+            **mc.model_dump(include=set(_MC_NAMESPACE_FIELDS)),
+            # Segmentation extras (SegmentationTrainConfig only — absent from base TrainConfig).
+            "mask_ce_loss_coef": getattr(tc, "mask_ce_loss_coef", 5.0),
+            "mask_dice_loss_coef": getattr(tc, "mask_dice_loss_coef", 5.0),
+            "mask_point_sample_ratio": getattr(tc, "mask_point_sample_ratio", 16),
+            # Transformations: fields requiring a default sentinel or transitional priority.
+            "cls_loss_coef": cls_loss_coef,
+            "resume": tc.resume or "",
+            "seed": tc.seed if tc.seed is not None else 42,
+        }
     )
 
 

--- a/src/rfdetr/_namespace.py
+++ b/src/rfdetr/_namespace.py
@@ -29,6 +29,12 @@ def _namespace_from_configs(
     namespace without going through the public ``build_namespace()`` API
     while still accepting overridable defaults.
 
+    This function is used by multiple modules as the transitional namespace
+    bridge: :func:`rfdetr.models.build_model_from_config`,
+    :func:`rfdetr.models.build_criterion_from_config`, and
+    :func:`rfdetr.detr._build_model_context` all call it directly to avoid
+    the public ``build_namespace()`` shim.
+
     Args:
         model_config: Architecture configuration.
         train_config: Training hyperparameter configuration.

--- a/src/rfdetr/_namespace.py
+++ b/src/rfdetr/_namespace.py
@@ -12,7 +12,6 @@ on ``main.py`` and can survive its deletion.
 """
 
 import types
-from typing import Any
 
 from rfdetr.config import ModelConfig, TrainConfig
 from rfdetr.models._defaults import MODEL_DEFAULTS, ModelDefaults
@@ -22,7 +21,7 @@ def _namespace_from_configs(
     model_config: ModelConfig,
     train_config: TrainConfig,
     defaults: ModelDefaults = MODEL_DEFAULTS,
-) -> Any:
+) -> types.SimpleNamespace:
     """Build a ``types.SimpleNamespace`` from configs and architectural defaults.
 
     This is the internal implementation behind :func:`build_namespace`.
@@ -177,7 +176,7 @@ def _namespace_from_configs(
     )
 
 
-def build_namespace(model_config: ModelConfig, train_config: TrainConfig) -> Any:
+def build_namespace(model_config: ModelConfig, train_config: TrainConfig) -> types.SimpleNamespace:
     """Build a ``types.SimpleNamespace`` from Pydantic model and train configs.
 
     Produces the same attribute set as the legacy ``populate_args()`` so that

--- a/src/rfdetr/_namespace.py
+++ b/src/rfdetr/_namespace.py
@@ -12,6 +12,7 @@ on ``main.py`` and can survive its deletion.
 """
 
 import types
+import warnings
 
 from rfdetr.config import ModelConfig, TrainConfig
 from rfdetr.models._defaults import MODEL_DEFAULTS, ModelDefaults
@@ -196,7 +197,7 @@ def build_namespace(model_config: ModelConfig, train_config: TrainConfig) -> typ
         - :func:`rfdetr._namespace._namespace_from_configs` — for the rare
           case where a raw namespace is still required (e.g. ``build_dataset``)
 
-        ``build_namespace`` will be formally deprecated in v1.9.
+        ``build_namespace`` will be removed in v1.9.
 
     Args:
         model_config: Architecture configuration.
@@ -206,4 +207,11 @@ def build_namespace(model_config: ModelConfig, train_config: TrainConfig) -> typ
         ``types.SimpleNamespace`` compatible with ``build_model``,
         ``build_criterion_and_postprocessors``, and ``build_dataset``.
     """
+    warnings.warn(
+        "build_namespace() is deprecated and will be removed in v1.9. "
+        "Use build_model_from_config() or build_criterion_from_config() instead; "
+        "for raw namespace access use rfdetr._namespace._namespace_from_configs().",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return _namespace_from_configs(model_config, train_config)

--- a/src/rfdetr/_namespace.py
+++ b/src/rfdetr/_namespace.py
@@ -185,12 +185,18 @@ def _namespace_from_configs(
 def build_namespace(model_config: ModelConfig, train_config: TrainConfig) -> types.SimpleNamespace:
     """Build a ``types.SimpleNamespace`` from Pydantic model and train configs.
 
-    Produces the same attribute set as the legacy ``populate_args()`` so that
-    ``build_model()``, ``build_criterion_and_postprocessors()``, and
-    ``build_dataset()`` continue to work without modification.
+    .. deprecated::
+        ``build_namespace`` is a backward-compatibility shim with no remaining
+        internal callers.  Use the config-native builders instead:
 
-    Fields not present in either config retain their ``populate_args()``
-    defaults, ensuring downstream consumers see a fully-populated namespace.
+        - :func:`rfdetr.models.build_model_from_config` — replaces
+          ``build_model(build_namespace(mc, tc))``
+        - :func:`rfdetr.models.build_criterion_from_config` — replaces
+          ``build_criterion_and_postprocessors(build_namespace(mc, tc))``
+        - :func:`rfdetr._namespace._namespace_from_configs` — for the rare
+          case where a raw namespace is still required (e.g. ``build_dataset``)
+
+        ``build_namespace`` will be formally deprecated in v1.9.
 
     Args:
         model_config: Architecture configuration.

--- a/src/rfdetr/_namespace.py
+++ b/src/rfdetr/_namespace.py
@@ -15,21 +15,26 @@ import types
 from typing import Any
 
 from rfdetr.config import ModelConfig, TrainConfig
+from rfdetr.models._defaults import MODEL_DEFAULTS, ModelDefaults
 
 
-def build_namespace(model_config: ModelConfig, train_config: TrainConfig) -> Any:
-    """Build a ``types.SimpleNamespace`` from Pydantic model and train configs.
+def _namespace_from_configs(
+    model_config: ModelConfig,
+    train_config: TrainConfig,
+    defaults: ModelDefaults = MODEL_DEFAULTS,
+) -> Any:
+    """Build a ``types.SimpleNamespace`` from configs and architectural defaults.
 
-    Produces the same attribute set as the legacy ``populate_args()`` so that
-    ``build_model()``, ``build_criterion_and_postprocessors()``, and
-    ``build_dataset()`` continue to work without modification.
-
-    Fields not present in either config retain their ``populate_args()``
-    defaults, ensuring downstream consumers see a fully-populated namespace.
+    This is the internal implementation behind :func:`build_namespace`.
+    Extracting it allows config-native builder functions to construct a
+    namespace without going through the public ``build_namespace()`` API
+    while still accepting overridable defaults.
 
     Args:
         model_config: Architecture configuration.
         train_config: Training hyperparameter configuration.
+        defaults: Hardcoded architectural constants.  Defaults to
+            :data:`MODEL_DEFAULTS`.
 
     Returns:
         ``types.SimpleNamespace`` compatible with ``build_model``,
@@ -37,6 +42,7 @@ def build_namespace(model_config: ModelConfig, train_config: TrainConfig) -> Any
     """
     mc = model_config
     tc = train_config
+    d = defaults
     train_fields_set = getattr(tc, "model_fields_set", set())
     model_fields_set = getattr(mc, "model_fields_set", set())
     # Transitional compatibility: during deprecation, preserve explicit
@@ -117,55 +123,76 @@ def build_namespace(model_config: ModelConfig, train_config: TrainConfig) -> Any
         train_log_sync_dist=tc.train_log_sync_dist,
         train_log_on_step=tc.train_log_on_step,
         prefetch_factor=tc.prefetch_factor,
-        # --- Hardcoded defaults (not in configs; kept for downstream consumers) ---
-        print_freq=10,
+        # --- Hardcoded defaults (from ModelDefaults) ---
+        print_freq=d.print_freq,
         clip_max_norm=tc.clip_max_norm,
-        do_benchmark=False,
-        dropout=0,
-        drop_mode="standard",
-        drop_schedule="constant",
-        cutoff_epoch=0,
-        pretrained_encoder=None,
-        pretrain_exclude_keys=None,
-        pretrain_keys_modify_to_load=None,
-        pretrained_distiller=None,
-        vit_encoder_num_layers=12,
-        window_block_indexes=None,
-        position_embedding="sine",
-        rms_norm=False,
-        force_no_pretrain=False,
-        dim_feedforward=2048,
-        decoder_norm="LN",
-        freeze_batch_norm=False,
-        set_cost_class=2,
-        set_cost_bbox=5,
-        set_cost_giou=2,
-        bbox_loss_coef=5,
-        giou_loss_coef=2,
-        focal_alpha=0.25,
-        aux_loss=True,
-        sum_group_losses=False,
-        use_varifocal_loss=False,
-        use_position_supervised_loss=False,
-        coco_path=None,
+        do_benchmark=d.do_benchmark,
+        dropout=d.dropout,
+        drop_mode=d.drop_mode,
+        drop_schedule=d.drop_schedule,
+        cutoff_epoch=d.cutoff_epoch,
+        pretrained_encoder=d.pretrained_encoder,
+        pretrain_exclude_keys=d.pretrain_exclude_keys,
+        pretrain_keys_modify_to_load=d.pretrain_keys_modify_to_load,
+        pretrained_distiller=d.pretrained_distiller,
+        vit_encoder_num_layers=d.vit_encoder_num_layers,
+        window_block_indexes=d.window_block_indexes,
+        position_embedding=d.position_embedding,
+        rms_norm=d.rms_norm,
+        force_no_pretrain=d.force_no_pretrain,
+        dim_feedforward=d.dim_feedforward,
+        decoder_norm=d.decoder_norm,
+        freeze_batch_norm=d.freeze_batch_norm,
+        set_cost_class=d.set_cost_class,
+        set_cost_bbox=d.set_cost_bbox,
+        set_cost_giou=d.set_cost_giou,
+        bbox_loss_coef=d.bbox_loss_coef,
+        giou_loss_coef=d.giou_loss_coef,
+        focal_alpha=d.focal_alpha,
+        aux_loss=d.aux_loss,
+        sum_group_losses=d.sum_group_losses,
+        use_varifocal_loss=d.use_varifocal_loss,
+        use_position_supervised_loss=d.use_position_supervised_loss,
+        coco_path=d.coco_path,
         aug_config=tc.aug_config,
-        dont_save_weights=False,
+        dont_save_weights=d.dont_save_weights,
         seed=tc.seed if tc.seed is not None else 42,
-        start_epoch=0,
-        eval=False,
+        start_epoch=d.start_epoch,
+        eval=d.eval,
         use_ema=tc.use_ema,
-        world_size=1,
-        dist_url="env://",
+        world_size=d.world_size,
+        dist_url=d.dist_url,
         sync_bn=tc.sync_bn,
         fp16_eval=tc.fp16_eval,
-        encoder_only=False,
-        backbone_only=False,
-        use_cls_token=False,
-        lr_scheduler="step",
-        lr_min_factor=0.0,
+        encoder_only=d.encoder_only,
+        backbone_only=d.backbone_only,
+        use_cls_token=d.use_cls_token,
+        lr_scheduler=d.lr_scheduler,
+        lr_min_factor=d.lr_min_factor,
         early_stopping=tc.early_stopping,
         early_stopping_patience=tc.early_stopping_patience,
         early_stopping_min_delta=tc.early_stopping_min_delta,
         early_stopping_use_ema=tc.early_stopping_use_ema,
-        subcommand=None,
+        subcommand=d.subcommand,
     )
+
+
+def build_namespace(model_config: ModelConfig, train_config: TrainConfig) -> Any:
+    """Build a ``types.SimpleNamespace`` from Pydantic model and train configs.
+
+    Produces the same attribute set as the legacy ``populate_args()`` so that
+    ``build_model()``, ``build_criterion_and_postprocessors()``, and
+    ``build_dataset()`` continue to work without modification.
+
+    Fields not present in either config retain their ``populate_args()``
+    defaults, ensuring downstream consumers see a fully-populated namespace.
+
+    Args:
+        model_config: Architecture configuration.
+        train_config: Training hyperparameter configuration.
+
+    Returns:
+        ``types.SimpleNamespace`` compatible with ``build_model``,
+        ``build_criterion_and_postprocessors``, and ``build_dataset``.
+    """
+    return _namespace_from_configs(model_config, train_config)

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -69,7 +69,7 @@ class ModelContext:
         postprocess: PostProcess instance for converting raw outputs to boxes.
         device: Device the model lives on.
         resolution: Input resolution (square side length in pixels).
-        args: Namespace produced by :func:`build_namespace`.
+        args: Namespace produced by :func:`rfdetr._namespace._namespace_from_configs`.
         class_names: Optional list of class name strings loaded from checkpoint.
     """
 

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -120,14 +120,9 @@ def _build_model_context(model_config: ModelConfig) -> "ModelContext":
 
     nn_model = build_model_from_config(model_config)
 
-    # A dummy TrainConfig is needed for the namespace stored on ModelContext.
-    # load_pretrain_weights retains train_config in its signature for backward
-    # compatibility but no longer uses it internally.
-    dummy_train_config = TrainConfig(dataset_dir=".", output_dir=".")
-
     class_names: List[str] = []
     if model_config.pretrain_weights is not None:
-        class_names = load_pretrain_weights(nn_model, model_config, dummy_train_config)
+        class_names = load_pretrain_weights(nn_model, model_config)
 
     if model_config.backbone_lora:
         apply_lora(nn_model)
@@ -138,6 +133,8 @@ def _build_model_context(model_config: ModelConfig) -> "ModelContext":
 
     # Build a namespace for ModelContext.args (still expected by downstream
     # consumers such as reinitialize_detection_head and export).
+    # TODO(Chapter 6, #828): replace with a direct ModelConfig read once args is removed.
+    dummy_train_config = TrainConfig(dataset_dir=".", output_dir=".")
     args = _namespace_from_configs(model_config, dummy_train_config)
 
     return ModelContext(

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -46,7 +46,7 @@ from rfdetr.config import (
 )
 from rfdetr.datasets.coco import is_valid_coco_dataset
 from rfdetr.datasets.yolo import is_valid_yolo_dataset
-from rfdetr.models import PostProcess, build_model
+from rfdetr.models import PostProcess
 from rfdetr.models.weights import apply_lora, load_pretrain_weights
 from rfdetr.utilities.logger import get_logger
 
@@ -115,28 +115,29 @@ def _build_model_context(model_config: ModelConfig) -> "ModelContext":
     Returns:
         Fully initialised ModelContext ready for inference or training.
     """
-    from rfdetr._namespace import build_namespace
+    from rfdetr._namespace import _namespace_from_configs
+    from rfdetr.models import build_model_from_config
 
-    # A dummy TrainConfig is needed only for build_namespace's required fields;
-    # dataset_dir/output_dir are unused during model construction.
+    nn_model = build_model_from_config(model_config)
+
+    # A dummy TrainConfig is needed for load_pretrain_weights and for the
+    # namespace stored on ModelContext.
     dummy_train_config = TrainConfig(dataset_dir=".", output_dir=".")
-    args = build_namespace(model_config, dummy_train_config)
-    nn_model = build_model(args)
 
     class_names: List[str] = []
     if model_config.pretrain_weights is not None:
         class_names = load_pretrain_weights(nn_model, model_config, dummy_train_config)
-        # ``load_pretrain_weights`` can mutate ``model_config.num_classes`` when
-        # aligning to checkpoint heads. Keep the derived namespace in sync.
-        if hasattr(args, "num_classes") and getattr(args, "num_classes") != model_config.num_classes:
-            args.num_classes = model_config.num_classes
 
     if model_config.backbone_lora:
         apply_lora(nn_model)
 
-    device = torch.device(args.device)
+    device = torch.device(model_config.device)
     nn_model = nn_model.to(device)
-    postprocess = PostProcess(num_select=args.num_select)
+    postprocess = PostProcess(num_select=model_config.num_select)
+
+    # Build a namespace for ModelContext.args (still expected by downstream
+    # consumers such as reinitialize_detection_head and export).
+    args = _namespace_from_configs(model_config, dummy_train_config)
 
     return ModelContext(
         model=nn_model,

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -120,8 +120,9 @@ def _build_model_context(model_config: ModelConfig) -> "ModelContext":
 
     nn_model = build_model_from_config(model_config)
 
-    # A dummy TrainConfig is needed for load_pretrain_weights and for the
-    # namespace stored on ModelContext.
+    # A dummy TrainConfig is needed for the namespace stored on ModelContext.
+    # load_pretrain_weights retains train_config in its signature for backward
+    # compatibility but no longer uses it internally.
     dummy_train_config = TrainConfig(dataset_dir=".", output_dir=".")
 
     class_names: List[str] = []

--- a/src/rfdetr/models/__init__.py
+++ b/src/rfdetr/models/__init__.py
@@ -13,17 +13,22 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 # ------------------------------------------------------------------------
 
+from rfdetr.models._defaults import MODEL_DEFAULTS, ModelDefaults
 from rfdetr.models._types import BuilderArgs
 from rfdetr.models.criterion import SetCriterion
-from rfdetr.models.lwdetr import build_model
+from rfdetr.models.lwdetr import build_criterion_from_config, build_model, build_model_from_config
 from rfdetr.models.math import MLP
 from rfdetr.models.postprocess import PostProcess
 from rfdetr.models.weights import apply_lora, load_pretrain_weights
 
 __all__ = [
     "BuilderArgs",
+    "MODEL_DEFAULTS",
+    "ModelDefaults",
     "SetCriterion",
+    "build_criterion_from_config",
     "build_model",
+    "build_model_from_config",
     "MLP",
     "PostProcess",
     "load_pretrain_weights",

--- a/src/rfdetr/models/_defaults.py
+++ b/src/rfdetr/models/_defaults.py
@@ -15,7 +15,7 @@ touching config validation.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Dict, List, Optional
 
 
 @dataclass(frozen=True, slots=True)
@@ -25,6 +25,13 @@ class ModelDefaults:
     These values mirror the legacy ``build_namespace()`` hardcoded section
     (``_namespace.py`` lines 120-170).  Making them explicit enables testing
     and future overrides without touching config validation.
+
+    Note:
+        ``ModelDefaults`` is public API as of v1.7.  Fields that represent
+        true architectural decisions (e.g. ``dim_feedforward``, ``aux_loss``)
+        will be promoted to ``ModelConfig`` or ``TrainConfig`` in future
+        phases; field names and defaults may change across minor versions
+        during this transitional period.
 
     Attributes:
         drop_mode: Drop-path mode used during training.
@@ -73,11 +80,11 @@ class ModelDefaults:
     drop_schedule: str = "constant"
     cutoff_epoch: int = 0
     pretrained_encoder: Optional[str] = None
-    pretrain_exclude_keys: Optional[Any] = None
-    pretrain_keys_modify_to_load: Optional[Any] = None
-    pretrained_distiller: Optional[Any] = None
+    pretrain_exclude_keys: Optional[List[str]] = None
+    pretrain_keys_modify_to_load: Optional[Dict[str, str]] = None
+    pretrained_distiller: Optional[str] = None
     vit_encoder_num_layers: int = 12
-    window_block_indexes: Optional[Any] = None
+    window_block_indexes: Optional[List[int]] = None
     position_embedding: str = "sine"
     rms_norm: bool = False
     force_no_pretrain: bool = False

--- a/src/rfdetr/models/_defaults.py
+++ b/src/rfdetr/models/_defaults.py
@@ -23,7 +23,7 @@ class ModelDefaults:
     """Hardcoded architectural constants not exposed in ModelConfig or TrainConfig.
 
     These values mirror the legacy ``build_namespace()`` hardcoded section
-    (``_namespace.py`` lines 120-170).  Making them explicit enables testing
+    implemented in ``_namespace.py``. Making them explicit enables testing
     and future overrides without touching config validation.
 
     Note:

--- a/src/rfdetr/models/_defaults.py
+++ b/src/rfdetr/models/_defaults.py
@@ -99,7 +99,7 @@ class ModelDefaults:
     use_position_supervised_loss: bool = False
     print_freq: int = 10
     do_benchmark: bool = False
-    dropout: int = 0
+    dropout: float = 0.0
     coco_path: Optional[str] = None
     dont_save_weights: bool = False
     start_epoch: int = 0

--- a/src/rfdetr/models/_defaults.py
+++ b/src/rfdetr/models/_defaults.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from typing import Any, Optional
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ModelDefaults:
     """Hardcoded architectural constants not exposed in ModelConfig or TrainConfig.
 
@@ -99,7 +99,7 @@ class ModelDefaults:
     use_position_supervised_loss: bool = False
     print_freq: int = 10
     do_benchmark: bool = False
-    dropout: int = 0
+    dropout: float = 0.0
     coco_path: Optional[str] = None
     dont_save_weights: bool = False
     start_epoch: int = 0

--- a/src/rfdetr/models/_defaults.py
+++ b/src/rfdetr/models/_defaults.py
@@ -1,0 +1,114 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Hardcoded architectural constants not exposed in ModelConfig or TrainConfig.
+
+These values correspond to the ``build_namespace()`` defaults in ``_namespace.py``
+that have no corresponding config field.  Making them explicit in a frozen
+dataclass enables testing, documentation, and (future) overrides without
+touching config validation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+@dataclass(frozen=True)
+class ModelDefaults:
+    """Hardcoded architectural constants not exposed in ModelConfig or TrainConfig.
+
+    These values mirror the legacy ``build_namespace()`` hardcoded section
+    (``_namespace.py`` lines 120-170).  Making them explicit enables testing
+    and future overrides without touching config validation.
+
+    Attributes:
+        drop_mode: Drop-path mode used during training.
+        drop_schedule: Schedule type for drop-path rate.
+        cutoff_epoch: Epoch at which drop-path schedule resets.
+        pretrained_encoder: Path/URL to a pretrained encoder checkpoint.
+        pretrain_exclude_keys: Keys to exclude when loading pretrained weights.
+        pretrain_keys_modify_to_load: Key remapping rules for pretrained weights.
+        pretrained_distiller: Path/URL to a distillation teacher checkpoint.
+        vit_encoder_num_layers: Number of layers in the ViT encoder.
+        window_block_indexes: Indices of encoder layers using window attention.
+        position_embedding: Type of positional embedding (``'sine'``).
+        rms_norm: Whether to use RMSNorm instead of LayerNorm.
+        force_no_pretrain: Force-disable pretrain weight loading.
+        dim_feedforward: FFN hidden dimension in decoder layers.
+        decoder_norm: Normalization type in decoder (``'LN'``).
+        freeze_batch_norm: Whether to freeze batch-norm layers.
+        use_cls_token: Whether to prepend a CLS token to the encoder.
+        encoder_only: Build encoder only (no decoder).
+        backbone_only: Build backbone only (no encoder or decoder).
+        aux_loss: Whether to compute auxiliary losses at intermediate layers.
+        focal_alpha: Alpha parameter for focal loss.
+        set_cost_class: Classification cost weight for the matcher.
+        set_cost_bbox: L1 bbox cost weight for the matcher.
+        set_cost_giou: GIoU cost weight for the matcher.
+        bbox_loss_coef: Bbox regression loss coefficient.
+        giou_loss_coef: GIoU loss coefficient.
+        sum_group_losses: Whether to sum (vs. average) group-DETR losses.
+        use_varifocal_loss: Whether to use varifocal loss instead of focal loss.
+        use_position_supervised_loss: Whether to use position-supervised loss.
+        print_freq: Logging frequency (steps).
+        do_benchmark: Whether to run in benchmark/profiling mode.
+        dropout: Dropout rate in the decoder.
+        coco_path: Path to a COCO dataset root (legacy).
+        dont_save_weights: Disable checkpoint saving.
+        start_epoch: Epoch to resume training from.
+        eval: Whether to run in eval-only mode.
+        world_size: Number of distributed processes.
+        dist_url: URL for distributed initialisation.
+        lr_scheduler: Learning-rate scheduler type.
+        lr_min_factor: Minimum LR factor for cosine annealing.
+        subcommand: CLI subcommand (legacy).
+    """
+
+    drop_mode: str = "standard"
+    drop_schedule: str = "constant"
+    cutoff_epoch: int = 0
+    pretrained_encoder: Optional[str] = None
+    pretrain_exclude_keys: Optional[Any] = None
+    pretrain_keys_modify_to_load: Optional[Any] = None
+    pretrained_distiller: Optional[Any] = None
+    vit_encoder_num_layers: int = 12
+    window_block_indexes: Optional[Any] = None
+    position_embedding: str = "sine"
+    rms_norm: bool = False
+    force_no_pretrain: bool = False
+    dim_feedforward: int = 2048
+    decoder_norm: str = "LN"
+    freeze_batch_norm: bool = False
+    use_cls_token: bool = False
+    encoder_only: bool = False
+    backbone_only: bool = False
+    aux_loss: bool = True
+    focal_alpha: float = 0.25
+    set_cost_class: float = 2.0
+    set_cost_bbox: float = 5.0
+    set_cost_giou: float = 2.0
+    bbox_loss_coef: float = 5.0
+    giou_loss_coef: float = 2.0
+    sum_group_losses: bool = False
+    use_varifocal_loss: bool = False
+    use_position_supervised_loss: bool = False
+    print_freq: int = 10
+    do_benchmark: bool = False
+    dropout: int = 0
+    coco_path: Optional[str] = None
+    dont_save_weights: bool = False
+    start_epoch: int = 0
+    eval: bool = False
+    world_size: int = 1
+    dist_url: str = "env://"
+    lr_scheduler: str = "step"
+    lr_min_factor: float = 0.0
+    subcommand: Optional[str] = None
+
+
+MODEL_DEFAULTS = ModelDefaults()

--- a/src/rfdetr/models/lwdetr.py
+++ b/src/rfdetr/models/lwdetr.py
@@ -22,11 +22,15 @@ LW-DETR model and criterion classes
 
 import copy
 import math
-from typing import Callable, Optional
+from typing import TYPE_CHECKING, Callable, Optional
 
 import torch
 from torch import nn
 
+if TYPE_CHECKING:
+    from rfdetr.config import ModelConfig, TrainConfig
+
+from rfdetr.models._defaults import MODEL_DEFAULTS, ModelDefaults
 from rfdetr.models._types import BuilderArgs
 from rfdetr.models.backbone import build_backbone
 
@@ -475,3 +479,52 @@ def build_criterion_and_postprocessors(args: "BuilderArgs"):
     postprocess = PostProcess(num_select=args.num_select)
 
     return criterion, postprocess
+
+
+def build_model_from_config(
+    model_config: "ModelConfig",
+    defaults: ModelDefaults = MODEL_DEFAULTS,
+) -> LWDETR:
+    """Build an LWDETR model directly from a ModelConfig.
+
+    A config-native alternative to ``build_model(build_namespace(mc, tc))``.
+    Constructs the namespace internally from ``model_config`` and ``defaults``,
+    then delegates to :func:`build_model`.
+
+    Args:
+        model_config: Architecture configuration.
+        defaults: Hardcoded architectural constants. Defaults to ``MODEL_DEFAULTS``.
+
+    Returns:
+        Fully initialised LWDETR model.
+    """
+    from rfdetr._namespace import _namespace_from_configs
+    from rfdetr.config import TrainConfig
+
+    _dummy_tc = TrainConfig(dataset_dir=".", output_dir=".")
+    ns = _namespace_from_configs(model_config, _dummy_tc, defaults)
+    return build_model(ns)
+
+
+def build_criterion_from_config(
+    model_config: "ModelConfig",
+    train_config: "TrainConfig",
+    defaults: ModelDefaults = MODEL_DEFAULTS,
+) -> tuple[SetCriterion, PostProcess]:
+    """Build criterion and postprocessor directly from config objects.
+
+    A config-native alternative to
+    ``build_criterion_and_postprocessors(build_namespace(mc, tc))``.
+
+    Args:
+        model_config: Architecture configuration.
+        train_config: Training hyperparameter configuration.
+        defaults: Hardcoded architectural constants. Defaults to ``MODEL_DEFAULTS``.
+
+    Returns:
+        A 2-tuple of ``(SetCriterion, PostProcess)``.
+    """
+    from rfdetr._namespace import _namespace_from_configs
+
+    ns = _namespace_from_configs(model_config, train_config, defaults)
+    return build_criterion_and_postprocessors(ns)

--- a/src/rfdetr/models/lwdetr.py
+++ b/src/rfdetr/models/lwdetr.py
@@ -483,26 +483,33 @@ def build_criterion_and_postprocessors(args: "BuilderArgs"):
 
 def build_model_from_config(
     model_config: "ModelConfig",
+    train_config: Optional["TrainConfig"] = None,
     defaults: ModelDefaults = MODEL_DEFAULTS,
 ) -> LWDETR:
     """Build an LWDETR model directly from a ModelConfig.
 
     A config-native alternative to ``build_model(build_namespace(mc, tc))``.
-    Constructs the namespace internally from ``model_config`` and ``defaults``,
-    then delegates to :func:`build_model`.
+    Constructs the namespace internally from ``model_config``, an optional
+    ``train_config``, and ``defaults``, then delegates to :func:`build_model`.
 
     Args:
         model_config: Architecture configuration.
+        train_config: Training hyperparameter configuration. If ``None``,
+            a minimal dummy ``TrainConfig(dataset_dir=".", output_dir=".")`` is
+            constructed, matching the previous default behavior.
         defaults: Hardcoded architectural constants. Defaults to ``MODEL_DEFAULTS``.
 
     Returns:
         Fully initialised LWDETR model.
     """
     from rfdetr._namespace import _namespace_from_configs
-    from rfdetr.config import TrainConfig
 
-    _dummy_tc = TrainConfig(dataset_dir=".", output_dir=".")
-    ns = _namespace_from_configs(model_config, _dummy_tc, defaults)
+    if train_config is None:
+        from rfdetr.config import TrainConfig
+
+        train_config = TrainConfig(dataset_dir=".", output_dir=".")
+
+    ns = _namespace_from_configs(model_config, train_config, defaults)
     return build_model(ns)
 
 

--- a/src/rfdetr/models/lwdetr.py
+++ b/src/rfdetr/models/lwdetr.py
@@ -483,26 +483,42 @@ def build_criterion_and_postprocessors(args: "BuilderArgs"):
 
 def build_model_from_config(
     model_config: "ModelConfig",
+    train_config: Optional["TrainConfig"] = None,
     defaults: ModelDefaults = MODEL_DEFAULTS,
 ) -> LWDETR:
     """Build an LWDETR model directly from a ModelConfig.
 
     A config-native alternative to ``build_model(build_namespace(mc, tc))``.
-    Constructs the namespace internally from ``model_config`` and ``defaults``,
-    then delegates to :func:`build_model`.
+    Constructs the namespace internally from ``model_config``, an optional
+    ``train_config``, and ``defaults``, then delegates to :func:`build_model`.
 
     Args:
         model_config: Architecture configuration.
+        train_config: Training hyperparameter configuration. If ``None``,
+            a minimal dummy ``TrainConfig(dataset_dir=".", output_dir=".")`` is
+            constructed, matching the previous default behavior.
         defaults: Hardcoded architectural constants. Defaults to ``MODEL_DEFAULTS``.
 
     Returns:
         Fully initialised LWDETR model.
+
+    Raises:
+        ValueError: If ``defaults`` request ``encoder_only`` or ``backbone_only``,
+            which would make the return type differ from ``LWDETR``.
     """
     from rfdetr._namespace import _namespace_from_configs
-    from rfdetr.config import TrainConfig
 
-    _dummy_tc = TrainConfig(dataset_dir=".", output_dir=".")
-    ns = _namespace_from_configs(model_config, _dummy_tc, defaults)
+    if defaults.encoder_only or defaults.backbone_only:
+        raise ValueError(
+            "build_model_from_config() requires defaults.encoder_only=False and defaults.backbone_only=False."
+        )
+
+    if train_config is None:
+        from rfdetr.config import TrainConfig
+
+        train_config = TrainConfig(dataset_dir=".", output_dir=".")
+
+    ns = _namespace_from_configs(model_config, train_config, defaults)
     return build_model(ns)
 
 

--- a/src/rfdetr/models/lwdetr.py
+++ b/src/rfdetr/models/lwdetr.py
@@ -492,6 +492,11 @@ def build_model_from_config(
     Constructs the namespace internally from ``model_config``, an optional
     ``train_config``, and ``defaults``, then delegates to :func:`build_model`.
 
+    Note:
+        The internal ``SimpleNamespace`` bridge is transitional — it will be
+        eliminated once all builder functions accept config objects directly.
+        Callers should not rely on the namespace shape or pass it externally.
+
     Args:
         model_config: Architecture configuration.
         train_config: Training hyperparameter configuration. If ``None``,

--- a/src/rfdetr/models/weights.py
+++ b/src/rfdetr/models/weights.py
@@ -23,7 +23,6 @@ from typing import List
 
 import torch
 
-from rfdetr._namespace import build_namespace
 from rfdetr.assets.model_weights import download_pretrain_weights, validate_pretrain_weights
 from rfdetr.config import ModelConfig, TrainConfig
 from rfdetr.utilities.logger import get_logger
@@ -64,8 +63,9 @@ def load_pretrain_weights(
         model_config: Pydantic ``ModelConfig`` instance. Must have
             ``pretrain_weights``, ``num_classes``, ``num_queries``, and
             ``group_detr`` attributes.
-        train_config: ``TrainConfig`` used to build the namespace for checkpoint
-            compatibility validation.
+        train_config: Retained for backward compatibility; no longer used
+            internally since checkpoint compatibility is validated directly
+            against ``model_config``.
 
     Returns:
         List of class name strings from the checkpoint, or an empty list if none
@@ -114,8 +114,7 @@ def load_pretrain_weights(
                 else:
                     class_names = [name for name in iterator if isinstance(name, str)]
 
-    ns = build_namespace(mc, train_config)
-    validate_checkpoint_compatibility(checkpoint, ns)
+    validate_checkpoint_compatibility(checkpoint, mc)
 
     # Determine whether the user explicitly set num_classes on the ModelConfig,
     # and whether that explicit value differs from the model default.

--- a/src/rfdetr/models/weights.py
+++ b/src/rfdetr/models/weights.py
@@ -19,7 +19,8 @@ extraction from ``detr.py:_load_pretrain_weights_into``.
 from __future__ import annotations
 
 import os
-from typing import List
+import warnings
+from typing import List, Optional
 
 import torch
 
@@ -36,7 +37,7 @@ __all__ = ["load_pretrain_weights", "apply_lora"]
 def load_pretrain_weights(
     nn_model: torch.nn.Module,
     model_config: ModelConfig,
-    train_config: TrainConfig,
+    train_config: Optional[TrainConfig] = None,
 ) -> List[str]:
     """Load pretrained checkpoint weights into *nn_model* in-place.
 
@@ -63,9 +64,8 @@ def load_pretrain_weights(
         model_config: Pydantic ``ModelConfig`` instance. Must have
             ``pretrain_weights``, ``num_classes``, ``num_queries``, and
             ``group_detr`` attributes.
-        train_config: Retained for backward compatibility; no longer used
-            internally since checkpoint compatibility is validated directly
-            against ``model_config``.
+        train_config: Deprecated — no longer used internally.  Pass
+            ``None`` (or omit the argument) instead.  Will be removed in v1.9.
 
     Returns:
         List of class name strings from the checkpoint, or an empty list if none
@@ -74,6 +74,13 @@ def load_pretrain_weights(
     Raises:
         Exception: If the checkpoint file cannot be loaded even after a re-download.
     """
+    if train_config is not None:
+        warnings.warn(
+            "load_pretrain_weights() train_config argument is deprecated and will be removed in v1.9. "
+            "The argument is no longer used; omit it from your call.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     mc = model_config
     pretrain_weights = mc.pretrain_weights
     if pretrain_weights is None:

--- a/src/rfdetr/models/weights.py
+++ b/src/rfdetr/models/weights.py
@@ -18,14 +18,16 @@ extraction from ``detr.py:_load_pretrain_weights_into``.
 
 from __future__ import annotations
 
+import functools
 import os
 import warnings
-from typing import List, Optional
+from typing import List
 
 import torch
 
 from rfdetr.assets.model_weights import download_pretrain_weights, validate_pretrain_weights
 from rfdetr.config import ModelConfig, TrainConfig
+from rfdetr.utilities.decorators import deprecated
 from rfdetr.utilities.logger import get_logger
 from rfdetr.utilities.state_dict import _ckpt_args_get, validate_checkpoint_compatibility
 
@@ -34,10 +36,22 @@ logger = get_logger()
 __all__ = ["load_pretrain_weights", "apply_lora"]
 
 
+@deprecated(
+    target=True,
+    args_mapping={"train_config": None},
+    deprecated_in="1.8",
+    remove_in="1.9",
+    num_warns=-1,
+    stream=functools.partial(warnings.warn, category=DeprecationWarning),
+    template_mgs=(
+        "%(source_name)s() `train_config` argument is deprecated and will be removed in "
+        "v%(remove_in)s. The argument is no longer used; omit it from your call."
+    ),
+)
 def load_pretrain_weights(
     nn_model: torch.nn.Module,
     model_config: ModelConfig,
-    train_config: Optional[TrainConfig] = None,
+    train_config: TrainConfig | None = None,
 ) -> List[str]:
     """Load pretrained checkpoint weights into *nn_model* in-place.
 
@@ -64,8 +78,9 @@ def load_pretrain_weights(
         model_config: Pydantic ``ModelConfig`` instance. Must have
             ``pretrain_weights``, ``num_classes``, ``num_queries``, and
             ``group_detr`` attributes.
-        train_config: Deprecated — no longer used internally.  Pass
-            ``None`` (or omit the argument) instead.  Will be removed in v1.9.
+        train_config: Deprecated since v1.8 — no longer used internally.
+            Passing a non-``None`` value emits a ``DeprecationWarning``.
+            Omit the argument; it will be removed in v1.9.
 
     Returns:
         List of class name strings from the checkpoint, or an empty list if none
@@ -74,13 +89,6 @@ def load_pretrain_weights(
     Raises:
         Exception: If the checkpoint file cannot be loaded even after a re-download.
     """
-    if train_config is not None:
-        warnings.warn(
-            "load_pretrain_weights() train_config argument is deprecated and will be removed in v1.9. "
-            "The argument is no longer used; omit it from your call.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
     mc = model_config
     pretrain_weights = mc.pretrain_weights
     if pretrain_weights is None:

--- a/src/rfdetr/models/weights.py
+++ b/src/rfdetr/models/weights.py
@@ -139,6 +139,7 @@ def load_pretrain_weights(
                 # ModelConfig default): treat the checkpoint as authoritative.
                 num_classes = checkpoint_num_classes - 1
                 configured_num_classes_plus_bg = checkpoint_num_classes
+                mc.num_classes = num_classes
         # In all mismatch cases we need the head to match the checkpoint's
         # class count so load_state_dict succeeds without size mismatches.
         nn_model.reinitialize_detection_head(checkpoint_num_classes)

--- a/src/rfdetr/models/weights.py
+++ b/src/rfdetr/models/weights.py
@@ -43,10 +43,6 @@ __all__ = ["load_pretrain_weights", "apply_lora"]
     remove_in="1.9",
     num_warns=-1,
     stream=functools.partial(warnings.warn, category=DeprecationWarning),
-    template_mgs=(
-        "%(source_name)s() `train_config` argument is deprecated and will be removed in "
-        "v%(remove_in)s. The argument is no longer used; omit it from your call."
-    ),
 )
 def load_pretrain_weights(
     nn_model: torch.nn.Module,

--- a/src/rfdetr/training/auto_batch.py
+++ b/src/rfdetr/training/auto_batch.py
@@ -25,10 +25,9 @@ from typing import Any
 
 import torch
 
-from rfdetr._namespace import build_namespace
 from rfdetr.config import ModelConfig, TrainConfig
 from rfdetr.datasets.coco import compute_multi_scale_scales
-from rfdetr.models.lwdetr import build_criterion_and_postprocessors
+from rfdetr.models import build_criterion_from_config
 from rfdetr.utilities.logger import get_logger
 from rfdetr.utilities.tensors import NestedTensor
 
@@ -328,8 +327,7 @@ def resolve_auto_batch_config(
 
     max_targets_per_image = getattr(train_config, "auto_batch_max_targets_per_image", 100)
 
-    args = build_namespace(model_config, train_config)
-    criterion, _ = build_criterion_and_postprocessors(args)
+    criterion, _ = build_criterion_from_config(model_config, train_config)
     criterion = criterion.to(device)
 
     safe_micro_batch = probe_max_micro_batch(

--- a/src/rfdetr/training/module_data.py
+++ b/src/rfdetr/training/module_data.py
@@ -13,7 +13,7 @@ import torch.utils.data
 from pytorch_lightning import LightningDataModule
 from torch.utils.data import DataLoader
 
-from rfdetr._namespace import build_namespace
+from rfdetr._namespace import _namespace_from_configs
 from rfdetr.config import ModelConfig, TrainConfig
 from rfdetr.datasets import build_dataset
 from rfdetr.utilities.logger import get_logger
@@ -73,7 +73,7 @@ class RFDETRDataModule(LightningDataModule):
                 ``"test"``, or ``"predict"``.
         """
         resolution = self.model_config.resolution
-        ns = build_namespace(self.model_config, self.train_config)
+        ns = _namespace_from_configs(self.model_config, self.train_config)
         if stage == "fit":
             if self._dataset_train is None:
                 self._dataset_train = build_dataset("train", ns, resolution)

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -50,7 +50,7 @@ class RFDETRModelModule(LightningModule):
             # Capture the configured class count before loading weights so we can
             # detect any automatic alignment to the checkpoint.
             prev_num_classes = self.model_config.num_classes
-            load_pretrain_weights(self.model, self.model_config, self.train_config)
+            load_pretrain_weights(self.model, self.model_config)
             # If the loaded checkpoint changed the model's effective number of
             # classes (e.g. to match a fine-tuned head), persist that back onto
             # the model_config so downstream components see the aligned value.

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -45,7 +45,7 @@ class RFDETRModelModule(LightningModule):
         self.strict_loading = False
 
         # Model, criterion, and postprocessor.
-        self.model = build_model_from_config(model_config)
+        self.model = build_model_from_config(model_config, train_config)
         if model_config.pretrain_weights is not None:
             # Capture the configured class count before loading weights so we can
             # detect any automatic alignment to the checkpoint.

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -17,7 +17,7 @@ import torch
 import torch.nn.functional as F
 from pytorch_lightning import LightningModule, seed_everything
 
-from rfdetr._namespace import build_namespace
+from rfdetr._namespace import _namespace_from_configs
 from rfdetr.config import ModelConfig, TrainConfig
 from rfdetr.datasets.coco import compute_multi_scale_scales
 from rfdetr.models import build_criterion_from_config, build_model_from_config
@@ -222,7 +222,7 @@ class RFDETRModelModule(LightningModule):
             PTL optimizer config dict with optimizer and step-interval scheduler.
         """
         tc = self.train_config
-        ns = build_namespace(self.model_config, tc)
+        ns = _namespace_from_configs(self.model_config, tc)
 
         # Unwrap torch.compile's OptimizedModule so get_param_dict sees the
         # original module's named_parameters() — compiled wrapper can cause

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -20,7 +20,7 @@ from pytorch_lightning import LightningModule, seed_everything
 from rfdetr._namespace import build_namespace
 from rfdetr.config import ModelConfig, TrainConfig
 from rfdetr.datasets.coco import compute_multi_scale_scales
-from rfdetr.models.lwdetr import build_criterion_and_postprocessors, build_model
+from rfdetr.models import build_criterion_from_config, build_model_from_config
 from rfdetr.models.weights import apply_lora, load_pretrain_weights
 from rfdetr.training.param_groups import get_param_dict
 from rfdetr.utilities.logger import get_logger
@@ -44,11 +44,8 @@ class RFDETRModelModule(LightningModule):
         # (which contains only model weights, not criterion/postprocess state).
         self.strict_loading = False
 
-        # Build a local namespace for the legacy builder functions.
-        ns = build_namespace(model_config, train_config)
-
         # Model, criterion, and postprocessor.
-        self.model = build_model(ns)
+        self.model = build_model_from_config(model_config)
         if model_config.pretrain_weights is not None:
             # Capture the configured class count before loading weights so we can
             # detect any automatic alignment to the checkpoint.
@@ -64,11 +61,9 @@ class RFDETRModelModule(LightningModule):
         if model_config.backbone_lora:
             apply_lora(self.model)
 
-        # Rebuild the namespace after potential num_classes alignment so that
-        # the criterion and postprocessors are constructed with a config that
-        # matches the current model head.
-        ns = build_namespace(self.model_config, self.train_config)
-        self.criterion, self.postprocess = build_criterion_and_postprocessors(ns)
+        # Build criterion and postprocessor after potential num_classes
+        # alignment so they match the current model head.
+        self.criterion, self.postprocess = build_criterion_from_config(self.model_config, self.train_config)
 
         # torch.compile is opt-in: set model_config.compile=True to enable.
         # Only enabled on CUDA; MPS and CPU do not benefit from compilation.

--- a/tests/models/test_builder_characterization.py
+++ b/tests/models/test_builder_characterization.py
@@ -1,0 +1,442 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Characterization tests for build_model() and build_criterion_and_postprocessors().
+
+These tests pin the current behavior of the legacy namespace-based builder
+functions. They serve as a safety net during the config-native builder
+refactoring (PR 5): any change that alters these outputs is a regression.
+
+All tests in this file must pass against the CURRENT codebase.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from rfdetr._namespace import build_namespace
+from rfdetr.config import (
+    RFDETRBaseConfig,
+    RFDETRNanoConfig,
+    RFDETRSegNanoConfig,
+    SegmentationTrainConfig,
+    TrainConfig,
+)
+from rfdetr.models.criterion import SetCriterion
+from rfdetr.models.lwdetr import LWDETR, build_criterion_and_postprocessors, build_model
+from rfdetr.models.postprocess import PostProcess
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ns(mc=None, tc=None):
+    """Build a namespace suitable for builder functions."""
+    mc = mc or RFDETRBaseConfig(num_classes=80, pretrain_weights=None, device="cpu")
+    tc = tc or TrainConfig(dataset_dir="/tmp")
+    return build_namespace(mc, tc)
+
+
+# ---------------------------------------------------------------------------
+# build_model characterization
+# ---------------------------------------------------------------------------
+
+
+class TestBuildModelCharacterization:
+    """Pin current build_model() behaviour for the standard code path."""
+
+    def test_returns_lwdetr_instance(self) -> None:
+        ns = _make_ns()
+        model = build_model(ns)
+        assert isinstance(model, LWDETR)
+
+    def test_num_classes_plus_one(self) -> None:
+        """build_model applies the +1 background class convention."""
+        mc = RFDETRBaseConfig(num_classes=5, pretrain_weights=None, device="cpu")
+        ns = _make_ns(mc=mc)
+        model = build_model(ns)
+        assert model.class_embed.out_features == 6
+
+    def test_num_queries_forwarded(self) -> None:
+        mc = RFDETRBaseConfig(num_classes=80, pretrain_weights=None, device="cpu")
+        ns = _make_ns(mc=mc)
+        model = build_model(ns)
+        assert model.num_queries == mc.num_queries
+
+    @pytest.mark.parametrize(
+        "config_class, expected_queries",
+        [
+            pytest.param(RFDETRBaseConfig, 300, id="base"),
+            pytest.param(RFDETRNanoConfig, 300, id="nano"),
+            pytest.param(RFDETRSegNanoConfig, 100, id="seg_nano"),
+        ],
+    )
+    def test_num_queries_per_config_variant(self, config_class, expected_queries) -> None:
+        mc = config_class(pretrain_weights=None, device="cpu")
+        ns = _make_ns(mc=mc)
+        model = build_model(ns)
+        assert model.num_queries == expected_queries
+
+    def test_segmentation_head_none_for_detection(self) -> None:
+        ns = _make_ns()
+        model = build_model(ns)
+        assert model.segmentation_head is None
+
+    def test_segmentation_head_present_for_seg_config(self) -> None:
+        mc = RFDETRSegNanoConfig(pretrain_weights=None, device="cpu")
+        ns = _make_ns(mc=mc)
+        model = build_model(ns)
+        assert model.segmentation_head is not None
+
+    def test_aux_loss_enabled_by_default(self) -> None:
+        ns = _make_ns()
+        model = build_model(ns)
+        assert model.aux_loss is True
+
+    def test_group_detr_forwarded(self) -> None:
+        mc = RFDETRBaseConfig(num_classes=80, pretrain_weights=None, device="cpu")
+        ns = _make_ns(mc=mc)
+        model = build_model(ns)
+        assert model.group_detr == mc.group_detr
+
+    def test_num_feature_levels_set_on_args(self) -> None:
+        """build_model mutates args.num_feature_levels = len(projector_scale)."""
+        mc = RFDETRBaseConfig(num_classes=80, pretrain_weights=None, device="cpu")
+        ns = _make_ns(mc=mc)
+        build_model(ns)
+        assert ns.num_feature_levels == len(mc.projector_scale)
+
+    @pytest.mark.parametrize(
+        "config_class, expected_param_count_range",
+        [
+            pytest.param(RFDETRBaseConfig, (25_000_000, 40_000_000), id="base"),
+            pytest.param(RFDETRNanoConfig, (25_000_000, 40_000_000), id="nano"),
+        ],
+    )
+    def test_param_count_in_expected_range(self, config_class, expected_param_count_range) -> None:
+        """Sanity check that the model has a plausible number of parameters."""
+        mc = config_class(num_classes=80, pretrain_weights=None, device="cpu")
+        ns = _make_ns(mc=mc)
+        model = build_model(ns)
+        total = sum(p.numel() for p in model.parameters())
+        low, high = expected_param_count_range
+        assert low <= total <= high, (
+            f"Expected param count in [{low}, {high}], got {total}"
+        )
+
+    def test_encoder_only_returns_triple(self) -> None:
+        """When encoder_only=True, build_model returns (encoder, None, None)."""
+        mc = RFDETRBaseConfig(num_classes=80, pretrain_weights=None, device="cpu")
+        ns = _make_ns(mc=mc)
+        ns.encoder_only = True
+        result = build_model(ns)
+        assert isinstance(result, tuple), f"Expected tuple, got {type(result)}"
+        assert len(result) == 3
+        encoder, second, third = result
+        assert second is None
+        assert third is None
+        assert encoder is not None
+
+    def test_backbone_only_returns_triple(self) -> None:
+        """When backbone_only=True, build_model returns (backbone, None, None)."""
+        mc = RFDETRBaseConfig(num_classes=80, pretrain_weights=None, device="cpu")
+        ns = _make_ns(mc=mc)
+        ns.backbone_only = True
+        result = build_model(ns)
+        assert isinstance(result, tuple), f"Expected tuple, got {type(result)}"
+        assert len(result) == 3
+        backbone, second, third = result
+        assert second is None
+        assert third is None
+        assert backbone is not None
+
+
+# ---------------------------------------------------------------------------
+# build_criterion_and_postprocessors characterization
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCriterionCharacterization:
+    """Pin current build_criterion_and_postprocessors() behaviour."""
+
+    def test_returns_criterion_and_postprocess(self) -> None:
+        ns = _make_ns()
+        criterion, postprocess = build_criterion_and_postprocessors(ns)
+        assert isinstance(criterion, SetCriterion)
+        assert isinstance(postprocess, PostProcess)
+
+    def test_detection_losses_list(self) -> None:
+        """Detection-only config has exactly ['labels', 'boxes', 'cardinality']."""
+        ns = _make_ns()
+        criterion, _ = build_criterion_and_postprocessors(ns)
+        assert criterion.losses == ["labels", "boxes", "cardinality"]
+
+    def test_segmentation_losses_include_masks(self) -> None:
+        mc = RFDETRSegNanoConfig(pretrain_weights=None, device="cpu")
+        tc = SegmentationTrainConfig(dataset_dir="/tmp")
+        ns = _make_ns(mc=mc, tc=tc)
+        criterion, _ = build_criterion_and_postprocessors(ns)
+        assert "masks" in criterion.losses
+
+    def test_num_select_forwarded_to_postprocess(self) -> None:
+        mc = RFDETRSegNanoConfig(pretrain_weights=None, device="cpu")
+        ns = _make_ns(mc=mc)
+        _, postprocess = build_criterion_and_postprocessors(ns)
+        assert postprocess.num_select == 100
+
+    def test_num_select_default_for_base(self) -> None:
+        ns = _make_ns()
+        _, postprocess = build_criterion_and_postprocessors(ns)
+        assert postprocess.num_select == 300
+
+    def test_weight_dict_contains_base_losses(self) -> None:
+        ns = _make_ns()
+        criterion, _ = build_criterion_and_postprocessors(ns)
+        assert "loss_ce" in criterion.weight_dict
+        assert "loss_bbox" in criterion.weight_dict
+        assert "loss_giou" in criterion.weight_dict
+
+    def test_weight_dict_values_match_namespace(self) -> None:
+        ns = _make_ns()
+        criterion, _ = build_criterion_and_postprocessors(ns)
+        assert criterion.weight_dict["loss_ce"] == ns.cls_loss_coef
+        assert criterion.weight_dict["loss_bbox"] == ns.bbox_loss_coef
+        assert criterion.weight_dict["loss_giou"] == ns.giou_loss_coef
+
+    def test_segmentation_weight_dict_contains_mask_losses(self) -> None:
+        mc = RFDETRSegNanoConfig(pretrain_weights=None, device="cpu")
+        tc = SegmentationTrainConfig(dataset_dir="/tmp")
+        ns = _make_ns(mc=mc, tc=tc)
+        criterion, _ = build_criterion_and_postprocessors(ns)
+        assert "loss_mask_ce" in criterion.weight_dict
+        assert "loss_mask_dice" in criterion.weight_dict
+
+    def test_aux_loss_expands_weight_dict(self) -> None:
+        """With aux_loss=True and 3 dec_layers, weight_dict has aux entries _0 and _1."""
+        mc = RFDETRBaseConfig(num_classes=80, pretrain_weights=None, device="cpu")
+        ns = _make_ns(mc=mc)
+        assert ns.aux_loss is True
+        criterion, _ = build_criterion_and_postprocessors(ns)
+        # dec_layers=3 -> 2 aux layers (0 and 1)
+        assert "loss_ce_0" in criterion.weight_dict
+        assert "loss_ce_1" in criterion.weight_dict
+
+    def test_two_stage_adds_enc_losses(self) -> None:
+        """With two_stage=True, weight_dict has '_enc' suffix entries."""
+        mc = RFDETRBaseConfig(num_classes=80, pretrain_weights=None, device="cpu")
+        ns = _make_ns(mc=mc)
+        assert ns.two_stage is True
+        criterion, _ = build_criterion_and_postprocessors(ns)
+        assert "loss_ce_enc" in criterion.weight_dict
+        assert "loss_bbox_enc" in criterion.weight_dict
+        assert "loss_giou_enc" in criterion.weight_dict
+
+    def test_criterion_num_classes_plus_one(self) -> None:
+        mc = RFDETRBaseConfig(num_classes=5, pretrain_weights=None, device="cpu")
+        ns = _make_ns(mc=mc)
+        criterion, _ = build_criterion_and_postprocessors(ns)
+        assert criterion.num_classes == 6
+
+    def test_focal_alpha_forwarded(self) -> None:
+        ns = _make_ns()
+        criterion, _ = build_criterion_and_postprocessors(ns)
+        assert criterion.focal_alpha == pytest.approx(0.25)
+
+    def test_group_detr_forwarded_to_criterion(self) -> None:
+        mc = RFDETRBaseConfig(num_classes=80, pretrain_weights=None, device="cpu")
+        ns = _make_ns(mc=mc)
+        criterion, _ = build_criterion_and_postprocessors(ns)
+        assert criterion.group_detr == mc.group_detr
+
+    def test_segmentation_criterion_has_mask_point_sample_ratio(self) -> None:
+        mc = RFDETRSegNanoConfig(pretrain_weights=None, device="cpu")
+        tc = SegmentationTrainConfig(dataset_dir="/tmp")
+        ns = _make_ns(mc=mc, tc=tc)
+        criterion, _ = build_criterion_and_postprocessors(ns)
+        assert criterion.mask_point_sample_ratio == 16
+
+    def test_ia_bce_loss_forwarded(self) -> None:
+        mc = RFDETRBaseConfig(num_classes=80, pretrain_weights=None, device="cpu")
+        ns = _make_ns(mc=mc)
+        criterion, _ = build_criterion_and_postprocessors(ns)
+        assert criterion.ia_bce_loss == mc.ia_bce_loss
+
+
+# ---------------------------------------------------------------------------
+# _build_model_context characterization
+# ---------------------------------------------------------------------------
+
+
+class TestBuildModelContextCharacterization:
+    """Pin current _build_model_context() behaviour.
+
+    _build_model_context is the inference-path factory used by RFDETR.get_model().
+    It has zero test coverage today.
+    """
+
+    def test_returns_model_context(self) -> None:
+        from rfdetr.detr import ModelContext, _build_model_context
+
+        mc = RFDETRBaseConfig(num_classes=80, pretrain_weights=None, device="cpu")
+        ctx = _build_model_context(mc)
+        assert isinstance(ctx, ModelContext)
+
+    def test_model_is_lwdetr(self) -> None:
+        from rfdetr.detr import _build_model_context
+
+        mc = RFDETRBaseConfig(num_classes=80, pretrain_weights=None, device="cpu")
+        ctx = _build_model_context(mc)
+        assert isinstance(ctx.model, LWDETR)
+
+    def test_postprocess_is_postprocess(self) -> None:
+        from rfdetr.detr import _build_model_context
+
+        mc = RFDETRBaseConfig(num_classes=80, pretrain_weights=None, device="cpu")
+        ctx = _build_model_context(mc)
+        assert isinstance(ctx.postprocess, PostProcess)
+
+    def test_resolution_from_config(self) -> None:
+        from rfdetr.detr import _build_model_context
+
+        mc = RFDETRBaseConfig(num_classes=80, pretrain_weights=None, device="cpu")
+        ctx = _build_model_context(mc)
+        assert ctx.resolution == mc.resolution
+
+    def test_device_from_config(self) -> None:
+        from rfdetr.detr import _build_model_context
+
+        mc = RFDETRBaseConfig(num_classes=80, pretrain_weights=None, device="cpu")
+        ctx = _build_model_context(mc)
+        assert ctx.device == torch.device("cpu")
+
+    def test_class_names_none_without_pretrain(self) -> None:
+        from rfdetr.detr import _build_model_context
+
+        mc = RFDETRBaseConfig(num_classes=80, pretrain_weights=None, device="cpu")
+        ctx = _build_model_context(mc)
+        assert ctx.class_names is None
+
+    def test_num_select_on_postprocess(self) -> None:
+        from rfdetr.detr import _build_model_context
+
+        mc = RFDETRSegNanoConfig(pretrain_weights=None, device="cpu")
+        ctx = _build_model_context(mc)
+        assert ctx.postprocess.num_select == 100
+
+    def test_args_namespace_attached(self) -> None:
+        from rfdetr.detr import _build_model_context
+
+        mc = RFDETRBaseConfig(num_classes=80, pretrain_weights=None, device="cpu")
+        ctx = _build_model_context(mc)
+        assert hasattr(ctx.args, "num_classes")
+        assert hasattr(ctx.args, "num_select")
+
+    def test_inference_model_initially_none(self) -> None:
+        from rfdetr.detr import _build_model_context
+
+        mc = RFDETRBaseConfig(num_classes=80, pretrain_weights=None, device="cpu")
+        ctx = _build_model_context(mc)
+        assert ctx.inference_model is None
+
+
+# ---------------------------------------------------------------------------
+# RFDETRModelModule.__init__ characterization
+# ---------------------------------------------------------------------------
+
+
+class TestRFDETRModelModuleInitCharacterization:
+    """Pin RFDETRModelModule.__init__() structural outputs.
+
+    The existing test_module_model.py tests the init via mocked build_model and
+    build_namespace. These tests exercise the REAL init path (no mocks) to
+    characterize what a freshly built module looks like.
+    """
+
+    def _make_module(self, mc=None, tc=None):
+        from rfdetr.training.module_model import RFDETRModelModule
+
+        mc = mc or RFDETRBaseConfig(num_classes=5, pretrain_weights=None, device="cpu")
+        tc = tc or TrainConfig(dataset_dir="/tmp")
+        return RFDETRModelModule(mc, tc)
+
+    def test_model_attribute_is_lwdetr(self) -> None:
+        module = self._make_module()
+        # model could be wrapped by torch.compile, so check the underlying type
+        underlying = getattr(module.model, "_orig_mod", module.model)
+        assert isinstance(underlying, LWDETR)
+
+    def test_criterion_is_set_criterion(self) -> None:
+        module = self._make_module()
+        assert isinstance(module.criterion, SetCriterion)
+
+    def test_postprocess_is_postprocess(self) -> None:
+        module = self._make_module()
+        assert isinstance(module.postprocess, PostProcess)
+
+    def test_strict_loading_false(self) -> None:
+        """strict_loading=False allows partial state-dict loading."""
+        module = self._make_module()
+        assert module.strict_loading is False
+
+    def test_configs_stored(self) -> None:
+        mc = RFDETRBaseConfig(num_classes=5, pretrain_weights=None, device="cpu")
+        tc = TrainConfig(dataset_dir="/tmp")
+        module = self._make_module(mc=mc, tc=tc)
+        assert module.model_config is mc
+        assert module.train_config is tc
+
+    def test_criterion_num_classes_matches_model(self) -> None:
+        """Criterion and model must agree on num_classes (both use +1 convention)."""
+        mc = RFDETRBaseConfig(num_classes=5, pretrain_weights=None, device="cpu")
+        module = self._make_module(mc=mc)
+        underlying = getattr(module.model, "_orig_mod", module.model)
+        assert module.criterion.num_classes == underlying.class_embed.out_features
+
+    def test_postprocess_num_select_matches_config(self) -> None:
+        mc = RFDETRSegNanoConfig(pretrain_weights=None, device="cpu")
+        tc = SegmentationTrainConfig(dataset_dir="/tmp")
+        module = self._make_module(mc=mc, tc=tc)
+        assert module.postprocess.num_select == mc.num_select
+
+    def test_segmentation_criterion_with_seg_config(self) -> None:
+        mc = RFDETRSegNanoConfig(pretrain_weights=None, device="cpu")
+        tc = SegmentationTrainConfig(dataset_dir="/tmp")
+        module = self._make_module(mc=mc, tc=tc)
+        assert "masks" in module.criterion.losses
+
+
+# ---------------------------------------------------------------------------
+# build_namespace hardcoded defaults parity with ModelDefaults
+# ---------------------------------------------------------------------------
+
+
+class TestBuildNamespaceDefaultsParity:
+    """Verify that build_namespace() hardcoded defaults match ModelDefaults values.
+
+    This is a critical characterization test: when the refactor replaces
+    hardcoded values with ModelDefaults, every field must match.
+    """
+
+    def test_all_defaults_match(self) -> None:
+        from rfdetr.models._defaults import MODEL_DEFAULTS, ModelDefaults
+
+        mc = RFDETRBaseConfig(num_classes=80, pretrain_weights=None, device="cpu")
+        tc = TrainConfig(dataset_dir="/tmp")
+        ns = build_namespace(mc, tc)
+
+        # Every field in ModelDefaults should have a matching ns attribute
+        for field_name in ModelDefaults.__dataclass_fields__:
+            expected = getattr(MODEL_DEFAULTS, field_name)
+            actual = getattr(ns, field_name, "MISSING")
+            assert actual != "MISSING", (
+                f"ModelDefaults.{field_name} has no matching namespace attribute"
+            )
+            assert actual == expected, (
+                f"ModelDefaults.{field_name}={expected!r} != namespace.{field_name}={actual!r}"
+            )

--- a/tests/models/test_builder_characterization.py
+++ b/tests/models/test_builder_characterization.py
@@ -404,5 +404,3 @@ class TestRFDETRModelModuleInitCharacterization:
         tc = SegmentationTrainConfig(dataset_dir="/tmp")
         module = self._make_module(mc=mc, tc=tc)
         assert "masks" in module.criterion.losses
-
-

--- a/tests/models/test_builder_characterization.py
+++ b/tests/models/test_builder_characterization.py
@@ -8,7 +8,7 @@
 
 These tests pin the current behavior of the legacy namespace-based builder
 functions. They serve as a safety net during the config-native builder
-refactoring (PR 5): any change that alters these outputs is a regression.
+refactoring: any change that alters these outputs is a regression.
 
 All tests in this file must pass against the CURRENT codebase.
 """
@@ -16,7 +16,7 @@ All tests in this file must pass against the CURRENT codebase.
 import pytest
 import torch
 
-from rfdetr._namespace import build_namespace
+from rfdetr._namespace import _namespace_from_configs
 from rfdetr.config import (
     RFDETRBaseConfig,
     RFDETRNanoConfig,
@@ -37,7 +37,7 @@ def _make_ns(mc=None, tc=None):
     """Build a namespace suitable for builder functions."""
     mc = mc or RFDETRBaseConfig(num_classes=80, pretrain_weights=None, device="cpu")
     tc = tc or TrainConfig(dataset_dir="/tmp")
-    return build_namespace(mc, tc)
+    return _namespace_from_configs(mc, tc)
 
 
 # ---------------------------------------------------------------------------
@@ -406,28 +406,3 @@ class TestRFDETRModelModuleInitCharacterization:
         assert "masks" in module.criterion.losses
 
 
-# ---------------------------------------------------------------------------
-# build_namespace hardcoded defaults parity with ModelDefaults
-# ---------------------------------------------------------------------------
-
-
-class TestBuildNamespaceDefaultsParity:
-    """Verify that build_namespace() hardcoded defaults match ModelDefaults values.
-
-    This is a critical characterization test: when the refactor replaces
-    hardcoded values with ModelDefaults, every field must match.
-    """
-
-    def test_all_defaults_match(self) -> None:
-        from rfdetr.models._defaults import MODEL_DEFAULTS, ModelDefaults
-
-        mc = RFDETRBaseConfig(num_classes=80, pretrain_weights=None, device="cpu")
-        tc = TrainConfig(dataset_dir="/tmp")
-        ns = build_namespace(mc, tc)
-
-        # Every field in ModelDefaults should have a matching ns attribute
-        for field_name in ModelDefaults.__dataclass_fields__:
-            expected = getattr(MODEL_DEFAULTS, field_name)
-            actual = getattr(ns, field_name, "MISSING")
-            assert actual != "MISSING", f"ModelDefaults.{field_name} has no matching namespace attribute"
-            assert actual == expected, f"ModelDefaults.{field_name}={expected!r} != namespace.{field_name}={actual!r}"

--- a/tests/models/test_builder_characterization.py
+++ b/tests/models/test_builder_characterization.py
@@ -13,8 +13,6 @@ refactoring (PR 5): any change that alters these outputs is a regression.
 All tests in this file must pass against the CURRENT codebase.
 """
 
-from types import SimpleNamespace
-
 import pytest
 import torch
 
@@ -29,7 +27,6 @@ from rfdetr.config import (
 from rfdetr.models.criterion import SetCriterion
 from rfdetr.models.lwdetr import LWDETR, build_criterion_and_postprocessors, build_model
 from rfdetr.models.postprocess import PostProcess
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -126,9 +123,7 @@ class TestBuildModelCharacterization:
         model = build_model(ns)
         total = sum(p.numel() for p in model.parameters())
         low, high = expected_param_count_range
-        assert low <= total <= high, (
-            f"Expected param count in [{low}, {high}], got {total}"
-        )
+        assert low <= total <= high, f"Expected param count in [{low}, {high}], got {total}"
 
     def test_encoder_only_returns_triple(self) -> None:
         """When encoder_only=True, build_model returns (encoder, None, None)."""
@@ -434,9 +429,5 @@ class TestBuildNamespaceDefaultsParity:
         for field_name in ModelDefaults.__dataclass_fields__:
             expected = getattr(MODEL_DEFAULTS, field_name)
             actual = getattr(ns, field_name, "MISSING")
-            assert actual != "MISSING", (
-                f"ModelDefaults.{field_name} has no matching namespace attribute"
-            )
-            assert actual == expected, (
-                f"ModelDefaults.{field_name}={expected!r} != namespace.{field_name}={actual!r}"
-            )
+            assert actual != "MISSING", f"ModelDefaults.{field_name} has no matching namespace attribute"
+            assert actual == expected, f"ModelDefaults.{field_name}={expected!r} != namespace.{field_name}={actual!r}"

--- a/tests/models/test_builders.py
+++ b/tests/models/test_builders.py
@@ -30,7 +30,7 @@ except ImportError:
 
 pytestmark = pytest.mark.skipif(
     not HAS_CONFIG_BUILDERS,
-    reason="build_model_from_config not yet implemented",
+    reason="config-native builder functions are not importable",
 )
 
 
@@ -64,7 +64,7 @@ class TestBuildModelFromConfig:
         mc = RFDETRBaseConfig(num_classes=80)
         tc = TrainConfig(dataset_dir="/tmp")
 
-        model_config_native = build_model_from_config(mc)
+        model_config_native = build_model_from_config(mc, tc)
         ns = build_namespace(mc, tc)
         model_namespace = build_model(ns)
 
@@ -79,6 +79,28 @@ class TestBuildModelFromConfig:
         mc = RFDETRSegNanoConfig()
         model = build_model_from_config(mc)
         assert model.segmentation_head is not None, "Expected segmentation_head to be created for RFDETRSegNanoConfig"
+
+    def test_drop_path_uses_train_config_value(self) -> None:
+        """Non-default TrainConfig.drop_path must reach the model builder path."""
+        mc = RFDETRBaseConfig(num_classes=80)
+        tc = TrainConfig(dataset_dir="/tmp", drop_path=0.2)
+        model = build_model_from_config(mc, tc)
+
+        layers = model._get_backbone_encoder_layers()
+        assert layers is not None
+        assert hasattr(layers[-1], "drop_path")
+        assert layers[-1].drop_path.drop_prob == pytest.approx(0.2)
+
+    def test_rejects_encoder_only_defaults(self) -> None:
+        """The config-native builder guarantees an LWDETR return value."""
+        from dataclasses import replace
+
+        from rfdetr.models import MODEL_DEFAULTS
+
+        mc = RFDETRBaseConfig(num_classes=80)
+
+        with pytest.raises(ValueError, match="encoder_only=False"):
+            build_model_from_config(mc, defaults=replace(MODEL_DEFAULTS, encoder_only=True))
 
 
 class TestBuildCriterionFromConfig:

--- a/tests/models/test_builders.py
+++ b/tests/models/test_builders.py
@@ -8,7 +8,7 @@
 
 These tests validate build_model_from_config() and build_criterion_from_config()
 which accept Pydantic config objects directly instead of requiring a pre-built
-SimpleNamespace.  Until the functions are implemented, all tests skip via the
+SimpleNamespace. If these functions cannot be imported, all tests skip via the
 module-level pytestmark.
 """
 

--- a/tests/models/test_builders.py
+++ b/tests/models/test_builders.py
@@ -22,7 +22,7 @@ from rfdetr.config import (
 )
 
 try:
-    from rfdetr.models import build_model_from_config, build_criterion_from_config
+    from rfdetr.models import build_criterion_from_config, build_model_from_config
 
     HAS_CONFIG_BUILDERS = True
 except ImportError:
@@ -43,9 +43,7 @@ class TestBuildModelFromConfig:
 
         mc = RFDETRBaseConfig(num_classes=80)
         model = build_model_from_config(mc)
-        assert isinstance(model, LWDETR), (
-            f"Expected LWDETR instance, got {type(model).__name__}"
-        )
+        assert isinstance(model, LWDETR), f"Expected LWDETR instance, got {type(model).__name__}"
 
     def test_num_classes_correct(self) -> None:
         """num_classes=5 in config should produce class_embed with out_features=6.
@@ -55,8 +53,7 @@ class TestBuildModelFromConfig:
         mc = RFDETRBaseConfig(num_classes=5)
         model = build_model_from_config(mc)
         assert model.class_embed.out_features == 6, (
-            f"Expected class_embed.out_features=6 (num_classes+1), "
-            f"got {model.class_embed.out_features}"
+            f"Expected class_embed.out_features=6 (num_classes+1), got {model.class_embed.out_features}"
         )
 
     def test_parity_with_build_model_via_namespace(self) -> None:
@@ -74,17 +71,14 @@ class TestBuildModelFromConfig:
         params_native = sum(p.numel() for p in model_config_native.parameters())
         params_namespace = sum(p.numel() for p in model_namespace.parameters())
         assert params_native == params_namespace, (
-            f"Parameter count mismatch: "
-            f"config-native={params_native}, namespace={params_namespace}"
+            f"Parameter count mismatch: config-native={params_native}, namespace={params_namespace}"
         )
 
     def test_segmentation_head_created_when_true(self) -> None:
         """RFDETRSegNanoConfig has segmentation_head=True; model must have it."""
         mc = RFDETRSegNanoConfig()
         model = build_model_from_config(mc)
-        assert model.segmentation_head is not None, (
-            "Expected segmentation_head to be created for RFDETRSegNanoConfig"
-        )
+        assert model.segmentation_head is not None, "Expected segmentation_head to be created for RFDETRSegNanoConfig"
 
 
 class TestBuildCriterionFromConfig:
@@ -98,32 +92,22 @@ class TestBuildCriterionFromConfig:
         mc = RFDETRBaseConfig(num_classes=80)
         tc = TrainConfig(dataset_dir="/tmp")
         result = build_criterion_from_config(mc, tc)
-        assert isinstance(result, tuple), (
-            f"Expected tuple, got {type(result).__name__}"
-        )
+        assert isinstance(result, tuple), f"Expected tuple, got {type(result).__name__}"
         assert len(result) == 2, f"Expected 2-tuple, got {len(result)}-tuple"
         criterion, postprocess = result
-        assert isinstance(criterion, SetCriterion), (
-            f"Expected SetCriterion, got {type(criterion).__name__}"
-        )
-        assert isinstance(postprocess, PostProcess), (
-            f"Expected PostProcess, got {type(postprocess).__name__}"
-        )
+        assert isinstance(criterion, SetCriterion), f"Expected SetCriterion, got {type(criterion).__name__}"
+        assert isinstance(postprocess, PostProcess), f"Expected PostProcess, got {type(postprocess).__name__}"
 
     def test_num_select_postprocess(self) -> None:
         """RFDETRSegNanoConfig has num_select=100; PostProcess must reflect it."""
         mc = RFDETRSegNanoConfig()
         tc = SegmentationTrainConfig(dataset_dir="/tmp")
         _, postprocess = build_criterion_from_config(mc, tc)
-        assert postprocess.num_select == 100, (
-            f"Expected PostProcess.num_select=100, got {postprocess.num_select}"
-        )
+        assert postprocess.num_select == 100, f"Expected PostProcess.num_select=100, got {postprocess.num_select}"
 
     def test_segmentation_losses_included(self) -> None:
         """With segmentation config, 'masks' must be in criterion.losses."""
         mc = RFDETRSegNanoConfig()
         tc = SegmentationTrainConfig(dataset_dir="/tmp")
         criterion, _ = build_criterion_from_config(mc, tc)
-        assert "masks" in criterion.losses, (
-            f"Expected 'masks' in criterion.losses, got {criterion.losses}"
-        )
+        assert "masks" in criterion.losses, f"Expected 'masks' in criterion.losses, got {criterion.losses}"

--- a/tests/models/test_builders.py
+++ b/tests/models/test_builders.py
@@ -58,14 +58,14 @@ class TestBuildModelFromConfig:
 
     def test_parity_with_build_model_via_namespace(self) -> None:
         """Parameter count must match between config-native and namespace paths."""
-        from rfdetr._namespace import build_namespace
+        from rfdetr._namespace import _namespace_from_configs
         from rfdetr.models.lwdetr import build_model
 
         mc = RFDETRBaseConfig(num_classes=80)
         tc = TrainConfig(dataset_dir="/tmp")
 
         model_config_native = build_model_from_config(mc, tc)
-        ns = build_namespace(mc, tc)
+        ns = _namespace_from_configs(mc, tc)
         model_namespace = build_model(ns)
 
         params_native = sum(p.numel() for p in model_config_native.parameters())

--- a/tests/models/test_builders.py
+++ b/tests/models/test_builders.py
@@ -1,0 +1,129 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Characterization tests for config-native builder functions.
+
+These tests validate build_model_from_config() and build_criterion_from_config()
+which accept Pydantic config objects directly instead of requiring a pre-built
+SimpleNamespace.  Until the functions are implemented, all tests skip via the
+module-level pytestmark.
+"""
+
+import pytest
+
+from rfdetr.config import (
+    RFDETRBaseConfig,
+    RFDETRSegNanoConfig,
+    SegmentationTrainConfig,
+    TrainConfig,
+)
+
+try:
+    from rfdetr.models import build_model_from_config, build_criterion_from_config
+
+    HAS_CONFIG_BUILDERS = True
+except ImportError:
+    HAS_CONFIG_BUILDERS = False
+
+pytestmark = pytest.mark.skipif(
+    not HAS_CONFIG_BUILDERS,
+    reason="build_model_from_config not yet implemented",
+)
+
+
+class TestBuildModelFromConfig:
+    """Tests for build_model_from_config(model_config, defaults=MODEL_DEFAULTS)."""
+
+    def test_returns_lwdetr_for_base_config(self) -> None:
+        """build_model_from_config with RFDETRBaseConfig returns an LWDETR instance."""
+        from rfdetr.models.lwdetr import LWDETR
+
+        mc = RFDETRBaseConfig(num_classes=80)
+        model = build_model_from_config(mc)
+        assert isinstance(model, LWDETR), (
+            f"Expected LWDETR instance, got {type(model).__name__}"
+        )
+
+    def test_num_classes_correct(self) -> None:
+        """num_classes=5 in config should produce class_embed with out_features=6.
+
+        build_model adds +1 to num_classes (background class convention).
+        """
+        mc = RFDETRBaseConfig(num_classes=5)
+        model = build_model_from_config(mc)
+        assert model.class_embed.out_features == 6, (
+            f"Expected class_embed.out_features=6 (num_classes+1), "
+            f"got {model.class_embed.out_features}"
+        )
+
+    def test_parity_with_build_model_via_namespace(self) -> None:
+        """Parameter count must match between config-native and namespace paths."""
+        from rfdetr._namespace import build_namespace
+        from rfdetr.models.lwdetr import build_model
+
+        mc = RFDETRBaseConfig(num_classes=80)
+        tc = TrainConfig(dataset_dir="/tmp")
+
+        model_config_native = build_model_from_config(mc)
+        ns = build_namespace(mc, tc)
+        model_namespace = build_model(ns)
+
+        params_native = sum(p.numel() for p in model_config_native.parameters())
+        params_namespace = sum(p.numel() for p in model_namespace.parameters())
+        assert params_native == params_namespace, (
+            f"Parameter count mismatch: "
+            f"config-native={params_native}, namespace={params_namespace}"
+        )
+
+    def test_segmentation_head_created_when_true(self) -> None:
+        """RFDETRSegNanoConfig has segmentation_head=True; model must have it."""
+        mc = RFDETRSegNanoConfig()
+        model = build_model_from_config(mc)
+        assert model.segmentation_head is not None, (
+            "Expected segmentation_head to be created for RFDETRSegNanoConfig"
+        )
+
+
+class TestBuildCriterionFromConfig:
+    """Tests for build_criterion_from_config(model_config, train_config, defaults)."""
+
+    def test_returns_tuple(self) -> None:
+        """build_criterion_from_config must return a 2-tuple (SetCriterion, PostProcess)."""
+        from rfdetr.models.criterion import SetCriterion
+        from rfdetr.models.postprocess import PostProcess
+
+        mc = RFDETRBaseConfig(num_classes=80)
+        tc = TrainConfig(dataset_dir="/tmp")
+        result = build_criterion_from_config(mc, tc)
+        assert isinstance(result, tuple), (
+            f"Expected tuple, got {type(result).__name__}"
+        )
+        assert len(result) == 2, f"Expected 2-tuple, got {len(result)}-tuple"
+        criterion, postprocess = result
+        assert isinstance(criterion, SetCriterion), (
+            f"Expected SetCriterion, got {type(criterion).__name__}"
+        )
+        assert isinstance(postprocess, PostProcess), (
+            f"Expected PostProcess, got {type(postprocess).__name__}"
+        )
+
+    def test_num_select_postprocess(self) -> None:
+        """RFDETRSegNanoConfig has num_select=100; PostProcess must reflect it."""
+        mc = RFDETRSegNanoConfig()
+        tc = SegmentationTrainConfig(dataset_dir="/tmp")
+        _, postprocess = build_criterion_from_config(mc, tc)
+        assert postprocess.num_select == 100, (
+            f"Expected PostProcess.num_select=100, got {postprocess.num_select}"
+        )
+
+    def test_segmentation_losses_included(self) -> None:
+        """With segmentation config, 'masks' must be in criterion.losses."""
+        mc = RFDETRSegNanoConfig()
+        tc = SegmentationTrainConfig(dataset_dir="/tmp")
+        criterion, _ = build_criterion_from_config(mc, tc)
+        assert "masks" in criterion.losses, (
+            f"Expected 'masks' in criterion.losses, got {criterion.losses}"
+        )

--- a/tests/models/test_builders.py
+++ b/tests/models/test_builders.py
@@ -102,6 +102,23 @@ class TestBuildModelFromConfig:
         with pytest.raises(ValueError, match="encoder_only=False"):
             build_model_from_config(mc, defaults=replace(MODEL_DEFAULTS, encoder_only=True))
 
+    def test_rejects_backbone_only_defaults(self) -> None:
+        """backbone_only=True in defaults must also raise ValueError."""
+        from dataclasses import replace
+
+        from rfdetr.models import MODEL_DEFAULTS
+
+        mc = RFDETRBaseConfig(num_classes=80)
+
+        with pytest.raises(ValueError, match="backbone_only=False"):
+            build_model_from_config(mc, defaults=replace(MODEL_DEFAULTS, backbone_only=True))
+
+    def test_none_train_config_uses_dummy(self) -> None:
+        """build_model_from_config with train_config=None must not raise."""
+        mc = RFDETRBaseConfig(num_classes=80)
+        model = build_model_from_config(mc, train_config=None)
+        assert model is not None, "Expected a model, got None"
+
 
 class TestBuildCriterionFromConfig:
     """Tests for build_criterion_from_config(model_config, train_config, defaults)."""
@@ -133,3 +150,15 @@ class TestBuildCriterionFromConfig:
         tc = SegmentationTrainConfig(dataset_dir="/tmp")
         criterion, _ = build_criterion_from_config(mc, tc)
         assert "masks" in criterion.losses, f"Expected 'masks' in criterion.losses, got {criterion.losses}"
+
+    def test_custom_defaults_focal_alpha_applied(self) -> None:
+        """Custom focal_alpha in ModelDefaults must reach SetCriterion."""
+        from dataclasses import replace
+
+        from rfdetr.models import MODEL_DEFAULTS
+
+        mc = RFDETRBaseConfig(num_classes=80)
+        tc = TrainConfig(dataset_dir="/tmp")
+        custom_defaults = replace(MODEL_DEFAULTS, focal_alpha=0.5)
+        criterion, _ = build_criterion_from_config(mc, tc, defaults=custom_defaults)
+        assert criterion.focal_alpha == pytest.approx(0.5), f"Expected focal_alpha=0.5, got {criterion.focal_alpha}"

--- a/tests/models/test_drop_path.py
+++ b/tests/models/test_drop_path.py
@@ -13,7 +13,7 @@ import torch
 import torch.nn as nn
 
 import rfdetr.models.backbone.dinov2 as dinov2_module
-from rfdetr._namespace import build_namespace
+from rfdetr._namespace import _namespace_from_configs
 from rfdetr.config import RFDETRNanoConfig, TrainConfig
 from rfdetr.models import build_model
 from rfdetr.models.backbone.dinov2 import DinoV2
@@ -38,7 +38,7 @@ def model_with_drop_path(monkeypatch: pytest.MonkeyPatch) -> LWDETR:
         output_dir=".",
         drop_path=0.1,
     )
-    args = build_namespace(mc, tc)
+    args = _namespace_from_configs(mc, tc)
     return build_model(args)
 
 
@@ -56,7 +56,7 @@ def model_without_drop_path(monkeypatch: pytest.MonkeyPatch) -> LWDETR:
         output_dir=".",
         drop_path=0.0,
     )
-    args = build_namespace(mc, tc)
+    args = _namespace_from_configs(mc, tc)
     return build_model(args)
 
 

--- a/tests/models/test_weights.py
+++ b/tests/models/test_weights.py
@@ -123,6 +123,7 @@ class TestLoadPretrainWeightsReinitScenarios:
             f"Expected exactly 1 reinit call; got {len(calls)}: {calls}. "
             "A second reinit to 91 would destroy loaded fine-tuned weights."
         )
+        assert mc.num_classes == 2, "Auto-aligned checkpoint class count must be persisted back onto ModelConfig."
 
     def test_characterization_backbone_pretrain_two_reinits(self, monkeypatch, tmp_path):
         """Backbone pretrain (more classes in checkpoint) + explicit small num_classes → 2 reinits.

--- a/tests/models/test_weights.py
+++ b/tests/models/test_weights.py
@@ -110,12 +110,11 @@ class TestLoadPretrainWeightsReinitScenarios:
         from rfdetr.models.weights import load_pretrain_weights
 
         mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu")
-        tc = _make_train_config(tmp_path)
         checkpoint = _make_checkpoint(num_classes=3)
         monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
 
         nn_model = _fake_nn_model()
-        load_pretrain_weights(nn_model, mc, tc)
+        load_pretrain_weights(nn_model, mc)
 
         calls = nn_model.reinitialize_detection_head.call_args_list
         assert calls[0] == call(3), f"First reinit must resize to checkpoint size 3, got {calls[0]}"
@@ -134,12 +133,11 @@ class TestLoadPretrainWeightsReinitScenarios:
         from rfdetr.models.weights import load_pretrain_weights
 
         mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu", num_classes=2)
-        tc = _make_train_config(tmp_path)
         checkpoint = _make_checkpoint(num_classes=91)
         monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
 
         nn_model = _fake_nn_model()
-        load_pretrain_weights(nn_model, mc, tc)
+        load_pretrain_weights(nn_model, mc)
 
         calls = nn_model.reinitialize_detection_head.call_args_list
         assert calls == [call(91), call(3)], f"Expected reinit to [91, 3] (expand then trim), got {calls}"
@@ -153,12 +151,11 @@ class TestLoadPretrainWeightsReinitScenarios:
         from rfdetr.models.weights import load_pretrain_weights
 
         mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu", num_classes=93)
-        tc = _make_train_config(tmp_path)
         checkpoint = _make_checkpoint(num_classes=91)
         monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
 
         nn_model = _fake_nn_model()
-        load_pretrain_weights(nn_model, mc, tc)
+        load_pretrain_weights(nn_model, mc)
 
         calls = nn_model.reinitialize_detection_head.call_args_list
         assert calls == [call(91), call(94)], f"Expected reinit to [91, 94] (load then expand), got {calls}"
@@ -171,12 +168,11 @@ class TestLoadPretrainWeightsReinitScenarios:
         from rfdetr.models.weights import load_pretrain_weights
 
         mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu", num_classes=90)
-        tc = _make_train_config(tmp_path)
         checkpoint = _make_checkpoint(num_classes=91)
         monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
 
         nn_model = _fake_nn_model()
-        load_pretrain_weights(nn_model, mc, tc)
+        load_pretrain_weights(nn_model, mc)
 
         nn_model.reinitialize_detection_head.assert_not_called()
 
@@ -201,7 +197,6 @@ class TestLoadPretrainWeightsClassNames:
         from rfdetr.models.weights import load_pretrain_weights
 
         mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu", num_classes=90)
-        tc = _make_train_config(tmp_path)
         checkpoint = _make_checkpoint(num_classes=91)
         checkpoint["args"] = SimpleNamespace(
             segmentation_head=False,
@@ -211,7 +206,7 @@ class TestLoadPretrainWeightsClassNames:
         monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
 
         nn_model = _fake_nn_model()
-        result = load_pretrain_weights(nn_model, mc, tc)
+        result = load_pretrain_weights(nn_model, mc)
 
         assert result == ["cat", "dog", "bird"], f"Expected class names from checkpoint, got {result!r}"
 
@@ -220,13 +215,12 @@ class TestLoadPretrainWeightsClassNames:
         from rfdetr.models.weights import load_pretrain_weights
 
         mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu", num_classes=90)
-        tc = _make_train_config(tmp_path)
         checkpoint = _make_checkpoint(num_classes=91)
         checkpoint.pop("args", None)  # no args key at all
         monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
 
         nn_model = _fake_nn_model()
-        result = load_pretrain_weights(nn_model, mc, tc)
+        result = load_pretrain_weights(nn_model, mc)
 
         assert result == [], f"Expected empty list when checkpoint has no class_names, got {result!r}"
 
@@ -235,10 +229,9 @@ class TestLoadPretrainWeightsClassNames:
         from rfdetr.models.weights import load_pretrain_weights
 
         mc = RFDETRBaseConfig(pretrain_weights=None, device="cpu")
-        tc = _make_train_config(tmp_path)
         nn_model = _fake_nn_model()
 
-        result = load_pretrain_weights(nn_model, mc, tc)
+        result = load_pretrain_weights(nn_model, mc)
 
         assert result == [], f"Expected [] for None pretrain_weights, got {result!r}"
         nn_model.load_state_dict.assert_not_called()

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -161,7 +161,6 @@ class TestBuildNamespaceDeprecated:
     def test_result_identical_to_namespace_from_configs(self) -> None:
         """build_namespace output must equal _namespace_from_configs output."""
         from rfdetr._namespace import build_namespace
-
         from rfdetr.models._defaults import MODEL_DEFAULTS
 
         mc = RFDETRBaseConfig(num_classes=80)

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -143,3 +143,36 @@ class TestBuildNamespaceFieldOwnership:
         tc = TrainConfig(dataset_dir="/tmp")
         ns = build_namespace(mc, tc)
         assert ns.num_select == expected_num_select
+
+
+class TestNamespaceFromConfigs:
+    """Parity tests ensuring _namespace_from_configs matches build_namespace output."""
+
+    def test_parity_with_build_namespace(self) -> None:
+        """_namespace_from_configs must produce identical attributes to build_namespace."""
+        try:
+            from rfdetr._namespace import _namespace_from_configs
+        except ImportError:
+            pytest.skip("_namespace_from_configs not yet extracted")
+
+        from rfdetr.models._defaults import MODEL_DEFAULTS
+
+        mc = RFDETRBaseConfig(num_classes=80)
+        tc = TrainConfig(dataset_dir="/tmp")
+
+        ns_legacy = build_namespace(mc, tc)
+        ns_new = _namespace_from_configs(mc, tc, MODEL_DEFAULTS)
+
+        legacy_attrs = vars(ns_legacy)
+        new_attrs = vars(ns_new)
+
+        assert set(legacy_attrs.keys()) == set(new_attrs.keys()), (
+            f"Key mismatch: "
+            f"legacy_only={set(legacy_attrs) - set(new_attrs)}, "
+            f"new_only={set(new_attrs) - set(legacy_attrs)}"
+        )
+        for key in sorted(legacy_attrs):
+            assert legacy_attrs[key] == new_attrs[key], (
+                f"Value mismatch for '{key}': "
+                f"legacy={legacy_attrs[key]!r}, new={new_attrs[key]!r}"
+            )

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -173,6 +173,5 @@ class TestNamespaceFromConfigs:
         )
         for key in sorted(legacy_attrs):
             assert legacy_attrs[key] == new_attrs[key], (
-                f"Value mismatch for '{key}': "
-                f"legacy={legacy_attrs[key]!r}, new={new_attrs[key]!r}"
+                f"Value mismatch for '{key}': legacy={legacy_attrs[key]!r}, new={new_attrs[key]!r}"
             )

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -4,62 +4,62 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
-"""Regression tests for build_namespace() config forwarding."""
+"""Regression tests for _namespace_from_configs() config forwarding."""
 
 import sys
 from typing import Any
 
 import pytest
 
-from rfdetr._namespace import build_namespace
+from rfdetr._namespace import _namespace_from_configs
 from rfdetr.config import RFDETRBaseConfig, RFDETRSegNanoConfig, SegmentationTrainConfig, TrainConfig
 from rfdetr.models._types import BuilderArgs
 
 
-class TestBuildNamespaceForwarding:
-    """Verify that build_namespace() forwards TrainConfig fields that were
+class TestNamespaceForwarding:
+    """Verify that _namespace_from_configs() forwards TrainConfig fields that were
     previously hardcoded to wrong defaults."""
 
-    def _make_ns(self: "TestBuildNamespaceForwarding", **tc_kwargs: Any) -> Any:
+    def _make_ns(self: "TestNamespaceForwarding", **tc_kwargs: Any) -> Any:
         """Build a namespace for tests with minimal default TrainConfig values."""
         mc = RFDETRBaseConfig(num_classes=80)
         tc_kwargs.setdefault("dataset_dir", "/tmp")
         tc = TrainConfig(**tc_kwargs)
-        return build_namespace(mc, tc)
+        return _namespace_from_configs(mc, tc)
 
-    def test_aug_config_forwarded_when_set(self: "TestBuildNamespaceForwarding") -> None:
+    def test_aug_config_forwarded_when_set(self: "TestNamespaceForwarding") -> None:
         aug = {"hsv_h": 0.015, "hsv_s": 0.7}
         ns = self._make_ns(aug_config=aug)
         assert ns.aug_config == aug
 
-    def test_aug_config_none_by_default(self: "TestBuildNamespaceForwarding") -> None:
+    def test_aug_config_none_by_default(self: "TestNamespaceForwarding") -> None:
         ns = self._make_ns()
         assert ns.aug_config is None
 
-    def test_use_ema_forwarded_true(self: "TestBuildNamespaceForwarding") -> None:
+    def test_use_ema_forwarded_true(self: "TestNamespaceForwarding") -> None:
         ns = self._make_ns(use_ema=True)
         assert ns.use_ema is True
 
-    def test_use_ema_forwarded_false(self: "TestBuildNamespaceForwarding") -> None:
+    def test_use_ema_forwarded_false(self: "TestNamespaceForwarding") -> None:
         ns = self._make_ns(use_ema=False)
         assert ns.use_ema is False
 
-    def test_early_stopping_use_ema_forwarded_true(self: "TestBuildNamespaceForwarding") -> None:
+    def test_early_stopping_use_ema_forwarded_true(self: "TestNamespaceForwarding") -> None:
         ns = self._make_ns(early_stopping_use_ema=True)
         assert ns.early_stopping_use_ema is True
 
-    def test_early_stopping_use_ema_forwarded_false(self: "TestBuildNamespaceForwarding") -> None:
+    def test_early_stopping_use_ema_forwarded_false(self: "TestNamespaceForwarding") -> None:
         ns = self._make_ns(early_stopping_use_ema=False)
         assert ns.early_stopping_use_ema is False
 
 
-class TestBuildNamespaceProtocol:
-    """build_namespace() output must satisfy the BuilderArgs Protocol."""
+class TestNamespaceProtocol:
+    """_namespace_from_configs() output must satisfy the BuilderArgs Protocol."""
 
     def _make_ns(self, mc=None, tc=None):
         mc = mc or RFDETRBaseConfig(num_classes=80)
         tc = tc or TrainConfig(dataset_dir="/tmp")
-        return build_namespace(mc, tc)
+        return _namespace_from_configs(mc, tc)
 
     @pytest.mark.skipif(
         sys.version_info < (3, 12),
@@ -81,13 +81,13 @@ class TestBuildNamespaceProtocol:
         assert isinstance(ns, BuilderArgs)
 
 
-class TestBuildNamespaceFieldOwnership:
+class TestNamespaceFieldOwnership:
     """Verify that the namespace reads each field from the authoritative owner."""
 
     def _make_ns(self, mc=None, tc=None):
         mc = mc or RFDETRBaseConfig(num_classes=80)
         tc = tc or TrainConfig(dataset_dir="/tmp")
-        return build_namespace(mc, tc)
+        return _namespace_from_configs(mc, tc)
 
     # --- cls_loss_coef must come from TrainConfig ---
 
@@ -95,14 +95,14 @@ class TestBuildNamespaceFieldOwnership:
         """ns.cls_loss_coef must reflect TrainConfig.cls_loss_coef, not ModelConfig."""
         mc = RFDETRBaseConfig(num_classes=80)  # cls_loss_coef=1.0 (ModelConfig default)
         tc = TrainConfig(dataset_dir="/tmp", cls_loss_coef=2.5)
-        ns = build_namespace(mc, tc)
+        ns = _namespace_from_configs(mc, tc)
         assert ns.cls_loss_coef == pytest.approx(2.5)
 
     def test_cls_loss_coef_segmentation_uses_train_config_value(self) -> None:
         """SegmentationTrainConfig.cls_loss_coef=5.0 must propagate to namespace."""
         mc = RFDETRSegNanoConfig()
         tc = SegmentationTrainConfig(dataset_dir="/tmp")  # cls_loss_coef=5.0
-        ns = build_namespace(mc, tc)
+        ns = _namespace_from_configs(mc, tc)
         assert ns.cls_loss_coef == pytest.approx(5.0)
 
     def test_cls_loss_coef_train_config_wins_over_explicit_model_config(self) -> None:
@@ -110,7 +110,7 @@ class TestBuildNamespaceFieldOwnership:
         with pytest.warns(DeprecationWarning, match="ModelConfig\\.cls_loss_coef is deprecated"):
             mc = RFDETRBaseConfig(num_classes=80, cls_loss_coef=0.5)
         tc = TrainConfig(dataset_dir="/tmp", cls_loss_coef=3.0)
-        ns = build_namespace(mc, tc)
+        ns = _namespace_from_configs(mc, tc)
         assert ns.cls_loss_coef == pytest.approx(3.0)
 
     def test_cls_loss_coef_model_config_explicit_is_preserved_during_deprecation(self) -> None:
@@ -118,7 +118,7 @@ class TestBuildNamespaceFieldOwnership:
         with pytest.warns(DeprecationWarning, match="ModelConfig\\.cls_loss_coef is deprecated"):
             mc = RFDETRBaseConfig(num_classes=80, cls_loss_coef=2.5)
         tc = TrainConfig(dataset_dir="/tmp")
-        ns = build_namespace(mc, tc)
+        ns = _namespace_from_configs(mc, tc)
         assert ns.cls_loss_coef == pytest.approx(2.5)
 
     # --- num_select must come from ModelConfig unconditionally ---
@@ -127,7 +127,7 @@ class TestBuildNamespaceFieldOwnership:
         """ns.num_select must equal mc.num_select regardless of tc.num_select."""
         mc = RFDETRSegNanoConfig()  # num_select=100
         tc = TrainConfig(dataset_dir="/tmp")  # num_select=300 (default — was the bug)
-        ns = build_namespace(mc, tc)
+        ns = _namespace_from_configs(mc, tc)
         assert ns.num_select == 100
 
     @pytest.mark.parametrize(
@@ -141,26 +141,34 @@ class TestBuildNamespaceFieldOwnership:
         """ns.num_select must equal the model config's num_select for each variant."""
         mc = config_class()
         tc = TrainConfig(dataset_dir="/tmp")
-        ns = build_namespace(mc, tc)
+        ns = _namespace_from_configs(mc, tc)
         assert ns.num_select == expected_num_select
 
 
-class TestNamespaceFromConfigs:
-    """Parity tests ensuring _namespace_from_configs matches build_namespace output."""
+class TestBuildNamespaceDeprecated:
+    """build_namespace() is a deprecated shim — verify the warning fires."""
 
-    def test_parity_with_build_namespace(self) -> None:
-        """_namespace_from_configs must produce identical attributes to build_namespace."""
-        try:
-            from rfdetr._namespace import _namespace_from_configs
-        except ImportError:
-            pytest.skip("_namespace_from_configs not yet extracted")
+    def test_emits_deprecation_warning(self) -> None:
+        """Every call to build_namespace() must emit a DeprecationWarning."""
+        from rfdetr._namespace import build_namespace
+
+        mc = RFDETRBaseConfig(num_classes=80)
+        tc = TrainConfig(dataset_dir="/tmp")
+
+        with pytest.warns(DeprecationWarning, match="build_namespace\\(\\) is deprecated"):
+            build_namespace(mc, tc)
+
+    def test_result_identical_to_namespace_from_configs(self) -> None:
+        """build_namespace output must equal _namespace_from_configs output."""
+        from rfdetr._namespace import build_namespace
 
         from rfdetr.models._defaults import MODEL_DEFAULTS
 
         mc = RFDETRBaseConfig(num_classes=80)
         tc = TrainConfig(dataset_dir="/tmp")
 
-        ns_legacy = build_namespace(mc, tc)
+        with pytest.warns(DeprecationWarning):
+            ns_legacy = build_namespace(mc, tc)
         ns_new = _namespace_from_configs(mc, tc, MODEL_DEFAULTS)
 
         legacy_attrs = vars(ns_legacy)

--- a/tests/training/test_args.py
+++ b/tests/training/test_args.py
@@ -4,25 +4,20 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
-"""Unit tests for build_namespace — the canonical config-to-Namespace mapping."""
+"""Unit tests for _namespace_from_configs — the canonical config-to-Namespace mapping."""
 
 import pytest
 
-from rfdetr._namespace import build_namespace
+from rfdetr._namespace import _namespace_from_configs
 
 
-class TestBuildNamespace:
-    """build_namespace maps ModelConfig + TrainConfig to a Namespace."""
-
-    def test_returns_namespace(self, base_model_config, base_train_config):
-        """The return value has attribute access (argparse.Namespace or similar)."""
-        args = build_namespace(base_model_config(), base_train_config())
-        assert hasattr(args, "encoder")
+class TestNamespaceFromConfigs:
+    """_namespace_from_configs maps ModelConfig + TrainConfig to a Namespace."""
 
     def test_forwards_model_config_fields(self, base_model_config, base_train_config):
         """All key ModelConfig fields are faithfully mapped."""
         mc = base_model_config(num_classes=7)
-        args = build_namespace(mc, base_train_config())
+        args = _namespace_from_configs(mc, base_train_config())
 
         assert args.encoder == mc.encoder
         assert args.num_classes == 7
@@ -50,7 +45,7 @@ class TestBuildNamespace:
             ema_update_interval=2,
             prefetch_factor=4,
         )
-        args = build_namespace(base_model_config(), tc)
+        args = _namespace_from_configs(base_model_config(), tc)
 
         assert args.lr == pytest.approx(3e-4)
         assert args.epochs == 20
@@ -67,9 +62,9 @@ class TestBuildNamespace:
         assert args.prefetch_factor == 4
 
     def test_forwards_promoted_train_fields(self, base_model_config, base_train_config):
-        """Promoted TrainConfig fields are forwarded to the legacy namespace."""
+        """Promoted TrainConfig fields are forwarded to the namespace."""
         tc = base_train_config(clip_max_norm=0.35, seed=123, sync_bn=True, fp16_eval=True)
-        args = build_namespace(base_model_config(), tc)
+        args = _namespace_from_configs(base_model_config(), tc)
 
         assert args.clip_max_norm == pytest.approx(0.35)
         assert args.seed == 123
@@ -77,15 +72,15 @@ class TestBuildNamespace:
         assert args.fp16_eval is True
 
     def test_seed_falls_back_to_legacy_default_when_unset(self, base_model_config, base_train_config):
-        """seed defaults to 42 in the legacy namespace when TrainConfig.seed is None."""
+        """seed defaults to 42 in the namespace when TrainConfig.seed is None."""
         tc = base_train_config(seed=None)
-        args = build_namespace(base_model_config(), tc)
+        args = _namespace_from_configs(base_model_config(), tc)
         assert args.seed == 42
 
     def test_forwards_dataset_fields(self, base_model_config, base_train_config):
         """Dataset-routing fields are forwarded to the Namespace."""
         tc = base_train_config(multi_scale=True, expanded_scales=True, dataset_file="coco")
-        args = build_namespace(base_model_config(), tc)
+        args = _namespace_from_configs(base_model_config(), tc)
 
         assert args.multi_scale is True
         assert args.expanded_scales is True
@@ -94,21 +89,21 @@ class TestBuildNamespace:
     def test_num_queries_from_subclass_config(self, base_model_config, base_train_config):
         """num_queries is read from subclass config attributes."""
         mc = base_model_config()  # RFDETRBaseConfig has num_queries=300
-        args = build_namespace(mc, base_train_config())
+        args = _namespace_from_configs(mc, base_train_config())
         assert args.num_queries == 300
 
     def test_resume_none_becomes_empty_string(self, base_model_config, base_train_config):
-        """resume=None (the default) is converted to '' for the legacy Namespace."""
+        """resume=None (the default) is converted to '' for the Namespace."""
         tc = base_train_config()
         assert tc.resume is None
-        args = build_namespace(base_model_config(), tc)
+        args = _namespace_from_configs(base_model_config(), tc)
         assert args.resume == ""
 
     def test_segmentation_extras_forwarded_from_seg_config(self, base_model_config, seg_train_config):
         """SegmentationTrainConfig mask loss coefficients are forwarded."""
         mc = base_model_config(segmentation_head=True)
         tc = seg_train_config()
-        args = build_namespace(mc, tc)
+        args = _namespace_from_configs(mc, tc)
 
         assert args.mask_ce_loss_coef == pytest.approx(5.0)
         assert args.mask_dice_loss_coef == pytest.approx(5.0)
@@ -120,29 +115,25 @@ class TestBuildNamespace:
         with pytest.warns(DeprecationWarning, match="TrainConfig.num_select is deprecated"):
             tc = seg_train_config(num_select=None)
 
-        args = build_namespace(mc, tc)
+        args = _namespace_from_configs(mc, tc)
 
         assert args.num_select == 200
 
     def test_segmentation_extras_default_for_plain_config(self, base_model_config, base_train_config):
         """mask_* attributes default to 5.0 for a plain TrainConfig (not segmentation)."""
-        args = build_namespace(base_model_config(), base_train_config())
+        args = _namespace_from_configs(base_model_config(), base_train_config())
         assert args.mask_ce_loss_coef == pytest.approx(5.0)
         assert args.mask_dice_loss_coef == pytest.approx(5.0)
 
     def test_segmentation_head_flag_forwarded(self, base_model_config, base_train_config):
         """segmentation_head=True from ModelConfig reaches the Namespace."""
         mc = base_model_config(segmentation_head=True)
-        args = build_namespace(mc, base_train_config())
+        args = _namespace_from_configs(mc, base_train_config())
         assert args.segmentation_head is True
 
-    def test_no_deprecation_warning_emitted(self, base_model_config, base_train_config):
-        """build_namespace must not emit any DeprecationWarning or FutureWarning."""
-        import warnings
+    def test_build_namespace_emits_deprecation_warning(self, base_model_config, base_train_config):
+        """build_namespace() must emit a DeprecationWarning on every call."""
+        from rfdetr._namespace import build_namespace
 
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
+        with pytest.warns(DeprecationWarning, match="build_namespace\\(\\) is deprecated"):
             build_namespace(base_model_config(), base_train_config())
-
-        bad = [w for w in caught if issubclass(w.category, (DeprecationWarning, FutureWarning))]
-        assert not bad

--- a/tests/training/test_auto_batch.py
+++ b/tests/training/test_auto_batch.py
@@ -106,7 +106,7 @@ def test_resolve_auto_batch_config_returns_expected_values():
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for segmentation probe")
 def test_probe_step_with_real_segmentation_criterion(tmp_path):
     """Run one probe step with real segmentation model and criterion so loss_masks and t['masks'] are exercised."""
-    from rfdetr._namespace import build_namespace
+    from rfdetr._namespace import _namespace_from_configs
     from rfdetr.config import RFDETRSegNanoConfig, SegmentationTrainConfig
     from rfdetr.models.lwdetr import build_criterion_and_postprocessors, build_model
 
@@ -118,7 +118,7 @@ def test_probe_step_with_real_segmentation_criterion(tmp_path):
         grad_accum_steps=1,
         tensorboard=False,
     )
-    args = build_namespace(mc, tc)
+    args = _namespace_from_configs(mc, tc)
     model = build_model(args)
     criterion, _ = build_criterion_and_postprocessors(args)
     device = torch.device("cuda")

--- a/tests/training/test_auto_batch.py
+++ b/tests/training/test_auto_batch.py
@@ -90,8 +90,7 @@ def test_resolve_auto_batch_config_returns_expected_values():
 
     with (
         patch("rfdetr.training.auto_batch.torch.cuda.is_available", return_value=True),
-        patch("rfdetr.training.auto_batch.build_namespace", return_value=SimpleNamespace()),
-        patch("rfdetr.training.auto_batch.build_criterion_and_postprocessors", return_value=(criterion, None)),
+        patch("rfdetr.training.auto_batch.build_criterion_from_config", return_value=(criterion, None)),
         patch("rfdetr.training.auto_batch.probe_max_micro_batch", return_value=5),
         patch("rfdetr.training.auto_batch.torch.cuda.get_device_name", return_value="Fake GPU"),
     ):

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -1033,10 +1033,9 @@ class TestLoadPretrainWeightsInto:
 
         fake_model = MagicMock()
         mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu", segmentation_head=False)
-        tc = _make_train_config(tmp_path)
 
         with pytest.raises(ValueError, match="segmentation head"):
-            load_pretrain_weights(fake_model, mc, tc)
+            load_pretrain_weights(fake_model, mc)
 
     def test_patch_size_mismatch_raises_via_detr_path(self, monkeypatch, tmp_path):
         """patch_size mismatch must raise ValueError via the load_pretrain_weights path."""
@@ -1047,10 +1046,9 @@ class TestLoadPretrainWeightsInto:
 
         fake_model = MagicMock()
         mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu", patch_size=16)
-        tc = _make_train_config(tmp_path)
 
         with pytest.raises(ValueError, match=r"patch_size"):
-            load_pretrain_weights(fake_model, mc, tc)
+            load_pretrain_weights(fake_model, mc)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/training/test_load_pretrain_weights.py
+++ b/tests/training/test_load_pretrain_weights.py
@@ -116,12 +116,11 @@ class TestLoadPretrainWeightsSecondReinit:
         from rfdetr.models.weights import load_pretrain_weights
 
         mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu")
-        tc = _make_train_config()
         checkpoint = _make_checkpoint(num_classes=3)
         monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
 
         fake_model = MagicMock()
-        load_pretrain_weights(fake_model, mc, tc)
+        load_pretrain_weights(fake_model, mc)
 
         calls = fake_model.reinitialize_detection_head.call_args_list
         assert calls[0] == call(3), f"First reinit should resize to checkpoint size 3, got {calls[0]}"
@@ -139,12 +138,11 @@ class TestLoadPretrainWeightsSecondReinit:
         from rfdetr.models.weights import load_pretrain_weights
 
         mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu", num_classes=90)
-        tc = _make_train_config()
         checkpoint = _make_checkpoint(num_classes=91)
         monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
 
         fake_model = MagicMock()
-        load_pretrain_weights(fake_model, mc, tc)
+        load_pretrain_weights(fake_model, mc)
 
         fake_model.reinitialize_detection_head.assert_not_called()
 
@@ -158,12 +156,11 @@ class TestLoadPretrainWeightsSecondReinit:
         from rfdetr.models.weights import load_pretrain_weights
 
         mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu", num_classes=2)
-        tc = _make_train_config()
         checkpoint = _make_checkpoint(num_classes=91)
         monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
 
         fake_model = MagicMock()
-        load_pretrain_weights(fake_model, mc, tc)
+        load_pretrain_weights(fake_model, mc)
 
         calls = fake_model.reinitialize_detection_head.call_args_list
         assert calls == [call(91), call(3)], f"Expected reinit to [91, 3] (expand then trim), got {calls}"
@@ -178,13 +175,31 @@ class TestLoadPretrainWeightsSecondReinit:
         from rfdetr.models.weights import load_pretrain_weights
 
         mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu", num_classes=93)
-        tc = _make_train_config()
         checkpoint = _make_checkpoint(num_classes=91)
         monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
 
         fake_model = MagicMock()
-        load_pretrain_weights(fake_model, mc, tc)
+        load_pretrain_weights(fake_model, mc)
 
         calls = fake_model.reinitialize_detection_head.call_args_list
         assert calls == [call(91), call(94)], f"Expected reinit to [91, 94] (load then expand), got {calls}"
         assert mc.num_classes == 93, "Explicitly configured num_classes must not be overwritten."
+
+
+# ---------------------------------------------------------------------------
+# Deprecation: train_config argument
+# ---------------------------------------------------------------------------
+
+
+class TestLoadPretrainWeightsDeprecation:
+    """Passing train_config must emit a DeprecationWarning."""
+
+    def test_emits_deprecation_warning_when_train_config_passed(self, monkeypatch):
+        """Any non-None train_config triggers a DeprecationWarning."""
+        from rfdetr.models.weights import load_pretrain_weights
+
+        mc = RFDETRBaseConfig(pretrain_weights=None, device="cpu")
+        tc = _make_train_config()
+
+        with pytest.warns(DeprecationWarning, match="train_config argument is deprecated"):
+            load_pretrain_weights(MagicMock(), mc, tc)

--- a/tests/training/test_load_pretrain_weights.py
+++ b/tests/training/test_load_pretrain_weights.py
@@ -201,5 +201,5 @@ class TestLoadPretrainWeightsDeprecation:
         mc = RFDETRBaseConfig(pretrain_weights=None, device="cpu")
         tc = _make_train_config()
 
-        with pytest.warns(DeprecationWarning, match="train_config argument is deprecated"):
+        with pytest.warns(DeprecationWarning, match="train_config.*deprecated"):
             load_pretrain_weights(MagicMock(), mc, tc)

--- a/tests/training/test_metrics_csv.py
+++ b/tests/training/test_metrics_csv.py
@@ -39,9 +39,9 @@ def _fit_and_read_csv(mc: RFDETRBaseConfig, tc: TrainConfig, criterion=None) -> 
     """Run 1 epoch (2 train + 2 val batches) and return the resulting metrics.csv."""
     fake_criterion = criterion or _FakeCriterion()
     with (
-        patch("rfdetr.training.module_model.build_model", return_value=_TinyModel()),
+        patch("rfdetr.training.module_model.build_model_from_config", return_value=_TinyModel()),
         patch(
-            "rfdetr.training.module_model.build_criterion_and_postprocessors",
+            "rfdetr.training.module_model.build_criterion_from_config",
             return_value=(fake_criterion, MagicMock(side_effect=_fake_postprocess)),
         ),
         patch("rfdetr.training.module_data.build_dataset", return_value=_FakeDataset(length=20)),

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -82,16 +82,16 @@ def _fake_postprocess():
 
 
 def _build_module(model_config=None, train_config=None, tmp_path=None):
-    """Construct RFDETRModelModule with build_model and build_criterion_and_postprocessors mocked."""
+    """Construct RFDETRModelModule with build_model_from_config and build_criterion_from_config mocked."""
     mc = model_config or _base_model_config()
     tc = train_config or _base_train_config(tmp_path)
     fake_model = _fake_model()
     fake_criterion = _fake_criterion()
     fake_postprocess = _fake_postprocess()
     with (
-        patch("rfdetr.training.module_model.build_model", return_value=fake_model),
+        patch("rfdetr.training.module_model.build_model_from_config", return_value=fake_model),
         patch(
-            "rfdetr.training.module_model.build_criterion_and_postprocessors",
+            "rfdetr.training.module_model.build_criterion_from_config",
             return_value=(fake_criterion, fake_postprocess),
         ),
     ):
@@ -445,9 +445,9 @@ class TestApplyLora:
         fake_model.backbone.__getitem__ = MagicMock(return_value=fake_backbone_0)
 
         with (
-            patch("rfdetr.training.module_model.build_model", return_value=fake_model),
+            patch("rfdetr.training.module_model.build_model_from_config", return_value=fake_model),
             patch(
-                "rfdetr.training.module_model.build_criterion_and_postprocessors",
+                "rfdetr.training.module_model.build_criterion_from_config",
                 return_value=(_fake_criterion(), _fake_postprocess()),
             ),
         ):

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -220,7 +220,7 @@ class TestLoadPretrainWeights:
 
         module, _, _, _ = build_module(model_config=mc)
         module.model_config = module.model_config.model_copy(update={"pretrain_weights": "/fake/weights.pth"})
-        load_pretrain_weights(module.model, module.model_config, module.train_config)
+        load_pretrain_weights(module.model, module.model_config)
 
         mock_validate.assert_called_once_with("/fake/weights.pth", strict=False)
         module.model.load_state_dict.assert_called_once()
@@ -237,7 +237,7 @@ class TestLoadPretrainWeights:
 
         module, fake_model, _, _ = build_module(model_config=mc)
         module.model_config = module.model_config.model_copy(update={"pretrain_weights": "/fake/weights.pth"})
-        load_pretrain_weights(module.model, module.model_config, module.train_config)
+        load_pretrain_weights(module.model, module.model_config)
 
         # First call: expand to checkpoint size so load_state_dict shapes match.
         # Second call: trim back to configured num_classes + 1 (background class).
@@ -258,7 +258,7 @@ class TestLoadPretrainWeights:
 
         module, fake_model, _, _ = build_module(model_config=mc)
         module.model_config = module.model_config.model_copy(update={"pretrain_weights": "/fake/weights.pth"})
-        load_pretrain_weights(module.model, module.model_config, module.train_config)
+        load_pretrain_weights(module.model, module.model_config)
 
         fake_model.reinitialize_detection_head.assert_not_called()
 
@@ -287,7 +287,7 @@ class TestLoadPretrainWeights:
         mock_torch_load.return_value = checkpoint
 
         module.model_config = module.model_config.model_copy(update={"pretrain_weights": "/fake/weights.pth"})
-        load_pretrain_weights(module.model, module.model_config, module.train_config)
+        load_pretrain_weights(module.model, module.model_config)
 
         assert checkpoint["model"]["refpoint_embed.weight"].shape[0] == desired
         assert checkpoint["model"]["query_feat.weight"].shape[0] == desired
@@ -313,7 +313,7 @@ class TestLoadPretrainWeights:
             return checkpoint
 
         with patch("rfdetr.models.weights.torch.load", side_effect=fake_torch_load):
-            load_pretrain_weights(module.model, module.model_config, module.train_config)
+            load_pretrain_weights(module.model, module.model_config)
 
         # Verify a redownload with validate_md5=False was triggered after load failure.
         redownload_calls = [c for c in mock_download.call_args_list if c.kwargs.get("redownload") is True]
@@ -341,7 +341,7 @@ class TestLoadPretrainWeights:
 
         module, _, _, _ = build_module(model_config=mc)
         module.model_config = module.model_config.model_copy(update={"pretrain_weights": "/content/rf-detr-base.pth"})
-        load_pretrain_weights(module.model, module.model_config, module.train_config)
+        load_pretrain_weights(module.model, module.model_config)
 
         # download_pretrain_weights must have been called at least once before any load
         assert mock_download.call_count >= 1
@@ -366,7 +366,7 @@ class TestLoadPretrainWeights:
         )
 
         with pytest.raises(ValueError, match="segmentation head"):
-            load_pretrain_weights(module.model, module.model_config, module.train_config)
+            load_pretrain_weights(module.model, module.model_config)
 
     @patch("rfdetr.models.weights.torch.load")
     @patch("rfdetr.models.weights.validate_pretrain_weights")
@@ -386,7 +386,7 @@ class TestLoadPretrainWeights:
         )
 
         with pytest.raises(ValueError, match="segmentation head"):
-            load_pretrain_weights(module.model, module.model_config, module.train_config)
+            load_pretrain_weights(module.model, module.model_config)
 
     @patch("rfdetr.models.weights.torch.load")
     @patch("rfdetr.models.weights.validate_pretrain_weights")
@@ -404,7 +404,7 @@ class TestLoadPretrainWeights:
         )
 
         with pytest.raises(ValueError, match="patch_size"):
-            load_pretrain_weights(module.model, module.model_config, module.train_config)
+            load_pretrain_weights(module.model, module.model_config)
 
     @patch("rfdetr.models.weights.torch.load")
     @patch("rfdetr.models.weights.validate_pretrain_weights")
@@ -424,7 +424,7 @@ class TestLoadPretrainWeights:
         )
 
         # Should not raise.
-        load_pretrain_weights(module.model, module.model_config, module.train_config)
+        load_pretrain_weights(module.model, module.model_config)
 
 
 class TestApplyLora:

--- a/tests/training/test_trainer_smoke.py
+++ b/tests/training/test_trainer_smoke.py
@@ -71,9 +71,9 @@ class TestDetectionSmoke:
         fake_dataset = _FakeDataset(length=20)
 
         with (
-            patch("rfdetr.training.module_model.build_model", return_value=tiny_model),
+            patch("rfdetr.training.module_model.build_model_from_config", return_value=tiny_model),
             patch(
-                "rfdetr.training.module_model.build_criterion_and_postprocessors",
+                "rfdetr.training.module_model.build_criterion_from_config",
                 return_value=(fake_criterion, fake_postprocess),
             ),
             patch("rfdetr.training.module_data.build_dataset", return_value=fake_dataset),
@@ -97,9 +97,9 @@ class TestDetectionSmoke:
         fake_dataset = _FakeDataset(length=20)
 
         with (
-            patch("rfdetr.training.module_model.build_model", return_value=tiny_model),
+            patch("rfdetr.training.module_model.build_model_from_config", return_value=tiny_model),
             patch(
-                "rfdetr.training.module_model.build_criterion_and_postprocessors",
+                "rfdetr.training.module_model.build_criterion_from_config",
                 return_value=(fake_criterion, fake_postprocess),
             ),
             patch("rfdetr.training.module_data.build_dataset", return_value=fake_dataset),
@@ -134,9 +134,9 @@ class TestDetectionSmoke:
         fake_dataset = _FakeDataset(length=20)
 
         with (
-            patch("rfdetr.training.module_model.build_model", return_value=tiny_model),
+            patch("rfdetr.training.module_model.build_model_from_config", return_value=tiny_model),
             patch(
-                "rfdetr.training.module_model.build_criterion_and_postprocessors",
+                "rfdetr.training.module_model.build_criterion_from_config",
                 return_value=(fake_criterion, fake_postprocess),
             ),
             patch("rfdetr.training.module_data.build_dataset", return_value=fake_dataset),
@@ -181,9 +181,9 @@ class TestDetectionSmoke:
         fake_criterion.weight_dict = {"loss_ce": 1.0}
 
         with (
-            patch("rfdetr.training.module_model.build_model", return_value=tiny_model),
+            patch("rfdetr.training.module_model.build_model_from_config", return_value=tiny_model),
             patch(
-                "rfdetr.training.module_model.build_criterion_and_postprocessors",
+                "rfdetr.training.module_model.build_criterion_from_config",
                 return_value=(fake_criterion, fake_postprocess),
             ),
             patch("rfdetr.training.module_data.build_dataset", return_value=fake_dataset),
@@ -214,9 +214,9 @@ class TestSegmentationSmoke:
         fake_dataset = _FakeDatasetWithMasks(length=20)
 
         with (
-            patch("rfdetr.training.module_model.build_model", return_value=tiny_model),
+            patch("rfdetr.training.module_model.build_model_from_config", return_value=tiny_model),
             patch(
-                "rfdetr.training.module_model.build_criterion_and_postprocessors",
+                "rfdetr.training.module_model.build_criterion_from_config",
                 return_value=(fake_criterion, fake_postprocess),
             ),
             patch("rfdetr.training.module_data.build_dataset", return_value=fake_dataset),
@@ -235,9 +235,9 @@ class TestSegmentationSmoke:
         tc = seg_train_config()
 
         with (
-            patch("rfdetr.training.module_model.build_model", return_value=_TinyModel()),
+            patch("rfdetr.training.module_model.build_model_from_config", return_value=_TinyModel()),
             patch(
-                "rfdetr.training.module_model.build_criterion_and_postprocessors",
+                "rfdetr.training.module_model.build_criterion_from_config",
                 return_value=(_FakeCriterion(), MagicMock(side_effect=_fake_postprocess)),
             ),
             patch("rfdetr.training.module_data.build_dataset", return_value=_FakeDatasetWithMasks()),
@@ -267,9 +267,9 @@ class TestBuildTrainerSmoke:
         tc = base_train_config(use_ema=False, run_test=False)
 
         with (
-            patch("rfdetr.training.module_model.build_model", return_value=_TinyModel()),
+            patch("rfdetr.training.module_model.build_model_from_config", return_value=_TinyModel()),
             patch(
-                "rfdetr.training.module_model.build_criterion_and_postprocessors",
+                "rfdetr.training.module_model.build_criterion_from_config",
                 return_value=(_FakeCriterion(), MagicMock(side_effect=_fake_postprocess)),
             ),
             patch("rfdetr.training.module_data.build_dataset", return_value=_FakeDataset(length=20)),
@@ -319,9 +319,9 @@ def test_ddp_spawn_fit_runs_without_error(base_model_config, base_train_config):
     fake_dataset = _FakeDataset(length=20)
 
     with (
-        patch("rfdetr.training.module_model.build_model", return_value=_TinyModel()),
+        patch("rfdetr.training.module_model.build_model_from_config", return_value=_TinyModel()),
         patch(
-            "rfdetr.training.module_model.build_criterion_and_postprocessors",
+            "rfdetr.training.module_model.build_criterion_from_config",
             return_value=(_FakeCriterion(), _FakePostProcess()),
         ),
     ):


### PR DESCRIPTION
## What does this PR do?

This pull request introduces a major refactor to the configuration and model-building workflow, making architectural defaults explicit and enabling config-native model construction. The changes improve type safety, flexibility, and future maintainability, while deprecating legacy namespace shims. The most important changes are summarized below.

**New config-native builder APIs and explicit architectural defaults:**

* Added `build_model_from_config` and `build_criterion_from_config` functions to `rfdetr.models`, allowing direct construction from Pydantic config objects without the legacy namespace indirection. These functions use a new `ModelDefaults` dataclass for architectural constants, which can be overridden for custom builds. The canonical singleton `MODEL_DEFAULTS` is now exported. (`CHANGELOG.md`, `src/rfdetr/models/__init__.py`, `src/rfdetr/models/_defaults.py`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR13-R22) [[2]](diffhunk://#diff-e41e4948ef2cb4cb9a7e456761e0d7d038f820227079bc5de2514beaef9456a9R16-R31) [[3]](diffhunk://#diff-900cdff3c9192405b2be5f3a58e357c9761983caf3f94592b34b46cb4eaab394R1-R121)

* Introduced the `ModelDefaults` dataclass and `MODEL_DEFAULTS` singleton, exposing 35 previously hardcoded architectural constants. This enables documentation, testing, and overrides without touching config validation. (`src/rfdetr/models/_defaults.py`)

**Namespace and builder refactor:**

* Refactored the legacy `build_namespace` logic into a new `_namespace_from_configs` function, which merges `ModelConfig`, `TrainConfig`, and `ModelDefaults` in a clear precedence order. The deprecated `build_namespace` now simply calls this function and emits a warning. (`src/rfdetr/_namespace.py`) [[1]](diffhunk://#diff-d4c96d7bfae4d0e7b4d1f6bbd2806d07f3923be7f5b319ecb1f807528fdf2c77R14-R135) [[2]](diffhunk://#diff-d4c96d7bfae4d0e7b4d1f6bbd2806d07f3923be7f5b319ecb1f807528fdf2c77L51-R200)

* Updated downstream usage to prefer config-native builders. For example, `_build_model_context` in `detr.py` now uses `build_model_from_config` and only constructs a namespace for legacy consumers. (`src/rfdetr/detr.py`) [[1]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86L49-R49) [[2]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86L72-R72) [[3]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86L118-R138)

**Deprecations and bugfixes:**

* Deprecated `build_namespace` and the `train_config` argument to `load_pretrain_weights`; both will be removed in v1.9. Updated documentation and changelog accordingly. (`CHANGELOG.md`, `src/rfdetr/_namespace.py`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR13-R22) [[2]](diffhunk://#diff-d4c96d7bfae4d0e7b4d1f6bbd2806d07f3923be7f5b319ecb1f807528fdf2c77L51-R200)

* Fixed a bug in `load_pretrain_weights` where the model head could mismatch the checkpoint if `num_classes` was not set explicitly. (`CHANGELOG.md`)

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)
- Refactoring (no functional changes)

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
