### PR TITLE
Feat/predict source image

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,20 +125,17 @@ RF-DETR achieves state-of-the-art results in both object detection and instance 
 RF-DETR provides multiple model sizes, ranging from Nano to 2XLarge. To use a different model size, replace the class name in the code snippet below with another class from the table.
 
 ```python
-import requests
 import supervision as sv
-from PIL import Image
 from rfdetr import RFDETRMedium
 from rfdetr.assets.coco_classes import COCO_CLASSES
 
 model = RFDETRMedium()
 
-image = Image.open(requests.get("https://media.roboflow.com/dog.jpg", stream=True).raw)
-detections = model.predict(image, threshold=0.5)
+detections = model.predict("https://media.roboflow.com/dog.jpg", threshold=0.5)
 
 labels = [f"{COCO_CLASSES[class_id]}" for class_id in detections.class_id]
 
-annotated_image = sv.BoxAnnotator().annotate(image, detections)
+annotated_image = sv.BoxAnnotator().annotate(detections.data["source_image"], detections)
 annotated_image = sv.LabelAnnotator().annotate(annotated_image, detections, labels)
 ```
 
@@ -183,20 +180,17 @@ annotated_image = sv.LabelAnnotator().annotate(annotated_image, detections)
 RF-DETR supports instance segmentation with model sizes from Nano to 2XLarge. To use a different model size, replace the class name in the code snippet below with another class from the table.
 
 ```python
-import requests
 import supervision as sv
-from PIL import Image
 from rfdetr import RFDETRSegMedium
 from rfdetr.assets.coco_classes import COCO_CLASSES
 
 model = RFDETRSegMedium()
 
-image = Image.open(requests.get("https://media.roboflow.com/dog.jpg", stream=True).raw)
-detections = model.predict(image, threshold=0.5)
+detections = model.predict("https://media.roboflow.com/dog.jpg", threshold=0.5)
 
 labels = [f"{COCO_CLASSES[class_id]}" for class_id in detections.class_id]
 
-annotated_image = sv.MaskAnnotator().annotate(image, detections)
+annotated_image = sv.MaskAnnotator().annotate(detections.data["source_image"], detections)
 annotated_image = sv.LabelAnnotator().annotate(annotated_image, detections, labels)
 ```
 

--- a/docs/learn/run/detection.md
+++ b/docs/learn/run/detection.md
@@ -24,20 +24,17 @@ Perform inference on an image using either the `rfdetr` package or the `inferenc
 === "rfdetr"
 
     ```python
-    import requests
     import supervision as sv
-    from PIL import Image
     from rfdetr import RFDETRMedium
     from rfdetr.assets.coco_classes import COCO_CLASSES
 
     model = RFDETRMedium()
 
-    image = Image.open(requests.get("https://media.roboflow.com/dog.jpg", stream=True).raw)
-    detections = model.predict(image, threshold=0.5)
+    detections = model.predict("https://media.roboflow.com/dog.jpg", threshold=0.5)
 
     labels = [f"{COCO_CLASSES[class_id]}" for class_id in detections.class_id]
 
-    annotated_image = sv.BoxAnnotator().annotate(image, detections)
+    annotated_image = sv.BoxAnnotator().annotate(detections.data["source_image"], detections)
     annotated_image = sv.LabelAnnotator().annotate(annotated_image, detections, labels)
     ```
 

--- a/docs/learn/run/segmentation.md
+++ b/docs/learn/run/segmentation.md
@@ -22,20 +22,17 @@ Perform inference on an image using either the `rfdetr` package or the `inferenc
 === "rfdetr"
 
     ```python
-    import requests
     import supervision as sv
-    from PIL import Image
     from rfdetr import RFDETRSegMedium
     from rfdetr.assets.coco_classes import COCO_CLASSES
 
     model = RFDETRSegMedium()
 
-    image = Image.open(requests.get("https://media.roboflow.com/dog.jpg", stream=True).raw)
-    detections = model.predict(image, threshold=0.5)
+    detections = model.predict("https://media.roboflow.com/dog.jpg", threshold=0.5)
 
     labels = [f"{COCO_CLASSES[class_id]}" for class_id in detections.class_id]
 
-    annotated_image = sv.MaskAnnotator().annotate(image, detections)
+    annotated_image = sv.MaskAnnotator().annotate(detections.data["source_image"], detections)
     annotated_image = sv.LabelAnnotator().annotate(annotated_image, detections, labels)
     ```
 

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -838,7 +838,10 @@ class RFDETR:
                 img = Image.open(img)
 
             if not isinstance(img, torch.Tensor):
-                source_images.append(np.array(img))
+                src = np.array(img)
+                if src.dtype != np.uint8:
+                    src = (src * 255).clip(0, 255).astype(np.uint8)
+                source_images.append(src)
                 img = F.to_tensor(img)
             else:
                 source_images.append((img.permute(1, 2, 0).cpu().numpy() * 255).astype(np.uint8))

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -914,6 +914,7 @@ class RFDETR:
                 )
 
             detections.data["source_image"] = source_images[i]
+            detections.data["source_shape"] = orig_sizes[i]
 
             detections_list.append(detections)
 

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -847,6 +847,10 @@ class RFDETR:
                 raise ValueError(
                     "Image has pixel values above 1. Please ensure the image is normalized (scaled to [0, 1]).",
                 )
+            if (img < 0).any():
+                raise ValueError(
+                    "Image has pixel values below 0. Please ensure the image is normalized (scaled to [0, 1]).",
+                )
             if img.shape[0] != 3:
                 raise ValueError(f"Invalid image shape. Expected 3 channels (RGB), but got {img.shape[0]} channels.")
             img_tensor = img

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -811,6 +811,7 @@ class RFDETR:
 
         orig_sizes = []
         processed_images = []
+        source_images = []
 
         for img in images:
             if isinstance(img, str):
@@ -819,7 +820,10 @@ class RFDETR:
                 img = Image.open(img)
 
             if not isinstance(img, torch.Tensor):
+                source_images.append(np.array(img))
                 img = F.to_tensor(img)
+            else:
+                source_images.append((img.permute(1, 2, 0).cpu().numpy() * 255).astype(np.uint8))
 
             if (img > 1).any():
                 raise ValueError(
@@ -882,7 +886,7 @@ class RFDETR:
             results = self.model.postprocess(predictions, target_sizes=target_sizes)
 
         detections_list = []
-        for result in results:
+        for i, result in enumerate(results):
             scores = result["scores"]
             labels = result["labels"]
             boxes = result["boxes"]
@@ -908,6 +912,8 @@ class RFDETR:
                     confidence=scores.float().cpu().numpy(),
                     class_id=labels.cpu().numpy(),
                 )
+
+            detections.data["source_image"] = source_images[i]
 
             detections_list.append(detections)
 

--- a/tests/models/test_predict.py
+++ b/tests/models/test_predict.py
@@ -95,6 +95,49 @@ def test_predict_accepts_image_url() -> None:
     assert detections.xyxy.shape == (1, 4)
 
 
+class TestPredictSourceData:
+    """Verify that ``predict()`` populates ``source_image`` and ``source_shape``."""
+
+    def test_source_image_from_pil(self) -> None:
+        """PIL input stores the original image as a numpy array."""
+        img = PIL.Image.new("RGB", (64, 48), color=(128, 128, 128))
+        model = _DummyRFDETR()
+        detections = model.predict(img)
+        assert "source_image" in detections.data
+        assert isinstance(detections.data["source_image"], np.ndarray)
+        assert detections.data["source_image"].shape == (48, 64, 3)
+
+    def test_source_shape_from_pil(self) -> None:
+        """PIL input stores the original (height, width) tuple."""
+        img = PIL.Image.new("RGB", (64, 48), color=(128, 128, 128))
+        model = _DummyRFDETR()
+        detections = model.predict(img)
+        assert "source_shape" in detections.data
+        assert detections.data["source_shape"] == (48, 64)
+
+    def test_source_image_from_tensor(self) -> None:
+        """Tensor input stores the original image as a uint8 numpy array."""
+        tensor = torch.rand(3, 48, 64)
+        model = _DummyRFDETR()
+        detections = model.predict(tensor)
+        assert "source_image" in detections.data
+        assert isinstance(detections.data["source_image"], np.ndarray)
+        assert detections.data["source_image"].dtype == np.uint8
+        assert detections.data["source_image"].shape == (48, 64, 3)
+
+    def test_source_image_batch(self) -> None:
+        """Batch predict stores a source_image per detection."""
+        img1 = PIL.Image.new("RGB", (64, 48), color=(100, 100, 100))
+        img2 = PIL.Image.new("RGB", (32, 24), color=(200, 200, 200))
+        model = _DummyRFDETR()
+        detections_list = model.predict([img1, img2])
+        assert isinstance(detections_list, list)
+        assert detections_list[0].data["source_image"].shape == (48, 64, 3)
+        assert detections_list[1].data["source_image"].shape == (24, 32, 3)
+        assert detections_list[0].data["source_shape"] == (48, 64)
+        assert detections_list[1].data["source_shape"] == (24, 32)
+
+
 class TestPredictShape:
     """Verify that ``predict(shape=...)`` controls the resize target.
 

--- a/tests/models/test_predict.py
+++ b/tests/models/test_predict.py
@@ -125,6 +125,13 @@ class TestPredictSourceData:
         assert detections.data["source_image"].dtype == np.uint8
         assert detections.data["source_image"].shape == (48, 64, 3)
 
+    def test_tensor_with_negative_values_raises(self) -> None:
+        """Tensor with negative pixel values raises ValueError."""
+        tensor = torch.full((3, 48, 64), -0.1)
+        model = _DummyRFDETR()
+        with pytest.raises(ValueError, match="below 0"):
+            model.predict(tensor)
+
     def test_source_image_batch(self) -> None:
         """Batch predict stores a source_image per detection."""
         img1 = PIL.Image.new("RGB", (64, 48), color=(100, 100, 100))


### PR DESCRIPTION
## What does this PR do?

Store the original image and its shape on returned `sv.Detections` objects via `detections.data["source_image"]` and `detections.data["source_shape"]`. This allows users to annotate without manually loading the image separately.

Before:
```python
import requests
from PIL import Image

image = Image.open(requests.get("https://media.roboflow.com/dog.jpg", stream=True).raw)
detections = model.predict(image, threshold=0.5)
annotated = sv.BoxAnnotator().annotate(image, detections)
```

After:
```python
detections = model.predict("https://media.roboflow.com/dog.jpg", threshold=0.5)
annotated = sv.BoxAnnotator().annotate(detections.data["source_image"], detections)
```

No more `import requests` or `from PIL import Image` needed for basic usage.

Follow-up to [this comment](https://github.com/roboflow/rf-detr/pull/891#issuecomment-4153909171).

**Related Issue(s):** Follow-up to #891

## Type of Change

- New feature (non-breaking change that adds functionality)
- Documentation update

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**
Added `TestPredictSourceData` in `tests/models/test_predict.py` with 4 tests covering:
- PIL image input stores `source_image` as numpy array with correct shape
- PIL image input stores `source_shape` as (height, width) tuple
- Tensor input stores `source_image` as uint8 numpy array
- Batch predict stores per-image `source_image` and `source_shape`

Also verified manually with `RFDETRNano` on a real image URL.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

Updated README and docs examples (`detection.md`, `segmentation.md`) to use the simplified pattern.
