### PR TITLE
fix: ONNX export shape ignored; validate divisibility by patch_size

### DIFF
--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -378,6 +378,8 @@ class RFDETR:
         if shape is None:
             shape = (self.model.resolution, self.model.resolution)
         else:
+            if shape[0] <= 0 or shape[1] <= 0:
+                raise ValueError(f"shape must contain positive integers for height and width, got {shape!r}.")
             if shape[0] % block_size != 0 or shape[1] % block_size != 0:
                 raise ValueError(
                     f"Shape must be divisible by {block_size} (patch_size={patch_size} * num_windows={num_windows})"

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -367,7 +367,7 @@ class RFDETR:
                     f"{model_patch_size}. Patch size is an architectural parameter; instantiate the model with the "
                     f"desired patch_size (and compatible checkpoint) before exporting."
                 )
-        if not isinstance(patch_size, int) or patch_size <= 0:
+        if isinstance(patch_size, bool) or not isinstance(patch_size, int) or patch_size <= 0:
             raise ValueError(f"patch_size must be a positive integer, got {patch_size!r}")
         num_windows = getattr(self.model_config, "num_windows", 1)
         block_size = patch_size * num_windows
@@ -568,7 +568,15 @@ class RFDETR:
 
         if patch_size is None:
             patch_size = getattr(self.model_config, "patch_size", 14)
-        if not isinstance(patch_size, int) or patch_size <= 0:
+        else:
+            model_patch_size = getattr(self.model_config, "patch_size", None)
+            if model_patch_size is not None and patch_size != model_patch_size:
+                raise ValueError(
+                    f"predict(patch_size={patch_size}) does not match the instantiated model's "
+                    f"patch_size={model_patch_size}. Patch size is an architectural parameter; "
+                    f"omit patch_size to use the model's configured value."
+                )
+        if isinstance(patch_size, bool) or not isinstance(patch_size, int) or patch_size <= 0:
             raise ValueError(f"patch_size must be a positive integer, got {patch_size!r}")
         num_windows = getattr(self.model_config, "num_windows", 1)
         block_size = patch_size * num_windows

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -582,9 +582,7 @@ class RFDETR:
             raise ValueError(f"patch_size must be a positive integer, got {patch_size!r}")
         num_windows = getattr(self.model_config, "num_windows", 1)
         if isinstance(num_windows, bool) or not isinstance(num_windows, int) or num_windows <= 0:
-            raise ValueError(
-                f"model_config.num_windows must be a positive integer, got {num_windows!r}"
-            )
+            raise ValueError(f"model_config.num_windows must be a positive integer, got {num_windows!r}")
         block_size = patch_size * num_windows
 
         if shape is not None:

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -521,7 +521,7 @@ class RFDETR:
                 When provided, overrides the model's default inference resolution. The
                 tuple should match the resolution used when exporting the model
                 (typically a square shape). Both dimensions must be positive integers
-                divisible by 14. Defaults to ``(model.resolution, model.resolution)``
+                divisible by patch_size. Defaults to ``(model.resolution, model.resolution)``
                 when not set.
             **kwargs:
                 Additional keyword arguments.
@@ -534,7 +534,7 @@ class RFDETR:
             ValueError: If ``shape`` cannot be unpacked as a two-element sequence,
                 if either dimension does not support the ``__index__`` protocol
                 (e.g. ``float``) or is a ``bool``, if either dimension is zero or
-                negative, or if either dimension is not divisible by 14.
+                negative, or if either dimension is not divisible by patch_size.
         """
         import supervision as sv
 

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -376,8 +376,7 @@ class RFDETR:
         else:
             if shape[0] % block_size != 0 or shape[1] % block_size != 0:
                 raise ValueError(
-                    f"Shape must be divisible by {block_size} "
-                    f"(patch_size={patch_size} * num_windows={num_windows})"
+                    f"Shape must be divisible by {block_size} (patch_size={patch_size} * num_windows={num_windows})"
                 )
 
         input_tensors = make_infer_image(infer_dir, shape, batch_size, device).to(device)

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -377,13 +377,39 @@ class RFDETR:
         block_size = patch_size * num_windows
         if shape is None:
             shape = (self.model.resolution, self.model.resolution)
-        else:
-            if shape[0] <= 0 or shape[1] <= 0:
-                raise ValueError(f"shape must contain positive integers for height and width, got {shape!r}.")
-            if shape[0] % block_size != 0 or shape[1] % block_size != 0:
+            if shape[0] % block_size != 0:
                 raise ValueError(
-                    f"Shape must be divisible by {block_size} (patch_size={patch_size} * num_windows={num_windows})"
+                    f"Model's default resolution ({self.model.resolution}) is not divisible by "
+                    f"block_size={block_size} (patch_size={patch_size} * num_windows={num_windows}). "
+                    f"Provide an explicit shape divisible by {block_size}."
                 )
+        else:
+            try:
+                height, width = shape
+            except (TypeError, ValueError):
+                raise ValueError(
+                    f"shape must be a sequence of two positive integers (height, width), got {shape!r}."
+                ) from None
+            for dim_name, dim in (("height", height), ("width", width)):
+                if isinstance(dim, bool):
+                    raise ValueError(
+                        f"shape {dim_name} must be an integer, got {type(dim).__name__} (shape={shape!r})."
+                    )
+                try:
+                    operator.index(dim)
+                except TypeError:
+                    raise ValueError(
+                        f"shape {dim_name} must be an integer, got {type(dim).__name__} (shape={shape!r})."
+                    ) from None
+                if dim <= 0:
+                    raise ValueError(f"shape must contain positive integers for height and width, got {shape!r}.")
+            height, width = operator.index(height), operator.index(width)
+            if height % block_size != 0 or width % block_size != 0:
+                raise ValueError(
+                    f"shape must have both dimensions divisible by {block_size} "
+                    f"(patch_size={patch_size} * num_windows={num_windows}), got {shape!r}."
+                )
+            shape = (height, width)
 
         input_tensors = make_infer_image(infer_dir, shape, batch_size, device).to(device)
         input_names = ["input"]
@@ -591,7 +617,15 @@ class RFDETR:
             raise ValueError(f"model_config.num_windows must be a positive integer, got {num_windows!r}")
         block_size = patch_size * num_windows
 
-        if shape is not None:
+        if shape is None:
+            default_res = self.model.resolution
+            if default_res % block_size != 0:
+                raise ValueError(
+                    f"Model's default resolution ({default_res}) is not divisible by "
+                    f"block_size={block_size} (patch_size={patch_size} * num_windows={num_windows}). "
+                    f"Provide an explicit shape divisible by {block_size}."
+                )
+        else:
             try:
                 height, width = shape
             except (TypeError, ValueError):

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -579,6 +579,10 @@ class RFDETR:
         if isinstance(patch_size, bool) or not isinstance(patch_size, int) or patch_size <= 0:
             raise ValueError(f"patch_size must be a positive integer, got {patch_size!r}")
         num_windows = getattr(self.model_config, "num_windows", 1)
+        if isinstance(num_windows, bool) or not isinstance(num_windows, int) or num_windows <= 0:
+            raise ValueError(
+                f"model_config.num_windows must be a positive integer, got {num_windows!r}"
+            )
         block_size = patch_size * num_windows
 
         if shape is not None:

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -67,6 +67,55 @@ _VARIANT_EXPORTS = (
 __all__ = ["RFDETR", "ModelContext", *_VARIANT_EXPORTS]
 
 
+def _validate_shape_dims(
+    shape: object,
+    block_size: int,
+    patch_size: int,
+    num_windows: int,
+) -> tuple[int, int]:
+    """Validate a user-supplied ``(height, width)`` shape tuple and return normalised plain-int dims.
+
+    Args:
+        shape: The raw value supplied by the caller (e.g. from ``export(shape=...)`` or
+            ``predict(shape=...)``).  Must be a two-element sequence of positive integers
+            (or integer-compatible types accepted by :func:`operator.index`).
+        block_size: Required divisor for both dimensions.  Equals ``patch_size * num_windows``.
+        patch_size: Backbone patch size — used only in error messages.
+        num_windows: Number of attention windows — used only in error messages.
+
+    Returns:
+        A ``(height, width)`` tuple of plain Python :class:`int` values.
+
+    Raises:
+        ValueError: If ``shape`` cannot be unpacked as a two-element sequence, if either
+            dimension is a bool, float, or other non-integer type, if either dimension is
+            not positive, or if either dimension is not divisible by ``block_size``.
+    """
+    try:
+        height, width = shape  # type: ignore[misc]
+    except (TypeError, ValueError):
+        raise ValueError(f"shape must be a sequence of two positive integers (height, width), got {shape!r}.") from None
+    for dim_name, dim in (("height", height), ("width", width)):
+        if isinstance(dim, bool):
+            raise ValueError(f"shape {dim_name} must be an integer, got {type(dim).__name__} (shape={shape!r}).")
+        try:
+            operator.index(dim)
+        except TypeError:
+            raise ValueError(
+                f"shape {dim_name} must be an integer, got {type(dim).__name__} (shape={shape!r})."
+            ) from None
+        if dim <= 0:
+            raise ValueError(f"shape must contain positive integers for height and width, got {shape!r}.")
+    # Normalise to plain Python ints; also accepts numpy.int64, torch scalars, etc.
+    height, width = operator.index(height), operator.index(width)
+    if height % block_size != 0 or width % block_size != 0:
+        raise ValueError(
+            f"shape must have both dimensions divisible by {block_size} "
+            f"(patch_size={patch_size} * num_windows={num_windows}), got {shape!r}."
+        )
+    return height, width
+
+
 class RFDETR:
     """
     The base RF-DETR class implements the core methods for training RF-DETR models,
@@ -384,32 +433,7 @@ class RFDETR:
                     f"Provide an explicit shape divisible by {block_size}."
                 )
         else:
-            try:
-                height, width = shape
-            except (TypeError, ValueError):
-                raise ValueError(
-                    f"shape must be a sequence of two positive integers (height, width), got {shape!r}."
-                ) from None
-            for dim_name, dim in (("height", height), ("width", width)):
-                if isinstance(dim, bool):
-                    raise ValueError(
-                        f"shape {dim_name} must be an integer, got {type(dim).__name__} (shape={shape!r})."
-                    )
-                try:
-                    operator.index(dim)
-                except TypeError:
-                    raise ValueError(
-                        f"shape {dim_name} must be an integer, got {type(dim).__name__} (shape={shape!r})."
-                    ) from None
-                if dim <= 0:
-                    raise ValueError(f"shape must contain positive integers for height and width, got {shape!r}.")
-            height, width = operator.index(height), operator.index(width)
-            if height % block_size != 0 or width % block_size != 0:
-                raise ValueError(
-                    f"shape must have both dimensions divisible by {block_size} "
-                    f"(patch_size={patch_size} * num_windows={num_windows}), got {shape!r}."
-                )
-            shape = (height, width)
+            shape = _validate_shape_dims(shape, block_size, patch_size, num_windows)
 
         input_tensors = make_infer_image(infer_dir, shape, batch_size, device).to(device)
         input_names = ["input"]
@@ -626,37 +650,7 @@ class RFDETR:
                     f"Provide an explicit shape divisible by {block_size}."
                 )
         else:
-            try:
-                height, width = shape
-            except (TypeError, ValueError):
-                raise ValueError(
-                    f"shape must be a sequence of two positive integers (height, width), got {shape!r}."
-                ) from None
-
-            for dim_name, dim in (("height", height), ("width", width)):
-                if isinstance(dim, bool):
-                    raise ValueError(
-                        f"shape {dim_name} must be an integer, got {type(dim).__name__} (shape={shape!r})."
-                    )
-                try:
-                    operator.index(dim)
-                except TypeError:
-                    raise ValueError(
-                        f"shape {dim_name} must be an integer, got {type(dim).__name__} (shape={shape!r})."
-                    ) from None
-                if dim <= 0:
-                    raise ValueError(f"shape must contain positive integers for height and width, got {shape!r}.")
-
-            # Normalize to plain Python ints; also accepts numpy.int64, torch scalars, etc.
-            height, width = operator.index(height), operator.index(width)
-
-            if height % block_size != 0 or width % block_size != 0:
-                raise ValueError(
-                    f"shape must have both dimensions divisible by {block_size} "
-                    f"(patch_size={patch_size} * num_windows={num_windows}), got {shape!r}."
-                )
-
-            shape = (height, width)
+            shape = _validate_shape_dims(shape, block_size, patch_size, num_windows)
 
         if not self._is_optimized_for_inference and not self._has_warned_about_not_being_optimized_for_inference:
             logger.warning(

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -314,6 +314,7 @@ class RFDETR:
         shape: tuple = None,
         batch_size: int = 1,
         dynamic_batch: bool = False,
+        patch_size: int = 14,
         **kwargs,
     ) -> None:
         """Export the trained model to ONNX format.
@@ -354,8 +355,8 @@ class RFDETR:
         if shape is None:
             shape = (self.model.resolution, self.model.resolution)
         else:
-            if shape[0] % 14 != 0 or shape[1] % 14 != 0:
-                raise ValueError("Shape must be divisible by 14")
+            if shape[0] % patch_size != 0 or shape[1] % patch_size != 0:
+                raise ValueError(f"Shape must be divisible by {patch_size}")
 
         input_tensors = make_infer_image(infer_dir, shape, batch_size, device).to(device)
         input_names = ["input"]
@@ -498,6 +499,7 @@ class RFDETR:
         ],
         threshold: float = 0.5,
         shape: tuple[int, int] | None = None,
+        patch_size: int = 14,
         **kwargs,
     ) -> Union[sv.Detections, List[sv.Detections]]:
         """Performs object detection on the input images and returns bounding box
@@ -561,8 +563,8 @@ class RFDETR:
             # Normalize to plain Python ints; also accepts numpy.int64, torch scalars, etc.
             height, width = operator.index(height), operator.index(width)
 
-            if height % 14 != 0 or width % 14 != 0:
-                raise ValueError(f"shape must have both dimensions divisible by 14, got {shape!r}.")
+            if height % patch_size != 0 or width % patch_size != 0:
+                raise ValueError(f"shape must have both dimensions divisible by {patch_size}, got {shape!r}.")
 
             shape = (height, width)
 

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -370,6 +370,8 @@ class RFDETR:
         if isinstance(patch_size, bool) or not isinstance(patch_size, int) or patch_size <= 0:
             raise ValueError(f"patch_size must be a positive integer, got {patch_size!r}")
         num_windows = getattr(self.model_config, "num_windows", 1)
+        if isinstance(num_windows, bool) or not isinstance(num_windows, int) or num_windows <= 0:
+            raise ValueError(f"num_windows must be a positive integer, got {num_windows!r}")
         block_size = patch_size * num_windows
         if shape is None:
             shape = (self.model.resolution, self.model.resolution)

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -521,7 +521,7 @@ class RFDETR:
         ],
         threshold: float = 0.5,
         shape: tuple[int, int] | None = None,
-        patch_size: int = 14,
+        patch_size: int | None = None,
         **kwargs,
     ) -> Union[sv.Detections, List[sv.Detections]]:
         """Performs object detection on the input images and returns bounding box
@@ -543,8 +543,13 @@ class RFDETR:
                 When provided, overrides the model's default inference resolution. The
                 tuple should match the resolution used when exporting the model
                 (typically a square shape). Both dimensions must be positive integers
-                divisible by patch_size. Defaults to ``(model.resolution, model.resolution)``
-                when not set.
+                divisible by ``patch_size * num_windows``. Defaults to
+                ``(model.resolution, model.resolution)`` when not set.
+            patch_size:
+                Backbone patch size used for shape divisibility validation. Defaults
+                to ``model_config.patch_size`` (typically 14 for large models, 16 for
+                smaller ones). Divisibility is checked against
+                ``patch_size * num_windows``.
             **kwargs:
                 Additional keyword arguments.
 
@@ -556,9 +561,18 @@ class RFDETR:
             ValueError: If ``shape`` cannot be unpacked as a two-element sequence,
                 if either dimension does not support the ``__index__`` protocol
                 (e.g. ``float``) or is a ``bool``, if either dimension is zero or
-                negative, or if either dimension is not divisible by patch_size.
+                negative, if either dimension is not divisible by
+                ``patch_size * num_windows``, or if ``patch_size`` is not a positive
+                integer.
         """
         import supervision as sv
+
+        if patch_size is None:
+            patch_size = getattr(self.model_config, "patch_size", 14)
+        if not isinstance(patch_size, int) or patch_size <= 0:
+            raise ValueError(f"patch_size must be a positive integer, got {patch_size!r}")
+        num_windows = getattr(self.model_config, "num_windows", 1)
+        block_size = patch_size * num_windows
 
         if shape is not None:
             try:
@@ -585,8 +599,11 @@ class RFDETR:
             # Normalize to plain Python ints; also accepts numpy.int64, torch scalars, etc.
             height, width = operator.index(height), operator.index(width)
 
-            if height % patch_size != 0 or width % patch_size != 0:
-                raise ValueError(f"shape must have both dimensions divisible by {patch_size}, got {shape!r}.")
+            if height % block_size != 0 or width % block_size != 0:
+                raise ValueError(
+                    f"shape must have both dimensions divisible by {block_size} "
+                    f"(patch_size={patch_size} * num_windows={num_windows}), got {shape!r}."
+                )
 
             shape = (height, width)
 

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -116,6 +116,41 @@ def _validate_shape_dims(
     return height, width
 
 
+def _resolve_patch_size(patch_size: int | None, model_config: object, caller: str) -> int:
+    """Resolve and validate the ``patch_size`` argument for :meth:`RFDETR.export` and :meth:`RFDETR.predict`.
+
+    Args:
+        patch_size: Value supplied by the caller, or ``None`` to read from ``model_config``.
+        model_config: The model's configuration object.  Must expose ``patch_size`` as a
+            positive integer attribute when ``patch_size`` is ``None`` or when a mismatch
+            check is needed.
+        caller: Name of the calling method (``"export"`` or ``"predict"``) — used in
+            error messages to help the caller locate the problem.
+
+    Returns:
+        A validated, positive :class:`int` patch size.
+
+    Raises:
+        ValueError: If the resolved or provided ``patch_size`` is not a positive integer,
+            or if a caller-provided value disagrees with ``model_config.patch_size``.
+    """
+    if patch_size is None:
+        patch_size = getattr(model_config, "patch_size", 14)
+    else:
+        if isinstance(patch_size, bool) or not isinstance(patch_size, int) or patch_size <= 0:
+            raise ValueError(f"patch_size must be a positive integer, got {patch_size!r}")
+        model_patch_size = getattr(model_config, "patch_size", None)
+        if model_patch_size is not None and patch_size != model_patch_size:
+            raise ValueError(
+                f"{caller}(patch_size={patch_size}) does not match the instantiated model's "
+                f"patch_size={model_patch_size}. Patch size is an architectural parameter; "
+                f"omit patch_size to use the model's configured value."
+            )
+    if isinstance(patch_size, bool) or not isinstance(patch_size, int) or patch_size <= 0:
+        raise ValueError(f"patch_size must be a positive integer, got {patch_size!r}")
+    return patch_size
+
+
 class RFDETR:
     """
     The base RF-DETR class implements the core methods for training RF-DETR models,
@@ -406,20 +441,7 @@ class RFDETR:
 
         os.makedirs(output_dir, exist_ok=True)
         output_dir_path = Path(output_dir)
-        if patch_size is None:
-            patch_size = getattr(self.model_config, "patch_size", 14)
-        else:
-            if isinstance(patch_size, bool) or not isinstance(patch_size, int) or patch_size <= 0:
-                raise ValueError(f"patch_size must be a positive integer, got {patch_size!r}")
-            model_patch_size = getattr(self.model_config, "patch_size", None)
-            if model_patch_size is not None and patch_size != model_patch_size:
-                raise ValueError(
-                    f"export(patch_size={patch_size}) does not match the instantiated model's patch_size="
-                    f"{model_patch_size}. Patch size is an architectural parameter; instantiate the model with the "
-                    f"desired patch_size (and compatible checkpoint) before exporting."
-                )
-        if isinstance(patch_size, bool) or not isinstance(patch_size, int) or patch_size <= 0:
-            raise ValueError(f"patch_size must be a positive integer, got {patch_size!r}")
+        patch_size = _resolve_patch_size(patch_size, self.model_config, "export")
         num_windows = getattr(self.model_config, "num_windows", 1)
         if isinstance(num_windows, bool) or not isinstance(num_windows, int) or num_windows <= 0:
             raise ValueError(f"num_windows must be a positive integer, got {num_windows!r}")
@@ -622,20 +644,7 @@ class RFDETR:
         """
         import supervision as sv
 
-        if patch_size is None:
-            patch_size = getattr(self.model_config, "patch_size", 14)
-        else:
-            if isinstance(patch_size, bool) or not isinstance(patch_size, int) or patch_size <= 0:
-                raise ValueError(f"patch_size must be a positive integer, got {patch_size!r}")
-            model_patch_size = getattr(self.model_config, "patch_size", None)
-            if model_patch_size is not None and patch_size != model_patch_size:
-                raise ValueError(
-                    f"predict(patch_size={patch_size}) does not match the instantiated model's "
-                    f"patch_size={model_patch_size}. Patch size is an architectural parameter; "
-                    f"omit patch_size to use the model's configured value."
-                )
-        if isinstance(patch_size, bool) or not isinstance(patch_size, int) or patch_size <= 0:
-            raise ValueError(f"patch_size must be a positive integer, got {patch_size!r}")
+        patch_size = _resolve_patch_size(patch_size, self.model_config, "predict")
         num_windows = getattr(self.model_config, "num_windows", 1)
         if isinstance(num_windows, bool) or not isinstance(num_windows, int) or num_windows <= 0:
             raise ValueError(f"model_config.num_windows must be a positive integer, got {num_windows!r}")

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -311,7 +311,7 @@ class RFDETR:
         opset_version: int = 17,
         verbose: bool = True,
         force: bool = False,
-        shape: tuple = None,
+        shape: tuple[int, int] | None = None,
         batch_size: int = 1,
         dynamic_batch: bool = False,
         patch_size: int | None = None,

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -331,9 +331,14 @@ class RFDETR:
             verbose: Print export progress information.
             force: Deprecated and ignored.
             shape: ``(height, width)`` tuple; defaults to square at model resolution.
+                Both dimensions must be divisible by ``patch_size * num_windows``.
             batch_size: Static batch size to bake into the ONNX graph.
             dynamic_batch: If True, export with a dynamic batch dimension
                 so the ONNX model accepts variable batch sizes at runtime.
+            patch_size: Backbone patch size. Defaults to the value stored in
+                ``model_config.patch_size`` (typically 14 or 16). When provided
+                explicitly it must match the instantiated model's patch size.
+                Shape divisibility is validated against ``patch_size * num_windows``.
             **kwargs: Additional keyword arguments forwarded to export_onnx.
         """
         logger.info("Exporting model to ONNX format")
@@ -362,11 +367,18 @@ class RFDETR:
                     f"{model_patch_size}. Patch size is an architectural parameter; instantiate the model with the "
                     f"desired patch_size (and compatible checkpoint) before exporting."
                 )
+        if not isinstance(patch_size, int) or patch_size <= 0:
+            raise ValueError(f"patch_size must be a positive integer, got {patch_size!r}")
+        num_windows = getattr(self.model_config, "num_windows", 1)
+        block_size = patch_size * num_windows
         if shape is None:
             shape = (self.model.resolution, self.model.resolution)
         else:
-            if shape[0] % patch_size != 0 or shape[1] % patch_size != 0:
-                raise ValueError(f"Shape must be divisible by {patch_size}")
+            if shape[0] % block_size != 0 or shape[1] % block_size != 0:
+                raise ValueError(
+                    f"Shape must be divisible by {block_size} "
+                    f"(patch_size={patch_size} * num_windows={num_windows})"
+                )
 
         input_tensors = make_infer_image(infer_dir, shape, batch_size, device).to(device)
         input_names = ["input"]

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -360,6 +360,8 @@ class RFDETR:
         if patch_size is None:
             patch_size = getattr(self.model_config, "patch_size", 14)
         else:
+            if isinstance(patch_size, bool) or not isinstance(patch_size, int) or patch_size <= 0:
+                raise ValueError(f"patch_size must be a positive integer, got {patch_size!r}")
             model_patch_size = getattr(self.model_config, "patch_size", None)
             if model_patch_size is not None and patch_size != model_patch_size:
                 raise ValueError(
@@ -571,6 +573,8 @@ class RFDETR:
         if patch_size is None:
             patch_size = getattr(self.model_config, "patch_size", 14)
         else:
+            if isinstance(patch_size, bool) or not isinstance(patch_size, int) or patch_size <= 0:
+                raise ValueError(f"patch_size must be a positive integer, got {patch_size!r}")
             model_patch_size = getattr(self.model_config, "patch_size", None)
             if model_patch_size is not None and patch_size != model_patch_size:
                 raise ValueError(
@@ -582,9 +586,7 @@ class RFDETR:
             raise ValueError(f"patch_size must be a positive integer, got {patch_size!r}")
         num_windows = getattr(self.model_config, "num_windows", 1)
         if isinstance(num_windows, bool) or not isinstance(num_windows, int) or num_windows <= 0:
-            raise ValueError(
-                f"model_config.num_windows must be a positive integer, got {num_windows!r}"
-            )
+            raise ValueError(f"model_config.num_windows must be a positive integer, got {num_windows!r}")
         block_size = patch_size * num_windows
 
         if shape is not None:

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -314,7 +314,7 @@ class RFDETR:
         shape: tuple = None,
         batch_size: int = 1,
         dynamic_batch: bool = False,
-        patch_size: int = 14,
+        patch_size: int | None = None,
         **kwargs,
     ) -> None:
         """Export the trained model to ONNX format.
@@ -352,6 +352,16 @@ class RFDETR:
 
         os.makedirs(output_dir, exist_ok=True)
         output_dir_path = Path(output_dir)
+        if patch_size is None:
+            patch_size = getattr(self.model_config, "patch_size", 14)
+        else:
+            model_patch_size = getattr(self.model_config, "patch_size", None)
+            if model_patch_size is not None and patch_size != model_patch_size:
+                raise ValueError(
+                    f"export(patch_size={patch_size}) does not match the instantiated model's patch_size="
+                    f"{model_patch_size}. Patch size is an architectural parameter; instantiate the model with the "
+                    f"desired patch_size (and compatible checkpoint) before exporting."
+                )
         if shape is None:
             shape = (self.model.resolution, self.model.resolution)
         else:

--- a/src/rfdetr/export/main.py
+++ b/src/rfdetr/export/main.py
@@ -40,7 +40,7 @@ def make_infer_image(infer_dir, shape, batch_size, device="cuda"):
 
     transforms = Compose(
         [
-            Resize((shape[0], shape[0])),
+            Resize((shape[0], shape[1])),
             ToImage(),
             ToDtype(torch.float32, scale=True),
             Normalize(),

--- a/tests/models/test_export.py
+++ b/tests/models/test_export.py
@@ -575,3 +575,88 @@ class TestCliExportMain:
         assert set(dynamic_axes.keys()) == expected_names, (
             f"expected keys {expected_names}, got {set(dynamic_axes.keys())}"
         )
+
+
+class TestExportPatchSize:
+    """RFDETR.export() patch_size validation and shape-divisibility tests."""
+
+    @staticmethod
+    def _scaffold(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, patch_size: int, num_windows: int):
+        """Build a minimal RFDETR-like namespace with controllable patch_size/num_windows."""
+        import types
+
+        class _DummyCoreModel:
+            def to(self, *_a, **_kw):
+                return self
+
+            def eval(self):
+                return self
+
+            def cpu(self):
+                return self
+
+            def __call__(self, *_a, **_kw):
+                return {"pred_boxes": torch.zeros(1, 1, 4), "pred_logits": torch.zeros(1, 1, 2)}
+
+        model = types.SimpleNamespace(
+            model=types.SimpleNamespace(
+                model=_DummyCoreModel(),
+                device="cpu",
+                resolution=patch_size * num_windows * 2,  # always valid
+            ),
+            model_config=types.SimpleNamespace(
+                segmentation_head=False,
+                patch_size=patch_size,
+                num_windows=num_windows,
+            ),
+        )
+
+        def _fake_make_infer_image(*_a, **_kw):
+            return torch.zeros(1, 3, 8, 8)
+
+        def _fake_export_onnx(*_a, **_kw):
+            return str(tmp_path / "inference_model.onnx")
+
+        monkeypatch.setattr("rfdetr.export.main.make_infer_image", _fake_make_infer_image)
+        monkeypatch.setattr("rfdetr.export.main.export_onnx", _fake_export_onnx)
+        monkeypatch.setattr("rfdetr.detr.deepcopy", lambda x: x)
+        return model
+
+    def test_export_patch_size_mismatch_raises(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """export(patch_size=X) must raise ValueError when X != model_config.patch_size."""
+        model = self._scaffold(monkeypatch, tmp_path, patch_size=14, num_windows=4)
+        with pytest.raises(ValueError, match="patch_size"):
+            _detr_module.RFDETR.export(model, output_dir=str(tmp_path), patch_size=16)
+
+    @pytest.mark.parametrize(
+        "bad_patch_size",
+        [
+            pytest.param(0, id="zero"),
+            pytest.param(-1, id="negative"),
+        ],
+    )
+    def test_export_invalid_patch_size_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_patch_size: int
+    ) -> None:
+        """export() must raise ValueError when patch_size is not a positive integer."""
+        model = self._scaffold(monkeypatch, tmp_path, patch_size=14, num_windows=4)
+        # Override model_config.patch_size so the mismatch check is bypassed
+        model.model_config.patch_size = bad_patch_size
+        with pytest.raises(ValueError, match="patch_size must be a positive integer"):
+            _detr_module.RFDETR.export(model, output_dir=str(tmp_path), patch_size=bad_patch_size)
+
+    def test_export_shape_must_be_divisible_by_block_size(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """export() must reject shapes not divisible by patch_size * num_windows."""
+        # patch_size=16, num_windows=2 → block_size=32; shape (48, 64): 48 % 32 != 0
+        model = self._scaffold(monkeypatch, tmp_path, patch_size=16, num_windows=2)
+        with pytest.raises(ValueError, match="divisible by 32"):
+            _detr_module.RFDETR.export(model, output_dir=str(tmp_path), shape=(48, 64))
+
+    def test_export_shape_valid_for_block_size(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """export() accepts shape divisible by patch_size * num_windows without error."""
+        # patch_size=16, num_windows=2 → block_size=32; shape (64, 64) is valid
+        model = self._scaffold(monkeypatch, tmp_path, patch_size=16, num_windows=2)
+        # Should not raise
+        _detr_module.RFDETR.export(model, output_dir=str(tmp_path), shape=(64, 64))

--- a/tests/models/test_export.py
+++ b/tests/models/test_export.py
@@ -631,10 +631,7 @@ class TestExportPatchSize:
 
     @pytest.mark.parametrize(
         "bad_patch_size",
-        [
-            pytest.param(0, id="zero"),
-            pytest.param(-1, id="negative"),
-        ],
+        [0,-1],
     )
     def test_export_invalid_patch_size_raises(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_patch_size: int
@@ -681,10 +678,7 @@ class TestExportPatchSize:
 
     @pytest.mark.parametrize(
         "bad_patch_size",
-        [
-            pytest.param(True, id="bool_true"),
-            pytest.param(False, id="bool_false"),
-        ],
+        [True, False],
     )
     def test_export_bool_patch_size_raises(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_patch_size: bool

--- a/tests/models/test_export.py
+++ b/tests/models/test_export.py
@@ -694,6 +694,60 @@ class TestExportPatchSize:
         with pytest.raises(ValueError, match="patch_size must be a positive integer"):
             _detr_module.RFDETR.export(model, output_dir=str(tmp_path), patch_size=bad_patch_size)
 
+    def test_export_explicit_patch_size_matching_config_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """export(patch_size=X) must succeed when X matches model_config.patch_size."""
+        model = self._scaffold(monkeypatch, tmp_path, patch_size=14, num_windows=4)
+        # patch_size=14 matches model_config.patch_size=14; block_size=56; resolution=112 (56*2)
+        _detr_module.RFDETR.export(model, output_dir=str(tmp_path), patch_size=14)
+
+    @pytest.mark.parametrize(
+        "bad_shape",
+        [
+            pytest.param((14.0, 14.0), id="float_dims"),
+            pytest.param((14,), id="wrong_arity_one_element"),
+            pytest.param((14, 14, 3), id="wrong_arity_three_elements"),
+            pytest.param((True, 14), id="bool_height"),
+            pytest.param((14, False), id="bool_width"),
+        ],
+    )
+    def test_export_invalid_shape_type_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_shape: tuple
+    ) -> None:
+        """export() must raise ValueError for float, bool, or wrong-arity shape tuples."""
+        model = self._scaffold(monkeypatch, tmp_path, patch_size=14, num_windows=1)
+        with pytest.raises(ValueError, match="shape"):
+            _detr_module.RFDETR.export(model, output_dir=str(tmp_path), shape=bad_shape)
+
+    @pytest.mark.parametrize(
+        "bad_num_windows",
+        [
+            pytest.param(0, id="zero"),
+            pytest.param(-1, id="negative"),
+            pytest.param(True, id="bool_true"),
+        ],
+    )
+    def test_export_invalid_num_windows_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_num_windows: int
+    ) -> None:
+        """export() must raise ValueError when model_config.num_windows is not a positive integer."""
+        model = self._scaffold(monkeypatch, tmp_path, patch_size=14, num_windows=1)
+        model.model_config.num_windows = bad_num_windows
+        with pytest.raises(ValueError, match="num_windows must be a positive integer"):
+            _detr_module.RFDETR.export(model, output_dir=str(tmp_path))
+
+    def test_export_default_resolution_not_divisible_by_block_size_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """export() with shape=None must raise ValueError when model.resolution % block_size != 0."""
+        # patch_size=14, num_windows=3 → block_size=42; scaffold sets resolution=84 (42*2) which is valid
+        # Override resolution to 50 (not divisible by 42) to trigger the check
+        model = self._scaffold(monkeypatch, tmp_path, patch_size=14, num_windows=3)
+        model.model.resolution = 50
+        with pytest.raises(ValueError, match="default resolution"):
+            _detr_module.RFDETR.export(model, output_dir=str(tmp_path))
+
 
 def test_make_infer_image_produces_correct_rectangular_shape() -> None:
     """make_infer_image must produce a (B, C, H, W) tensor for non-square shapes.

--- a/tests/models/test_export.py
+++ b/tests/models/test_export.py
@@ -581,7 +581,9 @@ class TestExportPatchSize:
     """RFDETR.export() patch_size validation and shape-divisibility tests."""
 
     @staticmethod
-    def _scaffold(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, patch_size: int, num_windows: int):
+    def _scaffold(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path, patch_size: int, num_windows: int
+    ) -> types.SimpleNamespace:
         """Build a minimal RFDETR-like namespace with controllable patch_size/num_windows."""
         import types
 

--- a/tests/models/test_export.py
+++ b/tests/models/test_export.py
@@ -629,10 +629,7 @@ class TestExportPatchSize:
         with pytest.raises(ValueError, match="patch_size"):
             _detr_module.RFDETR.export(model, output_dir=str(tmp_path), patch_size=16)
 
-    @pytest.mark.parametrize(
-        "bad_patch_size",
-        [0, -1],
-    )
+    @pytest.mark.parametrize("bad_patch_size", [0, -1])
     def test_export_invalid_patch_size_raises(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_patch_size: int
     ) -> None:
@@ -676,10 +673,7 @@ class TestExportPatchSize:
         # Should not raise
         _detr_module.RFDETR.export(model, output_dir=str(tmp_path), shape=(64, 64))
 
-    @pytest.mark.parametrize(
-        "bad_patch_size",
-        [True, False],
-    )
+    @pytest.mark.parametrize("bad_patch_size", [True, False])
     def test_export_bool_patch_size_raises(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_patch_size: bool
     ) -> None:

--- a/tests/models/test_export.py
+++ b/tests/models/test_export.py
@@ -641,7 +641,7 @@ class TestExportPatchSize:
     ) -> None:
         """export() must raise ValueError when patch_size is not a positive integer."""
         model = self._scaffold(monkeypatch, tmp_path, patch_size=14, num_windows=4)
-        # Override model_config.patch_size so the mismatch check is bypassed
+        # Keep model_config.patch_size consistent with the patch_size argument for this test
         model.model_config.patch_size = bad_patch_size
         with pytest.raises(ValueError, match="patch_size must be a positive integer"):
             _detr_module.RFDETR.export(model, output_dir=str(tmp_path), patch_size=bad_patch_size)

--- a/tests/models/test_export.py
+++ b/tests/models/test_export.py
@@ -714,14 +714,7 @@ class TestExportPatchSize:
         with pytest.raises(ValueError, match="shape"):
             _detr_module.RFDETR.export(model, output_dir=str(tmp_path), shape=bad_shape)
 
-    @pytest.mark.parametrize(
-        "bad_num_windows",
-        [
-            pytest.param(0, id="zero"),
-            pytest.param(-1, id="negative"),
-            pytest.param(True, id="bool_true"),
-        ],
-    )
+    @pytest.mark.parametrize("bad_num_windows", [0, -1, True])
     def test_export_invalid_num_windows_raises(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_num_windows: int
     ) -> None:

--- a/tests/models/test_export.py
+++ b/tests/models/test_export.py
@@ -585,7 +585,6 @@ class TestExportPatchSize:
         monkeypatch: pytest.MonkeyPatch, tmp_path: Path, patch_size: int, num_windows: int
     ) -> types.SimpleNamespace:
         """Build a minimal RFDETR-like namespace with controllable patch_size/num_windows."""
-        import types
 
         class _DummyCoreModel:
             def to(self, *_a, **_kw):
@@ -662,3 +661,32 @@ class TestExportPatchSize:
         model = self._scaffold(monkeypatch, tmp_path, patch_size=16, num_windows=2)
         # Should not raise
         _detr_module.RFDETR.export(model, output_dir=str(tmp_path), shape=(64, 64))
+
+    @pytest.mark.parametrize(
+        "bad_patch_size",
+        [
+            pytest.param(True, id="bool_true"),
+            pytest.param(False, id="bool_false"),
+        ],
+    )
+    def test_export_bool_patch_size_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_patch_size: bool
+    ) -> None:
+        """export() must reject bool values for patch_size (isinstance(True, int) is True)."""
+        model = self._scaffold(monkeypatch, tmp_path, patch_size=14, num_windows=1)
+        with pytest.raises(ValueError, match="patch_size must be a positive integer"):
+            _detr_module.RFDETR.export(model, output_dir=str(tmp_path), patch_size=bad_patch_size)
+
+
+def test_make_infer_image_produces_correct_rectangular_shape() -> None:
+    """make_infer_image must produce a (B, C, H, W) tensor for non-square shapes.
+
+    Regression test for the square-resize bug where ``Resize((shape[0], shape[0]))``
+    was used instead of ``Resize((shape[0], shape[1]))``, causing the output width
+    to silently equal the height.
+    """
+    from rfdetr.export.main import make_infer_image
+
+    h, w, b = 112, 224, 2
+    tensor = make_infer_image(infer_dir=None, shape=(h, w), batch_size=b, device="cpu")
+    assert tensor.shape == (b, 3, h, w), f"Expected shape ({b}, 3, {h}, {w}), got {tensor.shape}"

--- a/tests/models/test_export.py
+++ b/tests/models/test_export.py
@@ -631,7 +631,7 @@ class TestExportPatchSize:
 
     @pytest.mark.parametrize(
         "bad_patch_size",
-        [0,-1],
+        [0, -1],
     )
     def test_export_invalid_patch_size_raises(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_patch_size: int

--- a/tests/models/test_export.py
+++ b/tests/models/test_export.py
@@ -655,6 +655,23 @@ class TestExportPatchSize:
         with pytest.raises(ValueError, match="divisible by 32"):
             _detr_module.RFDETR.export(model, output_dir=str(tmp_path), shape=(48, 64))
 
+    @pytest.mark.parametrize(
+        "bad_shape",
+        [
+            pytest.param((-64, 64), id="negative_height"),
+            pytest.param((64, -64), id="negative_width"),
+            pytest.param((0, 64), id="zero_height"),
+            pytest.param((64, 0), id="zero_width"),
+        ],
+    )
+    def test_export_negative_or_zero_shape_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_shape: tuple[int, int]
+    ) -> None:
+        """export() must reject non-positive shape dimensions (Python -N % M == 0 wraps silently)."""
+        model = self._scaffold(monkeypatch, tmp_path, patch_size=16, num_windows=2)
+        with pytest.raises(ValueError, match="positive integers"):
+            _detr_module.RFDETR.export(model, output_dir=str(tmp_path), shape=bad_shape)
+
     def test_export_shape_valid_for_block_size(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         """export() accepts shape divisible by patch_size * num_windows without error."""
         # patch_size=16, num_windows=2 → block_size=32; shape (64, 64) is valid

--- a/tests/models/test_predict.py
+++ b/tests/models/test_predict.py
@@ -240,15 +240,7 @@ class TestPredictPatchSize:
         with pytest.raises(ValueError, match="divisible by 32"):
             model.predict(img, shape=(48, 64))
 
-    @pytest.mark.parametrize(
-        "bad_patch_size",
-        [
-            pytest.param(0, id="zero"),
-            pytest.param(-1, id="negative"),
-            pytest.param(True, id="bool_true"),
-            pytest.param(False, id="bool_false"),
-        ],
-    )
+    @pytest.mark.parametrize("bad_patch_size", [0, -1, True, False])
     def test_predict_invalid_patch_size_raises(self, bad_patch_size: int) -> None:
         """predict() must raise ValueError when patch_size is not a positive integer."""
         model = _DummyRFDETR()
@@ -272,14 +264,7 @@ class TestPredictPatchSize:
         # Should not raise — patch_size matches config, 64 % 32 == 0
         model.predict(img, shape=(64, 64), patch_size=16)
 
-    @pytest.mark.parametrize(
-        "bad_num_windows",
-        [
-            pytest.param(0, id="zero"),
-            pytest.param(-1, id="negative"),
-            pytest.param(True, id="bool_true"),
-        ],
-    )
+    @pytest.mark.parametrize("bad_num_windows", [0, -1, True])
     def test_predict_invalid_num_windows_raises(self, bad_num_windows: int) -> None:
         """predict() must raise ValueError when model_config.num_windows is not a positive integer."""
         model = self._make_model_with_config(patch_size=14, num_windows=1)

--- a/tests/models/test_predict.py
+++ b/tests/models/test_predict.py
@@ -211,3 +211,45 @@ class TestPredictShape:
         img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
         with pytest.raises(ValueError, match="shape"):
             model.predict(img, shape=bad_shape)  # type: ignore[arg-type]
+
+
+class TestPredictPatchSize:
+    """predict() patch_size resolution and validation tests."""
+
+    def _make_model_with_config(self, patch_size: int, num_windows: int) -> _DummyRFDETR:
+        """Return a _DummyRFDETR whose model_config carries patch_size and num_windows."""
+        from types import SimpleNamespace
+
+        model = _DummyRFDETR()
+        model.model_config = SimpleNamespace(patch_size=patch_size, num_windows=num_windows)
+        return model
+
+    def test_predict_defaults_patch_size_from_model_config(self) -> None:
+        """predict() reads patch_size from model_config when not provided by the caller."""
+        # patch_size=16, num_windows=2 → block_size=32; shape=(64,64) is valid
+        model = self._make_model_with_config(patch_size=16, num_windows=2)
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+        # Should not raise — 64 % 32 == 0
+        model.predict(img, shape=(64, 64))
+
+    def test_predict_shape_must_be_divisible_by_block_size(self) -> None:
+        """predict() rejects shapes not divisible by patch_size * num_windows."""
+        # patch_size=16, num_windows=2 → block_size=32; shape (48, 64) fails (48%32==16)
+        model = self._make_model_with_config(patch_size=16, num_windows=2)
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+        with pytest.raises(ValueError, match="divisible by 32"):
+            model.predict(img, shape=(48, 64))
+
+    @pytest.mark.parametrize(
+        "bad_patch_size",
+        [
+            pytest.param(0, id="zero"),
+            pytest.param(-1, id="negative"),
+        ],
+    )
+    def test_predict_invalid_patch_size_raises(self, bad_patch_size: int) -> None:
+        """predict() must raise ValueError when patch_size is not a positive integer."""
+        model = _DummyRFDETR()
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+        with pytest.raises(ValueError, match="patch_size must be a positive integer"):
+            model.predict(img, patch_size=bad_patch_size)  # type: ignore[arg-type]

--- a/tests/models/test_predict.py
+++ b/tests/models/test_predict.py
@@ -32,7 +32,7 @@ def _is_online(host: str, port: int, timeout_s: float = 3.0) -> bool:
 class _DummyModel:
     def __init__(self) -> None:
         self.device = torch.device("cpu")
-        self.resolution = 32
+        self.resolution = 28
         self.model = torch.nn.Identity()
 
     def postprocess(self, predictions: Any, target_sizes: torch.Tensor) -> list[dict[str, torch.Tensor]]:
@@ -114,7 +114,7 @@ class TestPredictShape:
             model.predict(img)
 
         resize_size = list(mock_resize.call_args[0][1])
-        assert resize_size == [32, 32], f"Expected resize to model resolution (32, 32), got {resize_size}"
+        assert resize_size == [28, 28], f"Expected resize to model resolution (28, 28), got {resize_size}"
 
     def test_predict_uses_provided_rectangular_shape(self) -> None:
         # Regression test for #682
@@ -263,3 +263,36 @@ class TestPredictPatchSize:
         img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
         with pytest.raises(ValueError, match="does not match"):
             model.predict(img, shape=(16, 16), patch_size=14)
+
+    def test_predict_explicit_patch_size_matching_config_succeeds(self) -> None:
+        """predict(patch_size=X) must succeed when X matches model_config.patch_size."""
+        # patch_size=16, num_windows=2 → block_size=32; shape=(64,64) is valid
+        model = self._make_model_with_config(patch_size=16, num_windows=2)
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+        # Should not raise — patch_size matches config, 64 % 32 == 0
+        model.predict(img, shape=(64, 64), patch_size=16)
+
+    @pytest.mark.parametrize(
+        "bad_num_windows",
+        [
+            pytest.param(0, id="zero"),
+            pytest.param(-1, id="negative"),
+            pytest.param(True, id="bool_true"),
+        ],
+    )
+    def test_predict_invalid_num_windows_raises(self, bad_num_windows: int) -> None:
+        """predict() must raise ValueError when model_config.num_windows is not a positive integer."""
+        model = self._make_model_with_config(patch_size=14, num_windows=1)
+        model.model_config.num_windows = bad_num_windows
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+        with pytest.raises(ValueError, match="num_windows must be a positive integer"):
+            model.predict(img, shape=(14, 14))
+
+    def test_predict_default_resolution_not_divisible_by_block_size_raises(self) -> None:
+        """predict() with shape=None must raise ValueError when model.resolution % block_size != 0."""
+        # patch_size=14, num_windows=1 → block_size=14; set resolution=25 (not divisible)
+        model = self._make_model_with_config(patch_size=14, num_windows=1)
+        model.model.resolution = 25
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+        with pytest.raises(ValueError, match="default resolution"):
+            model.predict(img)

--- a/tests/models/test_predict.py
+++ b/tests/models/test_predict.py
@@ -245,6 +245,8 @@ class TestPredictPatchSize:
         [
             pytest.param(0, id="zero"),
             pytest.param(-1, id="negative"),
+            pytest.param(True, id="bool_true"),
+            pytest.param(False, id="bool_false"),
         ],
     )
     def test_predict_invalid_patch_size_raises(self, bad_patch_size: int) -> None:
@@ -253,3 +255,11 @@ class TestPredictPatchSize:
         img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
         with pytest.raises(ValueError, match="patch_size must be a positive integer"):
             model.predict(img, patch_size=bad_patch_size)  # type: ignore[arg-type]
+
+    def test_predict_patch_size_mismatch_raises(self) -> None:
+        """predict() must raise ValueError when caller's patch_size != model_config.patch_size."""
+        # model has patch_size=16; passing patch_size=14 should raise immediately
+        model = self._make_model_with_config(patch_size=16, num_windows=1)
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+        with pytest.raises(ValueError, match="does not match"):
+            model.predict(img, shape=(16, 16), patch_size=14)

--- a/tests/models/test_validate_shape_dims.py
+++ b/tests/models/test_validate_shape_dims.py
@@ -1,0 +1,136 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Unit tests for :func:`rfdetr.detr._validate_shape_dims`.
+
+Tests call the helper directly so each validation path has a single focused
+test without the export/predict scaffolding overhead.
+"""
+
+import pytest
+
+from rfdetr.detr import _validate_shape_dims
+
+
+class TestValidateShapeDimsHappyPath:
+    """_validate_shape_dims returns normalised (height, width) for valid inputs."""
+
+    def test_exact_plain_ints(self) -> None:
+        """Plain int dims divisible by block_size are returned unchanged."""
+        assert _validate_shape_dims((56, 112), 14, 14, 1) == (56, 112)
+
+    def test_returns_plain_int_tuple(self) -> None:
+        """Return type is always a tuple of plain Python int."""
+        h, w = _validate_shape_dims((56, 56), 14, 14, 1)
+        assert type(h) is int and type(w) is int
+
+    def test_numpy_int_accepted(self) -> None:
+        """numpy.int64 dims are accepted via operator.index and normalised."""
+        import numpy as np
+
+        h, w = _validate_shape_dims((np.int64(56), np.int64(112)), 14, 14, 1)
+        assert (h, w) == (56, 112)
+        assert type(h) is int and type(w) is int
+
+    def test_non_square_shape(self) -> None:
+        """Non-square (H != W) shapes are returned correctly."""
+        assert _validate_shape_dims((112, 224), 14, 14, 1) == (112, 224)
+
+    def test_block_size_from_num_windows(self) -> None:
+        """block_size = patch_size * num_windows; both dims divisible by it."""
+        # patch_size=16, num_windows=2 → block_size=32
+        assert _validate_shape_dims((64, 128), 32, 16, 2) == (64, 128)
+
+
+class TestValidateShapeDimsArityErrors:
+    """_validate_shape_dims raises ValueError for non-two-element shapes."""
+
+    def test_one_element_raises(self) -> None:
+        """Single-element tuple must raise ValueError."""
+        with pytest.raises(ValueError, match="shape must be a sequence"):
+            _validate_shape_dims((56,), 14, 14, 1)
+
+    def test_three_element_raises(self) -> None:
+        """Three-element tuple must raise ValueError."""
+        with pytest.raises(ValueError, match="shape must be a sequence"):
+            _validate_shape_dims((56, 56, 3), 14, 14, 1)
+
+    def test_scalar_raises(self) -> None:
+        """Bare scalar (not a sequence) must raise ValueError."""
+        with pytest.raises(ValueError, match="shape must be a sequence"):
+            _validate_shape_dims(56, 14, 14, 1)  # type: ignore[arg-type]
+
+
+class TestValidateShapeDimsBoolRejection:
+    """_validate_shape_dims rejects bool dims (isinstance(True, int) is True)."""
+
+    def test_bool_height_raises(self) -> None:
+        """Bool height must raise ValueError even though bool is an int subtype."""
+        with pytest.raises(ValueError, match="height must be an integer"):
+            _validate_shape_dims((True, 56), 14, 14, 1)  # type: ignore[arg-type]
+
+    def test_bool_width_raises(self) -> None:
+        """Bool width must raise ValueError."""
+        with pytest.raises(ValueError, match="width must be an integer"):
+            _validate_shape_dims((56, False), 14, 14, 1)  # type: ignore[arg-type]
+
+
+class TestValidateShapeDimsFloatRejection:
+    """_validate_shape_dims rejects float dims via operator.index."""
+
+    @pytest.mark.parametrize(
+        "shape",
+        [
+            pytest.param((56.0, 56.0), id="both_floats"),
+            pytest.param((56.0, 56), id="float_height"),
+            pytest.param((56, 56.0), id="float_width"),
+        ],
+    )
+    def test_float_dim_raises(self, shape: tuple) -> None:
+        """Float dims must raise ValueError (operator.index rejects them)."""
+        with pytest.raises(ValueError, match="must be an integer"):
+            _validate_shape_dims(shape, 14, 14, 1)
+
+
+class TestValidateShapeDimsPositiveCheck:
+    """_validate_shape_dims rejects zero and negative dimensions."""
+
+    @pytest.mark.parametrize(
+        "shape",
+        [
+            pytest.param((0, 56), id="zero_height"),
+            pytest.param((56, 0), id="zero_width"),
+            pytest.param((-14, 56), id="negative_height"),
+            pytest.param((56, -14), id="negative_width"),
+        ],
+    )
+    def test_non_positive_dim_raises(self, shape: tuple[int, int]) -> None:
+        """Zero or negative dims must raise ValueError."""
+        with pytest.raises(ValueError, match="positive integers"):
+            _validate_shape_dims(shape, 14, 14, 1)
+
+
+class TestValidateShapeDimsDivisibilityCheck:
+    """_validate_shape_dims enforces divisibility by block_size."""
+
+    @pytest.mark.parametrize(
+        "shape, block_size",
+        [
+            pytest.param((55, 56), 14, id="height_not_divisible"),
+            pytest.param((56, 55), 14, id="width_not_divisible"),
+            pytest.param((48, 64), 32, id="height_not_divisible_large_block"),
+        ],
+    )
+    def test_indivisible_shape_raises(self, shape: tuple[int, int], block_size: int) -> None:
+        """Shapes not divisible by block_size must raise ValueError."""
+        with pytest.raises(ValueError, match=f"divisible by {block_size}"):
+            _validate_shape_dims(shape, block_size, 14, 1)
+
+    def test_error_message_includes_patch_size_and_num_windows(self) -> None:
+        """Error message must name patch_size and num_windows for debuggability."""
+        with pytest.raises(ValueError, match="patch_size=16") as exc_info:
+            _validate_shape_dims((48, 64), 32, 16, 2)
+        assert "num_windows=2" in str(exc_info.value)

--- a/tests/models/test_validate_shape_dims.py
+++ b/tests/models/test_validate_shape_dims.py
@@ -167,15 +167,7 @@ class TestResolvePatchSize:
         with pytest.raises(ValueError, match="predict"):
             _resolve_patch_size(16, self._cfg(14), "predict")
 
-    @pytest.mark.parametrize(
-        "bad",
-        [
-            pytest.param(0, id="zero"),
-            pytest.param(-1, id="negative"),
-            pytest.param(True, id="bool_true"),
-            pytest.param(False, id="bool_false"),
-        ],
-    )
+    @pytest.mark.parametrize("bad", [0, -1, True, False])
     def test_invalid_explicit_patch_size_raises(self, bad: int) -> None:
         """Non-positive-int patch_size must raise ValueError before the mismatch check."""
         cfg = SimpleNamespace(patch_size=bad)

--- a/tests/models/test_validate_shape_dims.py
+++ b/tests/models/test_validate_shape_dims.py
@@ -66,53 +66,31 @@ class TestValidateShapeDimsArityErrors:
             _validate_shape_dims(56, 14, 14, 1)  # type: ignore[arg-type]
 
 
-class TestValidateShapeDimsBoolRejection:
-    """_validate_shape_dims rejects bool dims (isinstance(True, int) is True)."""
-
-    def test_bool_height_raises(self) -> None:
-        """Bool height must raise ValueError even though bool is an int subtype."""
-        with pytest.raises(ValueError, match="height must be an integer"):
-            _validate_shape_dims((True, 56), 14, 14, 1)  # type: ignore[arg-type]
-
-    def test_bool_width_raises(self) -> None:
-        """Bool width must raise ValueError."""
-        with pytest.raises(ValueError, match="width must be an integer"):
-            _validate_shape_dims((56, False), 14, 14, 1)  # type: ignore[arg-type]
-
-
-class TestValidateShapeDimsFloatRejection:
-    """_validate_shape_dims rejects float dims via operator.index."""
-
-    @pytest.mark.parametrize(
-        "shape",
-        [
-            pytest.param((56.0, 56.0), id="both_floats"),
-            pytest.param((56.0, 56), id="float_height"),
-            pytest.param((56, 56.0), id="float_width"),
-        ],
-    )
-    def test_float_dim_raises(self, shape: tuple) -> None:
-        """Float dims must raise ValueError (operator.index rejects them)."""
-        with pytest.raises(ValueError, match="must be an integer"):
-            _validate_shape_dims(shape, 14, 14, 1)
+@pytest.mark.parametrize(
+    "shape,match",
+    [
+        ((True, 56), "height"),
+        ((56, False), "width"),
+    ],
+)
+def test_validate_shape_dims_bool_dim_raises(shape: tuple, match: str) -> None:
+    """Bool dims must raise ValueError even though bool is an int subtype."""
+    with pytest.raises(ValueError, match=f"{match} must be an integer"):
+        _validate_shape_dims(shape, 14, 14, 1)  # type: ignore[arg-type]
 
 
-class TestValidateShapeDimsPositiveCheck:
-    """_validate_shape_dims rejects zero and negative dimensions."""
+@pytest.mark.parametrize("shape", [(56.0, 56.0), (56.0, 56), (56, 56.0)])
+def test_validate_shape_dims_float_dim_raises(shape: tuple) -> None:
+    """Float dims must raise ValueError (operator.index rejects them)."""
+    with pytest.raises(ValueError, match="must be an integer"):
+        _validate_shape_dims(shape, 14, 14, 1)
 
-    @pytest.mark.parametrize(
-        "shape",
-        [
-            pytest.param((0, 56), id="zero_height"),
-            pytest.param((56, 0), id="zero_width"),
-            pytest.param((-14, 56), id="negative_height"),
-            pytest.param((56, -14), id="negative_width"),
-        ],
-    )
-    def test_non_positive_dim_raises(self, shape: tuple[int, int]) -> None:
-        """Zero or negative dims must raise ValueError."""
-        with pytest.raises(ValueError, match="positive integers"):
-            _validate_shape_dims(shape, 14, 14, 1)
+
+@pytest.mark.parametrize("shape", [(0, 56), (56, 0), (-14, 56), (56, -14)])
+def test_validate_shape_dims_non_positive_dim_raises(shape: tuple[int, int]) -> None:
+    """Zero or negative dims must raise ValueError."""
+    with pytest.raises(ValueError, match="positive integers"):
+        _validate_shape_dims(shape, 14, 14, 1)
 
 
 class TestValidateShapeDimsDivisibilityCheck:

--- a/tests/models/test_validate_shape_dims.py
+++ b/tests/models/test_validate_shape_dims.py
@@ -4,15 +4,17 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
-"""Unit tests for :func:`rfdetr.detr._validate_shape_dims`.
+"""Unit tests for :func:`rfdetr.detr._validate_shape_dims` and :func:`rfdetr.detr._resolve_patch_size`.
 
-Tests call the helper directly so each validation path has a single focused
+Tests call each helper directly so each validation path has a single focused
 test without the export/predict scaffolding overhead.
 """
 
+from types import SimpleNamespace
+
 import pytest
 
-from rfdetr.detr import _validate_shape_dims
+from rfdetr.detr import _resolve_patch_size, _validate_shape_dims
 
 
 class TestValidateShapeDimsHappyPath:
@@ -134,3 +136,53 @@ class TestValidateShapeDimsDivisibilityCheck:
         with pytest.raises(ValueError, match="patch_size=16") as exc_info:
             _validate_shape_dims((48, 64), 32, 16, 2)
         assert "num_windows=2" in str(exc_info.value)
+
+
+class TestResolvePatchSize:
+    """_resolve_patch_size resolves and validates patch_size for export()/predict()."""
+
+    def _cfg(self, patch_size: int) -> SimpleNamespace:
+        """Return a minimal model_config stub with the given patch_size."""
+        return SimpleNamespace(patch_size=patch_size)
+
+    def test_none_reads_from_model_config(self) -> None:
+        """patch_size=None resolves to model_config.patch_size."""
+        assert _resolve_patch_size(None, self._cfg(16), "export") == 16
+
+    def test_none_falls_back_to_14_when_config_missing(self) -> None:
+        """patch_size=None falls back to 14 when model_config has no patch_size."""
+        assert _resolve_patch_size(None, SimpleNamespace(), "export") == 14
+
+    def test_explicit_matching_config_accepted(self) -> None:
+        """Providing patch_size equal to model_config.patch_size succeeds."""
+        assert _resolve_patch_size(14, self._cfg(14), "export") == 14
+
+    def test_explicit_mismatch_raises(self) -> None:
+        """Providing patch_size != model_config.patch_size must raise ValueError."""
+        with pytest.raises(ValueError, match="does not match"):
+            _resolve_patch_size(16, self._cfg(14), "export")
+
+    def test_mismatch_error_includes_caller_name(self) -> None:
+        """Mismatch error message includes the caller name for context."""
+        with pytest.raises(ValueError, match="predict"):
+            _resolve_patch_size(16, self._cfg(14), "predict")
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            pytest.param(0, id="zero"),
+            pytest.param(-1, id="negative"),
+            pytest.param(True, id="bool_true"),
+            pytest.param(False, id="bool_false"),
+        ],
+    )
+    def test_invalid_explicit_patch_size_raises(self, bad: int) -> None:
+        """Non-positive-int patch_size must raise ValueError before the mismatch check."""
+        cfg = SimpleNamespace(patch_size=bad)
+        with pytest.raises(ValueError, match="patch_size must be a positive integer"):
+            _resolve_patch_size(bad, cfg, "export")
+
+    def test_invalid_config_patch_size_raises(self) -> None:
+        """Bad patch_size in model_config (when caller passes None) must raise ValueError."""
+        with pytest.raises(ValueError, match="patch_size must be a positive integer"):
+            _resolve_patch_size(None, SimpleNamespace(patch_size=0), "export")

--- a/tests/models/test_validate_shape_dims.py
+++ b/tests/models/test_validate_shape_dims.py
@@ -66,31 +66,26 @@ class TestValidateShapeDimsArityErrors:
             _validate_shape_dims(56, 14, 14, 1)  # type: ignore[arg-type]
 
 
-@pytest.mark.parametrize(
-    "shape,match",
-    [
-        ((True, 56), "height"),
-        ((56, False), "width"),
-    ],
-)
-def test_validate_shape_dims_bool_dim_raises(shape: tuple, match: str) -> None:
-    """Bool dims must raise ValueError even though bool is an int subtype."""
-    with pytest.raises(ValueError, match=f"{match} must be an integer"):
-        _validate_shape_dims(shape, 14, 14, 1)  # type: ignore[arg-type]
+class TestValidateShapeDimsInvalidDim:
+    """_validate_shape_dims rejects bool, float, and non-positive dimension values."""
 
+    @pytest.mark.parametrize("shape,match", [((True, 56), "height"), ((56, False), "width")])
+    def test_bool_dim_raises(self, shape: tuple, match: str) -> None:
+        """Bool dims must raise ValueError even though bool is an int subtype."""
+        with pytest.raises(ValueError, match=f"{match} must be an integer"):
+            _validate_shape_dims(shape, 14, 14, 1)  # type: ignore[arg-type]
 
-@pytest.mark.parametrize("shape", [(56.0, 56.0), (56.0, 56), (56, 56.0)])
-def test_validate_shape_dims_float_dim_raises(shape: tuple) -> None:
-    """Float dims must raise ValueError (operator.index rejects them)."""
-    with pytest.raises(ValueError, match="must be an integer"):
-        _validate_shape_dims(shape, 14, 14, 1)
+    @pytest.mark.parametrize("shape", [(56.0, 56.0), (56.0, 56), (56, 56.0)])
+    def test_float_dim_raises(self, shape: tuple) -> None:
+        """Float dims must raise ValueError (operator.index rejects them)."""
+        with pytest.raises(ValueError, match="must be an integer"):
+            _validate_shape_dims(shape, 14, 14, 1)
 
-
-@pytest.mark.parametrize("shape", [(0, 56), (56, 0), (-14, 56), (56, -14)])
-def test_validate_shape_dims_non_positive_dim_raises(shape: tuple[int, int]) -> None:
-    """Zero or negative dims must raise ValueError."""
-    with pytest.raises(ValueError, match="positive integers"):
-        _validate_shape_dims(shape, 14, 14, 1)
+    @pytest.mark.parametrize("shape", [(0, 56), (56, 0), (-14, 56), (56, -14)])
+    def test_non_positive_dim_raises(self, shape: tuple[int, int]) -> None:
+        """Zero or negative dims must raise ValueError."""
+        with pytest.raises(ValueError, match="positive integers"):
+            _validate_shape_dims(shape, 14, 14, 1)
 
 
 class TestValidateShapeDimsDivisibilityCheck:


### PR DESCRIPTION
## What does this PR do?

fix: The shape set when exporting to ONNX did not take effect. The patch_size corresponding to models of different sizes also varies. During export, it should be determined whether shape % patch_size equals 0

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
