### PR TITLE
feat(predict): add shape parameter for non-square inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `RFDETR.predict(shape=...)` — optional `(height, width)` tuple overrides the default square resize target, enabling non-square inference on models exported via `export(shape=(H, W))`. Both dimensions must be positive integers divisible by 14. (closes #682)
+- `RFDETR.predict(shape=...)` — optional `(height, width)` tuple overrides the default inference resolution; useful for matching the resolution used when exporting the model. Both dimensions must be positive integers divisible by 14. (closes #682)
 - `BuilderArgs` — a `@runtime_checkable` `typing.Protocol` documenting the minimum attribute set consumed by `build_model()`, `build_backbone()`, `build_transformer()`, and `build_criterion_and_postprocessors()`. Enables static type-checker support for custom builder integrations. Exported from `rfdetr.models`.
 - `build_model_from_config(model_config, train_config=None, defaults=MODEL_DEFAULTS)` — config-native alternative to `build_model(build_namespace(mc, tc))`; accepts Pydantic config objects directly and constructs the internal namespace automatically. Exported from `rfdetr.models`.
 - `build_criterion_from_config(model_config, train_config, defaults=MODEL_DEFAULTS)` — config-native alternative to `build_criterion_and_postprocessors(build_namespace(mc, tc))`; returns a `(SetCriterion, PostProcess)` tuple. Exported from `rfdetr.models`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `RFDETR.predict(shape=...)` — optional `(height, width)` tuple overrides the default square resize target, enabling non-square inference on models exported via `export(shape=(H, W))`. Both dimensions must be positive integers divisible by 14. (closes #682)
 - `BuilderArgs` — a `@runtime_checkable` `typing.Protocol` documenting the minimum attribute set consumed by `build_model()`, `build_backbone()`, `build_transformer()`, and `build_criterion_and_postprocessors()`. Enables static type-checker support for custom builder integrations. Exported from `rfdetr.models`.
 - `build_model_from_config(model_config, train_config=None, defaults=MODEL_DEFAULTS)` — config-native alternative to `build_model(build_namespace(mc, tc))`; accepts Pydantic config objects directly and constructs the internal namespace automatically. Exported from `rfdetr.models`.
 - `build_criterion_from_config(model_config, train_config, defaults=MODEL_DEFAULTS)` — config-native alternative to `build_criterion_and_postprocessors(build_namespace(mc, tc))`; returns a `(SetCriterion, PostProcess)` tuple. Exported from `rfdetr.models`.

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -503,14 +503,10 @@ class RFDETR:
                         f"shape {dim_name} must be an integer, got {type(dim).__name__} (shape={shape!r})."
                     )
                 if dim <= 0:
-                    raise ValueError(
-                        f"shape must contain positive integers for height and width, got {shape!r}."
-                    )
+                    raise ValueError(f"shape must contain positive integers for height and width, got {shape!r}.")
 
             if height % 14 != 0 or width % 14 != 0:
-                raise ValueError(
-                    f"shape must have both dimensions divisible by 14, got {shape!r}."
-                )
+                raise ValueError(f"shape must have both dimensions divisible by 14, got {shape!r}.")
 
             # Normalize shape to a tuple of validated integers
             shape = (height, width)

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -490,9 +490,30 @@ class RFDETR:
         import supervision as sv
 
         if shape is not None:
-            if shape[0] % 14 != 0 or shape[1] % 14 != 0:
-                raise ValueError(f"shape must have both dimensions divisible by 14, got {shape}.")
+            try:
+                height, width = shape  # type: ignore[misc]
+            except (TypeError, ValueError):
+                raise ValueError(
+                    f"shape must be a sequence of two positive integers (height, width), got {shape!r}."
+                ) from None
 
+            for dim_name, dim in (("height", height), ("width", width)):
+                if not isinstance(dim, int):
+                    raise ValueError(
+                        f"shape {dim_name} must be an integer, got {type(dim).__name__} (shape={shape!r})."
+                    )
+                if dim <= 0:
+                    raise ValueError(
+                        f"shape must contain positive integers for height and width, got {shape!r}."
+                    )
+
+            if height % 14 != 0 or width % 14 != 0:
+                raise ValueError(
+                    f"shape must have both dimensions divisible by 14, got {shape!r}."
+                )
+
+            # Normalize shape to a tuple of validated integers
+            shape = (height, width)
         if not self._is_optimized_for_inference and not self._has_warned_about_not_being_optimized_for_inference:
             logger.warning(
                 "Model is not optimized for inference. Latency may be higher than expected."

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -457,6 +457,7 @@ class RFDETR:
             str, Image.Image, np.ndarray, torch.Tensor, List[Union[str, np.ndarray, Image.Image, torch.Tensor]]
         ],
         threshold: float = 0.5,
+        shape: Optional[tuple[int, int]] = None,
         **kwargs,
     ) -> Union[sv.Detections, List[sv.Detections]]:
         """Performs object detection on the input images and returns bounding box
@@ -473,6 +474,12 @@ class RFDETR:
                 as file paths, PIL Images, NumPy arrays, or torch.Tensors.
             threshold:
                 The minimum confidence score needed to consider a detected bounding box valid.
+            shape:
+                Optional ``(height, width)`` tuple to resize images to before inference.
+                When provided, overrides the model's default square resolution. Useful
+                when running inference on a model exported with a non-square shape via
+                ``export(shape=(H, W))``. Defaults to
+                ``(model.resolution, model.resolution)`` when not set.
             **kwargs:
                 Additional keyword arguments.
 
@@ -481,6 +488,10 @@ class RFDETR:
             coordinates, confidence scores, and class IDs.
         """
         import supervision as sv
+
+        if shape is not None:
+            if shape[0] % 14 != 0 or shape[1] % 14 != 0:
+                raise ValueError(f"shape must have both dimensions divisible by 14, got {shape}.")
 
         if not self._is_optimized_for_inference and not self._has_warned_about_not_being_optimized_for_inference:
             logger.warning(
@@ -518,7 +529,8 @@ class RFDETR:
             orig_sizes.append((h, w))
 
             img_tensor = img_tensor.to(self.model.device)
-            img_tensor = F.resize(img_tensor, (self.model.resolution, self.model.resolution))
+            resize_to = list(shape) if shape is not None else [self.model.resolution, self.model.resolution]
+            img_tensor = F.resize(img_tensor, resize_to)
             img_tensor = F.normalize(img_tensor, self.means, self.stds)
 
             processed_images.append(img_tensor)
@@ -526,12 +538,16 @@ class RFDETR:
         batch_tensor = torch.stack(processed_images)
 
         if self._is_optimized_for_inference:
-            if self._optimized_resolution != batch_tensor.shape[2]:
-                # this could happen if someone manually changes self.model.resolution after optimizing the model
+            if (
+                self._optimized_resolution != batch_tensor.shape[2]
+                or self._optimized_resolution != batch_tensor.shape[3]
+            ):
+                # this could happen if someone manually changes self.model.resolution after optimizing the model,
+                # or if predict(shape=...) is used with a shape that doesn't match the compiled square resolution.
                 raise ValueError(
                     f"Resolution mismatch. "
-                    f"Model was optimized for resolution {self._optimized_resolution}, "
-                    f"but got {batch_tensor.shape[2]}."
+                    f"Model was optimized for resolution {self._optimized_resolution}x{self._optimized_resolution}, "
+                    f"but got {batch_tensor.shape[2]}x{batch_tensor.shape[3]}."
                     " You can explicitly remove the optimized model by calling model.remove_optimized_model()."
                 )
             if self._optimized_has_been_compiled:

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -9,6 +9,7 @@ import functools
 import glob
 import importlib
 import json
+import operator
 import os
 import warnings
 from collections import defaultdict
@@ -490,9 +491,9 @@ class RFDETR:
 
         Raises:
             ValueError: If ``shape`` cannot be unpacked as a two-element sequence,
-                if either dimension is not a plain ``int`` (e.g. ``float`` or ``bool``),
-                if either dimension is zero or negative, or if either dimension is
-                not divisible by 14.
+                if either dimension does not support the ``__index__`` protocol
+                (e.g. ``float``) or is a ``bool``, if either dimension is zero or
+                negative, or if either dimension is not divisible by 14.
         """
         import supervision as sv
 
@@ -505,17 +506,25 @@ class RFDETR:
                 ) from None
 
             for dim_name, dim in (("height", height), ("width", width)):
-                if not isinstance(dim, int) or isinstance(dim, bool):
+                if isinstance(dim, bool):
                     raise ValueError(
                         f"shape {dim_name} must be an integer, got {type(dim).__name__} (shape={shape!r})."
                     )
+                try:
+                    operator.index(dim)
+                except TypeError:
+                    raise ValueError(
+                        f"shape {dim_name} must be an integer, got {type(dim).__name__} (shape={shape!r})."
+                    ) from None
                 if dim <= 0:
                     raise ValueError(f"shape must contain positive integers for height and width, got {shape!r}.")
+
+            # Normalize to plain Python ints; also accepts numpy.int64, torch scalars, etc.
+            height, width = operator.index(height), operator.index(width)
 
             if height % 14 != 0 or width % 14 != 0:
                 raise ValueError(f"shape must have both dimensions divisible by 14, got {shape!r}.")
 
-            # Normalize shape to a tuple of validated integers
             shape = (height, width)
 
         if not self._is_optimized_for_inference and not self._has_warned_about_not_being_optimized_for_inference:

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -457,7 +457,7 @@ class RFDETR:
             str, Image.Image, np.ndarray, torch.Tensor, List[Union[str, np.ndarray, Image.Image, torch.Tensor]]
         ],
         threshold: float = 0.5,
-        shape: Optional[tuple[int, int]] = None,
+        shape: tuple[int, int] | None = None,
         **kwargs,
     ) -> Union[sv.Detections, List[sv.Detections]]:
         """Performs object detection on the input images and returns bounding box

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -478,7 +478,8 @@ class RFDETR:
                 Optional ``(height, width)`` tuple to resize images to before inference.
                 When provided, overrides the model's default square resolution. Useful
                 when running inference on a model exported with a non-square shape via
-                ``export(shape=(H, W))``. Defaults to
+                ``export(shape=(H, W))``. Both dimensions must be positive integers
+                divisible by 14. Defaults to
                 ``(model.resolution, model.resolution)`` when not set.
             **kwargs:
                 Additional keyword arguments.
@@ -486,19 +487,25 @@ class RFDETR:
         Returns:
             A single or multiple Detections objects, each containing bounding box
             coordinates, confidence scores, and class IDs.
+
+        Raises:
+            ValueError: If ``shape`` cannot be unpacked as a two-element sequence,
+                if either dimension is not a plain ``int`` (e.g. ``float`` or ``bool``),
+                if either dimension is zero or negative, or if either dimension is
+                not divisible by 14.
         """
         import supervision as sv
 
         if shape is not None:
             try:
-                height, width = shape  # type: ignore[misc]
+                height, width = shape
             except (TypeError, ValueError):
                 raise ValueError(
                     f"shape must be a sequence of two positive integers (height, width), got {shape!r}."
                 ) from None
 
             for dim_name, dim in (("height", height), ("width", width)):
-                if not isinstance(dim, int):
+                if not isinstance(dim, int) or isinstance(dim, bool):
                     raise ValueError(
                         f"shape {dim_name} must be an integer, got {type(dim).__name__} (shape={shape!r})."
                     )
@@ -510,6 +517,7 @@ class RFDETR:
 
             # Normalize shape to a tuple of validated integers
             shape = (height, width)
+
         if not self._is_optimized_for_inference and not self._has_warned_about_not_being_optimized_for_inference:
             logger.warning(
                 "Model is not optimized for inference. Latency may be higher than expected."

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -476,11 +476,11 @@ class RFDETR:
                 The minimum confidence score needed to consider a detected bounding box valid.
             shape:
                 Optional ``(height, width)`` tuple to resize images to before inference.
-                When provided, overrides the model's default square resolution. Useful
-                when running inference on a model exported with a non-square shape via
-                ``export(shape=(H, W))``. Both dimensions must be positive integers
-                divisible by 14. Defaults to
-                ``(model.resolution, model.resolution)`` when not set.
+                When provided, overrides the model's default inference resolution. The
+                tuple should match the resolution used when exporting the model
+                (typically a square shape). Both dimensions must be positive integers
+                divisible by 14. Defaults to ``(model.resolution, model.resolution)``
+                when not set.
             **kwargs:
                 Additional keyword arguments.
 

--- a/tests/models/test_predict.py
+++ b/tests/models/test_predict.py
@@ -92,3 +92,70 @@ def test_predict_accepts_image_url() -> None:
     detections = model.predict(_HTTP_IMAGE_URL)
     assert isinstance(detections, sv.Detections)
     assert detections.xyxy.shape == (1, 4)
+
+
+class TestPredictShape:
+    """Verify that ``predict(shape=...)`` controls the resize target.
+
+    Regression tests for https://github.com/roboflow/rf-detr/issues/682.
+    """
+
+    def test_predict_uses_resolution_when_no_shape_provided(self) -> None:
+        """Without ``shape=``, resize uses ``(resolution, resolution)``."""
+        from unittest.mock import patch
+
+        import torchvision.transforms.functional as F
+
+        model = _DummyRFDETR()
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+
+        with patch("rfdetr.detr.F.resize", wraps=F.resize) as mock_resize:
+            model.predict(img)
+
+        resize_size = list(mock_resize.call_args[0][1])
+        assert resize_size == [32, 32], f"Expected resize to model resolution (32, 32), got {resize_size}"
+
+    def test_predict_uses_provided_rectangular_shape(self) -> None:
+        # Regression test for #682
+        from unittest.mock import patch
+
+        import torchvision.transforms.functional as F
+
+        model = _DummyRFDETR()
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+
+        with patch("rfdetr.detr.F.resize", wraps=F.resize) as mock_resize:
+            model.predict(img, shape=(378, 672))
+
+        resize_size = list(mock_resize.call_args[0][1])
+        assert resize_size == [378, 672], (
+            f"Expected resize to user-provided shape (378, 672), got {resize_size}. "
+            "predict() must honour the shape parameter instead of falling back "
+            "to (resolution, resolution)."
+        )
+
+    def test_predict_shape_square_override(self) -> None:
+        # Regression test for #682 — square shape different from model resolution.
+        from unittest.mock import patch
+
+        import torchvision.transforms.functional as F
+
+        model = _DummyRFDETR()
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+
+        with patch("rfdetr.detr.F.resize", wraps=F.resize) as mock_resize:
+            model.predict(img, shape=(56, 56))
+
+        resize_size = list(mock_resize.call_args[0][1])
+        assert resize_size == [56, 56], (
+            f"Expected resize to user-provided shape (56, 56), got {resize_size}. "
+            "predict() must honour the shape parameter even for square sizes "
+            "that differ from the model's default resolution."
+        )
+
+    def test_predict_shape_not_divisible_by_14_raises(self) -> None:
+        """predict() must reject shapes with dimensions not divisible by 14."""
+        model = _DummyRFDETR()
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+        with pytest.raises(ValueError, match="divisible by 14"):
+            model.predict(img, shape=(378, 671))  # 671 % 14 != 0

--- a/tests/models/test_predict.py
+++ b/tests/models/test_predict.py
@@ -153,12 +153,19 @@ class TestPredictShape:
             "that differ from the model's default resolution."
         )
 
-    def test_predict_shape_not_divisible_by_14_raises(self) -> None:
+    @pytest.mark.parametrize(
+        "bad_shape",
+        [
+            pytest.param((378, 671), id="width_not_div_14"),  # 671 % 14 != 0
+            pytest.param((371, 672), id="height_not_div_14"),  # 371 % 14 != 0
+        ],
+    )
+    def test_predict_shape_not_divisible_by_14_raises(self, bad_shape: tuple[int, int]) -> None:
         """predict() must reject shapes with dimensions not divisible by 14."""
         model = _DummyRFDETR()
         img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
         with pytest.raises(ValueError, match="divisible by 14"):
-            model.predict(img, shape=(378, 671))  # 671 % 14 != 0
+            model.predict(img, shape=bad_shape)
 
     @pytest.mark.parametrize(
         "bad_shape",
@@ -169,13 +176,14 @@ class TestPredictShape:
             pytest.param((0, 56), id="zero_height"),
             pytest.param((-14, 56), id="negative_height"),
             pytest.param((56, 0), id="zero_width"),
+            pytest.param((56, -14), id="negative_width"),
             pytest.param((True, 56), id="bool_height"),
             pytest.param((56, False), id="bool_width"),
         ],
     )
-    def test_predict_shape_invalid_raises(self, bad_shape: tuple) -> None:
+    def test_predict_shape_invalid_raises(self, bad_shape: tuple[int | float | bool, ...]) -> None:
         """predict() must raise ValueError for invalid shape values."""
         model = _DummyRFDETR()
         img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="shape"):
             model.predict(img, shape=bad_shape)  # type: ignore[arg-type]

--- a/tests/models/test_predict.py
+++ b/tests/models/test_predict.py
@@ -159,3 +159,23 @@ class TestPredictShape:
         img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
         with pytest.raises(ValueError, match="divisible by 14"):
             model.predict(img, shape=(378, 671))  # 671 % 14 != 0
+
+    @pytest.mark.parametrize(
+        "bad_shape",
+        [
+            pytest.param((378.0, 672.0), id="float_dims"),
+            pytest.param((378,), id="wrong_arity_one_element"),
+            pytest.param((378, 672, 3), id="wrong_arity_three_elements"),
+            pytest.param((0, 56), id="zero_height"),
+            pytest.param((-14, 56), id="negative_height"),
+            pytest.param((56, 0), id="zero_width"),
+            pytest.param((True, 56), id="bool_height"),
+            pytest.param((56, False), id="bool_width"),
+        ],
+    )
+    def test_predict_shape_invalid_raises(self, bad_shape: tuple) -> None:
+        """predict() must raise ValueError for invalid shape values."""
+        model = _DummyRFDETR()
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+        with pytest.raises(ValueError):
+            model.predict(img, shape=bad_shape)  # type: ignore[arg-type]

--- a/tests/models/test_predict.py
+++ b/tests/models/test_predict.py
@@ -7,6 +7,7 @@ import socket
 from types import SimpleNamespace
 from typing import Any
 
+import numpy as np
 import PIL.Image
 import pytest
 import supervision as sv
@@ -152,6 +153,29 @@ class TestPredictShape:
             "predict() must honour the shape parameter even for square sizes "
             "that differ from the model's default resolution."
         )
+
+    @pytest.mark.parametrize(
+        "int_shape",
+        [
+            pytest.param((np.int64(378), np.int64(672)), id="numpy_int64"),
+            pytest.param((np.int32(378), np.int32(672)), id="numpy_int32"),
+            pytest.param((torch.tensor(378), torch.tensor(672)), id="torch_scalar"),
+        ],
+    )
+    def test_predict_shape_accepts_integer_like_types(self, int_shape: tuple) -> None:
+        """predict() accepts integer-like types (numpy, torch) via the __index__ protocol."""
+        from unittest.mock import patch
+
+        import torchvision.transforms.functional as F
+
+        model = _DummyRFDETR()
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+
+        with patch("rfdetr.detr.F.resize", wraps=F.resize) as mock_resize:
+            model.predict(img, shape=int_shape)  # type: ignore[arg-type]
+
+        resize_size = list(mock_resize.call_args[0][1])
+        assert resize_size == [378, 672], f"predict() must accept integer-like shape types, got resize {resize_size}"
 
     @pytest.mark.parametrize(
         "bad_shape",


### PR DESCRIPTION
## What does this PR do?

RFDETR.predict() previously ignored a shape kwarg and always resized inputs to the square (resolution, resolution) — making it impossible to run inference matching a non-square ONNX export. Add an explicit shape: Optional[tuple[int, int]] parameter that, when provided, overrides the default square resize, consistent with the existing export(shape=…) API.

Also fix the _optimized_resolution mismatch guard to compare both height and width (previously only height was checked), and validate that any provided shape has both dimensions divisible by 14 (same constraint as export()).

Fixes #682

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
