### PR TITLE
fix(aug): correct degenerate `translate_percent` range in AUG_AGGRESSIVE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ These fields will be **removed** in v1.9 after a full release cycle.
 - Fixed `_namespace.py`: `num_select` in the builder namespace now always reads from `ModelConfig`, eliminating a regression where `TrainConfig.num_select` (default 300) silently overrode model-specific values of 100–200 for segmentation variants (`RFDETRSegNano`, `RFDETRSegSmall`, `RFDETRSegMedium`, `RFDETRSegLarge`, `RFDETRSegPreview`). Post-processing now uses the correct top-k count for each model.
 - Fixed `models/weights.py`: `load_pretrain_weights` now correctly auto-aligns the model head when the checkpoint has fewer classes than the configured default, preventing a silent mismatch when `num_classes` was not explicitly set by the caller.
 - Fixed `RFDETR.train()`: a missing `rfdetr[train]` install (e.g. plain `pip install rfdetr` in Colab) now raises an `ImportError` with an actionable message — `pip install "rfdetr[train,loggers]"` — instead of a raw `ModuleNotFoundError` with no install hint.
+- Fixed `AUG_AGGRESSIVE` preset: `translate_percent` was `(0.1, 0.1)` — a degenerate range that forced Albumentations `Affine` to always translate right/down by exactly 10%. Corrected to `(-0.1, 0.1)` for symmetric bidirectional translation. (closes #855)
 
 ---
 

--- a/src/rfdetr/datasets/aug_config.py
+++ b/src/rfdetr/datasets/aug_config.py
@@ -94,7 +94,7 @@ AUG_AGGRESSIVE = {
     "Rotate": {"limit": 45, "p": 0.5},
     "Affine": {
         "scale": (0.8, 1.2),
-        "translate_percent": (0.1, 0.1),
+        "translate_percent": (-0.1, 0.1),
         "rotate": (-15, 15),
         "shear": (-5, 5),
         "p": 0.5,

--- a/tests/datasets/test_augmentations.py
+++ b/tests/datasets/test_augmentations.py
@@ -15,7 +15,7 @@ from torch.utils.data import DataLoader
 from torchvision.transforms.v2 import Compose
 
 from rfdetr.datasets._develop import _SimpleDataset
-from rfdetr.datasets.aug_config import AUG_CONFIG
+from rfdetr.datasets.aug_config import AUG_AGGRESSIVE, AUG_CONFIG
 from rfdetr.datasets.coco import make_coco_transforms, make_coco_transforms_square_div_64
 from rfdetr.datasets.transforms import AlbumentationsWrapper, _build_albu_transform
 from rfdetr.utilities import collate_fn
@@ -689,7 +689,7 @@ class TestAlbumentationsWrapperFromConfig:
         """Test building transforms with complex parameter structures."""
         config = {
             "Rotate": {"limit": (90, 90), "p": 0.5},
-            "Affine": {"scale": (0.9, 1.1), "translate_percent": (0.1, 0.1), "p": 0.3},
+            "Affine": {"scale": (0.9, 1.1), "translate_percent": (-0.1, 0.1), "p": 0.3},
         }
 
         transforms = AlbumentationsWrapper.from_config(config)
@@ -1524,5 +1524,26 @@ class TestMakeCocoTransformsAugConfig:
         """aug_config is ignored for test splits — only resize wrappers are present."""
         pipeline = make_transforms("test", 640, aug_config={"HorizontalFlip": {"p": 1.0}})
         wrappers = [t for t in pipeline.transforms if isinstance(t, AlbumentationsWrapper)]
-
         assert len(wrappers) == expected_resize_wrappers
+
+
+class TestAugPresets:
+    """Regression tests for built-in augmentation presets."""
+
+    def test_aug_aggressive_translate_percent_is_bidirectional(self) -> None:
+        """AUG_AGGRESSIVE translate_percent must allow both positive and negative translations.
+
+        (0.1, 0.1) is a degenerate range that only shifts right/down;
+        the correct range is (-0.1, 0.1).
+        """
+        translate = AUG_AGGRESSIVE["Affine"]["translate_percent"]
+        lo, hi = translate
+        assert lo < 0, (
+            f"AUG_AGGRESSIVE translate_percent lower bound must be negative to allow "
+            f"left/up translation; got {translate!r}"
+        )
+        assert hi > 0, (
+            f"AUG_AGGRESSIVE translate_percent upper bound must be positive to allow "
+            f"right/down translation; got {translate!r}"
+        )
+        assert lo < hi, f"AUG_AGGRESSIVE translate_percent must be a non-degenerate range; got {translate!r}"


### PR DESCRIPTION
## What does this PR do?

(0.1, 0.1) is a degenerate range that forces Albumentations Affine to always shift right/down by exactly 10%; never left or up. Corrected to (-0.1, 0.1) for symmetric bidirectional translation, consistent with the signed companion parameters rotate: (-15, 15) and shear: (-5, 5).

Fixes #855

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
