### PR TITLE
fix: correct Image.open URL usage in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ from rfdetr.assets.coco_classes import COCO_CLASSES
 
 model = RFDETRMedium()
 
-image = Image.open("https://media.roboflow.com/dog.jpg")
+image = Image.open(requests.get("https://media.roboflow.com/dog.jpg", stream=True).raw)
 detections = model.predict(image, threshold=0.5)
 
 labels = [f"{COCO_CLASSES[class_id]}" for class_id in detections.class_id]
@@ -157,7 +157,7 @@ from inference import get_model
 
 model = get_model("rfdetr-medium")
 
-image = Image.open("https://media.roboflow.com/dog.jpg")
+image = Image.open(requests.get("https://media.roboflow.com/dog.jpg", stream=True).raw)
 predictions = model.infer(image, confidence=0.5)[0]
 detections = sv.Detections.from_inference(predictions)
 
@@ -191,7 +191,7 @@ from rfdetr.assets.coco_classes import COCO_CLASSES
 
 model = RFDETRSegMedium()
 
-image = Image.open("https://media.roboflow.com/dog.jpg")
+image = Image.open(requests.get("https://media.roboflow.com/dog.jpg", stream=True).raw)
 detections = model.predict(image, threshold=0.5)
 
 labels = [f"{COCO_CLASSES[class_id]}" for class_id in detections.class_id]
@@ -215,7 +215,7 @@ from inference import get_model
 
 model = get_model("rfdetr-seg-medium")
 
-image = Image.open("https://media.roboflow.com/dog.jpg")
+image = Image.open(requests.get("https://media.roboflow.com/dog.jpg", stream=True).raw)
 predictions = model.infer(image, confidence=0.5)[0]
 detections = sv.Detections.from_inference(predictions)
 


### PR DESCRIPTION
## What does this PR do?

Fix broken code examples in README.md. `PIL.Image.open()` does not accept URLs directly — it raises `FileNotFoundError`. Updated all 4 examples to use `requests.get()` to fetch the image first, matching the docs website.

**Related Issue(s):** None (bug found while testing examples)

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
Confirmed `Image.open("https://...")` raises `FileNotFoundError`. Confirmed the fix works correctly.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors