### PR TITLE
fix: replace bare except: with except Exception: in COCO loader

### DIFF
--- a/src/rfdetr/datasets/coco.py
+++ b/src/rfdetr/datasets/coco.py
@@ -70,7 +70,7 @@ def convert_coco_poly_to_mask(segmentations: List[Any], height: int, width: int)
             continue
         try:
             rles = coco_mask.frPyObjects(polygons, height, width)
-        except:
+        except Exception:
             rles = polygons
         mask = coco_mask.decode(rles)
         if mask.ndim < 3:


### PR DESCRIPTION
## Summary

Replaces bare `except:` with `except Exception:` in the COCO dataset mask loader.

Bare `except:` inadvertently catches `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit`. Here the intent is clearly to handle polygon parsing errors gracefully by falling back to raw polygons — `except Exception:` is the correct scope.

**Change:**
```python
# Before
try:
    rles = coco_mask.frPyObjects(polygons, height, width)
except:
    rles = polygons

# After
try:
    rles = coco_mask.frPyObjects(polygons, height, width)
except Exception:
    rles = polygons
```

## Testing
No behavior change for normal flows. Fixes PEP 8 E722 bare-except lint warning.