### PR TITLE
releasing `1.6.1` [rebase & merge]

### DIFF
--- a/.github/workflows/ci-tests-gpu.yml
+++ b/.github/workflows/ci-tests-gpu.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: 🚀 Install Packages
         timeout-minutes: 5
-        run: uv sync --group tests --extra onnx --extra plus --extra train --extra visual
+        run: uv sync --group tests --group ci-gpu-pin --extra onnx --extra plus --extra train --extra visual
 
       - name: 🧪 Run the Test
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to RF-DETR are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+---
+
+## [1.6.1] — 2026-03-25
+
+### Deprecated
+
+- `RFDETR.export(..., simplify=..., force=...)` — both arguments are now no-ops and emit a `DeprecationWarning`. RF-DETR no longer runs ONNX simplification automatically; remove these arguments from your calls. They will be removed in v1.8. (#861)
+
+### Fixed
+
+- Fixed `RFDETR.train()`: a missing `rfdetr[train]` install (e.g. plain `pip install rfdetr` in Colab) now raises an `ImportError` with an actionable message — `pip install "rfdetr[train,loggers]"` — instead of a raw `ModuleNotFoundError` with no install hint. (#858)
+- Fixed `AUG_AGGRESSIVE` preset: `translate_percent` was `(0.1, 0.1)` — a degenerate range that forced Albumentations `Affine` to always translate right/down by exactly 10%. Corrected to `(-0.1, 0.1)` for symmetric bidirectional translation. (#863)
+- Fixed PTL training path: `latest.ckpt` and per-interval checkpoints (`checkpoint_interval_N.ckpt`) are now properly written and restored on resume. (#847)
+- Fixed `BestModelCallback` and checkpoint monitor raising `MisconfigurationException` on non-eval epochs when `eval_interval > 1` — monitor key absence is now handled gracefully. (#848)
+- Fixed `protobuf` version constraint in the `loggers` extra to guard against TensorBoard descriptor crash (`TypeError: Descriptors cannot be created directly`) with protobuf ≥ 4. (#846)
+- Fixed duplicate `ModelCheckpoint` state keys when `checkpoint_interval=1`; `last.ckpt` is omitted in that configuration to avoid collision. (#859)
+
+---
+
 ## [1.6.0] — 2026-03-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![version](https://badge.fury.io/py/rfdetr.svg)](https://badge.fury.io/py/rfdetr)
 [![downloads](https://img.shields.io/pypi/dm/rfdetr)](https://pypistats.org/packages/rfdetr)
+[![codecov](https://codecov.io/gh/roboflow/rf-detr/graph/badge.svg?token=K8V4ARR3XV)](https://codecov.io/gh/roboflow/rf-detr)
 [![python-version](https://img.shields.io/pypi/pyversions/rfdetr)](https://badge.fury.io/py/rfdetr)
 [![license](https://img.shields.io/badge/license-Apache%202.0-blue)](https://github.com/roboflow/rfdetr/blob/main/LICENSE)
 

--- a/docs/learn/export.md
+++ b/docs/learn/export.md
@@ -44,11 +44,11 @@ The `export()` method accepts several parameters to customize the export process
 | --------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `output_dir`    | `"output"` | Directory where the exported ONNX model will be saved.                                                                 |
 | `infer_dir`     | `None`     | Path to an image file to use for tracing. If not provided, a random dummy image is generated.                          |
-| `simplify`      | `False`    | Whether to simplify the ONNX model using onnxsim for better compatibility and performance.                             |
+| `simplify`      | `False`    | Deprecated and ignored. ONNX simplification is no longer run by `export()`.                                            |
 | `backbone_only` | `False`    | Export only the backbone feature extractor instead of the full model.                                                  |
 | `opset_version` | `17`       | ONNX opset version to use for export. Higher versions support more operations.                                         |
 | `verbose`       | `True`     | Whether to print verbose export information.                                                                           |
-| `force`         | `False`    | Force re-export even if simplified model already exists.                                                               |
+| `force`         | `False`    | Deprecated and ignored.                                                                                                |
 | `shape`         | `None`     | Input shape as tuple `(height, width)`. Must be divisible by 14. If not provided, uses the model's default resolution. |
 | `batch_size`    | `1`        | Batch size for the exported model.                                                                                     |
 
@@ -64,16 +64,16 @@ model = RFDETRMedium(pretrain_weights="<path/to/checkpoint.pth>")
 model.export(output_dir="exports/my_model")
 ```
 
-### Export with Simplification
+### Deprecated: Export with Simplification
 
-Simplifying the ONNX model can improve inference performance and compatibility with various runtimes:
+The `simplify` flag is deprecated and ignored:
 
 ```python
 from rfdetr import RFDETRMedium
 
 model = RFDETRMedium(pretrain_weights="<path/to/checkpoint.pth>")
 
-model.export(simplify=True)
+model.export(simplify=True)  # Deprecated: same result as model.export()
 ```
 
 ### Export with Custom Resolution
@@ -105,7 +105,6 @@ model.export(backbone_only=True)
 After running the export, you will find the following files in your output directory:
 
 - `inference_model.onnx` - The exported ONNX model (or `backbone_model.onnx` if `backbone_only=True`)
-- `inference_model.sim.onnx` - The simplified ONNX model (if `simplify=True`)
 
 ## Optional: Convert ONNX to TensorRT
 

--- a/docs/learn/train/customization.md
+++ b/docs/learn/train/customization.md
@@ -177,6 +177,8 @@ trainer.fit(module, datamodule, ckpt_path="output/last.ckpt")
 trainer.fit(module, datamodule, ckpt_path="output/checkpoint.pth")
 ```
 
+> **Note:** When `checkpoint_interval=1`, no `last.ckpt` is written. Use `checkpoint_{epoch}.ckpt` (e.g. `output/checkpoint_epoch=4.ckpt`) to resume instead.
+
 If you need to persist a converted checkpoint on disk (for example to inspect it, share it, or use it outside of PTL), convert it explicitly before passing it to `trainer.fit`:
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ trt = [
 ]
 loggers = [
     "tensorboard>=2.13.0",
+    "protobuf>=3.20.0,<4.0.0",  # Pins protobuf below 4.x to avoid TensorBoard descriptor crash with protobuf>=4 (see #844)
     "wandb",
     "mlflow",
     "clearml",
@@ -97,6 +98,7 @@ tests = [
   "pytest-xdist>=3.6,<4",
   "pytest-rerunfailures>=10,<15",
   "pytest-timeout>=2,<3",
+  "tomli>=2.0; python_version < '3.11'",
 ]
 
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rfdetr"
-version = "1.6.0"
+version = "1.6.1"
 description = "RF-DETR"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,13 @@ cli = ["jsonargparse[signatures]>=4.27.7"]
 plus = ["rfdetr_plus>=1.0.1, <2.0.0"]
 
 [dependency-groups]
+# TODO: Temporary: GPU runner only has CUDA 12.8 driver (12080); torch>=2.11 requires a newer driver.
+#   Remove this group and the --group ci-gpu-pin references in CI once the driver is updated.
+#   Does not affect users installing rfdetr from PyPI.
+ci-gpu-pin = [
+    "torch<2.11",
+]
+
 build = [
     "twine>=5.1.1",
     "wheel>=0.40",

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -9,7 +9,7 @@ import os
 from typing import Any, ClassVar, Dict, List, Literal, Mapping, Optional, Union
 
 import torch
-from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 DEVICE = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
 
@@ -324,7 +324,7 @@ class TrainConfig(BaseModel):
     ema_decay: float = 0.993
     ema_tau: int = 100
     lr_drop: int = 100
-    checkpoint_interval: int = 10
+    checkpoint_interval: int = Field(default=10, ge=1)
     warmup_epochs: float = 0.0
     lr_vit_layer_decay: float = 0.8
     lr_component_decay: float = 0.7

--- a/src/rfdetr/datasets/aug_config.py
+++ b/src/rfdetr/datasets/aug_config.py
@@ -94,7 +94,7 @@ AUG_AGGRESSIVE = {
     "Rotate": {"limit": 45, "p": 0.5},
     "Affine": {
         "scale": (0.8, 1.2),
-        "translate_percent": (0.1, 0.1),
+        "translate_percent": (-0.1, 0.1),
         "rotate": (-15, 15),
         "shear": (-5, 5),
         "p": 0.5,

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -289,9 +289,27 @@ class RFDETR:
         After training completes the underlying ``nn.Module`` is synced back
         onto ``self.model.model`` so that :meth:`predict` and :meth:`export`
         continue to work without reloading the checkpoint.
+
+        Raises:
+            ImportError: If training dependencies are not installed. Install with
+                ``pip install "rfdetr[train,loggers]"``.
         """
-        from rfdetr.training import RFDETRDataModule, RFDETRModelModule, build_trainer
-        from rfdetr.training.auto_batch import resolve_auto_batch_config
+        # Both imports are grouped in a single try block because they both live in
+        # the `rfdetr[train]` extras group — a missing `pytorch_lightning` (or any
+        # other training-extras package) causes either import to fail, and the
+        # remediation is identical: `pip install "rfdetr[train,loggers]"`.
+        try:
+            from rfdetr.training import RFDETRDataModule, RFDETRModelModule, build_trainer
+            from rfdetr.training.auto_batch import resolve_auto_batch_config
+        except ModuleNotFoundError as exc:
+            # Preserve internal import errors so packaging/regression issues in
+            # rfdetr.* are not misreported as missing optional extras.
+            if exc.name and exc.name.startswith("rfdetr."):
+                raise
+            raise ImportError(
+                "RF-DETR training dependencies are missing. "
+                'Install them with `pip install "rfdetr[train,loggers]"` and try again.'
+            ) from exc
 
         # Absorb legacy `callbacks` dict — warn if non-empty, then discard.
         callbacks_dict = kwargs.pop("callbacks", None)

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -5,6 +5,7 @@
 # ------------------------------------------------------------------------
 from __future__ import annotations
 
+import functools
 import glob
 import json
 import os
@@ -47,6 +48,7 @@ from rfdetr.config import (
 from rfdetr.datasets.coco import is_valid_coco_dataset
 from rfdetr.datasets.yolo import is_valid_yolo_dataset
 from rfdetr.models import PostProcess, build_model
+from rfdetr.utilities.decorators import deprecated
 from rfdetr.utilities.logger import get_logger
 from rfdetr.utilities.state_dict import _ckpt_args_get, validate_checkpoint_compatibility
 
@@ -418,6 +420,18 @@ class RFDETR:
         self._optimized_resolution = None
         self._optimized_dtype = None
 
+    @deprecated(
+        target=True,
+        # `simplify` / `force` are retained for API compatibility and treated as no-op.
+        args_mapping={
+            "simplify": False,
+            "force": False,
+        },
+        deprecated_in="1.6",
+        remove_in="1.8",
+        num_warns=1,
+        stream=functools.partial(warnings.warn, category=DeprecationWarning, stacklevel=2),
+    )
     def export(
         self,
         output_dir: str = "output",
@@ -439,18 +453,18 @@ class RFDETR:
         Args:
             output_dir: Directory to write the ONNX file to.
             infer_dir: Optional directory of sample images for dynamic-axes inference.
-            simplify: Whether to run onnx-simplifier on the exported graph.
+            simplify: Deprecated and ignored. Simplification is no longer run.
             backbone_only: Export only the backbone (feature extractor).
             opset_version: ONNX opset version to target.
             verbose: Print export progress information.
-            force: Force re-export even if output already exists.
+            force: Deprecated and ignored.
             shape: ``(height, width)`` tuple; defaults to square at model resolution.
             batch_size: Static batch size to bake into the ONNX graph.
             **kwargs: Additional keyword arguments forwarded to export_onnx.
         """
         logger.info("Exporting model to ONNX format")
         try:
-            from rfdetr.export.main import export_onnx, make_infer_image, onnx_simplify
+            from rfdetr.export.main import export_onnx, make_infer_image
         except ImportError:
             logger.error(
                 "It seems some dependencies for ONNX export are missing."
@@ -519,12 +533,6 @@ class RFDETR:
         )
 
         logger.info(f"Successfully exported ONNX model to: {output_file}")
-
-        if simplify:
-            sim_output_file = onnx_simplify(
-                onnx_dir=output_file, input_names=input_names, input_tensors=input_tensors, force=force
-            )
-            logger.info(f"Successfully simplified ONNX model to: {sim_output_file}")
 
         logger.info("ONNX export completed successfully")
         self.model.model = self.model.model.to(device)

--- a/src/rfdetr/export/main.py
+++ b/src/rfdetr/export/main.py
@@ -21,7 +21,7 @@ from PIL import Image
 from torchvision.transforms.v2 import Compose, Resize, ToDtype, ToImage
 
 from rfdetr.datasets.transforms import Normalize
-from rfdetr.export._onnx.exporter import export_onnx, onnx_simplify
+from rfdetr.export._onnx.exporter import export_onnx
 from rfdetr.export.tensorrt import trtexec
 from rfdetr.models import build_model
 from rfdetr.utilities.distributed import get_rank
@@ -166,7 +166,9 @@ def main(args):
     )
 
     if args.simplify:
-        output_file = onnx_simplify(output_file, input_names, input_tensors, args)
+        logger.warning(
+            "The simplify flag is deprecated and ignored. RF-DETR no longer runs ONNX simplification automatically."
+        )
 
     if args.tensorrt:
         output_file = trtexec(output_file, args)

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -34,6 +34,10 @@ class BestModelCallback(ModelCheckpoint):
     EMA) is copied to ``checkpoint_best_total.pth`` and optimizer/scheduler
     state is stripped via :func:`rfdetr.util.misc.strip_checkpoint`.
 
+    Checkpoints are only updated on validation epochs where the monitor metric
+    is actually logged.  On non-eval epochs (when ``eval_interval > 1`` causes
+    COCO evaluation to be skipped) the callback is a no-op.
+
     Args:
         output_dir: Directory where checkpoint files are written.
         monitor_regular: Metric key for the regular model mAP.
@@ -58,6 +62,7 @@ class BestModelCallback(ModelCheckpoint):
             monitor=monitor_regular,
             mode="max",
             save_top_k=1,
+            save_on_train_epoch_end=False,
             verbose=False,
             auto_insert_metric_name=False,
             enable_version_counter=False,
@@ -189,6 +194,11 @@ class BestModelCallback(ModelCheckpoint):
         """
         # Stash for use inside _save_checkpoint (which has no pl_module param).
         self._current_pl_module = pl_module
+        # Guard: only run checkpoint logic when the monitored metric was actually
+        # logged this epoch (non-eval epochs with eval_interval > 1 skip COCO eval
+        # so the key is absent from callback_metrics).
+        if self.monitor not in trainer.callback_metrics:
+            return
         super().on_validation_end(trainer, pl_module)
 
         # EMA model — custom tracking on top of parent.
@@ -285,6 +295,10 @@ class RFDETREarlyStopping(EarlyStopping):
     checkpoint resumption, NaN/inf guard via ``check_finite``, and
     ``stopping_threshold``/``divergence_threshold``.
 
+    Early stopping evaluates only on validation epochs where the monitored
+    metrics are logged; non-eval epochs (``eval_interval > 1``) are skipped
+    automatically.
+
     Args:
         patience: Number of epochs with no improvement before stopping.
         min_delta: Minimum mAP improvement to reset the patience counter.
@@ -312,6 +326,7 @@ class RFDETREarlyStopping(EarlyStopping):
             mode="max",
             patience=patience,
             min_delta=min_delta,
+            check_on_train_epoch_end=False,
             verbose=verbose,
             check_finite=True,
             strict=False,  # We inject the key ourselves; don't crash if temporarily absent.

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -32,7 +32,7 @@ class BestModelCallback(ModelCheckpoint):
 
     At the end of training the overall winner (regular vs EMA, strict ``>`` for
     EMA) is copied to ``checkpoint_best_total.pth`` and optimizer/scheduler
-    state is stripped via :func:`rfdetr.util.misc.strip_checkpoint`.
+    state is stripped via :func:`rfdetr.utilities.state_dict.strip_checkpoint`.
 
     Checkpoints are only updated on validation epochs where the monitor metric
     is actually logged.  On non-eval epochs (when ``eval_interval > 1`` causes

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -126,17 +126,19 @@ def build_trainer(
     )
 
     # Latest resume checkpoint — overwritten every epoch.
-    callbacks.append(
-        ModelCheckpoint(
-            dirpath=tc.output_dir,
-            filename="last",
-            every_n_epochs=1,
-            save_top_k=1,
-            enable_version_counter=False,
-            auto_insert_metric_name=False,
-            verbose=False,
+    # Skip when checkpoint_interval == 1 to avoid duplicate ModelCheckpoint state_key.
+    if tc.checkpoint_interval != 1:
+        callbacks.append(
+            ModelCheckpoint(
+                dirpath=tc.output_dir,
+                filename="last",
+                every_n_epochs=1,
+                save_top_k=1,
+                enable_version_counter=False,
+                auto_insert_metric_name=False,
+                verbose=False,
+            )
         )
-    )
 
     # Interval archive checkpoints — kept for the full run.
     callbacks.append(

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import torch
 from pytorch_lightning import Trainer
-from pytorch_lightning.callbacks import RichProgressBar, TQDMProgressBar
+from pytorch_lightning.callbacks import ModelCheckpoint, RichProgressBar, TQDMProgressBar
 from pytorch_lightning.callbacks.progress.rich_progress import RichProgressBarTheme
 from pytorch_lightning.loggers import CSVLogger, MLFlowLogger, TensorBoardLogger, WandbLogger
 
@@ -122,6 +122,32 @@ def build_trainer(
             segmentation=model_config.segmentation_head,
             eval_interval=tc.eval_interval,
             log_per_class_metrics=tc.log_per_class_metrics,
+        )
+    )
+
+    # Latest resume checkpoint — overwritten every epoch.
+    callbacks.append(
+        ModelCheckpoint(
+            dirpath=tc.output_dir,
+            filename="last",
+            every_n_epochs=1,
+            save_top_k=1,
+            enable_version_counter=False,
+            auto_insert_metric_name=False,
+            verbose=False,
+        )
+    )
+
+    # Interval archive checkpoints — kept for the full run.
+    callbacks.append(
+        ModelCheckpoint(
+            dirpath=tc.output_dir,
+            filename="checkpoint_{epoch}",
+            every_n_epochs=tc.checkpoint_interval,
+            save_top_k=-1,
+            enable_version_counter=False,
+            auto_insert_metric_name=False,
+            verbose=False,
         )
     )
 

--- a/tests/cli/test_optional_dependencies.py
+++ b/tests/cli/test_optional_dependencies.py
@@ -1,0 +1,66 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Tests for optional dependency declarations in pyproject.toml."""
+
+import pathlib
+
+import pytest
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # Python 3.10 fallback
+    import tomli as tomllib
+
+
+class TestOptionalDependencies:
+    """Validate selected extras constraints in pyproject.toml."""
+
+    @staticmethod
+    def read_loggers_extra() -> list[str]:
+        """Return the loggers optional-dependency list from pyproject.toml."""
+        root = pathlib.Path(__file__).parent.parent.parent
+        pyproject = tomllib.loads((root / "pyproject.toml").read_text())
+        loggers = pyproject["project"]["optional-dependencies"].get("loggers")
+        assert loggers, "loggers extra not found in [project.optional-dependencies]"
+        return loggers
+
+    @staticmethod
+    def has_upper_bound_below_4(requirement: Requirement) -> bool:
+        """Return True if the requirement specifier caps the version below 4.0.0."""
+        max_allowed_version = Version("4.0.0")
+        for spec in requirement.specifier:
+            spec_version = Version(spec.version)
+            if spec.operator == "<" and spec_version <= max_allowed_version:
+                return True
+            if spec.operator == "<=" and spec_version < max_allowed_version:
+                return True
+        return False
+
+    def test_loggers_extra_pins_protobuf_below_4(self):
+        """loggers extra must constrain protobuf for TensorBoard compatibility."""
+        requirements = [Requirement(dep) for dep in self.read_loggers_extra()]
+        protobuf_requirements = [req for req in requirements if req.name == "protobuf"]
+        assert protobuf_requirements, "loggers extra must include protobuf dependency"
+
+        assert any(self.has_upper_bound_below_4(req) for req in protobuf_requirements), (
+            "protobuf dependency must include an upper bound below 4.0.0"
+        )
+
+    @pytest.mark.parametrize(
+        "dep_str,expected",
+        [
+            pytest.param("protobuf>=3.20.0,<4.0.0", True, id="strict-upper-bound"),
+            pytest.param("protobuf>=3.20.0", False, id="lower-bound-only"),
+            pytest.param("protobuf>=3.20.0,<5.0.0", False, id="too-permissive-upper"),
+            pytest.param("protobuf<=3.9.0", True, id="le-bound-below-4"),
+        ],
+    )
+    def test_has_upper_bound_below_4(self, dep_str: str, expected: bool) -> None:
+        """has_upper_bound_below_4 correctly identifies specifiers bounded below 4.0.0."""
+        assert self.has_upper_bound_below_4(Requirement(dep_str)) == expected

--- a/tests/datasets/test_augmentations.py
+++ b/tests/datasets/test_augmentations.py
@@ -15,7 +15,7 @@ from torch.utils.data import DataLoader
 from torchvision.transforms.v2 import Compose
 
 from rfdetr.datasets._develop import _SimpleDataset
-from rfdetr.datasets.aug_config import AUG_CONFIG
+from rfdetr.datasets.aug_config import AUG_AGGRESSIVE, AUG_CONFIG
 from rfdetr.datasets.coco import make_coco_transforms, make_coco_transforms_square_div_64
 from rfdetr.datasets.transforms import AlbumentationsWrapper, _build_albu_transform
 from rfdetr.utilities import collate_fn
@@ -689,7 +689,7 @@ class TestAlbumentationsWrapperFromConfig:
         """Test building transforms with complex parameter structures."""
         config = {
             "Rotate": {"limit": (90, 90), "p": 0.5},
-            "Affine": {"scale": (0.9, 1.1), "translate_percent": (0.1, 0.1), "p": 0.3},
+            "Affine": {"scale": (0.9, 1.1), "translate_percent": (-0.1, 0.1), "p": 0.3},
         }
 
         transforms = AlbumentationsWrapper.from_config(config)
@@ -1524,5 +1524,26 @@ class TestMakeCocoTransformsAugConfig:
         """aug_config is ignored for test splits — only resize wrappers are present."""
         pipeline = make_transforms("test", 640, aug_config={"HorizontalFlip": {"p": 1.0}})
         wrappers = [t for t in pipeline.transforms if isinstance(t, AlbumentationsWrapper)]
-
         assert len(wrappers) == expected_resize_wrappers
+
+
+class TestAugPresets:
+    """Regression tests for built-in augmentation presets."""
+
+    def test_aug_aggressive_translate_percent_is_bidirectional(self) -> None:
+        """AUG_AGGRESSIVE translate_percent must allow both positive and negative translations.
+
+        (0.1, 0.1) is a degenerate range that only shifts right/down;
+        the correct range is (-0.1, 0.1).
+        """
+        translate = AUG_AGGRESSIVE["Affine"]["translate_percent"]
+        lo, hi = translate
+        assert lo < 0, (
+            f"AUG_AGGRESSIVE translate_percent lower bound must be negative to allow "
+            f"left/up translation; got {translate!r}"
+        )
+        assert hi > 0, (
+            f"AUG_AGGRESSIVE translate_percent upper bound must be positive to allow "
+            f"right/down translation; got {translate!r}"
+        )
+        assert lo < hi, f"AUG_AGGRESSIVE translate_percent must be a non-degenerate range; got {translate!r}"

--- a/tests/models/test_export.py
+++ b/tests/models/test_export.py
@@ -30,6 +30,7 @@ import torch
 from torch.jit import TracerWarning
 
 from rfdetr import RFDETRSegNano
+from rfdetr import detr as _detr_module
 from rfdetr.export import main as _cli_export_module
 
 _IS_ONNX_INSTALLED = importlib.util.find_spec("onnx") is not None
@@ -119,6 +120,68 @@ def test_export_does_not_change_original_training_state(tmp_path: Path) -> None:
 
     # After export, the original underlying model should still be in training mode
     assert torch_model.training is True, "export() should not change the original model's training state"
+
+
+@pytest.fixture
+def _detr_export_scaffold(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Shared scaffold for RFDETR.export() deprecated-argument tests."""
+
+    class _DummyCoreModel:
+        def to(self, *_args, **_kwargs):
+            return self
+
+        def eval(self):
+            return self
+
+        def cpu(self):
+            return self
+
+        def __call__(self, *_args, **_kwargs):
+            return {
+                "pred_boxes": torch.zeros(1, 1, 4),
+                "pred_logits": torch.zeros(1, 1, 2),
+                "pred_masks": torch.zeros(1, 1, 2, 2),
+            }
+
+    model = types.SimpleNamespace(
+        model=types.SimpleNamespace(
+            model=_DummyCoreModel(),
+            device="cpu",
+            resolution=14,
+        ),
+        model_config=types.SimpleNamespace(segmentation_head=False),
+    )
+
+    export_called: dict[str, bool] = {"value": False}
+
+    def _fake_make_infer_image(*_args, **_kwargs):
+        return torch.zeros(1, 3, 14, 14)
+
+    def _fake_export_onnx(*_args, **_kwargs):
+        export_called["value"] = True
+        return str(tmp_path / "inference_model.onnx")
+
+    monkeypatch.setattr("rfdetr.export.main.make_infer_image", _fake_make_infer_image)
+    monkeypatch.setattr("rfdetr.export.main.export_onnx", _fake_export_onnx)
+    monkeypatch.setattr("rfdetr.detr.deepcopy", lambda x: x)
+
+    return model, export_called
+
+
+def test_export_simplify_flag_is_ignored_with_deprecation_warning(_detr_export_scaffold: tuple, tmp_path: Path) -> None:
+    """`simplify=True` should not run ONNX simplification and should emit a deprecation warning."""
+    model, export_called = _detr_export_scaffold
+    with pytest.deprecated_call(match=r".*`export`.*deprecated.*`simplify`.*"):
+        _detr_module.RFDETR.export(model, output_dir=str(tmp_path), simplify=True, verbose=False, shape=(14, 14))
+    assert export_called["value"] is True
+
+
+def test_export_force_flag_is_ignored_with_deprecation_warning(_detr_export_scaffold: tuple, tmp_path: Path) -> None:
+    """`force=True` should be a no-op and emit a deprecation warning."""
+    model, export_called = _detr_export_scaffold
+    with pytest.deprecated_call(match=r".*`export`.*deprecated.*`force`.*"):
+        _detr_module.RFDETR.export(model, output_dir=str(tmp_path), force=True, verbose=False, shape=(14, 14))
+    assert export_called["value"] is True
 
 
 @pytest.mark.gpu
@@ -350,3 +413,44 @@ class TestCliExportMain:
             f"expected opset_version={args.opset_version!r}, got {kwargs.get('opset_version')!r}"
         )
         assert "backbone_only" in kwargs, "backbone_only kwarg missing from export_onnx call"
+
+    def test_simplify_flag_logs_warning_and_continues_export(self, output_dir: str) -> None:
+        """CLI --simplify=True must log a deprecation warning and still call export_onnx.
+
+        The flag is now a no-op: the logger emits a warning and export continues
+        without running ONNX simplification.
+        """
+        args = self._make_args(output_dir=output_dir, simplify=True)
+        export_onnx_called: dict[str, bool] = {"value": False}
+
+        mock_model = MagicMock()
+        mock_model.parameters.return_value = []
+        mock_model.backbone.parameters.return_value = []
+        mock_model.backbone.__getitem__.return_value.projector.parameters.return_value = []
+        mock_model.backbone.__getitem__.return_value.encoder.parameters.return_value = []
+        mock_model.transformer.parameters.return_value = []
+        mock_model.to.return_value = mock_model
+        mock_model.cpu.return_value = mock_model
+        mock_model.eval.return_value = mock_model
+        mock_model.return_value = {"pred_boxes": torch.zeros(1, 300, 4), "pred_logits": torch.zeros(1, 300, 90)}
+
+        mock_tensor = MagicMock()
+        mock_tensor.to.return_value = mock_tensor
+        mock_tensor.cpu.return_value = mock_tensor
+
+        def fake_export_onnx(*_args, **_kwargs):
+            export_onnx_called["value"] = True
+            return str(output_dir) + "/inference_model.onnx"
+
+        with (
+            patch.object(_cli_export_module, "build_model", return_value=(mock_model, MagicMock(), MagicMock())),
+            patch.object(_cli_export_module, "make_infer_image", return_value=mock_tensor),
+            patch.object(_cli_export_module, "export_onnx", side_effect=fake_export_onnx),
+            patch.object(_cli_export_module, "get_rank", return_value=0),
+            patch.object(_cli_export_module, "logger") as mock_logger,
+        ):
+            _cli_export_module.main(args)
+
+        mock_logger.warning.assert_called_once()
+        assert "simplify" in mock_logger.warning.call_args[0][0].lower()
+        assert export_onnx_called["value"] is True, "export_onnx should still be called with simplify=True"

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -86,6 +86,32 @@ class _ResumeTinyModule(LightningModule):
         return torch.optim.SGD(self.model.parameters(), lr=0.01)
 
 
+class _EvalIntervalModule(LightningModule):
+    """Tiny module that only logs val/mAP_50_95 every ``eval_interval`` epochs.
+
+    Simulates RF-DETR's COCO-eval skip behaviour: validation runs every epoch
+    but the metric key is absent on non-eval epochs.
+    """
+
+    def __init__(self, eval_interval: int = 2) -> None:
+        super().__init__()
+        self.model = torch.nn.Linear(4, 1)
+        self.train_config = {"lr": 0.01}
+        self._eval_interval = eval_interval
+
+    def training_step(self, batch, batch_idx):
+        x, y = batch
+        return torch.nn.functional.mse_loss(self.model(x), y)
+
+    def validation_step(self, batch, batch_idx):
+        del batch, batch_idx
+        if self.current_epoch % self._eval_interval == 0:
+            self.log("val/mAP_50_95", torch.tensor(0.5), on_step=False, on_epoch=True, prog_bar=False)
+
+    def configure_optimizers(self):
+        return torch.optim.SGD(self.model.parameters(), lr=0.01)
+
+
 class _ResumeProbeCallback(Callback):
     """Capture the first train epoch index for resume assertions."""
 
@@ -671,6 +697,51 @@ class TestBestModelCallback:
         assert not (tmp_path / "checkpoint_best_ema.pth").exists()
         assert not (tmp_path / "checkpoint_best_total.pth").exists()
 
+    def test_train_epoch_end_ignores_missing_validation_metrics(self, tmp_path: Path) -> None:
+        """Train-epoch end must not try to checkpoint when validation metrics were not logged."""
+        cb = BestModelCallback(output_dir=str(tmp_path))
+        trainer = _make_trainer({})
+
+        cb.on_train_epoch_end(trainer, _make_pl_module())
+
+        assert not (tmp_path / "checkpoint_best_regular.pth").exists()
+
+    def test_validation_end_ignores_missing_validation_metrics(self, tmp_path: Path) -> None:
+        """on_validation_end must not raise when val/mAP_50_95 was not logged (non-eval epoch)."""
+        cb = BestModelCallback(output_dir=str(tmp_path))
+        trainer = _make_trainer({})  # empty metrics — no val/mAP_50_95 key
+        trainer.fit_loop.epoch_loop.val_loop._has_run = True
+
+        cb.on_validation_end(trainer, _make_pl_module())  # must not raise
+
+        assert not (tmp_path / "checkpoint_best_regular.pth").exists()
+
+    def test_eval_interval_does_not_crash(self, tmp_path: Path) -> None:
+        """BestModelCallback must not crash over 3 epochs when metrics are only logged every 2nd epoch."""
+        torch.manual_seed(0)
+        x = torch.randn(8, 4)
+        y = torch.randn(8, 1)
+        train_loader = DataLoader(TensorDataset(x, y), batch_size=2)
+        val_loader = DataLoader(TensorDataset(x, y), batch_size=2)
+
+        cb = BestModelCallback(output_dir=str(tmp_path), run_test=False)
+        trainer = Trainer(
+            max_epochs=3,
+            accelerator="cpu",
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            logger=False,
+            num_sanity_val_steps=0,
+            limit_train_batches=2,
+            limit_val_batches=1,
+            callbacks=[cb],
+            default_root_dir=str(tmp_path),
+        )
+        trainer.fit(_EvalIntervalModule(eval_interval=2), train_dataloaders=train_loader, val_dataloaders=val_loader)
+
+        # Checkpoint must be written on eval epochs (0 and 2) — at least one must exist.
+        assert (tmp_path / "checkpoint_best_regular.pth").exists()
+
     def test_best_total_checkpoint_resumes_via_trainer_fit_ckpt_path(self, tmp_path: Path) -> None:
         """checkpoint_best_total.pth must restore epoch/step when passed to Trainer.fit(ckpt_path=...)."""
         torch.manual_seed(0)
@@ -845,6 +916,16 @@ class TestRFDETREarlyStopping:
 
         trainer = _make_trainer({})  # no metrics at all
         cb.on_validation_end(trainer, pl_module)
+
+        assert cb.wait_count == 0
+        assert trainer.should_stop is False
+
+    def test_train_epoch_end_ignores_missing_validation_metrics(self) -> None:
+        """Train-epoch end must not evaluate early stopping when validation did not run."""
+        cb = RFDETREarlyStopping(patience=1, min_delta=0.001)
+        trainer = _make_trainer({})
+
+        cb.on_train_epoch_end(trainer, _make_pl_module())
 
         assert cb.wait_count == 0
         assert trainer.should_stop is False

--- a/tests/training/test_build_trainer.py
+++ b/tests/training/test_build_trainer.py
@@ -90,10 +90,24 @@ class TestBuildTrainerCallbacks:
         assert BestModelCallback in types
 
     def test_latest_model_checkpoint_present(self, tmp_path):
-        """A ModelCheckpoint (not BestModelCallback) with every_n_epochs==1 is always included."""
-        trainer = build_trainer(_tc(tmp_path, use_ema=False), _mc())
+        """A ModelCheckpoint (not BestModelCallback) with every_n_epochs==1 is included when checkpoint_interval > 1."""
+        trainer = build_trainer(_tc(tmp_path, use_ema=False, checkpoint_interval=2), _mc())
         resume_cbs = _find_resume_checkpoints(trainer)
         assert any(cb._every_n_epochs == 1 for cb in resume_cbs)
+
+    def test_latest_model_checkpoint_absent_when_checkpoint_interval_one(self, tmp_path):
+        """No separate latest checkpoint callback when interval already saves every epoch."""
+        trainer = build_trainer(_tc(tmp_path, use_ema=False, checkpoint_interval=1), _mc())
+        resume_cbs = _find_resume_checkpoints(trainer)
+        assert resume_cbs
+        assert not any(cb._every_n_epochs == 1 and cb.save_top_k == 1 for cb in resume_cbs)
+        interval_cb = next(
+            (cb for cb in resume_cbs if cb._every_n_epochs == 1 and cb.save_top_k == -1),
+            None,
+        )
+        assert interval_cb is not None
+        assert interval_cb.filename == "checkpoint_{epoch}"
+        assert str(interval_cb.dirpath) == str(tmp_path / "out")
 
     def test_interval_model_checkpoint_present(self, tmp_path):
         """A ModelCheckpoint (not BestModelCallback) with every_n_epochs==checkpoint_interval is always included."""
@@ -101,6 +115,33 @@ class TestBuildTrainerCallbacks:
         trainer = build_trainer(tc, _mc())
         resume_cbs = _find_resume_checkpoints(trainer)
         assert any(cb._every_n_epochs == tc.checkpoint_interval for cb in resume_cbs)
+
+    def test_checkpoint_interval_one_has_single_resume_checkpoint_callback(self, tmp_path):
+        """checkpoint_interval=1 config creates only one non-best ModelCheckpoint callback."""
+        trainer = build_trainer(_tc(tmp_path, use_ema=False, checkpoint_interval=1), _mc())
+        resume_cbs = _find_resume_checkpoints(trainer)
+        assert len(resume_cbs) == 1
+        only_cb = resume_cbs[0]
+        assert only_cb._every_n_epochs == 1
+        assert only_cb.save_top_k == -1
+
+    @pytest.mark.parametrize(
+        "checkpoint_interval",
+        [
+            pytest.param(1, id="interval_1"),
+            pytest.param(2, id="interval_2"),
+            pytest.param(7, id="interval_7"),
+        ],
+    )
+    def test_all_model_checkpoints_have_unique_state_keys(self, tmp_path, checkpoint_interval):
+        """All ModelCheckpoint callbacks (including BestModelCallback) always have unique state keys."""
+        trainer = build_trainer(_tc(tmp_path, use_ema=False, checkpoint_interval=checkpoint_interval), _mc())
+        all_mc_cbs = [cb for cb in trainer.callbacks if isinstance(cb, ModelCheckpoint)]
+        state_keys = [cb.state_key for cb in all_mc_cbs]
+        assert len(state_keys) == len(set(state_keys)), (
+            f"Duplicate state_key with checkpoint_interval={checkpoint_interval}: "
+            f"{[k for k in state_keys if state_keys.count(k) > 1]}"
+        )
 
     def test_interval_checkpoint_uses_interval_from_config(self, tmp_path):
         """Interval ModelCheckpoint receives checkpoint_interval=7 from TrainConfig."""

--- a/tests/training/test_build_trainer.py
+++ b/tests/training/test_build_trainer.py
@@ -9,6 +9,7 @@
 import warnings
 
 import pytest
+from pytorch_lightning.callbacks import ModelCheckpoint
 
 from rfdetr.config import RFDETRBaseConfig, SegmentationTrainConfig, TrainConfig
 from rfdetr.training import build_trainer
@@ -23,6 +24,11 @@ def _mc(**kwargs):
     defaults = dict(pretrain_weights=None, device="cpu", num_classes=3)
     defaults.update(kwargs)
     return RFDETRBaseConfig(**defaults)
+
+
+def _find_resume_checkpoints(trainer):
+    """Return ModelCheckpoint callbacks that are NOT BestModelCallback."""
+    return [cb for cb in trainer.callbacks if isinstance(cb, ModelCheckpoint) and not isinstance(cb, BestModelCallback)]
 
 
 def _tc(tmp_path, **kwargs):
@@ -82,6 +88,32 @@ class TestBuildTrainerCallbacks:
         trainer = build_trainer(_tc(tmp_path, use_ema=False), _mc())
         types = [type(cb) for cb in trainer.callbacks]
         assert BestModelCallback in types
+
+    def test_latest_model_checkpoint_present(self, tmp_path):
+        """A ModelCheckpoint (not BestModelCallback) with every_n_epochs==1 is always included."""
+        trainer = build_trainer(_tc(tmp_path, use_ema=False), _mc())
+        resume_cbs = _find_resume_checkpoints(trainer)
+        assert any(cb._every_n_epochs == 1 for cb in resume_cbs)
+
+    def test_interval_model_checkpoint_present(self, tmp_path):
+        """A ModelCheckpoint (not BestModelCallback) with every_n_epochs==checkpoint_interval is always included."""
+        tc = _tc(tmp_path, use_ema=False)
+        trainer = build_trainer(tc, _mc())
+        resume_cbs = _find_resume_checkpoints(trainer)
+        assert any(cb._every_n_epochs == tc.checkpoint_interval for cb in resume_cbs)
+
+    def test_interval_checkpoint_uses_interval_from_config(self, tmp_path):
+        """Interval ModelCheckpoint receives checkpoint_interval=7 from TrainConfig."""
+        trainer = build_trainer(_tc(tmp_path, use_ema=False, checkpoint_interval=7), _mc())
+        resume_cbs = _find_resume_checkpoints(trainer)
+        assert any(cb._every_n_epochs == 7 for cb in resume_cbs)
+
+    def test_checkpoint_interval_validation(self, tmp_path):
+        """TrainConfig(checkpoint_interval=0) raises ValidationError."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            _tc(tmp_path, checkpoint_interval=0)
 
     def test_ema_callback_when_use_ema_true(self, tmp_path):
         """RFDETREMACallback is added when use_ema=True."""

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -14,6 +14,7 @@
 """
 
 import argparse
+import builtins
 import warnings
 from collections import defaultdict
 from types import SimpleNamespace
@@ -166,6 +167,42 @@ class TestRFDETRTrainPTL:
         with p_mod, p_dm, p_bt:
             result = RFDETR.train(mock_self)
         assert result is None
+
+    def test_missing_training_extra_raises_install_hint(self, tmp_path, monkeypatch):
+        """Missing training dependencies should raise ImportError with extras install hint."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        real_import = builtins.__import__
+
+        def _mock_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "rfdetr.training":
+                raise ModuleNotFoundError("No module named 'pytorch_lightning'", name="pytorch_lightning")
+            return real_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", _mock_import)
+
+        with pytest.raises(ImportError, match=r"rfdetr\[train,loggers\]") as exc_info:
+            RFDETR.train(mock_self)
+        assert exc_info.value.__cause__ is not None
+
+    @pytest.mark.parametrize(
+        "missing_name",
+        ["rfdetr.training", "rfdetr.training.auto_batch"],
+        ids=["training-package", "training-submodule"],
+    )
+    def test_internal_training_module_import_error_preserved(self, tmp_path, monkeypatch, missing_name):
+        """Missing internal training modules should keep original ModuleNotFoundError."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        real_import = builtins.__import__
+
+        def _mock_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == missing_name:
+                raise ModuleNotFoundError(f"No module named '{missing_name}'", name=missing_name)
+            return real_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", _mock_import)
+
+        with pytest.raises(ModuleNotFoundError, match=missing_name.replace(".", r"\.")):
+            RFDETR.train(mock_self)
 
     def test_class_names_synced_from_datamodule_after_training(self, tmp_path):
         """self.model.class_names is set from RFDETRDataModule.class_names after train().


### PR DESCRIPTION
## 🗑️ Deprecated

- **ONNX export simplification removed.** `RFDETR.export(..., simplify=..., force=...)` — both arguments are now no-ops and emit a `DeprecationWarning`. RF-DETR no longer runs ONNX simplification automatically; remove these arguments from your calls. They will be removed in v1.8. (#861)

## 🔧 Fixed

- Fixed `RFDETR.train()`: a missing `rfdetr[train]` install (e.g. plain `pip install rfdetr` in Colab) now raises an `ImportError` with an actionable message — `pip install "rfdetr[train,loggers]"` — instead of a raw `ModuleNotFoundError` with no install hint. (#858)
- Fixed `AUG_AGGRESSIVE` preset: `translate_percent` was `(0.1, 0.1)` — a degenerate range that forced Albumentations `Affine` to always translate right/down by exactly 10%. Corrected to `(-0.1, 0.1)` for symmetric bidirectional translation. (#863)
- Fixed PTL training path: `latest.ckpt` and per-interval checkpoints (`checkpoint_interval_N.ckpt`) are now properly written and restored on resume. (#847)
- Fixed `BestModelCallback` and checkpoint monitor raising `MisconfigurationException` on non-eval epochs when `eval_interval > 1` — monitor key absence is now handled gracefully. (#848)
- Fixed `protobuf` version constraint in the `loggers` extra to guard against TensorBoard descriptor crash (`TypeError: Descriptors cannot be created directly`) with protobuf ≥ 4. (#846)
- Fixed duplicate `ModelCheckpoint` state keys when `checkpoint_interval=1`; `last.ckpt` is omitted in that configuration to avoid collision. (#859)

---

## 🏆 Contributors

Thank you to everyone who helped with this release:

* **Jirka Borovec** (@Borda) ([LinkedIn](https://www.linkedin.com/in/jirka-borovec/)) – *Patch fixes: PTL checkpoint restore, BestModelCallback crash, duplicate checkpoint keys, Colab ImportError, protobuf pin, AUG_AGGRESSIVE translation, ONNX simplify deprecation*

---

**Full changelog**: https://github.com/roboflow/rf-detr/compare/1.6.0...1.6.1
