### PR TITLE
chore(ci): hotfix GPU-specific dependency pinning for GPU

### DIFF
--- a/.github/workflows/ci-tests-gpu.yml
+++ b/.github/workflows/ci-tests-gpu.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: 🚀 Install Packages
         timeout-minutes: 5
-        run: uv sync --group tests --extra onnx --extra plus --extra train --extra visual
+        run: uv sync --group tests --group ci-gpu-pin --extra onnx --extra plus --extra train --extra visual
 
       - name: 🧪 Run the Test
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,13 @@ cli = ["jsonargparse[signatures]>=4.27.7"]
 plus = ["rfdetr_plus>=1.0.1, <2.0.0"]
 
 [dependency-groups]
+# TODO: Temporary: GPU runner only has CUDA 12.8 driver (12080); torch>=2.11 requires a newer driver.
+#   Remove this group and the --group ci-pin references in CI once the driver is updated.
+#   Does not affect users installing rfdetr from PyPI.
+ci-gpu-pin = [
+    "torch<2.11",
+]
+
 build = [
     "twine>=5.1.1",
     "wheel>=0.40",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ plus = ["rfdetr_plus>=1.0.1, <2.0.0"]
 
 [dependency-groups]
 # TODO: Temporary: GPU runner only has CUDA 12.8 driver (12080); torch>=2.11 requires a newer driver.
-#   Remove this group and the --group ci-pin references in CI once the driver is updated.
+#   Remove this group and the --group ci-gpu-pin references in CI once the driver is updated.
 #   Does not affect users installing rfdetr from PyPI.
 ci-gpu-pin = [
     "torch<2.11",


### PR DESCRIPTION
## What does this PR do?

- Added temporary `ci-gpu-pin` dependency group to accommodate current GPU runner driver limitations (CUDA 12.8).
- Updated `ci-tests-gpu.yml` to use the new dependency group for compatibility.

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)
- Refactoring (no functional changes)

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
