### PR TITLE
releasing `1.6.2` [rebase & merge]

### DIFF
--- a/.github/workflows/ci-tests-gpu.yml
+++ b/.github/workflows/ci-tests-gpu.yml
@@ -26,7 +26,7 @@ jobs:
   run-gpu-tests:
     name: Testing
     if: github.event_name == 'push' || !github.event.pull_request.draft
-    timeout-minutes: 35
+    timeout-minutes: 40
     runs-on: Roboflow-GPU-VM-Runner
     steps:
       - name: 🖥️ Print GPU information

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+
+
+### Deprecated
+
+
+
+### Fixed
+
+- Fixed `ModelConfig.device` validation to raise `pydantic.ValidationError` consistently for invalid non-string inputs by converting the pre-validator fallback from `TypeError` to `ValueError`. `ModelConfig.device` now accepts `torch.device` objects and indexed device strings, normalizes them to canonical torch-style strings, and `RFDETR.train()` now warns when a valid but unmapped device type is left to PyTorch Lightning auto-detection.
+
 ---
 
 ## [1.6.1] — 2026-03-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-
+- `RFDETR.predict(shape=...)` — optional `(height, width)` tuple overrides the default inference resolution; useful for matching the resolution used when exporting the model. Both dimensions must be positive integers divisible by 14. (closes #682)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-
-
 ### Fixed
 
 - Fixed `ModelConfig.device` validation to raise `pydantic.ValidationError` consistently for invalid non-string inputs by converting the pre-validator fallback from `TypeError` to `ValueError`. `ModelConfig.device` now accepts `torch.device` objects and indexed device strings, normalizes them to canonical torch-style strings, and `RFDETR.train()` now warns when a valid but unmapped device type is left to PyTorch Lightning auto-detection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [1.6.2] — 2026-03-27
+
 ### Added
 
-- `RFDETR.predict(shape=...)` — optional `(height, width)` tuple overrides the default inference resolution; useful for matching the resolution used when exporting the model. Both dimensions must be positive integers divisible by 14. (closes #682)
+- `RFDETR.predict(shape=...)` — optional `(height, width)` tuple overrides the default square inference resolution; useful when matching a non-square ONNX export. Both dimensions must be positive integers divisible by `patch_size × num_windows` as determined by the model configuration. (#866)
 
-### Deprecated
+### Changed
+
+- `ModelConfig.device` and `RFDETR.train(device=...)` now accept `torch.device` objects and indexed device strings such as `"cuda:0"`. Values are normalized to canonical torch-style strings. `RFDETR.train()` warns when an unmapped device type is passed to PyTorch Lightning auto-detection. (#872)
 
 ### Fixed
 
-- Fixed `ModelConfig.device` validation to raise `pydantic.ValidationError` consistently for invalid non-string inputs by converting the pre-validator fallback from `TypeError` to `ValueError`. `ModelConfig.device` now accepts `torch.device` objects and indexed device strings, normalizes them to canonical torch-style strings, and `RFDETR.train()` now warns when a valid but unmapped device type is left to PyTorch Lightning auto-detection.
+- Fixed ONNX export ignoring an explicit `patch_size` argument: `export()` and `predict()` now resolve `patch_size` from `model_config` by default, validate it strictly (positive integer, not bool), and enforce that `(H, W)` dimensions are divisible by `patch_size × num_windows`. (#876)
+- Fixed ONNX export for models with dynamic batch dimensions — replaced `H_.expand(N_)` with `torch.full` for Python-int spatial dims to eliminate tracer failures. (#871)
 
 ---
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -70,6 +70,15 @@ Use the resources below to learn how to train, build with, and deploy RF-DETR mo
 
     [:octicons-arrow-right-24: Read the tutorial](https://blog.roboflow.com/how-to-deploy-rf-detr-to-an-nvidia-jetson/)
 
+- **Deploy RF-DETR with LitServe [Lightning AI Studio]**
+
+    ---
+
+    ![](https://blog.roboflow.com/content/images/size/w1000/format/webp/2025/03/img-blog-nycerebro--2--min.png)
+    Learn how to deploy RF-DETR as a scalable inference server using LitServe, the AI model serving framework from Lightning AI.
+
+    [:octicons-arrow-right-24: Open the Studio](https://lightning.ai/bhimrajyadav/studios/deploy-rf-detr-a-sota-real-time-object-detection-model-using-litserve)
+
 - **Train and Deploy RF-DETR Models with Roboflow**
 
     ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rfdetr"
-version = "1.6.1"
+version = "1.6.2"
 description = "RF-DETR"
 readme = "README.md"
 authors = [

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -68,7 +68,8 @@ class ModelConfig(BaseConfig):
     amp: bool = True
     num_classes: int = 90
     pretrain_weights: Optional[str] = None
-    device: Literal["cpu", "cuda", "mps"] = DEVICE
+    # torch.device values are accepted at validation time and normalized to string.
+    device: str = DEVICE
     resolution: int
     group_detr: int = 13
     gradient_checkpointing: bool = False
@@ -93,6 +94,32 @@ class ModelConfig(BaseConfig):
         if v is None:
             return v
         return os.path.realpath(os.path.expanduser(v))
+
+    @field_validator("device", mode="before")
+    @classmethod
+    def _normalize_device(cls, v: Any) -> str:
+        """Normalize supported device inputs to a canonical torch-style string.
+
+        Args:
+            v: Device specifier provided by callers. Supported values are
+                ``str`` (for example ``"cpu"``, ``"cuda"``, ``"cuda:1"``)
+                and ``torch.device``.
+
+        Returns:
+            Canonical string form of the parsed device (for example ``"cuda:1"``).
+
+        Raises:
+            ValueError: If a string value cannot be parsed as a valid torch device.
+            ValueError: If ``v`` is not a string or ``torch.device``.
+        """
+        if isinstance(v, torch.device):
+            return str(v)
+        if isinstance(v, str):
+            try:
+                return str(torch.device(v))
+            except (TypeError, ValueError, RuntimeError) as exc:
+                raise ValueError(f"Invalid device specifier: {v!r}.") from exc
+        raise ValueError("device must be a string or torch.device.")
 
 
 class RFDETRBaseConfig(ModelConfig):

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -272,6 +272,45 @@ class RFDETR:
         """
         return self._model_config_class(**kwargs)
 
+    @staticmethod
+    def _resolve_trainer_device_kwargs(device: Any) -> tuple[str | None, list[int] | None]:
+        """Map a torch-style device specifier to PTL ``accelerator``/``devices`` kwargs.
+
+        Args:
+            device: A device specifier accepted by ``torch.device``.
+
+        Returns:
+            ``(accelerator, devices)`` where ``devices`` is ``None`` unless an explicit
+            device index is provided (for example ``cuda:1``).
+
+        Raises:
+            ValueError: If ``device`` is not a valid torch device specifier.
+        """
+        if device is None:
+            return None, None
+        try:
+            resolved_device = torch.device(device)
+        except (TypeError, ValueError, RuntimeError) as exc:
+            raise ValueError(
+                f"Invalid device specifier for train(): {device!r}. "
+                "Expected values like 'cpu', 'cuda', 'cuda:0', or torch.device(...)."
+            ) from exc
+
+        if resolved_device.type == "cpu":
+            return "cpu", None
+        if resolved_device.type == "cuda":
+            return "gpu", [resolved_device.index] if resolved_device.index is not None else None
+        if resolved_device.type == "mps":
+            return "mps", [resolved_device.index] if resolved_device.index is not None else None
+
+        warnings.warn(
+            f"Device type {resolved_device.type!r} is not explicitly mapped to a PyTorch Lightning "
+            "accelerator; falling back to PTL auto-detection. Training may use an unexpected device.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return None, None
+
     def train(self, **kwargs):
         """Train an RF-DETR model via the PyTorch Lightning stack.
 
@@ -279,8 +318,12 @@ class RFDETR:
         a :class:`~rfdetr.config.TrainConfig`.  Several legacy kwargs are absorbed
         so existing call-sites do not break:
 
-        * ``device`` — mapped to ``TrainConfig.accelerator``; ``"cpu"`` becomes
-          ``accelerator="cpu"``, all others default to ``"auto"``.
+        * ``device`` — normalized via :class:`torch.device` and mapped to PyTorch
+          Lightning trainer arguments. ``"cpu"`` becomes ``accelerator="cpu"``;
+          ``"cuda"`` and ``"cuda:N"`` become ``accelerator="gpu"`` and optionally
+          ``devices=[N]``; ``"mps"`` becomes ``accelerator="mps"``. Other valid
+          torch device types fall back to PTL auto-detection and emit a
+          :class:`UserWarning`.
         * ``callbacks`` — if the dict contains any non-empty lists a
           :class:`DeprecationWarning` is emitted; the dict is then discarded.
           Use PTL :class:`~pytorch_lightning.Callback` objects passed via
@@ -322,23 +365,10 @@ class RFDETR:
                 stacklevel=2,
             )
 
-        # Absorb legacy `device` kwarg.  When the caller explicitly requests CPU
-        # (e.g. in tests or CPU-only environments), honour it by forwarding it as
-        # the PTL accelerator.  All other device strings (e.g. "cuda:1") are not
-        # forwarded — PTL auto-selects the best available device — so emit a
-        # DeprecationWarning so callers know the value was not honoured.
+        # Parse `device` kwarg and map it to PTL accelerator/devices.
+        # Supports torch-style strings and torch.device (e.g. "cuda:1").
         _device = kwargs.pop("device", None)
-        _accelerator = "cpu" if _device == "cpu" else None
-        if _device is not None and _device != "cpu":
-            warnings.warn(
-                f"`device='{_device}'` is deprecated and ignored; PTL auto-selects the"
-                " accelerator. To pin a specific device, configure your"
-                " accelerator/backend explicitly (for example, use"
-                " `CUDA_VISIBLE_DEVICES` for CUDA) or configure a PTL Trainer"
-                " directly.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+        _accelerator, _devices = RFDETR._resolve_trainer_device_kwargs(_device)
 
         # Absorb legacy `start_epoch` — PTL resumes automatically via ckpt_path.
         if "start_epoch" in kwargs:
@@ -375,7 +405,10 @@ class RFDETR:
             )
         module = RFDETRModelModule(self.model_config, config)
         datamodule = RFDETRDataModule(self.model_config, config)
-        trainer = build_trainer(config, self.model_config, accelerator=_accelerator)
+        trainer_kwargs = {"accelerator": _accelerator}
+        if _devices is not None:
+            trainer_kwargs["devices"] = _devices
+        trainer = build_trainer(config, self.model_config, **trainer_kwargs)
         trainer.fit(module, datamodule, ckpt_path=config.resume or None)
 
         # Sync the trained weights back so predict() / export() see the updated model.

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import functools
 import glob
 import json
+import operator
 import os
 import warnings
 from collections import defaultdict
@@ -660,6 +661,7 @@ class RFDETR:
             str, Image.Image, np.ndarray, torch.Tensor, List[Union[str, np.ndarray, Image.Image, torch.Tensor]]
         ],
         threshold: float = 0.5,
+        shape: tuple[int, int] | None = None,
         **kwargs,
     ) -> Union[sv.Detections, List[sv.Detections]]:
         """Performs object detection on the input images and returns bounding box
@@ -676,14 +678,57 @@ class RFDETR:
                 as file paths, PIL Images, NumPy arrays, or torch.Tensors.
             threshold:
                 The minimum confidence score needed to consider a detected bounding box valid.
+            shape:
+                Optional ``(height, width)`` tuple to resize images to before inference.
+                When provided, overrides the model's default inference resolution. The
+                tuple should match the resolution used when exporting the model
+                (typically a square shape). Both dimensions must be positive integers
+                divisible by 14. Defaults to ``(model.resolution, model.resolution)``
+                when not set.
             **kwargs:
                 Additional keyword arguments.
 
         Returns:
             A single or multiple Detections objects, each containing bounding box
             coordinates, confidence scores, and class IDs.
+
+        Raises:
+            ValueError: If ``shape`` cannot be unpacked as a two-element sequence,
+                if either dimension does not support the ``__index__`` protocol
+                (e.g. ``float``) or is a ``bool``, if either dimension is zero or
+                negative, or if either dimension is not divisible by 14.
         """
         import supervision as sv
+
+        if shape is not None:
+            try:
+                height, width = shape
+            except (TypeError, ValueError):
+                raise ValueError(
+                    f"shape must be a sequence of two positive integers (height, width), got {shape!r}."
+                ) from None
+
+            for dim_name, dim in (("height", height), ("width", width)):
+                if isinstance(dim, bool):
+                    raise ValueError(
+                        f"shape {dim_name} must be an integer, got {type(dim).__name__} (shape={shape!r})."
+                    )
+                try:
+                    operator.index(dim)
+                except TypeError:
+                    raise ValueError(
+                        f"shape {dim_name} must be an integer, got {type(dim).__name__} (shape={shape!r})."
+                    ) from None
+                if dim <= 0:
+                    raise ValueError(f"shape must contain positive integers for height and width, got {shape!r}.")
+
+            # Normalize to plain Python ints; also accepts numpy.int64, torch scalars, etc.
+            height, width = operator.index(height), operator.index(width)
+
+            if height % 14 != 0 or width % 14 != 0:
+                raise ValueError(f"shape must have both dimensions divisible by 14, got {shape!r}.")
+
+            shape = (height, width)
 
         if not self._is_optimized_for_inference and not self._has_warned_about_not_being_optimized_for_inference:
             logger.warning(
@@ -721,7 +766,8 @@ class RFDETR:
             orig_sizes.append((h, w))
 
             img_tensor = img_tensor.to(self.model.device)
-            img_tensor = F.resize(img_tensor, (self.model.resolution, self.model.resolution))
+            resize_to = list(shape) if shape is not None else [self.model.resolution, self.model.resolution]
+            img_tensor = F.resize(img_tensor, resize_to)
             img_tensor = F.normalize(img_tensor, self.means, self.stds)
 
             processed_images.append(img_tensor)
@@ -729,12 +775,16 @@ class RFDETR:
         batch_tensor = torch.stack(processed_images)
 
         if self._is_optimized_for_inference:
-            if self._optimized_resolution != batch_tensor.shape[2]:
-                # this could happen if someone manually changes self.model.resolution after optimizing the model
+            if (
+                self._optimized_resolution != batch_tensor.shape[2]
+                or self._optimized_resolution != batch_tensor.shape[3]
+            ):
+                # this could happen if someone manually changes self.model.resolution after optimizing the model,
+                # or if predict(shape=...) is used with a shape that doesn't match the compiled square resolution.
                 raise ValueError(
                     f"Resolution mismatch. "
-                    f"Model was optimized for resolution {self._optimized_resolution}, "
-                    f"but got {batch_tensor.shape[2]}."
+                    f"Model was optimized for resolution {self._optimized_resolution}x{self._optimized_resolution}, "
+                    f"but got {batch_tensor.shape[2]}x{batch_tensor.shape[3]}."
                     " You can explicitly remove the optimized model by calling model.remove_optimized_model()."
                 )
             if self._optimized_has_been_compiled:

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -443,6 +443,7 @@ class RFDETR:
         force: bool = False,
         shape: tuple = None,
         batch_size: int = 1,
+        dynamic_batch: bool = False,
         **kwargs,
     ) -> None:
         """Export the trained model to ONNX format.
@@ -460,6 +461,8 @@ class RFDETR:
             force: Deprecated and ignored.
             shape: ``(height, width)`` tuple; defaults to square at model resolution.
             batch_size: Static batch size to bake into the ONNX graph.
+            dynamic_batch: If True, export with a dynamic batch dimension
+                so the ONNX model accepts variable batch sizes at runtime.
             **kwargs: Additional keyword arguments forwarded to export_onnx.
         """
         logger.info("Exporting model to ONNX format")
@@ -493,7 +496,10 @@ class RFDETR:
         else:
             output_names = ["dets", "labels"]
 
-        dynamic_axes = None
+        if dynamic_batch:
+            dynamic_axes = {name: {0: "batch"} for name in input_names + output_names}
+        else:
+            dynamic_axes = None
         model.eval()
         with torch.no_grad():
             if backbone_only:

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -231,6 +231,90 @@ def _build_model_context(model_config: ModelConfig) -> "ModelContext":
     )
 
 
+def _validate_shape_dims(
+    shape: object,
+    block_size: int,
+    patch_size: int,
+    num_windows: int,
+) -> tuple[int, int]:
+    """Validate a user-supplied ``(height, width)`` shape tuple and return normalised plain-int dims.
+
+    Args:
+        shape: The raw value supplied by the caller (e.g. from ``export(shape=...)`` or
+            ``predict(shape=...)``).  Must be a two-element sequence of positive integers
+            (or integer-compatible types accepted by :func:`operator.index`).
+        block_size: Required divisor for both dimensions.  Equals ``patch_size * num_windows``.
+        patch_size: Backbone patch size — used only in error messages.
+        num_windows: Number of attention windows — used only in error messages.
+
+    Returns:
+        A ``(height, width)`` tuple of plain Python :class:`int` values.
+
+    Raises:
+        ValueError: If ``shape`` cannot be unpacked as a two-element sequence, if either
+            dimension is a bool, float, or other non-integer type, if either dimension is
+            not positive, or if either dimension is not divisible by ``block_size``.
+    """
+    try:
+        height, width = shape  # type: ignore[misc]
+    except (TypeError, ValueError):
+        raise ValueError(f"shape must be a sequence of two positive integers (height, width), got {shape!r}.") from None
+    for dim_name, dim in (("height", height), ("width", width)):
+        if isinstance(dim, bool):
+            raise ValueError(f"shape {dim_name} must be an integer, got {type(dim).__name__} (shape={shape!r}).")
+        try:
+            operator.index(dim)
+        except TypeError:
+            raise ValueError(
+                f"shape {dim_name} must be an integer, got {type(dim).__name__} (shape={shape!r})."
+            ) from None
+        if dim <= 0:
+            raise ValueError(f"shape must contain positive integers for height and width, got {shape!r}.")
+    # Normalise to plain Python ints; also accepts numpy.int64, torch scalars, etc.
+    height, width = operator.index(height), operator.index(width)
+    if height % block_size != 0 or width % block_size != 0:
+        raise ValueError(
+            f"shape must have both dimensions divisible by {block_size} "
+            f"(patch_size={patch_size} * num_windows={num_windows}), got {shape!r}."
+        )
+    return height, width
+
+
+def _resolve_patch_size(patch_size: int | None, model_config: object, caller: str) -> int:
+    """Resolve and validate the ``patch_size`` argument for :meth:`RFDETR.export` and :meth:`RFDETR.predict`.
+
+    Args:
+        patch_size: Value supplied by the caller, or ``None`` to read from ``model_config``.
+        model_config: The model's configuration object.  Must expose ``patch_size`` as a
+            positive integer attribute when ``patch_size`` is ``None`` or when a mismatch
+            check is needed.
+        caller: Name of the calling method (``"export"`` or ``"predict"``) — used in
+            error messages to help the caller locate the problem.
+
+    Returns:
+        A validated, positive :class:`int` patch size.
+
+    Raises:
+        ValueError: If the resolved or provided ``patch_size`` is not a positive integer,
+            or if a caller-provided value disagrees with ``model_config.patch_size``.
+    """
+    if patch_size is None:
+        patch_size = getattr(model_config, "patch_size", 14)
+    else:
+        if isinstance(patch_size, bool) or not isinstance(patch_size, int) or patch_size <= 0:
+            raise ValueError(f"patch_size must be a positive integer, got {patch_size!r}")
+        model_patch_size = getattr(model_config, "patch_size", None)
+        if model_patch_size is not None and patch_size != model_patch_size:
+            raise ValueError(
+                f"{caller}(patch_size={patch_size}) does not match the instantiated model's "
+                f"patch_size={model_patch_size}. Patch size is an architectural parameter; "
+                f"omit patch_size to use the model's configured value."
+            )
+    if isinstance(patch_size, bool) or not isinstance(patch_size, int) or patch_size <= 0:
+        raise ValueError(f"patch_size must be a positive integer, got {patch_size!r}")
+    return patch_size
+
+
 class RFDETR:
     """
     The base RF-DETR class implements the core methods for training RF-DETR models,
@@ -475,9 +559,10 @@ class RFDETR:
         opset_version: int = 17,
         verbose: bool = True,
         force: bool = False,
-        shape: tuple = None,
+        shape: tuple[int, int] | None = None,
         batch_size: int = 1,
         dynamic_batch: bool = False,
+        patch_size: int | None = None,
         **kwargs,
     ) -> None:
         """Export the trained model to ONNX format.
@@ -494,9 +579,14 @@ class RFDETR:
             verbose: Print export progress information.
             force: Deprecated and ignored.
             shape: ``(height, width)`` tuple; defaults to square at model resolution.
+                Both dimensions must be divisible by ``patch_size * num_windows``.
             batch_size: Static batch size to bake into the ONNX graph.
             dynamic_batch: If True, export with a dynamic batch dimension
                 so the ONNX model accepts variable batch sizes at runtime.
+            patch_size: Backbone patch size. Defaults to the value stored in
+                ``model_config.patch_size`` (typically 14 or 16). When provided
+                explicitly it must match the instantiated model's patch size.
+                Shape divisibility is validated against ``patch_size * num_windows``.
             **kwargs: Additional keyword arguments forwarded to export_onnx.
         """
         logger.info("Exporting model to ONNX format")
@@ -515,11 +605,21 @@ class RFDETR:
 
         os.makedirs(output_dir, exist_ok=True)
         output_dir_path = Path(output_dir)
+        patch_size = _resolve_patch_size(patch_size, self.model_config, "export")
+        num_windows = getattr(self.model_config, "num_windows", 1)
+        if isinstance(num_windows, bool) or not isinstance(num_windows, int) or num_windows <= 0:
+            raise ValueError(f"num_windows must be a positive integer, got {num_windows!r}")
+        block_size = patch_size * num_windows
         if shape is None:
             shape = (self.model.resolution, self.model.resolution)
+            if shape[0] % block_size != 0:
+                raise ValueError(
+                    f"Model's default resolution ({self.model.resolution}) is not divisible by "
+                    f"block_size={block_size} (patch_size={patch_size} * num_windows={num_windows}). "
+                    f"Provide an explicit shape divisible by {block_size}."
+                )
         else:
-            if shape[0] % 14 != 0 or shape[1] % 14 != 0:
-                raise ValueError("Shape must be divisible by 14")
+            shape = _validate_shape_dims(shape, block_size, patch_size, num_windows)
 
         input_tensors = make_infer_image(infer_dir, shape, batch_size, device).to(device)
         input_names = ["input"]
@@ -662,6 +762,7 @@ class RFDETR:
         ],
         threshold: float = 0.5,
         shape: tuple[int, int] | None = None,
+        patch_size: int | None = None,
         **kwargs,
     ) -> Union[sv.Detections, List[sv.Detections]]:
         """Performs object detection on the input images and returns bounding box
@@ -683,8 +784,13 @@ class RFDETR:
                 When provided, overrides the model's default inference resolution. The
                 tuple should match the resolution used when exporting the model
                 (typically a square shape). Both dimensions must be positive integers
-                divisible by 14. Defaults to ``(model.resolution, model.resolution)``
-                when not set.
+                divisible by ``patch_size * num_windows``. Defaults to
+                ``(model.resolution, model.resolution)`` when not set.
+            patch_size:
+                Backbone patch size used for shape divisibility validation. Defaults
+                to ``model_config.patch_size`` (typically 14 for large models, 16 for
+                smaller ones). Divisibility is checked against
+                ``patch_size * num_windows``.
             **kwargs:
                 Additional keyword arguments.
 
@@ -696,39 +802,28 @@ class RFDETR:
             ValueError: If ``shape`` cannot be unpacked as a two-element sequence,
                 if either dimension does not support the ``__index__`` protocol
                 (e.g. ``float``) or is a ``bool``, if either dimension is zero or
-                negative, or if either dimension is not divisible by 14.
+                negative, if either dimension is not divisible by
+                ``patch_size * num_windows``, or if ``patch_size`` is not a positive
+                integer.
         """
         import supervision as sv
 
-        if shape is not None:
-            try:
-                height, width = shape
-            except (TypeError, ValueError):
+        patch_size = _resolve_patch_size(patch_size, self.model_config, "predict")
+        num_windows = getattr(self.model_config, "num_windows", 1)
+        if isinstance(num_windows, bool) or not isinstance(num_windows, int) or num_windows <= 0:
+            raise ValueError(f"model_config.num_windows must be a positive integer, got {num_windows!r}")
+        block_size = patch_size * num_windows
+
+        if shape is None:
+            default_res = self.model.resolution
+            if default_res % block_size != 0:
                 raise ValueError(
-                    f"shape must be a sequence of two positive integers (height, width), got {shape!r}."
-                ) from None
-
-            for dim_name, dim in (("height", height), ("width", width)):
-                if isinstance(dim, bool):
-                    raise ValueError(
-                        f"shape {dim_name} must be an integer, got {type(dim).__name__} (shape={shape!r})."
-                    )
-                try:
-                    operator.index(dim)
-                except TypeError:
-                    raise ValueError(
-                        f"shape {dim_name} must be an integer, got {type(dim).__name__} (shape={shape!r})."
-                    ) from None
-                if dim <= 0:
-                    raise ValueError(f"shape must contain positive integers for height and width, got {shape!r}.")
-
-            # Normalize to plain Python ints; also accepts numpy.int64, torch scalars, etc.
-            height, width = operator.index(height), operator.index(width)
-
-            if height % 14 != 0 or width % 14 != 0:
-                raise ValueError(f"shape must have both dimensions divisible by 14, got {shape!r}.")
-
-            shape = (height, width)
+                    f"Model's default resolution ({default_res}) is not divisible by "
+                    f"block_size={block_size} (patch_size={patch_size} * num_windows={num_windows}). "
+                    f"Provide an explicit shape divisible by {block_size}."
+                )
+        else:
+            shape = _validate_shape_dims(shape, block_size, patch_size, num_windows)
 
         if not self._is_optimized_for_inference and not self._has_warned_about_not_being_optimized_for_inference:
             logger.warning(

--- a/src/rfdetr/export/main.py
+++ b/src/rfdetr/export/main.py
@@ -118,7 +118,10 @@ def main(args):
         output_names = ["dets", "labels", "masks"]
     else:
         output_names = ["dets", "labels"]
-    dynamic_axes = None
+    if getattr(args, "dynamic_batch", False):
+        dynamic_axes = {name: {0: "batch"} for name in input_names + output_names}
+    else:
+        dynamic_axes = None
     # Run model inference in pytorch mode
     model.eval().to("cuda")
     input_tensors = input_tensors.to("cuda")

--- a/src/rfdetr/export/main.py
+++ b/src/rfdetr/export/main.py
@@ -40,7 +40,7 @@ def make_infer_image(infer_dir, shape, batch_size, device="cuda"):
 
     transforms = Compose(
         [
-            Resize((shape[0], shape[0])),
+            Resize((shape[0], shape[1])),
             ToImage(),
             ToDtype(torch.float32, scale=True),
             Normalize(),

--- a/src/rfdetr/models/backbone/projector.py
+++ b/src/rfdetr/models/backbone/projector.py
@@ -43,7 +43,7 @@ class LayerNorm(nn.Module):
         TODO: this is a hack to avoid overflow when using fp16
         """
         x = x.permute(0, 2, 3, 1)
-        x = F.layer_norm(x, (x.size(3),), self.weight, self.bias, self.eps)
+        x = F.layer_norm(x, self.normalized_shape, self.weight, self.bias, self.eps)
         x = x.permute(0, 3, 1, 2)
         return x
 

--- a/src/rfdetr/models/transformer.py
+++ b/src/rfdetr/models/transformer.py
@@ -90,8 +90,14 @@ def gen_encoder_output_proposals(memory, memory_padding_mask, spatial_shapes, un
             valid_H = torch.sum(~mask_flatten_[:, :, 0, 0], 1)
             valid_W = torch.sum(~mask_flatten_[:, 0, :, 0], 1)
         else:
-            valid_H = torch.tensor([H_ for _ in range(N_)], device=memory.device)
-            valid_W = torch.tensor([W_ for _ in range(N_)], device=memory.device)
+            if isinstance(H_, torch.Tensor):
+                valid_H = H_.expand(N_).to(dtype=torch.long, device=memory.device)
+            else:
+                valid_H = torch.full((N_,), H_, dtype=torch.long, device=memory.device)
+            if isinstance(W_, torch.Tensor):
+                valid_W = W_.expand(N_).to(dtype=torch.long, device=memory.device)
+            else:
+                valid_W = torch.full((N_,), W_, dtype=torch.long, device=memory.device)
 
         grid_y, grid_x = torch.meshgrid(
             torch.linspace(0, H_ - 1, H_, dtype=torch.float32, device=memory.device),
@@ -224,12 +230,18 @@ class Transformer(nn.Module):
         src_flatten = []
         mask_flatten = [] if masks is not None else None
         lvl_pos_embed_flatten = []
-        spatial_shapes = []
+        # Build spatial_shapes as a tensor directly so that the ONNX tracer
+        # can track h/w symbolically instead of baking them in as constants.
+        spatial_shapes = torch.empty((len(srcs), 2), device=srcs[0].device, dtype=torch.long)
+        # Keep Python int pairs for gen_encoder_output_proposals — its loop uses h/w
+        # as slice indices and linspace steps, which require Python ints, not tensors.
+        spatial_shapes_hw: list[tuple[int, int]] = []
         valid_ratios = [] if masks is not None else None
         for lvl, (src, pos_embed) in enumerate(zip(srcs, pos_embeds)):
             bs, c, h, w = src.shape
-            spatial_shape = (h, w)
-            spatial_shapes.append(spatial_shape)
+            spatial_shapes[lvl, 0] = h
+            spatial_shapes[lvl, 1] = w
+            spatial_shapes_hw.append((h, w))
 
             src = src.flatten(2).transpose(1, 2)  # bs, hw, c
             pos_embed = pos_embed.flatten(2).transpose(1, 2)  # bs, hw, c
@@ -243,12 +255,6 @@ class Transformer(nn.Module):
             mask_flatten = torch.cat(mask_flatten, 1)  # bs, \sum{hxw}
             valid_ratios = torch.stack([self.get_valid_ratio(m) for m in masks], 1)
         lvl_pos_embed_flatten = torch.cat(lvl_pos_embed_flatten, 1)  # bs, \sum{hxw}, c
-        # Keep a plain Python list of (H, W) int pairs for gen_encoder_output_proposals.
-        # The tensor form is only needed by ms_deform_attn and level_start_index.
-        # Passing Python ints avoids .item() calls inside the function, which would
-        # cause torch.compile graph breaks on loop-accumulated slice indices.
-        spatial_shapes_hw = list(spatial_shapes)
-        spatial_shapes = torch.as_tensor(spatial_shapes, dtype=torch.long, device=memory.device)
         level_start_index = torch.cat((spatial_shapes.new_zeros((1,)), spatial_shapes.prod(1).cumsum(0)[:-1]))
 
         if self.two_stage:

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -5,6 +5,7 @@
 # ------------------------------------------------------------------------
 
 import pytest
+import torch
 from pydantic import ValidationError
 
 from rfdetr.config import (
@@ -50,6 +51,22 @@ class TestModelConfigValidation:
 
         with pytest.raises(ValueError, match=r"Unknown attribute: 'unknown'\."):
             setattr(config, "unknown", "value")
+
+    def test_accepts_indexed_cuda_device_string(self, sample_model_config) -> None:
+        config = ModelConfig(**sample_model_config, device="cuda:1")
+        assert config.device == "cuda:1"
+
+    def test_accepts_torch_device(self, sample_model_config) -> None:
+        config = ModelConfig(**sample_model_config, device=torch.device("cuda:2"))
+        assert config.device == "cuda:2"
+
+    def test_rejects_non_string_non_torch_device_with_validation_error(self, sample_model_config) -> None:
+        with pytest.raises(ValidationError, match="device must be a string or torch\\.device\\."):
+            ModelConfig(**sample_model_config, device=123)
+
+    def test_rejects_invalid_device_string(self, sample_model_config) -> None:
+        with pytest.raises(ValidationError, match="Invalid device specifier: 'notadevice'\\."):
+            ModelConfig(**sample_model_config, device="notadevice")
 
 
 class TestSegmentationTrainConfigNumSelect:

--- a/tests/models/test_export.py
+++ b/tests/models/test_export.py
@@ -168,6 +168,76 @@ def _detr_export_scaffold(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     return model, export_called
 
 
+@pytest.mark.parametrize(
+    "dynamic_batch, segmentation_head",
+    [
+        pytest.param(True, False, id="detection_dynamic"),
+        pytest.param(True, True, id="segmentation_dynamic"),
+        pytest.param(False, False, id="detection_static"),
+    ],
+)
+def test_rfdetr_export_dynamic_batch_forwards_dynamic_axes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    dynamic_batch: bool,
+    segmentation_head: bool,
+) -> None:
+    """`RFDETR.export(..., dynamic_batch=True)` must pass a non-None `dynamic_axes` dict
+    to `export_onnx`; `dynamic_batch=False` must pass `None`.
+    """
+
+    class _DummyCoreModel:
+        def to(self, *_args, **_kwargs):
+            return self
+
+        def eval(self):
+            return self
+
+        def cpu(self):
+            return self
+
+        def __call__(self, *_args, **_kwargs):
+            if segmentation_head:
+                return {
+                    "pred_boxes": torch.zeros(1, 1, 4),
+                    "pred_logits": torch.zeros(1, 1, 2),
+                    "pred_masks": torch.zeros(1, 1, 2, 2),
+                }
+            return {"pred_boxes": torch.zeros(1, 1, 4), "pred_logits": torch.zeros(1, 1, 2)}
+
+    model = types.SimpleNamespace(
+        model=types.SimpleNamespace(model=_DummyCoreModel(), device="cpu", resolution=14),
+        model_config=types.SimpleNamespace(segmentation_head=segmentation_head),
+    )
+
+    captured: dict = {}
+
+    def _fake_make_infer_image(*_args, **_kwargs):
+        return torch.zeros(1, 3, 14, 14)
+
+    def _fake_export_onnx(*_args, dynamic_axes=None, **_kw):
+        captured["dynamic_axes"] = dynamic_axes
+        return str(tmp_path / "inference_model.onnx")
+
+    monkeypatch.setattr("rfdetr.export.main.make_infer_image", _fake_make_infer_image)
+    monkeypatch.setattr("rfdetr.export.main.export_onnx", _fake_export_onnx)
+    monkeypatch.setattr("rfdetr.detr.deepcopy", lambda x: x)
+
+    _detr_module.RFDETR.export(model, output_dir=str(tmp_path), dynamic_batch=dynamic_batch, shape=(14, 14))
+
+    dynamic_axes = captured.get("dynamic_axes")
+    if not dynamic_batch:
+        assert dynamic_axes is None, f"expected None for static export, got {dynamic_axes!r}"
+        return
+
+    assert isinstance(dynamic_axes, dict), f"expected dict, got {dynamic_axes!r}"
+    for name, axes in dynamic_axes.items():
+        assert axes == {0: "batch"}, f"axis spec for {name!r} should be {{0: 'batch'}}, got {axes!r}"
+
+    expected_names = {"input", "dets", "labels", "masks"} if segmentation_head else {"input", "dets", "labels"}
+    assert set(dynamic_axes.keys()) == expected_names, f"expected keys {expected_names}, got {set(dynamic_axes.keys())}"
+
+
 def test_export_simplify_flag_is_ignored_with_deprecation_warning(_detr_export_scaffold: tuple, tmp_path: Path) -> None:
     """`simplify=True` should not run ONNX simplification and should emit a deprecation warning."""
     model, export_called = _detr_export_scaffold
@@ -243,6 +313,7 @@ class TestCliExportMain:
         opset_version: int = 17,
         simplify: bool = False,
         tensorrt: bool = False,
+        dynamic_batch: bool = False,
     ) -> types.SimpleNamespace:
         return types.SimpleNamespace(
             device="cpu",
@@ -259,6 +330,7 @@ class TestCliExportMain:
             opset_version=opset_version,
             simplify=simplify,
             tensorrt=tensorrt,
+            dynamic_batch=dynamic_batch,
         )
 
     @staticmethod
@@ -313,6 +385,7 @@ class TestCliExportMain:
             export_onnx_captured["output_dir"] = output_dir
             export_onnx_captured["model"] = model
             export_onnx_captured["output_names"] = output_names
+            export_onnx_captured["dynamic_axes"] = dynamic_axes
             export_onnx_captured["kwargs"] = kwargs
             return str(args.output_dir) + "/inference_model.onnx"
 
@@ -454,3 +527,51 @@ class TestCliExportMain:
         mock_logger.warning.assert_called_once()
         assert "simplify" in mock_logger.warning.call_args[0][0].lower()
         assert export_onnx_called["value"] is True, "export_onnx should still be called with simplify=True"
+
+    @pytest.mark.parametrize(
+        "dynamic_batch, segmentation_head, backbone_only",
+        [
+            pytest.param(True, False, False, id="detection_dynamic"),
+            pytest.param(True, True, False, id="segmentation_dynamic"),
+            pytest.param(True, False, True, id="backbone_only_dynamic"),
+            pytest.param(False, False, False, id="detection_static"),
+        ],
+    )
+    def test_dynamic_batch_forwards_dynamic_axes(
+        self,
+        output_dir: str,
+        dynamic_batch: bool,
+        segmentation_head: bool,
+        backbone_only: bool,
+    ) -> None:
+        """CLI --dynamic_batch=True must pass {name: {0: 'batch'}} for every I/O name.
+
+        When dynamic_batch=False, dynamic_axes must be None (static export).
+        """
+        args = self._make_args(
+            output_dir=output_dir,
+            dynamic_batch=dynamic_batch,
+            segmentation_head=segmentation_head,
+            backbone_only=backbone_only,
+        )
+        _, captured = self._run(args)
+
+        dynamic_axes = captured.get("dynamic_axes")
+        if not dynamic_batch:
+            assert dynamic_axes is None, f"expected None for static export, got {dynamic_axes!r}"
+            return
+
+        assert isinstance(dynamic_axes, dict), f"expected dict, got {dynamic_axes!r}"
+        for name, axes in dynamic_axes.items():
+            assert axes == {0: "batch"}, f"axis spec for {name!r} should be {{0: 'batch'}}, got {axes!r}"
+
+        # Every input/output name must have an entry
+        if backbone_only:
+            expected_names = {"input", "features"}
+        elif segmentation_head:
+            expected_names = {"input", "dets", "labels", "masks"}
+        else:
+            expected_names = {"input", "dets", "labels"}
+        assert set(dynamic_axes.keys()) == expected_names, (
+            f"expected keys {expected_names}, got {set(dynamic_axes.keys())}"
+        )

--- a/tests/models/test_export.py
+++ b/tests/models/test_export.py
@@ -575,3 +575,170 @@ class TestCliExportMain:
         assert set(dynamic_axes.keys()) == expected_names, (
             f"expected keys {expected_names}, got {set(dynamic_axes.keys())}"
         )
+
+
+class TestExportPatchSize:
+    """RFDETR.export() patch_size validation and shape-divisibility tests."""
+
+    @staticmethod
+    def _scaffold(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path, patch_size: int, num_windows: int
+    ) -> types.SimpleNamespace:
+        """Build a minimal RFDETR-like namespace with controllable patch_size/num_windows."""
+
+        class _DummyCoreModel:
+            def to(self, *_a, **_kw):
+                return self
+
+            def eval(self):
+                return self
+
+            def cpu(self):
+                return self
+
+            def __call__(self, *_a, **_kw):
+                return {"pred_boxes": torch.zeros(1, 1, 4), "pred_logits": torch.zeros(1, 1, 2)}
+
+        model = types.SimpleNamespace(
+            model=types.SimpleNamespace(
+                model=_DummyCoreModel(),
+                device="cpu",
+                resolution=patch_size * num_windows * 2,  # always valid
+            ),
+            model_config=types.SimpleNamespace(
+                segmentation_head=False,
+                patch_size=patch_size,
+                num_windows=num_windows,
+            ),
+        )
+
+        def _fake_make_infer_image(*_a, **_kw):
+            return torch.zeros(1, 3, 8, 8)
+
+        def _fake_export_onnx(*_a, **_kw):
+            return str(tmp_path / "inference_model.onnx")
+
+        monkeypatch.setattr("rfdetr.export.main.make_infer_image", _fake_make_infer_image)
+        monkeypatch.setattr("rfdetr.export.main.export_onnx", _fake_export_onnx)
+        monkeypatch.setattr("rfdetr.detr.deepcopy", lambda x: x)
+        return model
+
+    def test_export_patch_size_mismatch_raises(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """export(patch_size=X) must raise ValueError when X != model_config.patch_size."""
+        model = self._scaffold(monkeypatch, tmp_path, patch_size=14, num_windows=4)
+        with pytest.raises(ValueError, match="patch_size"):
+            _detr_module.RFDETR.export(model, output_dir=str(tmp_path), patch_size=16)
+
+    @pytest.mark.parametrize("bad_patch_size", [0, -1])
+    def test_export_invalid_patch_size_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_patch_size: int
+    ) -> None:
+        """export() must raise ValueError when patch_size is not a positive integer."""
+        model = self._scaffold(monkeypatch, tmp_path, patch_size=14, num_windows=4)
+        # Keep model_config.patch_size consistent with the patch_size argument for this test
+        model.model_config.patch_size = bad_patch_size
+        with pytest.raises(ValueError, match="patch_size must be a positive integer"):
+            _detr_module.RFDETR.export(model, output_dir=str(tmp_path), patch_size=bad_patch_size)
+
+    def test_export_shape_must_be_divisible_by_block_size(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """export() must reject shapes not divisible by patch_size * num_windows."""
+        # patch_size=16, num_windows=2 → block_size=32; shape (48, 64): 48 % 32 != 0
+        model = self._scaffold(monkeypatch, tmp_path, patch_size=16, num_windows=2)
+        with pytest.raises(ValueError, match="divisible by 32"):
+            _detr_module.RFDETR.export(model, output_dir=str(tmp_path), shape=(48, 64))
+
+    @pytest.mark.parametrize(
+        "bad_shape",
+        [
+            pytest.param((-64, 64), id="negative_height"),
+            pytest.param((64, -64), id="negative_width"),
+            pytest.param((0, 64), id="zero_height"),
+            pytest.param((64, 0), id="zero_width"),
+        ],
+    )
+    def test_export_negative_or_zero_shape_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_shape: tuple[int, int]
+    ) -> None:
+        """export() must reject non-positive shape dimensions (Python -N % M == 0 wraps silently)."""
+        model = self._scaffold(monkeypatch, tmp_path, patch_size=16, num_windows=2)
+        with pytest.raises(ValueError, match="positive integers"):
+            _detr_module.RFDETR.export(model, output_dir=str(tmp_path), shape=bad_shape)
+
+    def test_export_shape_valid_for_block_size(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """export() accepts shape divisible by patch_size * num_windows without error."""
+        # patch_size=16, num_windows=2 → block_size=32; shape (64, 64) is valid
+        model = self._scaffold(monkeypatch, tmp_path, patch_size=16, num_windows=2)
+        # Should not raise
+        _detr_module.RFDETR.export(model, output_dir=str(tmp_path), shape=(64, 64))
+
+    @pytest.mark.parametrize("bad_patch_size", [True, False])
+    def test_export_bool_patch_size_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_patch_size: bool
+    ) -> None:
+        """export() must reject bool values for patch_size (isinstance(True, int) is True)."""
+        model = self._scaffold(monkeypatch, tmp_path, patch_size=14, num_windows=1)
+        with pytest.raises(ValueError, match="patch_size must be a positive integer"):
+            _detr_module.RFDETR.export(model, output_dir=str(tmp_path), patch_size=bad_patch_size)
+
+    def test_export_explicit_patch_size_matching_config_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """export(patch_size=X) must succeed when X matches model_config.patch_size."""
+        model = self._scaffold(monkeypatch, tmp_path, patch_size=14, num_windows=4)
+        # patch_size=14 matches model_config.patch_size=14; block_size=56; resolution=112 (56*2)
+        _detr_module.RFDETR.export(model, output_dir=str(tmp_path), patch_size=14)
+
+    @pytest.mark.parametrize(
+        "bad_shape",
+        [
+            pytest.param((14.0, 14.0), id="float_dims"),
+            pytest.param((14,), id="wrong_arity_one_element"),
+            pytest.param((14, 14, 3), id="wrong_arity_three_elements"),
+            pytest.param((True, 14), id="bool_height"),
+            pytest.param((14, False), id="bool_width"),
+        ],
+    )
+    def test_export_invalid_shape_type_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_shape: tuple
+    ) -> None:
+        """export() must raise ValueError for float, bool, or wrong-arity shape tuples."""
+        model = self._scaffold(monkeypatch, tmp_path, patch_size=14, num_windows=1)
+        with pytest.raises(ValueError, match="shape"):
+            _detr_module.RFDETR.export(model, output_dir=str(tmp_path), shape=bad_shape)
+
+    @pytest.mark.parametrize("bad_num_windows", [0, -1, True])
+    def test_export_invalid_num_windows_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_num_windows: int
+    ) -> None:
+        """export() must raise ValueError when model_config.num_windows is not a positive integer."""
+        model = self._scaffold(monkeypatch, tmp_path, patch_size=14, num_windows=1)
+        model.model_config.num_windows = bad_num_windows
+        with pytest.raises(ValueError, match="num_windows must be a positive integer"):
+            _detr_module.RFDETR.export(model, output_dir=str(tmp_path))
+
+    def test_export_default_resolution_not_divisible_by_block_size_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """export() with shape=None must raise ValueError when model.resolution % block_size != 0."""
+        # patch_size=14, num_windows=3 → block_size=42; scaffold sets resolution=84 (42*2) which is valid
+        # Override resolution to 50 (not divisible by 42) to trigger the check
+        model = self._scaffold(monkeypatch, tmp_path, patch_size=14, num_windows=3)
+        model.model.resolution = 50
+        with pytest.raises(ValueError, match="default resolution"):
+            _detr_module.RFDETR.export(model, output_dir=str(tmp_path))
+
+
+def test_make_infer_image_produces_correct_rectangular_shape() -> None:
+    """make_infer_image must produce a (B, C, H, W) tensor for non-square shapes.
+
+    Regression test for the square-resize bug where ``Resize((shape[0], shape[0]))``
+    was used instead of ``Resize((shape[0], shape[1]))``, causing the output width
+    to silently equal the height.
+    """
+    from rfdetr.export.main import make_infer_image
+
+    h, w, b = 112, 224, 2
+    tensor = make_infer_image(infer_dir=None, shape=(h, w), batch_size=b, device="cpu")
+    assert tensor.shape == (b, 3, h, w), f"Expected shape ({b}, 3, {h}, {w}), got {tensor.shape}"

--- a/tests/models/test_predict.py
+++ b/tests/models/test_predict.py
@@ -7,6 +7,7 @@ import socket
 from types import SimpleNamespace
 from typing import Any
 
+import numpy as np
 import PIL.Image
 import pytest
 import supervision as sv
@@ -92,3 +93,121 @@ def test_predict_accepts_image_url() -> None:
     detections = model.predict(_HTTP_IMAGE_URL)
     assert isinstance(detections, sv.Detections)
     assert detections.xyxy.shape == (1, 4)
+
+
+class TestPredictShape:
+    """Verify that ``predict(shape=...)`` controls the resize target.
+
+    Regression tests for https://github.com/roboflow/rf-detr/issues/682.
+    """
+
+    def test_predict_uses_resolution_when_no_shape_provided(self) -> None:
+        """Without ``shape=``, resize uses ``(resolution, resolution)``."""
+        from unittest.mock import patch
+
+        import torchvision.transforms.functional as F
+
+        model = _DummyRFDETR()
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+
+        with patch("rfdetr.detr.F.resize", wraps=F.resize) as mock_resize:
+            model.predict(img)
+
+        resize_size = list(mock_resize.call_args[0][1])
+        assert resize_size == [32, 32], f"Expected resize to model resolution (32, 32), got {resize_size}"
+
+    def test_predict_uses_provided_rectangular_shape(self) -> None:
+        # Regression test for #682
+        from unittest.mock import patch
+
+        import torchvision.transforms.functional as F
+
+        model = _DummyRFDETR()
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+
+        with patch("rfdetr.detr.F.resize", wraps=F.resize) as mock_resize:
+            model.predict(img, shape=(378, 672))
+
+        resize_size = list(mock_resize.call_args[0][1])
+        assert resize_size == [378, 672], (
+            f"Expected resize to user-provided shape (378, 672), got {resize_size}. "
+            "predict() must honour the shape parameter instead of falling back "
+            "to (resolution, resolution)."
+        )
+
+    def test_predict_shape_square_override(self) -> None:
+        # Regression test for #682 — square shape different from model resolution.
+        from unittest.mock import patch
+
+        import torchvision.transforms.functional as F
+
+        model = _DummyRFDETR()
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+
+        with patch("rfdetr.detr.F.resize", wraps=F.resize) as mock_resize:
+            model.predict(img, shape=(56, 56))
+
+        resize_size = list(mock_resize.call_args[0][1])
+        assert resize_size == [56, 56], (
+            f"Expected resize to user-provided shape (56, 56), got {resize_size}. "
+            "predict() must honour the shape parameter even for square sizes "
+            "that differ from the model's default resolution."
+        )
+
+    @pytest.mark.parametrize(
+        "int_shape",
+        [
+            pytest.param((np.int64(378), np.int64(672)), id="numpy_int64"),
+            pytest.param((np.int32(378), np.int32(672)), id="numpy_int32"),
+            pytest.param((torch.tensor(378), torch.tensor(672)), id="torch_scalar"),
+        ],
+    )
+    def test_predict_shape_accepts_integer_like_types(self, int_shape: tuple) -> None:
+        """predict() accepts integer-like types (numpy, torch) via the __index__ protocol."""
+        from unittest.mock import patch
+
+        import torchvision.transforms.functional as F
+
+        model = _DummyRFDETR()
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+
+        with patch("rfdetr.detr.F.resize", wraps=F.resize) as mock_resize:
+            model.predict(img, shape=int_shape)  # type: ignore[arg-type]
+
+        resize_size = list(mock_resize.call_args[0][1])
+        assert resize_size == [378, 672], f"predict() must accept integer-like shape types, got resize {resize_size}"
+
+    @pytest.mark.parametrize(
+        "bad_shape",
+        [
+            pytest.param((378, 671), id="width_not_div_14"),  # 671 % 14 != 0
+            pytest.param((371, 672), id="height_not_div_14"),  # 371 % 14 != 0
+        ],
+    )
+    def test_predict_shape_not_divisible_by_14_raises(self, bad_shape: tuple[int, int]) -> None:
+        """predict() must reject shapes with dimensions not divisible by 14."""
+        model = _DummyRFDETR()
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+        with pytest.raises(ValueError, match="divisible by 14"):
+            model.predict(img, shape=bad_shape)
+
+    @pytest.mark.parametrize(
+        "bad_shape",
+        [
+            pytest.param((378.0, 672.0), id="float_dims"),
+            pytest.param((378,), id="wrong_arity_one_element"),
+            pytest.param((378, 672, 3), id="wrong_arity_three_elements"),
+            pytest.param((0, 56), id="zero_height"),
+            pytest.param((-14, 56), id="negative_height"),
+            pytest.param((56, 0), id="zero_width"),
+            pytest.param((56, -14), id="negative_width"),
+            pytest.param((True, 56), id="bool_height"),
+            pytest.param((56, False), id="bool_width"),
+        ],
+    )
+    def test_predict_shape_invalid_raises(self, bad_shape: tuple[int | float | bool, ...]) -> None:
+        """predict() must raise ValueError for invalid shape values."""
+        model = _DummyRFDETR()
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+        with pytest.raises(ValueError, match="shape"):
+            model.predict(img, shape=bad_shape)  # type: ignore[arg-type]

--- a/tests/models/test_predict.py
+++ b/tests/models/test_predict.py
@@ -32,7 +32,7 @@ def _is_online(host: str, port: int, timeout_s: float = 3.0) -> bool:
 class _DummyModel:
     def __init__(self) -> None:
         self.device = torch.device("cpu")
-        self.resolution = 32
+        self.resolution = 28
         self.model = torch.nn.Identity()
 
     def postprocess(self, predictions: Any, target_sizes: torch.Tensor) -> list[dict[str, torch.Tensor]]:
@@ -114,7 +114,7 @@ class TestPredictShape:
             model.predict(img)
 
         resize_size = list(mock_resize.call_args[0][1])
-        assert resize_size == [32, 32], f"Expected resize to model resolution (32, 32), got {resize_size}"
+        assert resize_size == [28, 28], f"Expected resize to model resolution (28, 28), got {resize_size}"
 
     def test_predict_uses_provided_rectangular_shape(self) -> None:
         # Regression test for #682
@@ -211,3 +211,73 @@ class TestPredictShape:
         img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
         with pytest.raises(ValueError, match="shape"):
             model.predict(img, shape=bad_shape)  # type: ignore[arg-type]
+
+
+class TestPredictPatchSize:
+    """predict() patch_size resolution and validation tests."""
+
+    def _make_model_with_config(self, patch_size: int, num_windows: int) -> _DummyRFDETR:
+        """Return a _DummyRFDETR whose model_config carries patch_size and num_windows."""
+        from types import SimpleNamespace
+
+        model = _DummyRFDETR()
+        model.model_config = SimpleNamespace(patch_size=patch_size, num_windows=num_windows)
+        return model
+
+    def test_predict_defaults_patch_size_from_model_config(self) -> None:
+        """predict() reads patch_size from model_config when not provided by the caller."""
+        # patch_size=16, num_windows=2 → block_size=32; shape=(64,64) is valid
+        model = self._make_model_with_config(patch_size=16, num_windows=2)
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+        # Should not raise — 64 % 32 == 0
+        model.predict(img, shape=(64, 64))
+
+    def test_predict_shape_must_be_divisible_by_block_size(self) -> None:
+        """predict() rejects shapes not divisible by patch_size * num_windows."""
+        # patch_size=16, num_windows=2 → block_size=32; shape (48, 64) fails (48%32==16)
+        model = self._make_model_with_config(patch_size=16, num_windows=2)
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+        with pytest.raises(ValueError, match="divisible by 32"):
+            model.predict(img, shape=(48, 64))
+
+    @pytest.mark.parametrize("bad_patch_size", [0, -1, True, False])
+    def test_predict_invalid_patch_size_raises(self, bad_patch_size: int) -> None:
+        """predict() must raise ValueError when patch_size is not a positive integer."""
+        model = _DummyRFDETR()
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+        with pytest.raises(ValueError, match="patch_size must be a positive integer"):
+            model.predict(img, patch_size=bad_patch_size)  # type: ignore[arg-type]
+
+    def test_predict_patch_size_mismatch_raises(self) -> None:
+        """predict() must raise ValueError when caller's patch_size != model_config.patch_size."""
+        # model has patch_size=16; passing patch_size=14 should raise immediately
+        model = self._make_model_with_config(patch_size=16, num_windows=1)
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+        with pytest.raises(ValueError, match="does not match"):
+            model.predict(img, shape=(16, 16), patch_size=14)
+
+    def test_predict_explicit_patch_size_matching_config_succeeds(self) -> None:
+        """predict(patch_size=X) must succeed when X matches model_config.patch_size."""
+        # patch_size=16, num_windows=2 → block_size=32; shape=(64,64) is valid
+        model = self._make_model_with_config(patch_size=16, num_windows=2)
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+        # Should not raise — patch_size matches config, 64 % 32 == 0
+        model.predict(img, shape=(64, 64), patch_size=16)
+
+    @pytest.mark.parametrize("bad_num_windows", [0, -1, True])
+    def test_predict_invalid_num_windows_raises(self, bad_num_windows: int) -> None:
+        """predict() must raise ValueError when model_config.num_windows is not a positive integer."""
+        model = self._make_model_with_config(patch_size=14, num_windows=1)
+        model.model_config.num_windows = bad_num_windows
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+        with pytest.raises(ValueError, match="num_windows must be a positive integer"):
+            model.predict(img, shape=(14, 14))
+
+    def test_predict_default_resolution_not_divisible_by_block_size_raises(self) -> None:
+        """predict() with shape=None must raise ValueError when model.resolution % block_size != 0."""
+        # patch_size=14, num_windows=1 → block_size=14; set resolution=25 (not divisible)
+        model = self._make_model_with_config(patch_size=14, num_windows=1)
+        model.model.resolution = 25
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+        with pytest.raises(ValueError, match="default resolution"):
+            model.predict(img)

--- a/tests/models/test_transformer.py
+++ b/tests/models/test_transformer.py
@@ -36,3 +36,25 @@ def test_gen_encoder_output_proposals_passes_ij_indexing_to_meshgrid(monkeypatch
     assert call_count == 1
     assert output_memory.shape == memory.shape
     assert output_proposals.shape == (1, 4, 4)
+
+
+def test_gen_encoder_output_proposals_accepts_int_tuple_spatial_shapes() -> None:
+    """Regression: spatial_shapes as list[tuple[int, int]] with masks=None must not crash.
+
+    Transformer.forward() passes Python int pairs (from bs, c, h, w = src.shape) to
+    gen_encoder_output_proposals. The export path (masks=None) triggers the else branch
+    which previously called H_.expand(N_) — failing with AttributeError on a Python int.
+    """
+    batch, h, w, d = 2, 3, 4, 8
+    memory = torch.randn(batch, h * w, d)
+    spatial_shapes = [(h, w)]  # Python int pairs, as produced by Transformer.forward()
+
+    output_memory, output_proposals = gen_encoder_output_proposals(
+        memory=memory,
+        memory_padding_mask=None,
+        spatial_shapes=spatial_shapes,
+        unsigmoid=True,
+    )
+
+    assert output_memory.shape == memory.shape
+    assert output_proposals.shape == (batch, h * w, 4)

--- a/tests/models/test_validate_shape_dims.py
+++ b/tests/models/test_validate_shape_dims.py
@@ -1,0 +1,153 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Unit tests for :func:`rfdetr.detr._validate_shape_dims` and :func:`rfdetr.detr._resolve_patch_size`.
+
+Tests call each helper directly so each validation path has a single focused
+test without the export/predict scaffolding overhead.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from rfdetr.detr import _resolve_patch_size, _validate_shape_dims
+
+
+class TestValidateShapeDimsHappyPath:
+    """_validate_shape_dims returns normalised (height, width) for valid inputs."""
+
+    def test_exact_plain_ints(self) -> None:
+        """Plain int dims divisible by block_size are returned unchanged."""
+        assert _validate_shape_dims((56, 112), 14, 14, 1) == (56, 112)
+
+    def test_returns_plain_int_tuple(self) -> None:
+        """Return type is always a tuple of plain Python int."""
+        h, w = _validate_shape_dims((56, 56), 14, 14, 1)
+        assert type(h) is int and type(w) is int
+
+    def test_numpy_int_accepted(self) -> None:
+        """numpy.int64 dims are accepted via operator.index and normalised."""
+        import numpy as np
+
+        h, w = _validate_shape_dims((np.int64(56), np.int64(112)), 14, 14, 1)
+        assert (h, w) == (56, 112)
+        assert type(h) is int and type(w) is int
+
+    def test_non_square_shape(self) -> None:
+        """Non-square (H != W) shapes are returned correctly."""
+        assert _validate_shape_dims((112, 224), 14, 14, 1) == (112, 224)
+
+    def test_block_size_from_num_windows(self) -> None:
+        """block_size = patch_size * num_windows; both dims divisible by it."""
+        # patch_size=16, num_windows=2 → block_size=32
+        assert _validate_shape_dims((64, 128), 32, 16, 2) == (64, 128)
+
+
+class TestValidateShapeDimsArityErrors:
+    """_validate_shape_dims raises ValueError for non-two-element shapes."""
+
+    def test_one_element_raises(self) -> None:
+        """Single-element tuple must raise ValueError."""
+        with pytest.raises(ValueError, match="shape must be a sequence"):
+            _validate_shape_dims((56,), 14, 14, 1)
+
+    def test_three_element_raises(self) -> None:
+        """Three-element tuple must raise ValueError."""
+        with pytest.raises(ValueError, match="shape must be a sequence"):
+            _validate_shape_dims((56, 56, 3), 14, 14, 1)
+
+    def test_scalar_raises(self) -> None:
+        """Bare scalar (not a sequence) must raise ValueError."""
+        with pytest.raises(ValueError, match="shape must be a sequence"):
+            _validate_shape_dims(56, 14, 14, 1)  # type: ignore[arg-type]
+
+
+class TestValidateShapeDimsInvalidDim:
+    """_validate_shape_dims rejects bool, float, and non-positive dimension values."""
+
+    @pytest.mark.parametrize("shape,match", [((True, 56), "height"), ((56, False), "width")])
+    def test_bool_dim_raises(self, shape: tuple, match: str) -> None:
+        """Bool dims must raise ValueError even though bool is an int subtype."""
+        with pytest.raises(ValueError, match=f"{match} must be an integer"):
+            _validate_shape_dims(shape, 14, 14, 1)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("shape", [(56.0, 56.0), (56.0, 56), (56, 56.0)])
+    def test_float_dim_raises(self, shape: tuple) -> None:
+        """Float dims must raise ValueError (operator.index rejects them)."""
+        with pytest.raises(ValueError, match="must be an integer"):
+            _validate_shape_dims(shape, 14, 14, 1)
+
+    @pytest.mark.parametrize("shape", [(0, 56), (56, 0), (-14, 56), (56, -14)])
+    def test_non_positive_dim_raises(self, shape: tuple[int, int]) -> None:
+        """Zero or negative dims must raise ValueError."""
+        with pytest.raises(ValueError, match="positive integers"):
+            _validate_shape_dims(shape, 14, 14, 1)
+
+
+class TestValidateShapeDimsDivisibilityCheck:
+    """_validate_shape_dims enforces divisibility by block_size."""
+
+    @pytest.mark.parametrize(
+        "shape, block_size",
+        [
+            pytest.param((55, 56), 14, id="height_not_divisible"),
+            pytest.param((56, 55), 14, id="width_not_divisible"),
+            pytest.param((48, 64), 32, id="height_not_divisible_large_block"),
+        ],
+    )
+    def test_indivisible_shape_raises(self, shape: tuple[int, int], block_size: int) -> None:
+        """Shapes not divisible by block_size must raise ValueError."""
+        with pytest.raises(ValueError, match=f"divisible by {block_size}"):
+            _validate_shape_dims(shape, block_size, 14, 1)
+
+    def test_error_message_includes_patch_size_and_num_windows(self) -> None:
+        """Error message must name patch_size and num_windows for debuggability."""
+        with pytest.raises(ValueError, match="patch_size=16") as exc_info:
+            _validate_shape_dims((48, 64), 32, 16, 2)
+        assert "num_windows=2" in str(exc_info.value)
+
+
+class TestResolvePatchSize:
+    """_resolve_patch_size resolves and validates patch_size for export()/predict()."""
+
+    def _cfg(self, patch_size: int) -> SimpleNamespace:
+        """Return a minimal model_config stub with the given patch_size."""
+        return SimpleNamespace(patch_size=patch_size)
+
+    def test_none_reads_from_model_config(self) -> None:
+        """patch_size=None resolves to model_config.patch_size."""
+        assert _resolve_patch_size(None, self._cfg(16), "export") == 16
+
+    def test_none_falls_back_to_14_when_config_missing(self) -> None:
+        """patch_size=None falls back to 14 when model_config has no patch_size."""
+        assert _resolve_patch_size(None, SimpleNamespace(), "export") == 14
+
+    def test_explicit_matching_config_accepted(self) -> None:
+        """Providing patch_size equal to model_config.patch_size succeeds."""
+        assert _resolve_patch_size(14, self._cfg(14), "export") == 14
+
+    def test_explicit_mismatch_raises(self) -> None:
+        """Providing patch_size != model_config.patch_size must raise ValueError."""
+        with pytest.raises(ValueError, match="does not match"):
+            _resolve_patch_size(16, self._cfg(14), "export")
+
+    def test_mismatch_error_includes_caller_name(self) -> None:
+        """Mismatch error message includes the caller name for context."""
+        with pytest.raises(ValueError, match="predict"):
+            _resolve_patch_size(16, self._cfg(14), "predict")
+
+    @pytest.mark.parametrize("bad", [0, -1, True, False])
+    def test_invalid_explicit_patch_size_raises(self, bad: int) -> None:
+        """Non-positive-int patch_size must raise ValueError before the mismatch check."""
+        cfg = SimpleNamespace(patch_size=bad)
+        with pytest.raises(ValueError, match="patch_size must be a positive integer"):
+            _resolve_patch_size(bad, cfg, "export")
+
+    def test_invalid_config_patch_size_raises(self) -> None:
+        """Bad patch_size in model_config (when caller passes None) must raise ValueError."""
+        with pytest.raises(ValueError, match="patch_size must be a positive integer"):
+            _resolve_patch_size(None, SimpleNamespace(patch_size=0), "export")

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -264,17 +264,24 @@ class TestRFDETRTrainPTL:
         assert not any(issubclass(x.category, DeprecationWarning) for x in w)
         mock_self.get_train_config.assert_called_once_with()
 
-    def test_device_kwarg_non_cpu_emits_deprecation(self, tmp_path):
-        """Non-'cpu' device= emits a DeprecationWarning and is not forwarded."""
+    def test_device_kwarg_cuda_forwards_gpu_accelerator_without_devices(self, tmp_path):
+        """device='cuda' is mapped to accelerator='gpu' without explicit devices override."""
         mock_self = _make_rfdetr_self(tmp_path)
         p_mod, p_dm, p_bt, *_ = _patch_lit()
         with p_mod, p_dm, p_bt, warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             RFDETR.train(mock_self, device="cuda")
-        dep_warns = [x for x in w if issubclass(x.category, DeprecationWarning)]
-        assert len(dep_warns) == 1
-        assert "cuda" in str(dep_warns[0].message)
-        # device must not have been forwarded to get_train_config
+        assert not any(issubclass(x.category, DeprecationWarning) for x in w)
+        mock_self.get_train_config.assert_called_once_with()
+
+    def test_device_kwarg_torch_device_cuda_index_forwards_gpu_accelerator_and_devices(self, tmp_path):
+        """torch.device('cuda:1') is mapped to accelerator='gpu' and devices=[1]."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        p_mod, p_dm, p_bt, *_ = _patch_lit()
+        with p_mod, p_dm, p_bt, warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            RFDETR.train(mock_self, device=torch.device("cuda:1"))
+        assert not any(issubclass(x.category, DeprecationWarning) for x in w)
         mock_self.get_train_config.assert_called_once_with()
 
     def test_callbacks_none_no_warning(self, tmp_path):
@@ -427,6 +434,56 @@ class TestRFDETRTrainPTLAbsorption:
             RFDETR.train(mock_self, device="cpu")
         config = mock_self.get_train_config.return_value
         mock_bt.assert_called_once_with(config, mock_self.model_config, accelerator="cpu")
+
+    def test_device_cuda_absorbed_as_accelerator_gpu(self, tmp_path):
+        """device='cuda' forwards accelerator='gpu' without a devices kwarg."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = _patch_lit()
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self, device="cuda")
+        config = mock_self.get_train_config.return_value
+        mock_bt.assert_called_once_with(config, mock_self.model_config, accelerator="gpu")
+        assert "devices" not in mock_bt.call_args.kwargs
+
+    def test_device_cuda_index_absorbed_as_accelerator_gpu_devices_list(self, tmp_path):
+        """device='cuda:1' forwards accelerator='gpu' and devices=[1]."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = _patch_lit()
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self, device="cuda:1")
+        config = mock_self.get_train_config.return_value
+        mock_bt.assert_called_once_with(config, mock_self.model_config, accelerator="gpu", devices=[1])
+
+    def test_device_torch_device_cuda_index_absorbed_as_accelerator_gpu_devices_list(self, tmp_path):
+        """device=torch.device('cuda:2') forwards accelerator='gpu' and devices=[2]."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = _patch_lit()
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self, device=torch.device("cuda:2"))
+        config = mock_self.get_train_config.return_value
+        mock_bt.assert_called_once_with(config, mock_self.model_config, accelerator="gpu", devices=[2])
+
+    def test_device_invalid_raises_value_error_with_expected_message(self, tmp_path):
+        """Invalid device strings raise a ValueError with the train() device hint."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        p_mod, p_dm, p_bt, *_ = _patch_lit()
+        with (
+            p_mod,
+            p_dm,
+            p_bt,
+            pytest.raises(ValueError, match=r"Invalid device specifier for train\(\): 'notadevice'"),
+        ):
+            RFDETR.train(mock_self, device="notadevice")
+
+    def test_device_unmapped_valid_type_warns_and_falls_back_to_auto_detection(self, tmp_path):
+        """Valid but unmapped torch device types warn and use PTL auto-detection."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = _patch_lit()
+        with p_mod, p_dm, p_bt, pytest.warns(UserWarning, match="auto-detection"):
+            RFDETR.train(mock_self, device="meta")
+        config = mock_self.get_train_config.return_value
+        mock_bt.assert_called_once_with(config, mock_self.model_config, accelerator=None)
+        assert "devices" not in mock_bt.call_args.kwargs
 
     def test_callbacks_empty_dict_no_error(self, tmp_path):
         """callbacks={} is accepted without error."""


### PR DESCRIPTION
## 🚀 Added

- **`RFDETR.predict(shape=...)`** — pass an explicit `(height, width)` tuple to run inference at a non-square resolution, matching the resolution used when exporting the model. Both dimensions must be positive integers divisible by 14. (#866)

```python
detections = model.predict("image.jpg", shape=(480, 640))
```

## 🌱 Changed

- **`ModelConfig.device` and `RFDETR.train(device=...)`** now accept `torch.device` objects and indexed device strings (`"cuda:0"`, `"cuda:1"`). Existing string values (`"cpu"`, `"cuda"`) are unchanged. `RFDETR.train()` warns when a valid but unmapped device type is passed to PyTorch Lightning auto-detection. (#872)

```python
from rfdetr import RFDETRSmall
from torch import device

model = RFDETRSmall(...)

model.train(..., device=device("cuda:1"))
model.train(..., device="cuda:0")
```

## 🔧 Fixed

- Fixed ONNX export ignoring an explicit `patch_size` argument: `export()` and `predict()` now resolve `patch_size` from `model_config` by default, validate it strictly (must be a positive integer, not bool), and enforce that `(H, W)` dimensions are divisible by `patch_size × num_windows`. (#876)
- Fixed ONNX export for models traced with dynamic batch dimensions — `torch.full` is now used for Python-int spatial dims to avoid `H_.expand(N_)` tracer failures. (#871)

---

## 🏆 Contributors

Welcome to our new contributors, and thank you to everyone who helped with this release:

- **zhaoshuo** (@zhaoshuo1223) — *ONNX export shape validation and patch_size fixes*
- **Sven Goluza** (@svengoluza) — *ONNX export dynamic batch fix*
- **Jirka Borovec** (@Borda) ([LinkedIn](https://www.linkedin.com/in/jirka-borovec/)) — *shape inference, torch.device support, release coordination*

---

**Full changelog**: https://github.com/roboflow/rf-detr/compare/1.6.1...1.6.2
