### PR TITLE
refactor: modernize typing in evaluation and utilities modules 

### DIFF
--- a/src/rfdetr/evaluation/coco_eval.py
+++ b/src/rfdetr/evaluation/coco_eval.py
@@ -25,7 +25,7 @@ https://github.com/pytorch/vision/blob/edfd5a7/references/detection/coco_eval.py
 import contextlib
 import copy
 import os
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 import numpy as np
 import pycocotools.mask as mask_util
@@ -49,27 +49,27 @@ def _xyxy_to_xywh(boxes: np.ndarray) -> np.ndarray:
 class CocoEvaluator:
     """COCO evaluator that works in distributed mode."""
 
-    def __init__(self, coco_gt: COCO, iou_types: List[str], max_dets: int = 100) -> None:
+    def __init__(self, coco_gt: COCO, iou_types: list[str], max_dets: int = 100) -> None:
         assert isinstance(iou_types, (list, tuple))
         coco_gt = copy.deepcopy(coco_gt)
         self.coco_gt = coco_gt
         self.max_dets = max_dets
         # label2cat maps contiguous model label indices back to original COCO category_ids.
         # Set by CocoDetection when cat2label remapping is active; None otherwise.
-        self.label2cat: Dict[int, int] | None = getattr(coco_gt, "label2cat", None)
+        self.label2cat: dict[int, int] | None = getattr(coco_gt, "label2cat", None)
 
         self.iou_types = iou_types
-        self.coco_eval: Dict[str, COCOeval] = {}
+        self.coco_eval: dict[str, COCOeval] = {}
         for iou_type in iou_types:
             self.coco_eval[iou_type] = COCOeval(coco_gt, iouType=iou_type)
             self.coco_eval[iou_type].params.maxDets = [1, 10, max_dets]
 
-        self.img_ids: List[int] = []
-        self.eval_imgs: Dict[str, List[Any]] = {k: [] for k in iou_types}
+        self.img_ids: list[int] = []
+        self.eval_imgs: dict[str, list[Any]] = {k: [] for k in iou_types}
         self.cat_ids = set(coco_gt.cats.keys())
         self._prefer_raw_category_ids = False
 
-    def _resolve_category_id(self, label: int, use_raw_category_ids: bool) -> Optional[int]:
+    def _resolve_category_id(self, label: int, use_raw_category_ids: bool) -> int | None:
         """Resolve a predicted label to a COCO category_id."""
         if use_raw_category_ids:
             return label if label in self.cat_ids else None
@@ -79,7 +79,7 @@ class CocoEvaluator:
             return label
         return None
 
-    def _should_use_raw_category_ids(self, labels: List[int]) -> bool:
+    def _should_use_raw_category_ids(self, labels: list[int]) -> bool:
         """Detect whether model predictions are already raw COCO category IDs."""
         if self.label2cat is None:
             return True
@@ -91,7 +91,7 @@ class CocoEvaluator:
             return True
         return False
 
-    def update(self, predictions: Dict[int, Any]) -> None:
+    def update(self, predictions: dict[int, Any]) -> None:
         """Accumulate per-image predictions."""
         img_ids = list(np.unique(list(predictions.keys())))
         self.img_ids.extend(img_ids)
@@ -127,7 +127,7 @@ class CocoEvaluator:
             logger.info("IoU metric: {}".format(iou_type))
             patched_pycocotools_summarize(coco_eval)
 
-    def prepare(self, predictions: Dict[int, Any], iou_type: str) -> List[Dict[str, Any]]:
+    def prepare(self, predictions: dict[int, Any], iou_type: str) -> list[dict[str, Any]]:
         """Convert predictions to COCO format for the given iou_type."""
         if iou_type == "bbox":
             return self.prepare_for_coco_detection(predictions)
@@ -138,7 +138,7 @@ class CocoEvaluator:
         else:
             raise ValueError("Unknown iou type {}".format(iou_type))
 
-    def prepare_for_coco_detection(self, predictions: Dict[int, Any]) -> List[Dict[str, Any]]:
+    def prepare_for_coco_detection(self, predictions: dict[int, Any]) -> list[dict[str, Any]]:
         """Format bounding-box predictions as COCO result dicts."""
         coco_results = []
         for original_id, prediction in predictions.items():
@@ -164,7 +164,7 @@ class CocoEvaluator:
                 )
         return coco_results
 
-    def prepare_for_coco_segmentation(self, predictions: Dict[int, Any]) -> List[Dict[str, Any]]:
+    def prepare_for_coco_segmentation(self, predictions: dict[int, Any]) -> list[dict[str, Any]]:
         """Format segmentation mask predictions as COCO result dicts."""
         coco_results = []
         for original_id, prediction in predictions.items():
@@ -202,7 +202,7 @@ class CocoEvaluator:
                 )
         return coco_results
 
-    def prepare_for_coco_keypoint(self, predictions: Dict[int, Any]) -> List[Dict[str, Any]]:
+    def prepare_for_coco_keypoint(self, predictions: dict[int, Any]) -> list[dict[str, Any]]:
         """Format keypoint predictions as COCO result dicts."""
         coco_results = []
         for original_id, prediction in predictions.items():
@@ -231,12 +231,12 @@ class CocoEvaluator:
         return coco_results
 
 
-def merge(img_ids: List[int], eval_imgs: Any) -> Tuple[np.ndarray, np.ndarray]:
+def merge(img_ids: list[int], eval_imgs: Any) -> tuple[np.ndarray, np.ndarray]:
     """Merge distributed per-image evaluation results."""
     all_img_ids = all_gather(img_ids)
     all_eval_imgs = all_gather(eval_imgs)
 
-    merged_img_ids: List[int] = []
+    merged_img_ids: list[int] = []
     for p in all_img_ids:
         merged_img_ids.extend(p)
 
@@ -254,7 +254,7 @@ def merge(img_ids: List[int], eval_imgs: Any) -> Tuple[np.ndarray, np.ndarray]:
     return merged_img_ids_arr, merged_eval_imgs_arr
 
 
-def create_common_coco_eval(coco_eval: COCOeval, img_ids: List[int], eval_imgs: Any) -> None:
+def create_common_coco_eval(coco_eval: COCOeval, img_ids: list[int], eval_imgs: Any) -> None:
     """Populate a COCOeval object with merged distributed results."""
     img_ids_arr, eval_imgs = merge(img_ids, eval_imgs)
     img_ids_list = list(img_ids_arr)
@@ -269,7 +269,7 @@ def create_common_coco_eval(coco_eval: COCOeval, img_ids: List[int], eval_imgs: 
 # From pycocotools, just removed the prints and fixed
 # a Python3 bug about unicode not defined
 #################################################################
-def evaluate(self: COCOeval) -> Tuple[List[int], np.ndarray]:
+def evaluate(self: COCOeval) -> tuple[list[int], np.ndarray]:
     """Run per-image evaluation and store results in self.evalImgs."""
     p = self.params
     if p.useSegm is not None:
@@ -307,7 +307,7 @@ def evaluate(self: COCOeval) -> Tuple[List[int], np.ndarray]:
 def patched_pycocotools_summarize(self: COCOeval) -> None:
     """Compute and display summary metrics for evaluation results."""
 
-    def _summarize(ap: int = 1, iouThr: Optional[float] = None, areaRng: str = "all", maxDets: int = 100) -> float:
+    def _summarize(ap: int = 1, iouThr: float | None = None, areaRng: str = "all", maxDets: int = 100) -> float:
         p = self.params
         iStr = " {:<18} {} @[ IoU={:<9} | area={:>6s} | maxDets={:>3d} ] = {:0.3f}"
         titleStr = "Average Precision" if ap == 1 else "Average Recall"

--- a/src/rfdetr/evaluation/matching.py
+++ b/src/rfdetr/evaluation/matching.py
@@ -16,7 +16,7 @@
 
 """Greedy matching and accumulation functions for evaluation metrics."""
 
-from typing import Any, List
+from typing import Any
 
 import numpy as np
 import torch
@@ -300,7 +300,7 @@ def distributed_merge_matching_data(
     Returns:
         Merged accumulator containing contributions from all ranks.
     """
-    gathered: List[dict[int, dict[str, Any]]] = all_gather(local_data)
+    gathered: list[dict[int, dict[str, Any]]] = all_gather(local_data)
     merged: dict[int, dict[str, Any]] = {}
     for rank_data in gathered:
         merge_matching_data(merged, rank_data)

--- a/src/rfdetr/utilities/box_ops.py
+++ b/src/rfdetr/utilities/box_ops.py
@@ -17,8 +17,6 @@
 
 """Utilities for bounding box manipulation and GIoU."""
 
-from typing import Tuple
-
 import torch
 import torch.nn.functional as F
 from torchvision.ops.boxes import box_area
@@ -42,7 +40,7 @@ def box_xyxy_to_cxcywh(x: torch.Tensor) -> torch.Tensor:
 
 
 # modified from torchvision to also return the union
-def box_iou(boxes1: torch.Tensor, boxes2: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+def box_iou(boxes1: torch.Tensor, boxes2: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     """Compute pairwise IoU and union for two sets of boxes.
 
     Returns:

--- a/src/rfdetr/utilities/distributed.py
+++ b/src/rfdetr/utilities/distributed.py
@@ -14,7 +14,7 @@
 """Distributed-training helpers (world-size, rank, all_gather, reduce_dict)."""
 
 import pickle
-from typing import Any, Dict, List
+from typing import Any
 
 import torch
 import torch.distributed as dist
@@ -63,7 +63,7 @@ def save_on_master(obj: Any, f: Any, *args: Any, **kwargs: Any) -> None:
         torch.save(obj, f, *args, **kwargs)
 
 
-def all_gather(data: Any) -> List[Any]:
+def all_gather(data: Any) -> list[Any]:
     """Run all_gather on arbitrary picklable data (not necessarily tensors).
 
     Args:
@@ -108,7 +108,7 @@ def all_gather(data: Any) -> List[Any]:
     return data_list
 
 
-def reduce_dict(input_dict: Dict[str, torch.Tensor], average: bool = True) -> Dict[str, torch.Tensor]:
+def reduce_dict(input_dict: dict[str, torch.Tensor], average: bool = True) -> dict[str, torch.Tensor]:
     """Reduce values in *input_dict* across all processes.
 
     Args:

--- a/src/rfdetr/utilities/files.py
+++ b/src/rfdetr/utilities/files.py
@@ -9,7 +9,6 @@
 import hashlib
 import os
 import shutil
-from typing import Optional
 
 import requests
 from tqdm.auto import tqdm
@@ -56,7 +55,7 @@ def _validate_file_md5(filepath: str, expected_md5: str) -> bool:
 def _download_file(
     url: str,
     filename: str,
-    expected_md5: Optional[str] = None,
+    expected_md5: str | None = None,
     timeout: float = DEFAULT_DOWNLOAD_TIMEOUT_SECONDS,
 ) -> None:
     """Download a file from a URL with optional MD5 validation.

--- a/src/rfdetr/utilities/logger.py
+++ b/src/rfdetr/utilities/logger.py
@@ -9,7 +9,6 @@
 import logging
 import os
 import sys
-from typing import Optional
 
 
 class _RFDETRLogger(logging.Logger):
@@ -26,7 +25,7 @@ class _RFDETRLogger(logging.Logger):
             self.warning(msg, *args, **kwargs)
 
 
-def get_logger(name: str = "rf-detr", level: Optional[int] = None) -> _RFDETRLogger:
+def get_logger(name: str = "rf-detr", level: int | None = None) -> _RFDETRLogger:
     """Creates and configures a logger with stdout and stderr handlers.
 
     This function creates a logger that sends INFO and DEBUG level logs to stdout,

--- a/src/rfdetr/utilities/package.py
+++ b/src/rfdetr/utilities/package.py
@@ -9,10 +9,9 @@
 import os
 import subprocess
 from importlib.metadata import PackageNotFoundError, version
-from typing import List, Optional
 
 
-def get_version(package_name: str = "rfdetr") -> Optional[str]:
+def get_version(package_name: str = "rfdetr") -> str | None:
     """Get the current version of the specified package.
 
     Args:
@@ -37,7 +36,7 @@ def get_sha() -> str:
     """
     cwd = os.path.dirname(os.path.abspath(__file__))
 
-    def _run(command: List[str]) -> str:
+    def _run(command: list[str]) -> str:
         return subprocess.check_output(command, cwd=cwd).decode("ascii").strip()
 
     try:

--- a/src/rfdetr/utilities/state_dict.py
+++ b/src/rfdetr/utilities/state_dict.py
@@ -9,7 +9,7 @@
 import os
 import tempfile
 from collections import OrderedDict
-from typing import Any, Dict, Optional
+from typing import Any
 
 from rfdetr.utilities.logger import get_logger
 
@@ -158,7 +158,7 @@ def strip_checkpoint(checkpoint: str | os.PathLike[str]) -> None:
             os.remove(tmp_path)
 
 
-def clean_state_dict(state_dict: Dict[str, Any]) -> OrderedDict[str, Any]:
+def clean_state_dict(state_dict: dict[str, Any]) -> OrderedDict[str, Any]:
     """Remove the ``module.`` prefix added by ``DataParallel`` / ``DistributedDataParallel``.
 
     Args:
@@ -175,7 +175,7 @@ def clean_state_dict(state_dict: Dict[str, Any]) -> OrderedDict[str, Any]:
     return new_state_dict
 
 
-def validate_checkpoint_compatibility(checkpoint: Dict[str, Any], model_args: Any) -> None:
+def validate_checkpoint_compatibility(checkpoint: dict[str, Any], model_args: Any) -> None:
     """Validate that a checkpoint is compatible with the model configuration.
 
     Checks for mismatches in ``segmentation_head`` and ``patch_size`` between
@@ -222,7 +222,7 @@ def validate_checkpoint_compatibility(checkpoint: Dict[str, Any], model_args: An
     ckpt_class_bias = checkpoint.get("model", {}).get("class_embed.bias", None)
     if ckpt_class_bias is not None:
         ckpt_num_classes = ckpt_class_bias.shape[0]
-        model_num_classes: Optional[int] = getattr(model_args, "num_classes", None)
+        model_num_classes: int | None = getattr(model_args, "num_classes", None)
         if model_num_classes is not None and ckpt_num_classes != model_num_classes + 1:
             if model_num_classes + 1 < ckpt_num_classes:
                 # Backbone pretrain scenario: checkpoint has more classes, head will be trimmed.
@@ -249,8 +249,8 @@ def validate_checkpoint_compatibility(checkpoint: Dict[str, Any], model_args: An
         return
 
     ckpt_args = checkpoint["args"]
-    ckpt_segmentation_head: Optional[bool] = _ckpt_args_get(ckpt_args, "segmentation_head")
-    model_segmentation_head: Optional[bool] = getattr(model_args, "segmentation_head", None)
+    ckpt_segmentation_head: bool | None = _ckpt_args_get(ckpt_args, "segmentation_head")
+    model_segmentation_head: bool | None = getattr(model_args, "segmentation_head", None)
 
     if ckpt_segmentation_head is not None and model_segmentation_head is not None:
         if ckpt_segmentation_head != model_segmentation_head:
@@ -265,8 +265,8 @@ def validate_checkpoint_compatibility(checkpoint: Dict[str, Any], model_args: An
                     "Load the weights into a detection model (e.g. RFDETRNano) instead of a segmentation model."
                 )
 
-    ckpt_patch_size: Optional[int] = _ckpt_args_get(ckpt_args, "patch_size")
-    model_patch_size: Optional[int] = getattr(model_args, "patch_size", None)
+    ckpt_patch_size: int | None = _ckpt_args_get(ckpt_args, "patch_size")
+    model_patch_size: int | None = getattr(model_args, "patch_size", None)
     if ckpt_patch_size is not None and model_patch_size is not None and ckpt_patch_size != model_patch_size:
         raise ValueError(
             f"The checkpoint was trained with patch_size={ckpt_patch_size}, but the current model uses "

--- a/src/rfdetr/utilities/tensors.py
+++ b/src/rfdetr/utilities/tensors.py
@@ -13,14 +13,14 @@
 
 """Tensor utilities: NestedTensor, collate_fn, and helpers."""
 
-from typing import Any, List, Optional, Tuple
+from typing import Any
 
 import torch
 import torchvision
 from torch import Tensor
 
 
-def _max_by_axis(the_list: List[List[int]]) -> List[int]:
+def _max_by_axis(the_list: list[list[int]]) -> list[int]:
     """Return element-wise maximums of a list of lists.
 
     Args:
@@ -42,7 +42,7 @@ class NestedTensor:
     Stores both the padded tensor and a boolean mask indicating padding positions.
     """
 
-    def __init__(self, tensors: Tensor, mask: Optional[Tensor]) -> None:
+    def __init__(self, tensors: Tensor, mask: Tensor | None) -> None:
         self.tensors = tensors
         self.mask = mask
 
@@ -76,7 +76,7 @@ class NestedTensor:
             self.mask.pin_memory() if self.mask is not None else None,
         )
 
-    def decompose(self) -> Tuple[Tensor, Optional[Tensor]]:
+    def decompose(self) -> tuple[Tensor, Tensor | None]:
         """Return ``(tensors, mask)`` tuple.
 
         Returns:
@@ -88,7 +88,7 @@ class NestedTensor:
         return str(self.tensors)
 
 
-def nested_tensor_from_tensor_list(tensor_list: List[Tensor]) -> NestedTensor:
+def nested_tensor_from_tensor_list(tensor_list: list[Tensor]) -> NestedTensor:
     """Pad a list of variable-size tensors into a single NestedTensor.
 
     Args:
@@ -124,7 +124,7 @@ def nested_tensor_from_tensor_list(tensor_list: List[Tensor]) -> NestedTensor:
 # _onnx_nested_tensor_from_tensor_list() is an implementation of
 # nested_tensor_from_tensor_list() that is supported by ONNX tracing.
 @torch.jit.unused
-def _onnx_nested_tensor_from_tensor_list(tensor_list: List[Tensor]) -> NestedTensor:
+def _onnx_nested_tensor_from_tensor_list(tensor_list: list[Tensor]) -> NestedTensor:
     """ONNX-tracing-compatible variant of ``nested_tensor_from_tensor_list``.
 
     Args:
@@ -258,7 +258,7 @@ def _bilinear_grid_sample(
     return wx0 * wy0 * v00 + wx1 * wy0 * v10 + wx0 * wy1 * v01 + wx1 * wy1 * v11
 
 
-def collate_fn(batch: List[Tuple[Any, ...]]) -> Tuple[Any, ...]:
+def collate_fn(batch: list[tuple[Any, ...]]) -> tuple[Any, ...]:
     """Collate a list of (image, target) pairs into a batched NestedTensor.
 
     Args:


### PR DESCRIPTION
## What does this PR do?

Replace deprecated `typing` generics with PEP 585/604 built-in types across `rfdetr/evaluation` and `rfdetr/utilities` modules:                                                    
  - `Dict` → `dict`, `List` → `list`, `Tuple` → `tuple`                                                                                                                              
  - `Optional[X]` → `X | None`                              
  - Remove unused `typing` imports 

**Related Issue(s):** Part of #564

## Type of Change

- Refactoring (no functional changes)

## Testing

  - [x] I have tested this change locally
  - [ ] I have added/updated tests for this change

**Test details:**
Ran `pre-commit run --all-files` — all checks passed. Ran `pytest src/ tests/ -n 2 -m "not gpu"` — no new failures introduced (pre-existing failures on `develop` remain unchanged). 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

