### PR TITLE
feat: store model_name in checkpoint for model identification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `model_name` is now stored in checkpoint files during training so that `RFDETR.from_checkpoint()` can resolve the correct model class directly from the checkpoint, without requiring the caller to know or pass a class hint. `strip_checkpoint()` preserves this key. Backward-compatible: checkpoints without `model_name` continue to resolve via `pretrain_weights` filename matching. (closes #887)
 - `RFDETR.predict(shape=...)` — optional `(height, width)` tuple overrides the default inference resolution; useful for matching the resolution used when exporting the model. Both dimensions must be positive integers divisible by 14. (closes #682)
 - `BuilderArgs` — a `@runtime_checkable` `typing.Protocol` documenting the minimum attribute set consumed by `build_model()`, `build_backbone()`, `build_transformer()`, and `build_criterion_and_postprocessors()`. Enables static type-checker support for custom builder integrations. Exported from `rfdetr.models`.
 - `build_model_from_config(model_config, train_config=None, defaults=MODEL_DEFAULTS)` — config-native alternative to `build_model(build_namespace(mc, tc))`; accepts Pydantic config objects directly and constructs the internal namespace automatically. Exported from `rfdetr.models`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ModelDefaults` dataclass — exposes the 35 hardcoded architectural constants previously buried inside `build_namespace()`. Pass a `dataclasses.replace(MODEL_DEFAULTS, ...)` override to the new config-native builders to customise individual constants. **Note:** fields may be promoted to `ModelConfig`/`TrainConfig` in future phases. Exported from `rfdetr.models`.
 - `MODEL_DEFAULTS` — the canonical `ModelDefaults` singleton with production defaults. Exported from `rfdetr.models`.
 
-
 ### Deprecated
 
 - `build_namespace(model_config, train_config)` — no longer used internally and deprecated in this release; use `build_model_from_config`, `build_criterion_from_config`, or `_namespace_from_configs` directly. It will be removed in v1.9 and currently emits a `DeprecationWarning` on use.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ModelDefaults` dataclass — exposes the 35 hardcoded architectural constants previously buried inside `build_namespace()`. Pass a `dataclasses.replace(MODEL_DEFAULTS, ...)` override to the new config-native builders to customise individual constants. **Note:** fields may be promoted to `ModelConfig`/`TrainConfig` in future phases. Exported from `rfdetr.models`.
 - `MODEL_DEFAULTS` — the canonical `ModelDefaults` singleton with production defaults. Exported from `rfdetr.models`.
 
+### Changed
+
+- `RFDETRBase`, `RFDETRLargeDeprecated`, and `RFDETRSegPreview` now raise `RuntimeError` on instantiation. Previously `@deprecated_class` emitted a `FutureWarning` only; a `RuntimeError` is now also raised inside `__init__` to enforce the deprecation hard. Any code still constructing these classes directly will break at instantiation time. Migrate to `RFDETRLarge` (for `RFDETRBase` / `RFDETRLargeDeprecated`) or the appropriate current segmentation variant (for `RFDETRSegPreview`).
+
 ### Deprecated
 
 - `build_namespace(model_config, train_config)` — no longer used internally and deprecated in this release; use `build_model_from_config`, `build_criterion_from_config`, or `_namespace_from_configs` directly. It will be removed in v1.9 and currently emits a `DeprecationWarning` on use.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ModelDefaults` dataclass — exposes the 35 hardcoded architectural constants previously buried inside `build_namespace()`. Pass a `dataclasses.replace(MODEL_DEFAULTS, ...)` override to the new config-native builders to customise individual constants. **Note:** fields may be promoted to `ModelConfig`/`TrainConfig` in future phases. Exported from `rfdetr.models`.
 - `MODEL_DEFAULTS` — the canonical `ModelDefaults` singleton with production defaults. Exported from `rfdetr.models`.
 
-### Changed
-
-- `RFDETRBase`, `RFDETRLargeDeprecated`, and `RFDETRSegPreview` now raise `RuntimeError` on instantiation. Previously `@deprecated_class` emitted a `FutureWarning` only; a `RuntimeError` is now also raised inside `__init__` to enforce the deprecation hard. Any code still constructing these classes directly will break at instantiation time. Migrate to `RFDETRLarge` (for `RFDETRBase` / `RFDETRLargeDeprecated`) or the appropriate current segmentation variant (for `RFDETRSegPreview`).
 
 ### Deprecated
 

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -84,6 +84,7 @@ class ModelConfig(BaseConfig):
     backbone_lora: bool = False
     freeze_encoder: bool = False
     license: str = "Apache-2.0"
+    model_name: Optional[str] = None
 
     @model_validator(mode="after")
     def _warn_deprecated_model_config_fields(self) -> "ModelConfig":

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -84,7 +84,15 @@ class ModelConfig(BaseConfig):
     backbone_lora: bool = False
     freeze_encoder: bool = False
     license: str = "Apache-2.0"
-    model_name: Optional[str] = None
+    model_name: Optional[str] = Field(
+        default=None,
+        description=(
+            'Name of the model class stored in training checkpoints (e.g. ``"RFDETRLarge"``). '
+            "Set automatically by ``RFDETR.train()`` before saving. "
+            "Used by ``RFDETR.from_checkpoint()`` to resolve the correct subclass directly "
+            "without inspecting ``pretrain_weights``."
+        ),
+    )
 
     @model_validator(mode="after")
     def _warn_deprecated_model_config_fields(self) -> "ModelConfig":

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -260,15 +260,21 @@ class RFDETR:
             >>> model = RFDETRSmall.from_checkpoint("checkpoint_best_total.pth")  # doctest: +SKIP
         """
         # Local imports break the variants → detr import cycle.
+        import rfdetr.variants as variants
 
         _plus_available = False
+        _plus_symbols: dict[str, type[RFDETR]] = {}
         try:
-            from rfdetr.platform.models import RFDETR2XLarge, RFDETRXLarge
+            import rfdetr.platform.models as plus_models
 
             _plus_entries: list[tuple[str, type[RFDETR]]] = [
-                (name, cast("type[RFDETR]", locals()[class_symbol]))
+                (name, cast("type[RFDETR]", getattr(plus_models, class_symbol)))
                 for name, class_symbol in _CHECKPOINT_PLUS_MODEL_MAP_ENTRIES
             ]
+            _plus_symbols = {
+                class_symbol: cast("type[RFDETR]", getattr(plus_models, class_symbol))
+                for class_symbol in _CHECKPOINT_PLUS_MODEL_NAME_CLASS_SYMBOLS
+            }
             _plus_available = True
         except ImportError:
             _plus_entries = []
@@ -282,24 +288,20 @@ class RFDETR:
         # Ordered most-specific first so "seg-xxlarge"/"seg-2xlarge" match before
         # "seg-xlarge", "xxlarge" before "xlarge", and "seg-*" prefixes before
         # their bare counterparts.
+        _variant_symbols: dict[str, type[RFDETR]] = {
+            class_symbol: cast("type[RFDETR]", getattr(variants, class_symbol))
+            for class_symbol in _CHECKPOINT_MODEL_NAME_CLASS_SYMBOLS
+        }
         _model_map: list[tuple[str, type[RFDETR]]] = [
-            (name, cast("type[RFDETR]", locals()[class_symbol])) for name, class_symbol in _CHECKPOINT_MODEL_MAP_ENTRIES
+            (name, _variant_symbols[class_symbol]) for name, class_symbol in _CHECKPOINT_MODEL_MAP_ENTRIES
         ]
         _model_map[8:8] = _plus_entries
 
         # New checkpoints store model_name directly — use it when available.
-        _name_map: dict[str, type[RFDETR]] = {
-            class_symbol: cast("type[RFDETR]", locals()[class_symbol])
-            for class_symbol in _CHECKPOINT_MODEL_NAME_CLASS_SYMBOLS
-        }
+        _name_map: dict[str, type[RFDETR]] = dict(_variant_symbols)
         # Plus-model classes are resolved only when rfdetr_plus is installed.
         if _plus_available:
-            _name_map.update(
-                {
-                    class_symbol: cast("type[RFDETR]", locals()[class_symbol])
-                    for class_symbol in _CHECKPOINT_PLUS_MODEL_NAME_CLASS_SYMBOLS
-                }
-            )
+            _name_map.update(_plus_symbols)
         saved_model_name = ckpt.get("model_name")
         model_cls: type[RFDETR] | None = None
         if isinstance(saved_model_name, str):

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -225,7 +225,7 @@ class RFDETR:
         The correct subclass is resolved in order of preference:
 
         1. ``model_name`` key in the checkpoint (written by the PTL training
-           stack since v1.7).
+           stack since v1.7.0).
         2. ``pretrain_weights`` field in the checkpoint's ``args`` entry
            (legacy fallback).
 

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -295,15 +295,12 @@ class RFDETR:
             "RFDETRSmall": RFDETRSmall,
             "RFDETRMedium": RFDETRMedium,
             "RFDETRLarge": RFDETRLarge,
-            "RFDETRLargeDeprecated": RFDETRLargeDeprecated,
-            "RFDETRBase": RFDETRBase,
             "RFDETRSegNano": RFDETRSegNano,
             "RFDETRSegSmall": RFDETRSegSmall,
             "RFDETRSegMedium": RFDETRSegMedium,
             "RFDETRSegLarge": RFDETRSegLarge,
             "RFDETRSegXLarge": RFDETRSegXLarge,
             "RFDETRSeg2XLarge": RFDETRSeg2XLarge,
-            "RFDETRSegPreview": RFDETRSegPreview,
         }
         # Plus-model classes are resolved only when rfdetr_plus is installed.
         if _plus_available:

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -305,6 +305,10 @@ class RFDETR:
             "RFDETRSeg2XLarge": RFDETRSeg2XLarge,
             "RFDETRSegPreview": RFDETRSegPreview,
         }
+        # Plus-model classes are resolved only when rfdetr_plus is installed.
+        if _plus_available:
+            _name_map["RFDETRXLarge"] = RFDETRXLarge  # type: ignore[possibly-undefined]
+            _name_map["RFDETR2XLarge"] = RFDETR2XLarge  # type: ignore[possibly-undefined]
         saved_model_name = ckpt.get("model_name")
         model_cls: type[RFDETR] | None = None
         if isinstance(saved_model_name, str):

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -15,7 +15,7 @@ import warnings
 from collections import defaultdict
 from copy import deepcopy
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import requests
@@ -66,6 +66,32 @@ _VARIANT_EXPORTS = (
     "RFDETRSmall",
 )
 __all__ = ["RFDETR", "ModelContext", *_VARIANT_EXPORTS]
+
+_CHECKPOINT_MODEL_NAME_EXCLUDED_SYMBOLS = frozenset({"RFDETRBase", "RFDETRLargeDeprecated", "RFDETRSeg"})
+_CHECKPOINT_MODEL_NAME_CLASS_SYMBOLS: tuple[str, ...] = tuple(
+    class_symbol for class_symbol in _VARIANT_EXPORTS if class_symbol not in _CHECKPOINT_MODEL_NAME_EXCLUDED_SYMBOLS
+)
+_CHECKPOINT_PLUS_MODEL_NAME_CLASS_SYMBOLS: tuple[str, ...] = ("RFDETRXLarge", "RFDETR2XLarge")
+_CHECKPOINT_MODEL_MAP_ENTRIES: tuple[tuple[str, str], ...] = (
+    ("seg-2xlarge", "RFDETRSeg2XLarge"),
+    ("seg-xxlarge", "RFDETRSeg2XLarge"),
+    ("seg-xlarge", "RFDETRSegXLarge"),
+    ("seg-large", "RFDETRSegLarge"),
+    ("seg-medium", "RFDETRSegMedium"),
+    ("seg-small", "RFDETRSegSmall"),
+    ("seg-nano", "RFDETRSegNano"),
+    ("seg-preview", "RFDETRSegPreview"),
+    ("large", "RFDETRLarge"),
+    ("medium", "RFDETRMedium"),
+    ("small", "RFDETRSmall"),
+    ("nano", "RFDETRNano"),
+    ("base", "RFDETRBase"),
+)
+_CHECKPOINT_PLUS_MODEL_MAP_ENTRIES: tuple[tuple[str, str], ...] = (
+    ("2xlarge", "RFDETR2XLarge"),
+    ("xxlarge", "RFDETR2XLarge"),
+    ("xlarge", "RFDETRXLarge"),
+)
 
 
 def _validate_shape_dims(
@@ -254,9 +280,8 @@ class RFDETR:
             from rfdetr.platform.models import RFDETR2XLarge, RFDETRXLarge
 
             _plus_entries: list[tuple[str, type[RFDETR]]] = [
-                ("2xlarge", RFDETR2XLarge),  # alias for "rfdetr-2xlarge" size label (training ckpts)
-                ("xxlarge", RFDETR2XLarge),  # official weight filename "rf-detr-xxlarge.pth"
-                ("xlarge", RFDETRXLarge),
+                (name, cast("type[RFDETR]", locals()[class_symbol]))
+                for name, class_symbol in _CHECKPOINT_PLUS_MODEL_MAP_ENTRIES
             ]
             _plus_available = True
         except ImportError:
@@ -272,39 +297,24 @@ class RFDETR:
         # "seg-xlarge", "xxlarge" before "xlarge", and "seg-*" prefixes before
         # their bare counterparts.
         _model_map: list[tuple[str, type[RFDETR]]] = [
-            ("seg-2xlarge", RFDETRSeg2XLarge),  # alias for "rfdetr-seg-2xlarge" size label
-            ("seg-xxlarge", RFDETRSeg2XLarge),  # official weight filename "rf-detr-seg-xxlarge.pt"
-            ("seg-xlarge", RFDETRSegXLarge),
-            ("seg-large", RFDETRSegLarge),
-            ("seg-medium", RFDETRSegMedium),
-            ("seg-small", RFDETRSegSmall),
-            ("seg-nano", RFDETRSegNano),
-            ("seg-preview", RFDETRSegPreview),
-            *_plus_entries,
-            ("large", RFDETRLarge),
-            ("medium", RFDETRMedium),
-            ("small", RFDETRSmall),
-            ("nano", RFDETRNano),
-            ("base", RFDETRBase),
+            (name, cast("type[RFDETR]", locals()[class_symbol]))
+            for name, class_symbol in _CHECKPOINT_MODEL_MAP_ENTRIES
         ]
+        _model_map[8:8] = _plus_entries
 
         # New checkpoints store model_name directly — use it when available.
         _name_map: dict[str, type[RFDETR]] = {
-            "RFDETRNano": RFDETRNano,
-            "RFDETRSmall": RFDETRSmall,
-            "RFDETRMedium": RFDETRMedium,
-            "RFDETRLarge": RFDETRLarge,
-            "RFDETRSegNano": RFDETRSegNano,
-            "RFDETRSegSmall": RFDETRSegSmall,
-            "RFDETRSegMedium": RFDETRSegMedium,
-            "RFDETRSegLarge": RFDETRSegLarge,
-            "RFDETRSegXLarge": RFDETRSegXLarge,
-            "RFDETRSeg2XLarge": RFDETRSeg2XLarge,
+            class_symbol: cast("type[RFDETR]", locals()[class_symbol])
+            for class_symbol in _CHECKPOINT_MODEL_NAME_CLASS_SYMBOLS
         }
         # Plus-model classes are resolved only when rfdetr_plus is installed.
         if _plus_available:
-            _name_map["RFDETRXLarge"] = RFDETRXLarge  # type: ignore[possibly-undefined]
-            _name_map["RFDETR2XLarge"] = RFDETR2XLarge  # type: ignore[possibly-undefined]
+            _name_map.update(
+                {
+                    class_symbol: cast("type[RFDETR]", locals()[class_symbol])
+                    for class_symbol in _CHECKPOINT_PLUS_MODEL_NAME_CLASS_SYMBOLS
+                }
+            )
         saved_model_name = ckpt.get("model_name")
         model_cls: type[RFDETR] | None = None
         if isinstance(saved_model_name, str):

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -322,8 +322,7 @@ class RFDETR:
             "RFDETRSmall": RFDETRSmall,
         }
         _variant_symbols: dict[str, type[RFDETR]] = {
-            class_symbol: _variant_name_to_class[class_symbol]
-            for class_symbol in _CHECKPOINT_MODEL_NAME_CLASS_SYMBOLS
+            class_symbol: _variant_name_to_class[class_symbol] for class_symbol in _CHECKPOINT_MODEL_NAME_CLASS_SYMBOLS
         }
         # Build in three explicit segments: seg-* entries, then plus-model entries
         # (xlarge/2xlarge), then base entries — order determines lookup priority.

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -237,6 +237,7 @@ class RFDETR:
         from rfdetr.variants import (
             RFDETRBase,
             RFDETRLarge,
+            RFDETRLargeDeprecated,
             RFDETRMedium,
             RFDETRNano,
             RFDETRSeg2XLarge,
@@ -294,6 +295,7 @@ class RFDETR:
             "RFDETRSmall": RFDETRSmall,
             "RFDETRMedium": RFDETRMedium,
             "RFDETRLarge": RFDETRLarge,
+            "RFDETRLargeDeprecated": RFDETRLargeDeprecated,
             "RFDETRBase": RFDETRBase,
             "RFDETRSegNano": RFDETRSegNano,
             "RFDETRSegSmall": RFDETRSegSmall,

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -335,7 +335,7 @@ class RFDETR:
 
         if model_cls is None:
             raise ValueError(
-                f"Could not infer model size from checkpoint at {path!r} "
+                f"Could not infer model class from checkpoint at {path!r} "
                 f"(model_name={saved_model_name!r}, pretrain_weights={weights_name!r}). "
                 f"Please instantiate the model class directly."
             )

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -194,13 +194,18 @@ class RFDETR:
     @classmethod
     def from_checkpoint(cls, path: str | os.PathLike[str], **kwargs: Any) -> RFDETR:
         """Load an RF-DETR model from a training checkpoint, automatically
-        inferring the model size from the saved args.
+        inferring the model class.
 
-        The correct subclass is inferred from the ``pretrain_weights`` field
-        stored in the checkpoint's ``args`` entry.  Both legacy
-        ``argparse.Namespace`` checkpoints (produced by ``engine.py``) and
-        dict-style checkpoints (produced by the PTL training stack) are
-        supported.
+        The correct subclass is resolved in order of preference:
+
+        1. ``model_name`` key in the checkpoint (written by the PTL training
+           stack since v1.7).
+        2. ``pretrain_weights`` field in the checkpoint's ``args`` entry
+           (legacy fallback).
+
+        Both legacy ``argparse.Namespace`` checkpoints (produced by
+        ``engine.py``) and dict-style checkpoints (produced by the PTL
+        training stack) are supported.
 
         Args:
             path: Path to a checkpoint file (e.g. ``checkpoint_best_total.pth``).
@@ -221,8 +226,8 @@ class RFDETR:
             FileNotFoundError: If *path* does not exist.
             OSError: If *path* exists but cannot be read.
             KeyError: If the checkpoint does not contain an ``"args"`` key.
-            ValueError: If the model size cannot be inferred from the
-                ``pretrain_weights`` field in the saved args.
+            ValueError: If the model class cannot be inferred from
+                ``model_name`` or ``pretrain_weights``.
 
         Examples:
             >>> model = RFDETR.from_checkpoint("checkpoint_best_total.pth")  # doctest: +SKIP
@@ -299,15 +304,19 @@ class RFDETR:
             "RFDETRSegPreview": RFDETRSegPreview,
         }
         saved_model_name = ckpt.get("model_name")
-        model_cls: type[RFDETR] | None = _name_map.get(saved_model_name) if saved_model_name else None
+        model_cls: type[RFDETR] | None = None
+        if isinstance(saved_model_name, str):
+            normalized_name = saved_model_name.strip()
+            if normalized_name:
+                model_cls = _name_map.get(normalized_name)
 
         # Fall back to pretrain_weights filename parsing for older checkpoints.
-        if model_cls is None:
-            if isinstance(args, dict):
-                weights_name = str(args.get("pretrain_weights", "")).lower()
-            else:
-                weights_name = str(getattr(args, "pretrain_weights", "")).lower()
+        if isinstance(args, dict):
+            weights_name = str(args.get("pretrain_weights", "")).lower()
+        else:
+            weights_name = str(getattr(args, "pretrain_weights", "")).lower()
 
+        if model_cls is None:
             # Guard: "xlarge"/"xxlarge" without a "seg-" prefix are plus-only models.
             if not _plus_available and "xlarge" in weights_name and "seg-" not in weights_name:
                 from rfdetr.platform import _INSTALL_MSG
@@ -324,7 +333,9 @@ class RFDETR:
 
         if model_cls is None:
             raise ValueError(
-                f"Could not infer model size from checkpoint at {path!r}. Please instantiate the model class directly."
+                f"Could not infer model size from checkpoint at {path!r} "
+                f"(model_name={saved_model_name!r}, pretrain_weights={weights_name!r}). "
+                f"Please instantiate the model class directly."
             )
 
         if isinstance(args, dict):

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -15,7 +15,7 @@ import warnings
 from collections import defaultdict
 from copy import deepcopy
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import requests
@@ -260,22 +260,38 @@ class RFDETR:
             >>> model = RFDETRSmall.from_checkpoint("checkpoint_best_total.pth")  # doctest: +SKIP
         """
         # Local imports break the variants → detr import cycle.
-        # `import ... as` alias is an intentional exception to the project's direct-import
-        # convention (AGENTS.md) — the alias is required for the dynamic getattr() resolution
-        # in the _variant_symbols / _plus_symbols maps below.
-        import rfdetr.variants as variants
+        from rfdetr.variants import (
+            RFDETRBase,
+            RFDETRLarge,
+            RFDETRMedium,
+            RFDETRNano,
+            RFDETRSeg2XLarge,
+            RFDETRSegLarge,
+            RFDETRSegMedium,
+            RFDETRSegNano,
+            RFDETRSegPreview,
+            RFDETRSegSmall,
+            RFDETRSegXLarge,
+            RFDETRSmall,
+        )
 
         _plus_available = False
         _plus_symbols: dict[str, type[RFDETR]] = {}
         try:
-            import rfdetr.platform.models as plus_models
+            from rfdetr.platform.models import (
+                RFDETR2XLarge,
+                RFDETRXLarge,
+            )
 
+            _plus_name_to_class: dict[str, type[RFDETR]] = {
+                "RFDETRXLarge": RFDETRXLarge,
+                "RFDETR2XLarge": RFDETR2XLarge,
+            }
             _plus_entries: list[tuple[str, type[RFDETR]]] = [
-                (name, cast("type[RFDETR]", getattr(plus_models, class_symbol)))
-                for name, class_symbol in _CHECKPOINT_PLUS_MODEL_MAP_ENTRIES
+                (name, _plus_name_to_class[class_symbol]) for name, class_symbol in _CHECKPOINT_PLUS_MODEL_MAP_ENTRIES
             ]
             _plus_symbols = {
-                class_symbol: cast("type[RFDETR]", getattr(plus_models, class_symbol))
+                class_symbol: _plus_name_to_class[class_symbol]
                 for class_symbol in _CHECKPOINT_PLUS_MODEL_NAME_CLASS_SYMBOLS
             }
             _plus_available = True
@@ -291,8 +307,22 @@ class RFDETR:
         # Ordered most-specific first so "seg-xxlarge"/"seg-2xlarge" match before
         # "seg-xlarge", "xxlarge" before "xlarge", and "seg-*" prefixes before
         # their bare counterparts.
+        _variant_name_to_class: dict[str, type[RFDETR]] = {
+            "RFDETRBase": RFDETRBase,
+            "RFDETRLarge": RFDETRLarge,
+            "RFDETRMedium": RFDETRMedium,
+            "RFDETRNano": RFDETRNano,
+            "RFDETRSeg2XLarge": RFDETRSeg2XLarge,
+            "RFDETRSegLarge": RFDETRSegLarge,
+            "RFDETRSegMedium": RFDETRSegMedium,
+            "RFDETRSegNano": RFDETRSegNano,
+            "RFDETRSegPreview": RFDETRSegPreview,
+            "RFDETRSegSmall": RFDETRSegSmall,
+            "RFDETRSegXLarge": RFDETRSegXLarge,
+            "RFDETRSmall": RFDETRSmall,
+        }
         _variant_symbols: dict[str, type[RFDETR]] = {
-            class_symbol: cast("type[RFDETR]", getattr(variants, class_symbol))
+            class_symbol: _variant_name_to_class[class_symbol]
             for class_symbol in _CHECKPOINT_MODEL_NAME_CLASS_SYMBOLS
         }
         # Build in three explicit segments: seg-* entries, then plus-model entries

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -260,20 +260,6 @@ class RFDETR:
             >>> model = RFDETRSmall.from_checkpoint("checkpoint_best_total.pth")  # doctest: +SKIP
         """
         # Local imports break the variants → detr import cycle.
-        from rfdetr.variants import (
-            RFDETRBase,
-            RFDETRLarge,
-            RFDETRMedium,
-            RFDETRNano,
-            RFDETRSeg2XLarge,
-            RFDETRSegLarge,
-            RFDETRSegMedium,
-            RFDETRSegNano,
-            RFDETRSegPreview,
-            RFDETRSegSmall,
-            RFDETRSegXLarge,
-            RFDETRSmall,
-        )
 
         _plus_available = False
         try:
@@ -297,8 +283,7 @@ class RFDETR:
         # "seg-xlarge", "xxlarge" before "xlarge", and "seg-*" prefixes before
         # their bare counterparts.
         _model_map: list[tuple[str, type[RFDETR]]] = [
-            (name, cast("type[RFDETR]", locals()[class_symbol]))
-            for name, class_symbol in _CHECKPOINT_MODEL_MAP_ENTRIES
+            (name, cast("type[RFDETR]", locals()[class_symbol])) for name, class_symbol in _CHECKPOINT_MODEL_MAP_ENTRIES
         ]
         _model_map[8:8] = _plus_entries
 

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -67,7 +67,7 @@ _VARIANT_EXPORTS = (
 )
 __all__ = ["RFDETR", "ModelContext", *_VARIANT_EXPORTS]
 
-_CHECKPOINT_MODEL_NAME_EXCLUDED_SYMBOLS = frozenset({"RFDETRBase", "RFDETRLargeDeprecated", "RFDETRSeg"})
+_CHECKPOINT_MODEL_NAME_EXCLUDED_SYMBOLS = frozenset({"RFDETRLargeDeprecated", "RFDETRSeg"})
 _CHECKPOINT_MODEL_NAME_CLASS_SYMBOLS: tuple[str, ...] = tuple(
     class_symbol for class_symbol in _VARIANT_EXPORTS if class_symbol not in _CHECKPOINT_MODEL_NAME_EXCLUDED_SYMBOLS
 )
@@ -306,6 +306,8 @@ class RFDETR:
             normalized_name = saved_model_name.strip()
             if normalized_name:
                 model_cls = _name_map.get(normalized_name)
+        else:
+            normalized_name = ""
 
         # Fall back to pretrain_weights filename parsing for older checkpoints.
         if isinstance(args, dict):
@@ -314,12 +316,16 @@ class RFDETR:
             weights_name = str(getattr(args, "pretrain_weights", "")).lower()
 
         if model_cls is None:
-            # Guard: "xlarge"/"xxlarge" without a "seg-" prefix are plus-only models.
-            if not _plus_available and "xlarge" in weights_name and "seg-" not in weights_name:
+            # Guard: plus-only checkpoints should raise an actionable install error
+            # when rfdetr_plus is missing, regardless of whether class inference
+            # relies on model_name (new format) or pretrain_weights (legacy format).
+            plus_by_model_name = normalized_name in _CHECKPOINT_PLUS_MODEL_NAME_CLASS_SYMBOLS
+            plus_by_weights_name = "xlarge" in weights_name and "seg-" not in weights_name
+            if not _plus_available and (plus_by_model_name or plus_by_weights_name):
                 from rfdetr.platform import _INSTALL_MSG
 
                 raise ImportError(
-                    f"Checkpoint pretrain_weights={weights_name!r} requires the "
+                    f"Checkpoint model_name={saved_model_name!r}, pretrain_weights={weights_name!r} requires the "
                     f"rfdetr_plus package. " + _INSTALL_MSG.format(name="platform model downloads")
                 )
 

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -260,6 +260,7 @@ class RFDETR:
             >>> model = RFDETRSmall.from_checkpoint("checkpoint_best_total.pth")  # doctest: +SKIP
         """
         # Local imports break the variants → detr import cycle.
+        # Module aliases are needed for dynamic getattr() resolution below.
         import rfdetr.variants as variants
 
         _plus_available = False
@@ -292,10 +293,19 @@ class RFDETR:
             class_symbol: cast("type[RFDETR]", getattr(variants, class_symbol))
             for class_symbol in _CHECKPOINT_MODEL_NAME_CLASS_SYMBOLS
         }
-        _model_map: list[tuple[str, type[RFDETR]]] = [
-            (name, _variant_symbols[class_symbol]) for name, class_symbol in _CHECKPOINT_MODEL_MAP_ENTRIES
+        # Build in three explicit segments: seg-* entries, then plus-model entries
+        # (xlarge/2xlarge), then base entries — order determines lookup priority.
+        _seg_map: list[tuple[str, type[RFDETR]]] = [
+            (name, _variant_symbols[class_symbol])
+            for name, class_symbol in _CHECKPOINT_MODEL_MAP_ENTRIES
+            if name.startswith("seg-")
         ]
-        _model_map[8:8] = _plus_entries
+        _base_map: list[tuple[str, type[RFDETR]]] = [
+            (name, _variant_symbols[class_symbol])
+            for name, class_symbol in _CHECKPOINT_MODEL_MAP_ENTRIES
+            if not name.startswith("seg-")
+        ]
+        _model_map: list[tuple[str, type[RFDETR]]] = _seg_map + _plus_entries + _base_map
 
         # New checkpoints store model_name directly — use it when available.
         _name_map: dict[str, type[RFDETR]] = dict(_variant_symbols)

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -589,10 +589,7 @@ class RFDETR:
     @deprecated(
         target=True,
         # `simplify` / `force` are retained for API compatibility and treated as no-op.
-        args_mapping={
-            "simplify": False,
-            "force": False,
-        },
+        args_mapping={"simplify": False, "force": False},
         deprecated_in="1.6",
         remove_in="1.8",
         num_warns=1,

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -264,25 +264,19 @@ class RFDETR:
 
         _plus_available = False
         _plus_symbols: dict[str, type[RFDETR]] = {}
+        _plus_entries: list[tuple[str, type[RFDETR]]] = []
         try:
             import rfdetr.platform.models as platform_models
 
-            _plus_symbols_by_name: dict[str, type[RFDETR]] = {
-                getattr(plus_obj, "__name__", symbol): plus_obj
-                for symbol in dir(platform_models)
-                if symbol.startswith("RFDETR")
-                for plus_obj in [getattr(platform_models, symbol)]
-            }
-            _plus_symbols = {
-                class_symbol: _plus_symbols_by_name[class_symbol]
-                for class_symbol in _CHECKPOINT_PLUS_MODEL_NAME_CLASS_SYMBOLS
-            }
-            _plus_entries: list[tuple[str, type[RFDETR]]] = [
+            for class_symbol in _CHECKPOINT_PLUS_MODEL_NAME_CLASS_SYMBOLS:
+                plus_obj = getattr(platform_models, class_symbol)
+                _plus_symbols[class_symbol] = plus_obj
+            _plus_entries = [
                 (name, _plus_symbols[class_symbol]) for name, class_symbol in _CHECKPOINT_PLUS_MODEL_MAP_ENTRIES
             ]
             _plus_available = True
-        except ImportError:
-            _plus_entries = []
+        except (ImportError, AttributeError):
+            _plus_symbols = {}
 
         # weights_only=False is required because legacy checkpoints embed
         # argparse.Namespace objects that cannot be deserialised with

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -260,7 +260,9 @@ class RFDETR:
             >>> model = RFDETRSmall.from_checkpoint("checkpoint_best_total.pth")  # doctest: +SKIP
         """
         # Local imports break the variants → detr import cycle.
-        # Module aliases are needed for dynamic getattr() resolution below.
+        # `import ... as` alias is an intentional exception to the project's direct-import
+        # convention (AGENTS.md) — the alias is required for the dynamic getattr() resolution
+        # in the _variant_symbols / _plus_symbols maps below.
         import rfdetr.variants as variants
 
         _plus_available = False

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -284,7 +284,20 @@ class RFDETR:
         ]
 
         # New checkpoints store model_name directly — use it when available.
-        _name_map: dict[str, type[RFDETR]] = {klass.__name__: klass for _, klass in _model_map}
+        _name_map: dict[str, type[RFDETR]] = {
+            "RFDETRNano": RFDETRNano,
+            "RFDETRSmall": RFDETRSmall,
+            "RFDETRMedium": RFDETRMedium,
+            "RFDETRLarge": RFDETRLarge,
+            "RFDETRBase": RFDETRBase,
+            "RFDETRSegNano": RFDETRSegNano,
+            "RFDETRSegSmall": RFDETRSegSmall,
+            "RFDETRSegMedium": RFDETRSegMedium,
+            "RFDETRSegLarge": RFDETRSegLarge,
+            "RFDETRSegXLarge": RFDETRSegXLarge,
+            "RFDETRSeg2XLarge": RFDETRSeg2XLarge,
+            "RFDETRSegPreview": RFDETRSegPreview,
+        }
         saved_model_name = ckpt.get("model_name")
         model_cls: type[RFDETR] | None = _name_map.get(saved_model_name) if saved_model_name else None
 

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -237,7 +237,6 @@ class RFDETR:
         from rfdetr.variants import (
             RFDETRBase,
             RFDETRLarge,
-            RFDETRLargeDeprecated,
             RFDETRMedium,
             RFDETRNano,
             RFDETRSeg2XLarge,

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -259,41 +259,27 @@ class RFDETR:
             >>> model = RFDETR.from_checkpoint("checkpoint_best_total.pth")  # doctest: +SKIP
             >>> model = RFDETRSmall.from_checkpoint("checkpoint_best_total.pth")  # doctest: +SKIP
         """
-        # Local imports break the variants → detr import cycle.
-        from rfdetr.variants import (
-            RFDETRBase,
-            RFDETRLarge,
-            RFDETRMedium,
-            RFDETRNano,
-            RFDETRSeg2XLarge,
-            RFDETRSegLarge,
-            RFDETRSegMedium,
-            RFDETRSegNano,
-            RFDETRSegPreview,
-            RFDETRSegSmall,
-            RFDETRSegXLarge,
-            RFDETRSmall,
-        )
+        # Local import breaks the variants → detr import cycle.
+        import rfdetr.variants as rfdetr_variants
 
         _plus_available = False
         _plus_symbols: dict[str, type[RFDETR]] = {}
         try:
-            from rfdetr.platform.models import (
-                RFDETR2XLarge,
-                RFDETRXLarge,
-            )
+            import rfdetr.platform.models as platform_models
 
-            _plus_name_to_class: dict[str, type[RFDETR]] = {
-                "RFDETRXLarge": RFDETRXLarge,
-                "RFDETR2XLarge": RFDETR2XLarge,
+            _plus_symbols_by_name: dict[str, type[RFDETR]] = {
+                getattr(plus_obj, "__name__", symbol): plus_obj
+                for symbol in dir(platform_models)
+                if symbol.startswith("RFDETR")
+                for plus_obj in [getattr(platform_models, symbol)]
             }
-            _plus_entries: list[tuple[str, type[RFDETR]]] = [
-                (name, _plus_name_to_class[class_symbol]) for name, class_symbol in _CHECKPOINT_PLUS_MODEL_MAP_ENTRIES
-            ]
             _plus_symbols = {
-                class_symbol: _plus_name_to_class[class_symbol]
+                class_symbol: _plus_symbols_by_name[class_symbol]
                 for class_symbol in _CHECKPOINT_PLUS_MODEL_NAME_CLASS_SYMBOLS
             }
+            _plus_entries: list[tuple[str, type[RFDETR]]] = [
+                (name, _plus_symbols[class_symbol]) for name, class_symbol in _CHECKPOINT_PLUS_MODEL_MAP_ENTRIES
+            ]
             _plus_available = True
         except ImportError:
             _plus_entries = []
@@ -304,22 +290,11 @@ class RFDETR:
         ckpt: dict[str, Any] = torch.load(path, map_location="cpu", weights_only=False)
         args = ckpt["args"]
 
-        # Ordered most-specific first so "seg-xxlarge"/"seg-2xlarge" match before
-        # "seg-xlarge", "xxlarge" before "xlarge", and "seg-*" prefixes before
-        # their bare counterparts.
         _variant_name_to_class: dict[str, type[RFDETR]] = {
-            "RFDETRBase": RFDETRBase,
-            "RFDETRLarge": RFDETRLarge,
-            "RFDETRMedium": RFDETRMedium,
-            "RFDETRNano": RFDETRNano,
-            "RFDETRSeg2XLarge": RFDETRSeg2XLarge,
-            "RFDETRSegLarge": RFDETRSegLarge,
-            "RFDETRSegMedium": RFDETRSegMedium,
-            "RFDETRSegNano": RFDETRSegNano,
-            "RFDETRSegPreview": RFDETRSegPreview,
-            "RFDETRSegSmall": RFDETRSegSmall,
-            "RFDETRSegXLarge": RFDETRSegXLarge,
-            "RFDETRSmall": RFDETRSmall,
+            getattr(variant_obj, "__name__", symbol): variant_obj
+            for symbol in dir(rfdetr_variants)
+            if symbol.startswith("RFDETR")
+            for variant_obj in [getattr(rfdetr_variants, symbol)]
         }
         _variant_symbols: dict[str, type[RFDETR]] = {
             class_symbol: _variant_name_to_class[class_symbol] for class_symbol in _CHECKPOINT_MODEL_NAME_CLASS_SYMBOLS

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -263,22 +263,6 @@ class RFDETR:
         ckpt: dict[str, Any] = torch.load(path, map_location="cpu", weights_only=False)
         args = ckpt["args"]
 
-        if isinstance(args, dict):
-            weights_name = str(args.get("pretrain_weights", "")).lower()
-        else:
-            weights_name = str(getattr(args, "pretrain_weights", "")).lower()
-
-        # Guard: "xlarge"/"xxlarge" without a "seg-" prefix are plus-only models.
-        # Without the plus package, "xlarge" would otherwise silently fall through
-        # to the generic "large" key and instantiate the wrong class.
-        if not _plus_available and "xlarge" in weights_name and "seg-" not in weights_name:
-            from rfdetr.platform import _INSTALL_MSG
-
-            raise ImportError(
-                f"Checkpoint pretrain_weights={weights_name!r} requires the "
-                f"rfdetr_plus package. " + _INSTALL_MSG.format(name="platform model downloads")
-            )
-
         # Ordered most-specific first so "seg-xxlarge"/"seg-2xlarge" match before
         # "seg-xlarge", "xxlarge" before "xlarge", and "seg-*" prefixes before
         # their bare counterparts.
@@ -299,16 +283,35 @@ class RFDETR:
             ("base", RFDETRBase),
         ]
 
-        model_cls: type[RFDETR] | None = None
-        for name, klass in _model_map:
-            if name in weights_name:
-                model_cls = klass
-                break
+        # New checkpoints store model_name directly — use it when available.
+        _name_map: dict[str, type[RFDETR]] = {klass.__name__: klass for _, klass in _model_map}
+        saved_model_name = ckpt.get("model_name")
+        model_cls: type[RFDETR] | None = _name_map.get(saved_model_name) if saved_model_name else None
+
+        # Fall back to pretrain_weights filename parsing for older checkpoints.
+        if model_cls is None:
+            if isinstance(args, dict):
+                weights_name = str(args.get("pretrain_weights", "")).lower()
+            else:
+                weights_name = str(getattr(args, "pretrain_weights", "")).lower()
+
+            # Guard: "xlarge"/"xxlarge" without a "seg-" prefix are plus-only models.
+            if not _plus_available and "xlarge" in weights_name and "seg-" not in weights_name:
+                from rfdetr.platform import _INSTALL_MSG
+
+                raise ImportError(
+                    f"Checkpoint pretrain_weights={weights_name!r} requires the "
+                    f"rfdetr_plus package. " + _INSTALL_MSG.format(name="platform model downloads")
+                )
+
+            for name, klass in _model_map:
+                if name in weights_name:
+                    model_cls = klass
+                    break
 
         if model_cls is None:
             raise ValueError(
-                f"Could not infer model size from pretrain_weights={weights_name!r}. "
-                "Please instantiate the model class directly."
+                f"Could not infer model size from checkpoint at {path!r}. Please instantiate the model class directly."
             )
 
         if isinstance(args, dict):
@@ -457,6 +460,7 @@ class RFDETR:
                 config.grad_accum_steps,
                 auto_batch.effective_batch_size,
             )
+        self.model_config.model_name = type(self).__name__
         module = RFDETRModelModule(self.model_config, config)
         datamodule = RFDETRDataModule(self.model_config, config)
         trainer_kwargs = {"accelerator": _accelerator}

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -137,6 +137,26 @@ class BestModelCallback(ModelCheckpoint):
         raw = _orig if isinstance(_orig, torch.nn.Module) else pl_module.model
         return raw.state_dict()
 
+    @staticmethod
+    def _resolve_model_name(pl_module: LightningModule) -> str | None:
+        """Resolve checkpoint model_name from model_config or config type.
+
+        The CLI/PTL path does not call ``RFDETR.train()``, so
+        ``model_config.model_name`` may be unset. In that case, infer the model
+        class from concrete config names like ``RFDETRSmallConfig``.
+        """
+        model_config = getattr(pl_module, "model_config", None)
+        configured_name = getattr(model_config, "model_name", None) if model_config is not None else None
+        if isinstance(configured_name, str):
+            normalized_name = configured_name.strip()
+            if normalized_name:
+                return normalized_name
+
+        config_type_name = type(model_config).__name__ if model_config is not None else ""
+        if config_type_name.startswith("RFDETR") and config_type_name.endswith("Config"):
+            return config_type_name.removesuffix("Config")
+        return None
+
     def _save_checkpoint(self, trainer: Trainer, filepath: str) -> None:
         """Save stripped ``.pth`` format instead of a full ``.ckpt``.
 
@@ -179,9 +199,7 @@ class BestModelCallback(ModelCheckpoint):
         ):
             train_config = train_config.model_copy(update={"class_names": dataset_class_names})
         args_dict = train_config.model_dump() if hasattr(train_config, "model_dump") else train_config
-        _cfg = getattr(pl_module, "model_config", None)
-        _raw_name = getattr(_cfg, "model_name", None) if _cfg is not None else None
-        model_name = _raw_name if isinstance(_raw_name, str) else None
+        model_name = self._resolve_model_name(pl_module)
         torch.save(
             self._build_checkpoint_payload(model_state_dict, args_dict, trainer, model_name=model_name), pth_path
         )
@@ -230,9 +248,7 @@ class BestModelCallback(ModelCheckpoint):
             ema_args_dict = (
                 ema_train_config.model_dump() if hasattr(ema_train_config, "model_dump") else ema_train_config
             )
-            _ema_cfg = getattr(pl_module, "model_config", None)
-            _raw_ema_name = getattr(_ema_cfg, "model_name", None) if _ema_cfg is not None else None
-            ema_model_name = _raw_ema_name if isinstance(_raw_ema_name, str) else None
+            ema_model_name = self._resolve_model_name(pl_module)
             torch.save(
                 self._build_checkpoint_payload(ema_state_dict, ema_args_dict, trainer, model_name=ema_model_name),
                 self._output_dir / "checkpoint_best_ema.pth",

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -79,6 +79,7 @@ class BestModelCallback(ModelCheckpoint):
         model_state_dict: dict[str, torch.Tensor],
         args_dict: object,
         trainer: Trainer,
+        model_name: str | None = None,
     ) -> dict[str, object]:
         """Build a PTL-compatible RF-DETR checkpoint payload.
 
@@ -86,6 +87,7 @@ class BestModelCallback(ModelCheckpoint):
             model_state_dict: Model weights with raw (non-prefixed) keys.
             args_dict: Serialized training args/config payload.
             trainer: Active Lightning trainer providing epoch/step counters.
+            model_name: Name of the model class (e.g. ``"RFDETRLarge"``).
 
         Returns:
             Checkpoint dictionary that supports ``Trainer.fit(ckpt_path=...)``
@@ -94,6 +96,7 @@ class BestModelCallback(ModelCheckpoint):
         return {
             "model": model_state_dict,
             "args": args_dict,
+            "model_name": model_name,
             "epoch": trainer.current_epoch,
             # PTL-compatible keys so trainer.fit(ckpt_path=...) works directly.
             "state_dict": {f"model.{k}": v for k, v in model_state_dict.items()},
@@ -176,7 +179,10 @@ class BestModelCallback(ModelCheckpoint):
         ):
             train_config = train_config.model_copy(update={"class_names": dataset_class_names})
         args_dict = train_config.model_dump() if hasattr(train_config, "model_dump") else train_config
-        torch.save(self._build_checkpoint_payload(model_state_dict, args_dict, trainer), pth_path)
+        model_name = getattr(pl_module.model_config, "model_name", None)
+        torch.save(
+            self._build_checkpoint_payload(model_state_dict, args_dict, trainer, model_name=model_name), pth_path
+        )
         self._last_global_step_saved = trainer.global_step
         logger.info("Best regular mAP saved to %s (epoch %d)", pth_path, trainer.current_epoch)
 
@@ -222,8 +228,9 @@ class BestModelCallback(ModelCheckpoint):
             ema_args_dict = (
                 ema_train_config.model_dump() if hasattr(ema_train_config, "model_dump") else ema_train_config
             )
+            ema_model_name = getattr(pl_module.model_config, "model_name", None)
             torch.save(
-                self._build_checkpoint_payload(ema_state_dict, ema_args_dict, trainer),
+                self._build_checkpoint_payload(ema_state_dict, ema_args_dict, trainer, model_name=ema_model_name),
                 self._output_dir / "checkpoint_best_ema.pth",
             )
             logger.info(

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -158,11 +158,6 @@ class BestModelCallback(ModelCheckpoint):
 
         config_type_name = type(model_config).__name__ if model_config is not None else ""
         if config_type_name.startswith("RFDETR") and config_type_name.endswith("Config"):
-            # Strip "DeprecatedConfig" before "Config" to match the canonical class
-            # name used by RFDETR.train() (type(self).__name__ on the user-facing class).
-            # e.g. "RFDETRLargeDeprecatedConfig" -> "RFDETRLarge", not "RFDETRLargeDeprecated".
-            if config_type_name.endswith("DeprecatedConfig"):
-                return config_type_name.removesuffix("DeprecatedConfig")
             return config_type_name.removesuffix("Config")
         return None
 

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -157,6 +157,17 @@ class BestModelCallback(ModelCheckpoint):
                 return normalized_name
 
         config_type_name = type(model_config).__name__ if model_config is not None else ""
+
+        # Handle deprecated config types that should resolve to a canonical model name.
+        deprecated_aliases: dict[str, str] = {
+            # RFDETRLargeDeprecatedConfig should resolve to canonical RFDETRLarge
+            "RFDETRLargeDeprecatedConfig": "RFDETRLarge",
+        }
+        if config_type_name in deprecated_aliases:
+            return deprecated_aliases[config_type_name]
+        if config_type_name.startswith("RFDETR") and config_type_name.endswith("DeprecatedConfig"):
+            # Generic fallback for other RFDETR*DeprecatedConfig types.
+            return config_type_name.removesuffix("DeprecatedConfig")
         if config_type_name.startswith("RFDETR") and config_type_name.endswith("Config"):
             return config_type_name.removesuffix("Config")
         return None

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -179,7 +179,8 @@ class BestModelCallback(ModelCheckpoint):
         ):
             train_config = train_config.model_copy(update={"class_names": dataset_class_names})
         args_dict = train_config.model_dump() if hasattr(train_config, "model_dump") else train_config
-        _raw_name = getattr(pl_module.model_config, "model_name", None)
+        _cfg = getattr(pl_module, "model_config", None)
+        _raw_name = getattr(_cfg, "model_name", None) if _cfg is not None else None
         model_name = _raw_name if isinstance(_raw_name, str) else None
         torch.save(
             self._build_checkpoint_payload(model_state_dict, args_dict, trainer, model_name=model_name), pth_path
@@ -229,7 +230,8 @@ class BestModelCallback(ModelCheckpoint):
             ema_args_dict = (
                 ema_train_config.model_dump() if hasattr(ema_train_config, "model_dump") else ema_train_config
             )
-            _raw_ema_name = getattr(pl_module.model_config, "model_name", None)
+            _ema_cfg = getattr(pl_module, "model_config", None)
+            _raw_ema_name = getattr(_ema_cfg, "model_name", None) if _ema_cfg is not None else None
             ema_model_name = _raw_ema_name if isinstance(_raw_ema_name, str) else None
             torch.save(
                 self._build_checkpoint_payload(ema_state_dict, ema_args_dict, trainer, model_name=ema_model_name),

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -93,10 +93,9 @@ class BestModelCallback(ModelCheckpoint):
             Checkpoint dictionary that supports ``Trainer.fit(ckpt_path=...)``
             while intentionally omitting optimizer/scheduler states.
         """
-        return {
+        payload: dict[str, object] = {
             "model": model_state_dict,
             "args": args_dict,
-            "model_name": model_name,
             "epoch": trainer.current_epoch,
             # PTL-compatible keys so trainer.fit(ckpt_path=...) works directly.
             "state_dict": {f"model.{k}": v for k, v in model_state_dict.items()},
@@ -108,6 +107,11 @@ class BestModelCallback(ModelCheckpoint):
             "optimizer_states": [],
             "lr_schedulers": [],
         }
+        # Only write model_name when resolved — omit the key entirely when None
+        # so old-format and unresolved checkpoints are indistinguishable.
+        if model_name is not None:
+            payload["model_name"] = model_name
+        return payload
 
     @staticmethod
     def _get_ema_model_state_dict(
@@ -154,6 +158,11 @@ class BestModelCallback(ModelCheckpoint):
 
         config_type_name = type(model_config).__name__ if model_config is not None else ""
         if config_type_name.startswith("RFDETR") and config_type_name.endswith("Config"):
+            # Strip "DeprecatedConfig" before "Config" to match the canonical class
+            # name used by RFDETR.train() (type(self).__name__ on the user-facing class).
+            # e.g. "RFDETRLargeDeprecatedConfig" -> "RFDETRLarge", not "RFDETRLargeDeprecated".
+            if config_type_name.endswith("DeprecatedConfig"):
+                return config_type_name.removesuffix("DeprecatedConfig")
             return config_type_name.removesuffix("Config")
         return None
 

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -179,7 +179,8 @@ class BestModelCallback(ModelCheckpoint):
         ):
             train_config = train_config.model_copy(update={"class_names": dataset_class_names})
         args_dict = train_config.model_dump() if hasattr(train_config, "model_dump") else train_config
-        model_name = getattr(pl_module.model_config, "model_name", None)
+        _raw_name = getattr(pl_module.model_config, "model_name", None)
+        model_name = _raw_name if isinstance(_raw_name, str) else None
         torch.save(
             self._build_checkpoint_payload(model_state_dict, args_dict, trainer, model_name=model_name), pth_path
         )
@@ -228,7 +229,8 @@ class BestModelCallback(ModelCheckpoint):
             ema_args_dict = (
                 ema_train_config.model_dump() if hasattr(ema_train_config, "model_dump") else ema_train_config
             )
-            ema_model_name = getattr(pl_module.model_config, "model_name", None)
+            _raw_ema_name = getattr(pl_module.model_config, "model_name", None)
+            ema_model_name = _raw_ema_name if isinstance(_raw_ema_name, str) else None
             torch.save(
                 self._build_checkpoint_payload(ema_state_dict, ema_args_dict, trainer, model_name=ema_model_name),
                 self._output_dir / "checkpoint_best_ema.pth",

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -148,6 +148,14 @@ class BestModelCallback(ModelCheckpoint):
         The CLI/PTL path does not call ``RFDETR.train()``, so
         ``model_config.model_name`` may be unset. In that case, infer the model
         class from concrete config names like ``RFDETRSmallConfig``.
+
+        Note:
+            The ``DeprecatedConfig`` ``RuntimeError`` guard is only reachable
+            from the CLI/PTL path. ``RFDETR.train()`` pre-populates
+            ``model_config.model_name`` before saving any checkpoint, so the
+            config type-name branch (and therefore the ``DeprecatedConfig``
+            guard) is never reached when training is started via
+            ``RFDETR.train()``.
         """
         model_config = getattr(pl_module, "model_config", None)
         configured_name = getattr(model_config, "model_name", None) if model_config is not None else None

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -158,16 +158,11 @@ class BestModelCallback(ModelCheckpoint):
 
         config_type_name = type(model_config).__name__ if model_config is not None else ""
 
-        # Handle deprecated config types that should resolve to a canonical model name.
-        deprecated_aliases: dict[str, str] = {
-            # RFDETRLargeDeprecatedConfig should resolve to canonical RFDETRLarge
-            "RFDETRLargeDeprecatedConfig": "RFDETRLarge",
-        }
-        if config_type_name in deprecated_aliases:
-            return deprecated_aliases[config_type_name]
-        if config_type_name.startswith("RFDETR") and config_type_name.endswith("DeprecatedConfig"):
-            # Generic fallback for other RFDETR*DeprecatedConfig types.
-            return config_type_name.removesuffix("DeprecatedConfig")
+        if config_type_name.endswith("DeprecatedConfig"):
+            raise RuntimeError(
+                f"Deprecated model config '{config_type_name}' is no longer supported. "
+                "Re-train your model using a current model variant."
+            )
         if config_type_name.startswith("RFDETR") and config_type_name.endswith("Config"):
             return config_type_name.removesuffix("Config")
         return None

--- a/src/rfdetr/utilities/state_dict.py
+++ b/src/rfdetr/utilities/state_dict.py
@@ -141,6 +141,9 @@ def strip_checkpoint(checkpoint: str | os.PathLike[str]) -> None:
         "model": state_dict["model"],
         "args": state_dict["args"],
     }
+    # Preserve model_name when present (#887).
+    if "model_name" in state_dict:
+        new_state_dict["model_name"] = state_dict["model_name"]
     # Preserve PTL-compatible keys when present (written by BestModelCallback).
     for key in _PTL_COMPAT_KEYS:
         if key in state_dict:

--- a/src/rfdetr/utilities/state_dict.py
+++ b/src/rfdetr/utilities/state_dict.py
@@ -120,7 +120,10 @@ def _make_fit_loop_state(epoch: int) -> dict:
 def strip_checkpoint(checkpoint: str | os.PathLike[str]) -> None:
     """Strip a checkpoint file down to ``model``, ``args``, and PTL-compatible keys.
 
-    Preserves ``state_dict``, ``global_step``, ``pytorch-lightning_version``,
+    Preserves ``model_name`` (when present) so that ``RFDETR.from_checkpoint()``
+    can still resolve the model class from the stripped file.
+
+    Also preserves ``state_dict``, ``global_step``, ``pytorch-lightning_version``,
     ``loops``, ``optimizer_states``, and ``lr_schedulers`` when present so the
     stripped checkpoint can still be used directly with
     ``trainer.fit(ckpt_path=...)``.

--- a/src/rfdetr/variants.py
+++ b/src/rfdetr/variants.py
@@ -105,8 +105,6 @@ class RFDETRLargeDeprecated(RFDETR):
     size = "rfdetr-large"
     _model_config_class = RFDETRLargeDeprecatedConfig
 
-        )
-
 
 class RFDETRLarge(RFDETR):
     size = "rfdetr-large"

--- a/src/rfdetr/variants.py
+++ b/src/rfdetr/variants.py
@@ -61,7 +61,7 @@ logger = get_logger()
     remove_in="2.0.0",
 )
 class RFDETRBase(RFDETR):
-    """RF-DETR Base model — deprecated since v1.7.0.
+    """RF-DETR Base model — removed in v1.7.0.
 
     .. deprecated:: 1.7.0
         Use one of the supported variants: :class:`RFDETRNano`, :class:`RFDETRSmall`,
@@ -70,6 +70,12 @@ class RFDETRBase(RFDETR):
 
     size = "rfdetr-base"
     _model_config_class = RFDETRBaseConfig
+
+    def __init__(self, **kwargs: object) -> None:
+        raise RuntimeError(
+            "RFDETRBase was deprecated in v1.7.0 and is no longer supported. "
+            "Use RFDETRNano, RFDETRSmall, RFDETRMedium, or RFDETRLarge instead."
+        )
 
 
 class RFDETRNano(RFDETR):
@@ -105,7 +111,7 @@ class RFDETRMedium(RFDETR):
     remove_in="2.0.0",
 )
 class RFDETRLargeDeprecated(RFDETR):
-    """RF-DETR Large model (legacy config) — deprecated since v1.7.0.
+    """RF-DETR Large model (legacy config) — removed in v1.7.0.
 
     .. deprecated:: 1.7.0
         Use :class:`RFDETRLarge` instead.
@@ -113,6 +119,11 @@ class RFDETRLargeDeprecated(RFDETR):
 
     size = "rfdetr-large"
     _model_config_class = RFDETRLargeDeprecatedConfig
+
+    def __init__(self, **kwargs: object) -> None:
+        raise RuntimeError(
+            "RFDETRLargeDeprecated was deprecated in v1.7.0 and is no longer supported. Use RFDETRLarge instead."
+        )
 
 
 class RFDETRLarge(RFDETR):
@@ -190,7 +201,7 @@ class RFDETRSeg(RFDETR):
     remove_in="2.0.0",
 )
 class RFDETRSegPreview(RFDETRSeg):
-    """RF-DETR Segmentation Preview model — deprecated since v1.7.0.
+    """RF-DETR Segmentation Preview model — removed in v1.7.0.
 
     .. deprecated:: 1.7.0
         Use one of the supported segmentation variants: :class:`RFDETRSegNano`, :class:`RFDETRSegSmall`,
@@ -199,6 +210,12 @@ class RFDETRSegPreview(RFDETRSeg):
 
     size = "rfdetr-seg-preview"
     _model_config_class = RFDETRSegPreviewConfig
+
+    def __init__(self, **kwargs: object) -> None:
+        raise RuntimeError(
+            "RFDETRSegPreview was deprecated in v1.7.0 and is no longer supported. "
+            "Use RFDETRSegNano, RFDETRSegSmall, RFDETRSegMedium, or RFDETRSegLarge instead."
+        )
 
 
 class RFDETRSegNano(RFDETRSeg):

--- a/src/rfdetr/variants.py
+++ b/src/rfdetr/variants.py
@@ -61,8 +61,7 @@ logger = get_logger()
     remove_in="2.0.0",
 )
 class RFDETRBase(RFDETR):
-    """RF-DETR Base model — deprecated in v1.7.0, scheduled for removal in v2.0.0.
-    """
+    """RF-DETR Base model — deprecated in v1.7.0, scheduled for removal in v2.0.0."""
 
     size = "rfdetr-base"
     _model_config_class = RFDETRBaseConfig
@@ -107,8 +106,7 @@ class RFDETRMedium(RFDETR):
     remove_in="2.0.0",
 )
 class RFDETRLargeDeprecated(RFDETR):
-    """RF-DETR Large model (legacy config) — deprecated in v1.7.0, scheduled for removal in v2.0.0.
-    """
+    """RF-DETR Large model (legacy config) — deprecated in v1.7.0, scheduled for removal in v2.0.0."""
 
     size = "rfdetr-large"
     _model_config_class = RFDETRLargeDeprecatedConfig
@@ -194,8 +192,7 @@ class RFDETRSeg(RFDETR):
     remove_in="2.0.0",
 )
 class RFDETRSegPreview(RFDETRSeg):
-    """RF-DETR Segmentation Preview model — deprecated in v1.7.0, scheduled for removal in v2.0.0.
-    """
+    """RF-DETR Segmentation Preview model — deprecated in v1.7.0, scheduled for removal in v2.0.0."""
 
     size = "rfdetr-seg-preview"
     _model_config_class = RFDETRSegPreviewConfig

--- a/src/rfdetr/variants.py
+++ b/src/rfdetr/variants.py
@@ -66,12 +66,6 @@ class RFDETRBase(RFDETR):
     size = "rfdetr-base"
     _model_config_class = RFDETRBaseConfig
 
-    def __init__(self, **kwargs: object) -> None:
-        raise RuntimeError(
-            "RFDETRBase was deprecated in v1.7.0 and is no longer supported. "
-            "Use RFDETRNano, RFDETRSmall, RFDETRMedium, or RFDETRLarge instead."
-        )
-
 
 class RFDETRNano(RFDETR):
     """
@@ -111,9 +105,6 @@ class RFDETRLargeDeprecated(RFDETR):
     size = "rfdetr-large"
     _model_config_class = RFDETRLargeDeprecatedConfig
 
-    def __init__(self, **kwargs: object) -> None:
-        raise RuntimeError(
-            "RFDETRLargeDeprecated was deprecated in v1.7.0 and is no longer supported. Use RFDETRLarge instead."
         )
 
 
@@ -196,12 +187,6 @@ class RFDETRSegPreview(RFDETRSeg):
 
     size = "rfdetr-seg-preview"
     _model_config_class = RFDETRSegPreviewConfig
-
-    def __init__(self, **kwargs: object) -> None:
-        raise RuntimeError(
-            "RFDETRSegPreview was deprecated in v1.7.0 and is no longer supported. "
-            "Use RFDETRSegNano, RFDETRSegSmall, RFDETRSegMedium, or RFDETRSegLarge instead."
-        )
 
 
 class RFDETRSegNano(RFDETRSeg):

--- a/src/rfdetr/variants.py
+++ b/src/rfdetr/variants.py
@@ -201,7 +201,7 @@ class RFDETRSeg(RFDETR):
     remove_in="2.0.0",
 )
 class RFDETRSegPreview(RFDETRSeg):
-    """RF-DETR Segmentation Preview model — removed in v1.7.0.
+    """RF-DETR Segmentation Preview model — deprecated in v1.7.0 and will be removed in v2.0.0.
 
     .. deprecated:: 1.7.0
         Use one of the supported segmentation variants: :class:`RFDETRSegNano`, :class:`RFDETRSegSmall`,

--- a/src/rfdetr/variants.py
+++ b/src/rfdetr/variants.py
@@ -61,7 +61,7 @@ logger = get_logger()
     remove_in="2.0.0",
 )
 class RFDETRBase(RFDETR):
-    """RF-DETR Base model — removed in v1.7.0.
+    """RF-DETR Base model — deprecated in v1.7.0, scheduled for removal in v2.0.0.
 
     .. deprecated:: 1.7.0
         Use one of the supported variants: :class:`RFDETRNano`, :class:`RFDETRSmall`,
@@ -111,7 +111,7 @@ class RFDETRMedium(RFDETR):
     remove_in="2.0.0",
 )
 class RFDETRLargeDeprecated(RFDETR):
-    """RF-DETR Large model (legacy config) — removed in v1.7.0.
+    """RF-DETR Large model (legacy config) — deprecated in v1.7.0, scheduled for removal in v2.0.0.
 
     .. deprecated:: 1.7.0
         Use :class:`RFDETRLarge` instead.
@@ -201,7 +201,7 @@ class RFDETRSeg(RFDETR):
     remove_in="2.0.0",
 )
 class RFDETRSegPreview(RFDETRSeg):
-    """RF-DETR Segmentation Preview model — removed in v1.7.0.
+    """RF-DETR Segmentation Preview model — deprecated in v1.7.0, scheduled for removal in v2.0.0.
 
     .. deprecated:: 1.7.0
         Use one of the supported segmentation variants: :class:`RFDETRSegNano`, :class:`RFDETRSegSmall`,

--- a/src/rfdetr/variants.py
+++ b/src/rfdetr/variants.py
@@ -30,7 +30,7 @@ __all__ = [
     "RFDETRSeg2XLarge",
 ]
 
-import warnings
+from deprecate import deprecated_class
 
 from rfdetr.config import (
     ModelConfig,
@@ -55,9 +55,22 @@ from rfdetr.utilities.logger import get_logger
 logger = get_logger()
 
 
+def _raise_deprecated_class(msg: str, **_: object) -> None:
+    raise RuntimeError(msg)
+
+
+@deprecated_class(
+    target=None,
+    deprecated_in="1.7.0",
+    remove_in="2.0.0",
+    stream=_raise_deprecated_class,
+)
 class RFDETRBase(RFDETR):
-    """
-    Train an RF-DETR Base model (29M parameters).
+    """RF-DETR Base model — deprecated since v1.7.0.
+
+    .. deprecated:: 1.7.0
+        Use one of the supported variants: :class:`RFDETRNano`, :class:`RFDETRSmall`,
+        :class:`RFDETRMedium`, or :class:`RFDETRLarge`.
     """
 
     size = "rfdetr-base"
@@ -91,22 +104,21 @@ class RFDETRMedium(RFDETR):
     _model_config_class = RFDETRMediumConfig
 
 
+@deprecated_class(
+    target=None,
+    deprecated_in="1.7.0",
+    remove_in="2.0.0",
+    stream=_raise_deprecated_class,
+)
 class RFDETRLargeDeprecated(RFDETR):
-    """
-    Train an RF-DETR Large model.
+    """RF-DETR Large model (legacy config) — deprecated since v1.7.0.
+
+    .. deprecated:: 1.7.0
+        Use :class:`RFDETRLarge` instead.
     """
 
     size = "rfdetr-large"
     _model_config_class = RFDETRLargeDeprecatedConfig
-
-    def __init__(self, **kwargs):
-        warnings.warn(
-            "RFDETRLargeDeprecated is deprecated and will be removed in a future version."
-            " Please use RFDETRLarge instead.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        super().__init__(**kwargs)
 
 
 class RFDETRLarge(RFDETR):
@@ -178,7 +190,20 @@ class RFDETRSeg(RFDETR):
     _train_config_class = SegmentationTrainConfig
 
 
+@deprecated_class(
+    target=None,
+    deprecated_in="1.7.0",
+    remove_in="2.0.0",
+    stream=_raise_deprecated_class,
+)
 class RFDETRSegPreview(RFDETRSeg):
+    """RF-DETR Segmentation Preview model — deprecated since v1.7.0.
+
+    .. deprecated:: 1.7.0
+        Use one of the supported segmentation variants: :class:`RFDETRSegNano`, :class:`RFDETRSegSmall`,
+        :class:`RFDETRSegMedium`, or :class:`RFDETRSegLarge`.
+    """
+
     size = "rfdetr-seg-preview"
     _model_config_class = RFDETRSegPreviewConfig
 

--- a/tests/models/test_from_checkpoint.py
+++ b/tests/models/test_from_checkpoint.py
@@ -217,3 +217,72 @@ class TestFromCheckpointEdgeCases:
             with patch("rfdetr.detr.torch.load", return_value=ckpt):
                 with pytest.raises(ImportError):
                     RFDETR.from_checkpoint(tmp_path / "ckpt.pth")
+
+
+# ---------------------------------------------------------------------------
+# model_name in checkpoint (#887)
+# ---------------------------------------------------------------------------
+
+
+def _ckpt_with_model_name(model_name: str, num_classes: int = 80) -> dict:
+    """Fake checkpoint with model_name key (new format)."""
+    return {
+        "args": {"pretrain_weights": "rf-detr-small.pth", "num_classes": num_classes},
+        "model_name": model_name,
+    }
+
+
+class TestFromCheckpointModelName:
+    """from_checkpoint uses model_name when present in checkpoint."""
+
+    @pytest.mark.parametrize(
+        "model_name, patch_target",
+        [
+            pytest.param("RFDETRNano", "rfdetr.variants.RFDETRNano", id="nano"),
+            pytest.param("RFDETRSmall", "rfdetr.variants.RFDETRSmall", id="small"),
+            pytest.param("RFDETRMedium", "rfdetr.variants.RFDETRMedium", id="medium"),
+            pytest.param("RFDETRLarge", "rfdetr.variants.RFDETRLarge", id="large"),
+            pytest.param("RFDETRBase", "rfdetr.variants.RFDETRBase", id="base"),
+            pytest.param("RFDETRSegNano", "rfdetr.variants.RFDETRSegNano", id="seg-nano"),
+            pytest.param("RFDETRSegSmall", "rfdetr.variants.RFDETRSegSmall", id="seg-small"),
+            pytest.param("RFDETRSegMedium", "rfdetr.variants.RFDETRSegMedium", id="seg-medium"),
+            pytest.param("RFDETRSegLarge", "rfdetr.variants.RFDETRSegLarge", id="seg-large"),
+            pytest.param("RFDETRSegXLarge", "rfdetr.variants.RFDETRSegXLarge", id="seg-xlarge"),
+            pytest.param("RFDETRSeg2XLarge", "rfdetr.variants.RFDETRSeg2XLarge", id="seg-2xlarge"),
+        ],
+    )
+    def test_model_name_resolves_correct_class(
+        self,
+        tmp_path: Path,
+        model_name: str,
+        patch_target: str,
+    ) -> None:
+        """model_name in checkpoint maps directly to the correct subclass."""
+        result, mock_cls = _call_from_checkpoint(_ckpt_with_model_name(model_name), tmp_path / "ckpt.pth", patch_target)
+        mock_cls.assert_called_once()
+        assert result is mock_cls.return_value
+
+    def test_model_name_takes_priority_over_pretrain_weights(self, tmp_path: Path) -> None:
+        """model_name is used even when pretrain_weights points to a different size."""
+        ckpt = {
+            "args": {"pretrain_weights": "rf-detr-nano.pth", "num_classes": 80},
+            "model_name": "RFDETRLarge",
+        }
+        _, mock_cls = _call_from_checkpoint(ckpt, tmp_path / "ckpt.pth", "rfdetr.variants.RFDETRLarge")
+        mock_cls.assert_called_once()
+
+    def test_falls_back_to_pretrain_weights_without_model_name(self, tmp_path: Path) -> None:
+        """Old checkpoints without model_name still work via pretrain_weights parsing."""
+        ckpt = _dict("rf-detr-small.pth")
+        assert "model_name" not in ckpt
+        _, mock_cls = _call_from_checkpoint(ckpt, tmp_path / "ckpt.pth", "rfdetr.variants.RFDETRSmall")
+        mock_cls.assert_called_once()
+
+    def test_unknown_model_name_falls_back_to_pretrain_weights(self, tmp_path: Path) -> None:
+        """Unrecognised model_name falls back to pretrain_weights parsing."""
+        ckpt = {
+            "args": {"pretrain_weights": "rf-detr-small.pth", "num_classes": 80},
+            "model_name": "UnknownModel",
+        }
+        _, mock_cls = _call_from_checkpoint(ckpt, tmp_path / "ckpt.pth", "rfdetr.variants.RFDETRSmall")
+        mock_cls.assert_called_once()

--- a/tests/models/test_from_checkpoint.py
+++ b/tests/models/test_from_checkpoint.py
@@ -242,19 +242,12 @@ class TestFromCheckpointModelName:
             pytest.param("RFDETRSmall", "rfdetr.variants.RFDETRSmall", id="small"),
             pytest.param("RFDETRMedium", "rfdetr.variants.RFDETRMedium", id="medium"),
             pytest.param("RFDETRLarge", "rfdetr.variants.RFDETRLarge", id="large"),
-            pytest.param(
-                "RFDETRLargeDeprecated",
-                "rfdetr.variants.RFDETRLargeDeprecated",
-                id="large-deprecated",
-            ),
-            pytest.param("RFDETRBase", "rfdetr.variants.RFDETRBase", id="base"),
             pytest.param("RFDETRSegNano", "rfdetr.variants.RFDETRSegNano", id="seg-nano"),
             pytest.param("RFDETRSegSmall", "rfdetr.variants.RFDETRSegSmall", id="seg-small"),
             pytest.param("RFDETRSegMedium", "rfdetr.variants.RFDETRSegMedium", id="seg-medium"),
             pytest.param("RFDETRSegLarge", "rfdetr.variants.RFDETRSegLarge", id="seg-large"),
             pytest.param("RFDETRSegXLarge", "rfdetr.variants.RFDETRSegXLarge", id="seg-xlarge"),
             pytest.param("RFDETRSeg2XLarge", "rfdetr.variants.RFDETRSeg2XLarge", id="seg-2xlarge"),
-            pytest.param("RFDETRSegPreview", "rfdetr.variants.RFDETRSegPreview", id="seg-preview"),
         ],
     )
     def test_model_name_resolves_correct_class(

--- a/tests/models/test_from_checkpoint.py
+++ b/tests/models/test_from_checkpoint.py
@@ -237,7 +237,7 @@ class TestDeprecatedClassInstantiation:
             ("RFDETRBase", "rfdetr.variants.RFDETRBase"),
             ("RFDETRLargeDeprecated", "rfdetr.variants.RFDETRLargeDeprecated"),
             ("RFDETRSegPreview", "rfdetr.variants.RFDETRSegPreview"),
-        ]
+        ],
     )
     def test_direct_instantiation_is_allowed(self, cls_name: str, import_path: str) -> None:
         """Direct instantiation of a deprecated class does not raise RuntimeError."""
@@ -250,13 +250,7 @@ class TestDeprecatedClassInstantiation:
             model = cls()
         assert model.__class__.__name__ == cls_name
 
-    @pytest.mark.parametrize(
-        "pretrain_weights",
-        [
-            "rf-detr-base.pth",
-            "rf-detr-seg-preview.pt"
-        ]
-    )
+    @pytest.mark.parametrize("pretrain_weights", ["rf-detr-base.pth", "rf-detr-seg-preview.pt"])
     def test_from_checkpoint_resolves_deprecated_class(
         self,
         tmp_path: Path,
@@ -305,12 +299,7 @@ class TestFromCheckpointModelName:
             ("RFDETRSeg2XLarge", "RFDETRSeg2XLarge"),
         ],
     )
-    def test_model_name_resolves_correct_class(
-        self,
-        tmp_path: Path,
-        model_name: str,
-        patch_target: str
-    ) -> None:
+    def test_model_name_resolves_correct_class(self, tmp_path: Path, model_name: str, patch_target: str) -> None:
         """model_name in checkpoint maps directly to the correct subclass."""
         result, mock_cls = _call_from_checkpoint(
             _ckpt_with_model_name(model_name), tmp_path / "ckpt.pth", f"rfdetr.variants.{patch_target}"

--- a/tests/models/test_from_checkpoint.py
+++ b/tests/models/test_from_checkpoint.py
@@ -74,18 +74,18 @@ class TestFromCheckpointNamespaceArgs:
     @pytest.mark.parametrize(
         "pretrain_weights, patch_target",
         [
-            ("rf-detr-nano.pth", "rfdetr.variants.RFDETRNano"),
-            ("rf-detr-small.pth", "rfdetr.variants.RFDETRSmall"),
-            ("rf-detr-medium.pth", "rfdetr.variants.RFDETRMedium"),
-            ("rf-detr-large.pth", "rfdetr.variants.RFDETRLarge"),
-            ("rf-detr-base.pth", "rfdetr.variants.RFDETRBase"),
-            ("rf-detr-seg-nano.pt", "rfdetr.variants.RFDETRSegNano"),
-            ("rf-detr-seg-small.pt", "rfdetr.variants.RFDETRSegSmall"),
-            ("rf-detr-seg-medium.pt", "rfdetr.variants.RFDETRSegMedium"),
-            ("rf-detr-seg-large.pt", "rfdetr.variants.RFDETRSegLarge"),
-            ("rf-detr-seg-xlarge.pt", "rfdetr.variants.RFDETRSegXLarge"),
-            ("rf-detr-seg-xxlarge.pt", "rfdetr.variants.RFDETRSeg2XLarge"),
-            ("rf-detr-seg-preview.pt", "rfdetr.variants.RFDETRSegPreview"),
+            ("rf-detr-nano.pth", "RFDETRNano"),
+            ("rf-detr-small.pth", "RFDETRSmall"),
+            ("rf-detr-medium.pth", "RFDETRMedium"),
+            ("rf-detr-large.pth", "RFDETRLarge"),
+            ("rf-detr-base.pth", "RFDETRBase"),
+            ("rf-detr-seg-nano.pt", "RFDETRSegNano"),
+            ("rf-detr-seg-small.pt", "RFDETRSegSmall"),
+            ("rf-detr-seg-medium.pt", "RFDETRSegMedium"),
+            ("rf-detr-seg-large.pt", "RFDETRSegLarge"),
+            ("rf-detr-seg-xlarge.pt", "RFDETRSegXLarge"),
+            ("rf-detr-seg-xxlarge.pt", "RFDETRSeg2XLarge"),
+            ("rf-detr-seg-preview.pt", "RFDETRSegPreview"),
         ],
         ids=[
             "nano",
@@ -109,7 +109,9 @@ class TestFromCheckpointNamespaceArgs:
         patch_target: str,
     ) -> None:
         """Namespace-style args: correct subclass is called for each model size."""
-        result, mock_cls = _call_from_checkpoint(_ns(pretrain_weights), tmp_path / "ckpt.pth", patch_target)
+        result, mock_cls = _call_from_checkpoint(
+            _ns(pretrain_weights), tmp_path / "ckpt.pth", f"rfdetr.variants.{patch_target}"
+        )
 
         mock_cls.assert_called_once()
         call_kwargs = mock_cls.call_args.kwargs
@@ -127,12 +129,11 @@ class TestFromCheckpointDictArgs:
     """from_checkpoint with dict-style args (PTL or convert_legacy_checkpoint output)."""
 
     @pytest.mark.parametrize(
-        "pretrain_weights, patch_target",
+        ("pretrain_weights, patch_target"),
         [
-            ("rf-detr-small.pth", "rfdetr.variants.RFDETRSmall"),
-            ("rf-detr-base.pth", "rfdetr.variants.RFDETRBase"),
+            ("rf-detr-small.pth", "RFDETRSmall"),
+            ("rf-detr-base.pth", "RFDETRBase"),
         ],
-        ids=["small", "base"],
     )
     def test_characterization_infers_correct_class_dict(
         self,
@@ -141,7 +142,9 @@ class TestFromCheckpointDictArgs:
         patch_target: str,
     ) -> None:
         """Dict-style args: correct subclass is called without AttributeError."""
-        _, mock_cls = _call_from_checkpoint(_dict(pretrain_weights), tmp_path / "ckpt.pth", patch_target)
+        _, mock_cls = _call_from_checkpoint(
+            _dict(pretrain_weights), tmp_path / "ckpt.pth", f"rfdetr.variants.{patch_target}"
+        )
 
         mock_cls.assert_called_once()
         call_kwargs = mock_cls.call_args.kwargs
@@ -243,7 +246,7 @@ class TestDeprecatedClassInstantiation:
     """Deprecated model classes emit deprecation warnings on instantiation."""
 
     @pytest.mark.parametrize(
-        "cls_name, import_path",
+        ("cls_name, import_path"),
         [
             ("RFDETRBase", "rfdetr.variants.RFDETRBase"),
             ("RFDETRLargeDeprecated", "rfdetr.variants.RFDETRLargeDeprecated"),
@@ -304,19 +307,19 @@ class TestFromCheckpointModelName:
     @pytest.mark.parametrize(
         ("model_name, patch_target"),
         [
-            ("RFDETRNano", "rfdetr.variants.RFDETRNano"),
-            ("RFDETRSmall", "rfdetr.variants.RFDETRSmall"),
-            ("RFDETRMedium", "rfdetr.variants.RFDETRMedium"),
-            ("RFDETRLarge", "rfdetr.variants.RFDETRLarge"),
-            ("RFDETRBase", "rfdetr.variants.RFDETRBase"),
-            ("RFDETRSegNano", "rfdetr.variants.RFDETRSegNano"),
-            ("RFDETRSegPreview", "rfdetr.variants.RFDETRSegPreview"),
-            ("RFDETRSegSmall", "rfdetr.variants.RFDETRSegSmall"),
-            ("RFDETRSegMedium", "rfdetr.variants.RFDETRSegMedium"),
-            ("RFDETRSegLarge", "rfdetr.variants.RFDETRSegLarge"),
-            ("RFDETRSegXLarge", "rfdetr.variants.RFDETRSegXLarge"),
-            ("RFDETRSeg2XLarge", "rfdetr.variants.RFDETRSeg2XLarge"),
-        ]
+            ("RFDETRNano", "RFDETRNano"),
+            ("RFDETRSmall", "RFDETRSmall"),
+            ("RFDETRMedium", "RFDETRMedium"),
+            ("RFDETRLarge", "RFDETRLarge"),
+            ("RFDETRBase", "RFDETRBase"),
+            ("RFDETRSegNano", "RFDETRSegNano"),
+            ("RFDETRSegPreview", "RFDETRSegPreview"),
+            ("RFDETRSegSmall", "RFDETRSegSmall"),
+            ("RFDETRSegMedium", "RFDETRSegMedium"),
+            ("RFDETRSegLarge", "RFDETRSegLarge"),
+            ("RFDETRSegXLarge", "RFDETRSegXLarge"),
+            ("RFDETRSeg2XLarge", "RFDETRSeg2XLarge"),
+        ],
     )
     def test_model_name_resolves_correct_class(
         self,
@@ -325,7 +328,9 @@ class TestFromCheckpointModelName:
         patch_target: str,
     ) -> None:
         """model_name in checkpoint maps directly to the correct subclass."""
-        result, mock_cls = _call_from_checkpoint(_ckpt_with_model_name(model_name), tmp_path / "ckpt.pth", patch_target)
+        result, mock_cls = _call_from_checkpoint(
+            _ckpt_with_model_name(model_name), tmp_path / "ckpt.pth", f"rfdetr.variants.{patch_target}"
+        )
         mock_cls.assert_called_once()
         assert result is mock_cls.return_value
 
@@ -366,7 +371,6 @@ class TestFromCheckpointModelName:
             ("RFDETRBase", "RFDETRBase"),
             ("RFDETRSegPreview", "RFDETRSegPreview"),
         ],
-        ids=["base", "seg-preview"],
     )
     def test_model_name_deprecated_class_resolves_and_instantiates(
         self, tmp_path: Path, model_name: str, expected_class: str
@@ -381,14 +385,7 @@ class TestFromCheckpointModelName:
         assert model.__class__.__name__ == expected_class
 
     @pytest.mark.skipif(HAS_PLUS, reason="rfdetr_plus is installed — guard not active")
-    @pytest.mark.parametrize(
-        "model_name",
-        [
-            "RFDETRXLarge",
-            "RFDETR2XLarge",
-        ],
-        ids=["xlarge", "2xlarge"],
-    )
+    @pytest.mark.parametrize("model_name", ["RFDETRXLarge", "RFDETR2XLarge"])
     def test_plus_model_name_without_plus_raises_import_error(self, tmp_path: Path, model_name: str) -> None:
         """Plus checkpoints using model_name raise install guidance without rfdetr_plus."""
         ckpt = {

--- a/tests/models/test_from_checkpoint.py
+++ b/tests/models/test_from_checkpoint.py
@@ -153,7 +153,7 @@ class TestFromCheckpointEdgeCases:
         """Unrecognised pretrain_weights name raises a descriptive ValueError."""
         ckpt = _ns("/my/custom/finetuned.pth")
         with patch("rfdetr.detr.torch.load", return_value=ckpt):
-            with pytest.raises(ValueError, match="Could not infer model size"):
+            with pytest.raises(ValueError, match="Could not infer model class"):
                 RFDETR.from_checkpoint(tmp_path / "ckpt.pth")
 
     def test_characterization_missing_args_key_raises_key_error(self, tmp_path: Path) -> None:
@@ -244,6 +244,7 @@ class TestFromCheckpointModelName:
             pytest.param("RFDETRLarge", "rfdetr.variants.RFDETRLarge", id="large"),
             pytest.param("RFDETRBase", "rfdetr.variants.RFDETRBase", id="base"),
             pytest.param("RFDETRSegNano", "rfdetr.variants.RFDETRSegNano", id="seg-nano"),
+            pytest.param("RFDETRSegPreview", "rfdetr.variants.RFDETRSegPreview", id="seg-preview"),
             pytest.param("RFDETRSegSmall", "rfdetr.variants.RFDETRSegSmall", id="seg-small"),
             pytest.param("RFDETRSegMedium", "rfdetr.variants.RFDETRSegMedium", id="seg-medium"),
             pytest.param("RFDETRSegLarge", "rfdetr.variants.RFDETRSegLarge", id="seg-large"),

--- a/tests/models/test_from_checkpoint.py
+++ b/tests/models/test_from_checkpoint.py
@@ -242,6 +242,7 @@ class TestFromCheckpointModelName:
             pytest.param("RFDETRSmall", "rfdetr.variants.RFDETRSmall", id="small"),
             pytest.param("RFDETRMedium", "rfdetr.variants.RFDETRMedium", id="medium"),
             pytest.param("RFDETRLarge", "rfdetr.variants.RFDETRLarge", id="large"),
+            pytest.param("RFDETRBase", "rfdetr.variants.RFDETRBase", id="base"),
             pytest.param("RFDETRSegNano", "rfdetr.variants.RFDETRSegNano", id="seg-nano"),
             pytest.param("RFDETRSegSmall", "rfdetr.variants.RFDETRSegSmall", id="seg-small"),
             pytest.param("RFDETRSegMedium", "rfdetr.variants.RFDETRSegMedium", id="seg-medium"),
@@ -285,3 +286,15 @@ class TestFromCheckpointModelName:
         }
         _, mock_cls = _call_from_checkpoint(ckpt, tmp_path / "ckpt.pth", "rfdetr.variants.RFDETRSmall")
         mock_cls.assert_called_once()
+
+    @pytest.mark.skipif(HAS_PLUS, reason="rfdetr_plus is installed — guard not active")
+    def test_plus_model_name_without_plus_raises_import_error(self, tmp_path: Path) -> None:
+        """Plus checkpoints using model_name still raise install guidance without rfdetr_plus."""
+        for model_name in ("RFDETRXLarge", "RFDETR2XLarge"):
+            ckpt = {
+                "args": {"pretrain_weights": "", "num_classes": 80},
+                "model_name": model_name,
+            }
+            with patch("rfdetr.detr.torch.load", return_value=ckpt):
+                with pytest.raises(ImportError, match="rfdetr_plus package"):
+                    RFDETR.from_checkpoint(tmp_path / "ckpt.pth")

--- a/tests/models/test_from_checkpoint.py
+++ b/tests/models/test_from_checkpoint.py
@@ -74,18 +74,32 @@ class TestFromCheckpointNamespaceArgs:
     @pytest.mark.parametrize(
         "pretrain_weights, patch_target",
         [
-            pytest.param("rf-detr-nano.pth", "rfdetr.variants.RFDETRNano", id="nano"),
-            pytest.param("rf-detr-small.pth", "rfdetr.variants.RFDETRSmall", id="small"),
-            pytest.param("rf-detr-medium.pth", "rfdetr.variants.RFDETRMedium", id="medium"),
-            pytest.param("rf-detr-large.pth", "rfdetr.variants.RFDETRLarge", id="large"),
-            pytest.param("rf-detr-base.pth", "rfdetr.variants.RFDETRBase", id="base"),
-            pytest.param("rf-detr-seg-nano.pt", "rfdetr.variants.RFDETRSegNano", id="seg-nano"),
-            pytest.param("rf-detr-seg-small.pt", "rfdetr.variants.RFDETRSegSmall", id="seg-small"),
-            pytest.param("rf-detr-seg-medium.pt", "rfdetr.variants.RFDETRSegMedium", id="seg-medium"),
-            pytest.param("rf-detr-seg-large.pt", "rfdetr.variants.RFDETRSegLarge", id="seg-large"),
-            pytest.param("rf-detr-seg-xlarge.pt", "rfdetr.variants.RFDETRSegXLarge", id="seg-xlarge"),
-            pytest.param("rf-detr-seg-xxlarge.pt", "rfdetr.variants.RFDETRSeg2XLarge", id="seg-2xlarge"),
-            pytest.param("rf-detr-seg-preview.pt", "rfdetr.variants.RFDETRSegPreview", id="seg-preview"),
+            ("rf-detr-nano.pth", "rfdetr.variants.RFDETRNano"),
+            ("rf-detr-small.pth", "rfdetr.variants.RFDETRSmall"),
+            ("rf-detr-medium.pth", "rfdetr.variants.RFDETRMedium"),
+            ("rf-detr-large.pth", "rfdetr.variants.RFDETRLarge"),
+            ("rf-detr-base.pth", "rfdetr.variants.RFDETRBase"),
+            ("rf-detr-seg-nano.pt", "rfdetr.variants.RFDETRSegNano"),
+            ("rf-detr-seg-small.pt", "rfdetr.variants.RFDETRSegSmall"),
+            ("rf-detr-seg-medium.pt", "rfdetr.variants.RFDETRSegMedium"),
+            ("rf-detr-seg-large.pt", "rfdetr.variants.RFDETRSegLarge"),
+            ("rf-detr-seg-xlarge.pt", "rfdetr.variants.RFDETRSegXLarge"),
+            ("rf-detr-seg-xxlarge.pt", "rfdetr.variants.RFDETRSeg2XLarge"),
+            ("rf-detr-seg-preview.pt", "rfdetr.variants.RFDETRSegPreview"),
+        ],
+        ids=[
+            "nano",
+            "small",
+            "medium",
+            "large",
+            "base",
+            "seg-nano",
+            "seg-small",
+            "seg-medium",
+            "seg-large",
+            "seg-xlarge",
+            "seg-2xlarge",
+            "seg-preview",
         ],
     )
     def test_characterization_infers_correct_class_namespace(
@@ -115,9 +129,10 @@ class TestFromCheckpointDictArgs:
     @pytest.mark.parametrize(
         "pretrain_weights, patch_target",
         [
-            pytest.param("rf-detr-small.pth", "rfdetr.variants.RFDETRSmall", id="small"),
-            pytest.param("rf-detr-base.pth", "rfdetr.variants.RFDETRBase", id="base"),
+            ("rf-detr-small.pth", "rfdetr.variants.RFDETRSmall"),
+            ("rf-detr-base.pth", "rfdetr.variants.RFDETRBase"),
         ],
+        ids=["small", "base"],
     )
     def test_characterization_infers_correct_class_dict(
         self,
@@ -225,44 +240,49 @@ class TestFromCheckpointEdgeCases:
 
 
 class TestDeprecatedClassInstantiation:
-    """Deprecated model classes raise RuntimeError on instantiation."""
+    """Deprecated model classes emit deprecation warnings on instantiation."""
 
     @pytest.mark.parametrize(
         "cls_name, import_path",
         [
-            pytest.param("RFDETRBase", "rfdetr.variants.RFDETRBase", id="base"),
-            pytest.param("RFDETRLargeDeprecated", "rfdetr.variants.RFDETRLargeDeprecated", id="large-deprecated"),
-            pytest.param("RFDETRSegPreview", "rfdetr.variants.RFDETRSegPreview", id="seg-preview"),
+            ("RFDETRBase", "rfdetr.variants.RFDETRBase"),
+            ("RFDETRLargeDeprecated", "rfdetr.variants.RFDETRLargeDeprecated"),
+            ("RFDETRSegPreview", "rfdetr.variants.RFDETRSegPreview"),
         ],
+        ids=["base", "large-deprecated", "seg-preview"],
     )
-    def test_direct_instantiation_raises_runtime_error(self, cls_name: str, import_path: str) -> None:
-        """Direct instantiation of a deprecated class raises RuntimeError."""
+    def test_direct_instantiation_is_allowed(self, cls_name: str, import_path: str) -> None:
+        """Direct instantiation of a deprecated class does not raise RuntimeError."""
         import importlib
 
         module_path, attr = import_path.rsplit(".", 1)
         module = importlib.import_module(module_path)
         cls = getattr(module, attr)
-        with pytest.raises(RuntimeError, match="deprecated"):
-            cls()
+        with patch("rfdetr.detr.RFDETR.__init__", return_value=None):
+            model = cls()
+        assert model.__class__.__name__ == cls_name
 
     @pytest.mark.parametrize(
-        "pretrain_weights, patch_target",
+        "pretrain_weights",
         [
-            pytest.param("rf-detr-base.pth", "rfdetr.variants.RFDETRBase", id="base"),
-            pytest.param("rf-detr-seg-preview.pt", "rfdetr.variants.RFDETRSegPreview", id="seg-preview"),
+            "rf-detr-base.pth",
+            "rf-detr-seg-preview.pt",
         ],
+        ids=["base", "seg-preview"],
     )
-    def test_from_checkpoint_raises_for_deprecated_class(
+    def test_from_checkpoint_resolves_deprecated_class(
         self,
         tmp_path: Path,
         pretrain_weights: str,
-        patch_target: str,
     ) -> None:
-        """from_checkpoint raises RuntimeError when the resolved class is deprecated."""
+        """from_checkpoint still resolves deprecated classes without KeyError on minimal mocked checkpoints."""
         ckpt = _ns(pretrain_weights)
-        with patch("rfdetr.detr.torch.load", return_value=ckpt):
-            with pytest.raises(RuntimeError, match="deprecated"):
-                RFDETR.from_checkpoint(tmp_path / "ckpt.pth")
+        with (
+            patch("rfdetr.detr.torch.load", return_value=ckpt),
+            patch("rfdetr.detr.RFDETR.__init__", return_value=None),
+        ):
+            model = RFDETR.from_checkpoint(tmp_path / "ckpt.pth")
+        assert model.__class__.__name__ in {"RFDETRBase", "RFDETRSegPreview"}
 
 
 # ---------------------------------------------------------------------------
@@ -284,18 +304,32 @@ class TestFromCheckpointModelName:
     @pytest.mark.parametrize(
         "model_name, patch_target",
         [
-            pytest.param("RFDETRNano", "rfdetr.variants.RFDETRNano", id="nano"),
-            pytest.param("RFDETRSmall", "rfdetr.variants.RFDETRSmall", id="small"),
-            pytest.param("RFDETRMedium", "rfdetr.variants.RFDETRMedium", id="medium"),
-            pytest.param("RFDETRLarge", "rfdetr.variants.RFDETRLarge", id="large"),
-            pytest.param("RFDETRBase", "rfdetr.variants.RFDETRBase", id="base"),
-            pytest.param("RFDETRSegNano", "rfdetr.variants.RFDETRSegNano", id="seg-nano"),
-            pytest.param("RFDETRSegPreview", "rfdetr.variants.RFDETRSegPreview", id="seg-preview"),
-            pytest.param("RFDETRSegSmall", "rfdetr.variants.RFDETRSegSmall", id="seg-small"),
-            pytest.param("RFDETRSegMedium", "rfdetr.variants.RFDETRSegMedium", id="seg-medium"),
-            pytest.param("RFDETRSegLarge", "rfdetr.variants.RFDETRSegLarge", id="seg-large"),
-            pytest.param("RFDETRSegXLarge", "rfdetr.variants.RFDETRSegXLarge", id="seg-xlarge"),
-            pytest.param("RFDETRSeg2XLarge", "rfdetr.variants.RFDETRSeg2XLarge", id="seg-2xlarge"),
+            ("RFDETRNano", "rfdetr.variants.RFDETRNano"),
+            ("RFDETRSmall", "rfdetr.variants.RFDETRSmall"),
+            ("RFDETRMedium", "rfdetr.variants.RFDETRMedium"),
+            ("RFDETRLarge", "rfdetr.variants.RFDETRLarge"),
+            ("RFDETRBase", "rfdetr.variants.RFDETRBase"),
+            ("RFDETRSegNano", "rfdetr.variants.RFDETRSegNano"),
+            ("RFDETRSegPreview", "rfdetr.variants.RFDETRSegPreview"),
+            ("RFDETRSegSmall", "rfdetr.variants.RFDETRSegSmall"),
+            ("RFDETRSegMedium", "rfdetr.variants.RFDETRSegMedium"),
+            ("RFDETRSegLarge", "rfdetr.variants.RFDETRSegLarge"),
+            ("RFDETRSegXLarge", "rfdetr.variants.RFDETRSegXLarge"),
+            ("RFDETRSeg2XLarge", "rfdetr.variants.RFDETRSeg2XLarge"),
+        ],
+        ids=[
+            "nano",
+            "small",
+            "medium",
+            "large",
+            "base",
+            "seg-nano",
+            "seg-preview",
+            "seg-small",
+            "seg-medium",
+            "seg-large",
+            "seg-xlarge",
+            "seg-2xlarge",
         ],
     )
     def test_model_name_resolves_correct_class(
@@ -341,26 +375,33 @@ class TestFromCheckpointModelName:
         mock_cls.assert_called_once()
 
     @pytest.mark.parametrize(
-        "model_name",
+        "model_name, expected_class",
         [
-            pytest.param("RFDETRBase", id="base"),
-            pytest.param("RFDETRSegPreview", id="seg-preview"),
+            ("RFDETRBase", "RFDETRBase"),
+            ("RFDETRSegPreview", "RFDETRSegPreview"),
         ],
+        ids=["base", "seg-preview"],
     )
-    def test_model_name_deprecated_class_raises_runtime_error(self, tmp_path: Path, model_name: str) -> None:
-        """from_checkpoint raises RuntimeError when model_name resolves to a deprecated class (unmocked constructor)."""
+    def test_model_name_deprecated_class_resolves_and_instantiates(
+        self, tmp_path: Path, model_name: str, expected_class: str
+    ) -> None:
+        """from_checkpoint resolves deprecated model_name values and instantiates the resolved class."""
         ckpt = _ckpt_with_model_name(model_name)
-        with patch("rfdetr.detr.torch.load", return_value=ckpt):
-            with pytest.raises(RuntimeError, match="deprecated"):
-                RFDETR.from_checkpoint(tmp_path / "ckpt.pth")
+        with (
+            patch("rfdetr.detr.torch.load", return_value=ckpt),
+            patch("rfdetr.detr.RFDETR.__init__", return_value=None),
+        ):
+            model = RFDETR.from_checkpoint(tmp_path / "ckpt.pth")
+        assert model.__class__.__name__ == expected_class
 
     @pytest.mark.skipif(HAS_PLUS, reason="rfdetr_plus is installed — guard not active")
     @pytest.mark.parametrize(
         "model_name",
         [
-            pytest.param("RFDETRXLarge", id="xlarge"),
-            pytest.param("RFDETR2XLarge", id="2xlarge"),
+            "RFDETRXLarge",
+            "RFDETR2XLarge",
         ],
+        ids=["xlarge", "2xlarge"],
     )
     def test_plus_model_name_without_plus_raises_import_error(self, tmp_path: Path, model_name: str) -> None:
         """Plus checkpoints using model_name raise install guidance without rfdetr_plus."""

--- a/tests/models/test_from_checkpoint.py
+++ b/tests/models/test_from_checkpoint.py
@@ -302,7 +302,7 @@ class TestFromCheckpointModelName:
     """from_checkpoint uses model_name when present in checkpoint."""
 
     @pytest.mark.parametrize(
-        "model_name, patch_target",
+        ("model_name, patch_target"),
         [
             ("RFDETRNano", "rfdetr.variants.RFDETRNano"),
             ("RFDETRSmall", "rfdetr.variants.RFDETRSmall"),
@@ -316,21 +316,7 @@ class TestFromCheckpointModelName:
             ("RFDETRSegLarge", "rfdetr.variants.RFDETRSegLarge"),
             ("RFDETRSegXLarge", "rfdetr.variants.RFDETRSegXLarge"),
             ("RFDETRSeg2XLarge", "rfdetr.variants.RFDETRSeg2XLarge"),
-        ],
-        ids=[
-            "nano",
-            "small",
-            "medium",
-            "large",
-            "base",
-            "seg-nano",
-            "seg-preview",
-            "seg-small",
-            "seg-medium",
-            "seg-large",
-            "seg-xlarge",
-            "seg-2xlarge",
-        ],
+        ]
     )
     def test_model_name_resolves_correct_class(
         self,

--- a/tests/models/test_from_checkpoint.py
+++ b/tests/models/test_from_checkpoint.py
@@ -237,8 +237,7 @@ class TestDeprecatedClassInstantiation:
             ("RFDETRBase", "rfdetr.variants.RFDETRBase"),
             ("RFDETRLargeDeprecated", "rfdetr.variants.RFDETRLargeDeprecated"),
             ("RFDETRSegPreview", "rfdetr.variants.RFDETRSegPreview"),
-        ],
-        ids=["base", "large-deprecated", "seg-preview"],
+        ]
     )
     def test_direct_instantiation_is_allowed(self, cls_name: str, import_path: str) -> None:
         """Direct instantiation of a deprecated class does not raise RuntimeError."""
@@ -255,9 +254,8 @@ class TestDeprecatedClassInstantiation:
         "pretrain_weights",
         [
             "rf-detr-base.pth",
-            "rf-detr-seg-preview.pt",
-        ],
-        ids=["base", "seg-preview"],
+            "rf-detr-seg-preview.pt"
+        ]
     )
     def test_from_checkpoint_resolves_deprecated_class(
         self,
@@ -311,7 +309,7 @@ class TestFromCheckpointModelName:
         self,
         tmp_path: Path,
         model_name: str,
-        patch_target: str,
+        patch_target: str
     ) -> None:
         """model_name in checkpoint maps directly to the correct subclass."""
         result, mock_cls = _call_from_checkpoint(

--- a/tests/models/test_from_checkpoint.py
+++ b/tests/models/test_from_checkpoint.py
@@ -220,6 +220,52 @@ class TestFromCheckpointEdgeCases:
 
 
 # ---------------------------------------------------------------------------
+# Deprecated class instantiation
+# ---------------------------------------------------------------------------
+
+
+class TestDeprecatedClassInstantiation:
+    """Deprecated model classes raise RuntimeError on instantiation."""
+
+    @pytest.mark.parametrize(
+        "cls_name, import_path",
+        [
+            pytest.param("RFDETRBase", "rfdetr.variants.RFDETRBase", id="base"),
+            pytest.param("RFDETRLargeDeprecated", "rfdetr.variants.RFDETRLargeDeprecated", id="large-deprecated"),
+            pytest.param("RFDETRSegPreview", "rfdetr.variants.RFDETRSegPreview", id="seg-preview"),
+        ],
+    )
+    def test_direct_instantiation_raises_runtime_error(self, cls_name: str, import_path: str) -> None:
+        """Direct instantiation of a deprecated class raises RuntimeError."""
+        import importlib
+
+        module_path, attr = import_path.rsplit(".", 1)
+        module = importlib.import_module(module_path)
+        cls = getattr(module, attr)
+        with pytest.raises(RuntimeError, match="deprecated"):
+            cls()
+
+    @pytest.mark.parametrize(
+        "pretrain_weights, patch_target",
+        [
+            pytest.param("rf-detr-base.pth", "rfdetr.variants.RFDETRBase", id="base"),
+            pytest.param("rf-detr-seg-preview.pt", "rfdetr.variants.RFDETRSegPreview", id="seg-preview"),
+        ],
+    )
+    def test_from_checkpoint_raises_for_deprecated_class(
+        self,
+        tmp_path: Path,
+        pretrain_weights: str,
+        patch_target: str,
+    ) -> None:
+        """from_checkpoint raises RuntimeError when the resolved class is deprecated."""
+        ckpt = _ns(pretrain_weights)
+        with patch("rfdetr.detr.torch.load", return_value=ckpt):
+            with pytest.raises(RuntimeError, match="deprecated"):
+                RFDETR.from_checkpoint(tmp_path / "ckpt.pth")
+
+
+# ---------------------------------------------------------------------------
 # model_name in checkpoint (#887)
 # ---------------------------------------------------------------------------
 

--- a/tests/models/test_from_checkpoint.py
+++ b/tests/models/test_from_checkpoint.py
@@ -316,7 +316,7 @@ class TestFromCheckpointModelName:
             ("RFDETRSegLarge", "rfdetr.variants.RFDETRSegLarge"),
             ("RFDETRSegXLarge", "rfdetr.variants.RFDETRSegXLarge"),
             ("RFDETRSeg2XLarge", "rfdetr.variants.RFDETRSeg2XLarge"),
-        ]
+        ],
     )
     def test_model_name_resolves_correct_class(
         self,

--- a/tests/models/test_from_checkpoint.py
+++ b/tests/models/test_from_checkpoint.py
@@ -86,7 +86,7 @@ class TestFromCheckpointNamespaceArgs:
             ("rf-detr-seg-xlarge.pt", "RFDETRSegXLarge"),
             ("rf-detr-seg-xxlarge.pt", "RFDETRSeg2XLarge"),
             ("rf-detr-seg-preview.pt", "RFDETRSegPreview"),
-        ]
+        ],
     )
     def test_characterization_infers_correct_class_namespace(
         self,

--- a/tests/models/test_from_checkpoint.py
+++ b/tests/models/test_from_checkpoint.py
@@ -255,6 +255,18 @@ class TestFromCheckpointModelName:
             pytest.param("RFDETRSegXLarge", "rfdetr.variants.RFDETRSegXLarge", id="seg-xlarge"),
             pytest.param("RFDETRSeg2XLarge", "rfdetr.variants.RFDETRSeg2XLarge", id="seg-2xlarge"),
             pytest.param("RFDETRSegPreview", "rfdetr.variants.RFDETRSegPreview", id="seg-preview"),
+            pytest.param(
+                "RFDETRXLarge",
+                "rfdetr.platform.models.RFDETRXLarge",
+                id="xlarge",
+                marks=pytest.mark.skipif(not HAS_PLUS, reason="rfdetr_plus not installed"),
+            ),
+            pytest.param(
+                "RFDETR2XLarge",
+                "rfdetr.platform.models.RFDETR2XLarge",
+                id="2xlarge",
+                marks=pytest.mark.skipif(not HAS_PLUS, reason="rfdetr_plus not installed"),
+            ),
         ],
     )
     def test_model_name_resolves_correct_class(

--- a/tests/models/test_from_checkpoint.py
+++ b/tests/models/test_from_checkpoint.py
@@ -249,6 +249,7 @@ class TestFromCheckpointModelName:
             pytest.param("RFDETRSegLarge", "rfdetr.variants.RFDETRSegLarge", id="seg-large"),
             pytest.param("RFDETRSegXLarge", "rfdetr.variants.RFDETRSegXLarge", id="seg-xlarge"),
             pytest.param("RFDETRSeg2XLarge", "rfdetr.variants.RFDETRSeg2XLarge", id="seg-2xlarge"),
+            pytest.param("RFDETRSegPreview", "rfdetr.variants.RFDETRSegPreview", id="seg-preview"),
         ],
     )
     def test_model_name_resolves_correct_class(

--- a/tests/models/test_from_checkpoint.py
+++ b/tests/models/test_from_checkpoint.py
@@ -334,14 +334,40 @@ class TestFromCheckpointModelName:
         _, mock_cls = _call_from_checkpoint(ckpt, tmp_path / "ckpt.pth", "rfdetr.variants.RFDETRSmall")
         mock_cls.assert_called_once()
 
+    def test_model_name_with_whitespace_is_stripped(self, tmp_path: Path) -> None:
+        """Leading/trailing whitespace in model_name is stripped before class resolution."""
+        ckpt = _ckpt_with_model_name("  RFDETRSmall  ")
+        _, mock_cls = _call_from_checkpoint(ckpt, tmp_path / "ckpt.pth", "rfdetr.variants.RFDETRSmall")
+        mock_cls.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            pytest.param("RFDETRBase", id="base"),
+            pytest.param("RFDETRSegPreview", id="seg-preview"),
+        ],
+    )
+    def test_model_name_deprecated_class_raises_runtime_error(self, tmp_path: Path, model_name: str) -> None:
+        """from_checkpoint raises RuntimeError when model_name resolves to a deprecated class (unmocked constructor)."""
+        ckpt = _ckpt_with_model_name(model_name)
+        with patch("rfdetr.detr.torch.load", return_value=ckpt):
+            with pytest.raises(RuntimeError, match="deprecated"):
+                RFDETR.from_checkpoint(tmp_path / "ckpt.pth")
+
     @pytest.mark.skipif(HAS_PLUS, reason="rfdetr_plus is installed — guard not active")
-    def test_plus_model_name_without_plus_raises_import_error(self, tmp_path: Path) -> None:
-        """Plus checkpoints using model_name still raise install guidance without rfdetr_plus."""
-        for model_name in ("RFDETRXLarge", "RFDETR2XLarge"):
-            ckpt = {
-                "args": {"pretrain_weights": "", "num_classes": 80},
-                "model_name": model_name,
-            }
-            with patch("rfdetr.detr.torch.load", return_value=ckpt):
-                with pytest.raises(ImportError, match="rfdetr_plus package"):
-                    RFDETR.from_checkpoint(tmp_path / "ckpt.pth")
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            pytest.param("RFDETRXLarge", id="xlarge"),
+            pytest.param("RFDETR2XLarge", id="2xlarge"),
+        ],
+    )
+    def test_plus_model_name_without_plus_raises_import_error(self, tmp_path: Path, model_name: str) -> None:
+        """Plus checkpoints using model_name raise install guidance without rfdetr_plus."""
+        ckpt = {
+            "args": {"pretrain_weights": "", "num_classes": 80},
+            "model_name": model_name,
+        }
+        with patch("rfdetr.detr.torch.load", return_value=ckpt):
+            with pytest.raises(ImportError, match="rfdetr_plus package"):
+                RFDETR.from_checkpoint(tmp_path / "ckpt.pth")

--- a/tests/models/test_from_checkpoint.py
+++ b/tests/models/test_from_checkpoint.py
@@ -242,6 +242,11 @@ class TestFromCheckpointModelName:
             pytest.param("RFDETRSmall", "rfdetr.variants.RFDETRSmall", id="small"),
             pytest.param("RFDETRMedium", "rfdetr.variants.RFDETRMedium", id="medium"),
             pytest.param("RFDETRLarge", "rfdetr.variants.RFDETRLarge", id="large"),
+            pytest.param(
+                "RFDETRLargeDeprecated",
+                "rfdetr.variants.RFDETRLargeDeprecated",
+                id="large-deprecated",
+            ),
             pytest.param("RFDETRBase", "rfdetr.variants.RFDETRBase", id="base"),
             pytest.param("RFDETRSegNano", "rfdetr.variants.RFDETRSegNano", id="seg-nano"),
             pytest.param("RFDETRSegSmall", "rfdetr.variants.RFDETRSegSmall", id="seg-small"),

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -983,3 +983,52 @@ class TestRFDETREarlyStopping:
                 break
 
         assert new_stop_epoch == expected_stop_epoch
+
+
+# ---------------------------------------------------------------------------
+# model_name in checkpoint payload (#887)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckpointModelName:
+    """Verify model_name is stored in checkpoint payloads."""
+
+    def test_regular_checkpoint_contains_model_name(self, tmp_path: Path) -> None:
+        """Regular checkpoint includes model_name from model_config."""
+        cb = BestModelCallback(output_dir=str(tmp_path))
+        trainer = _make_trainer({"val/mAP_50_95": 0.5})
+        pl_module = _make_pl_module()
+        pl_module.model_config = MagicMock()
+        pl_module.model_config.model_name = "RFDETRLarge"
+
+        cb.on_validation_end(trainer, pl_module)
+
+        ckpt = torch.load(tmp_path / "checkpoint_best_regular.pth", weights_only=False)
+        assert ckpt["model_name"] == "RFDETRLarge"
+
+    def test_regular_checkpoint_model_name_none_when_not_set(self, tmp_path: Path) -> None:
+        """model_name is None when model_config has no model_name attribute."""
+        cb = BestModelCallback(output_dir=str(tmp_path))
+        trainer = _make_trainer({"val/mAP_50_95": 0.5})
+        pl_module = _make_pl_module()
+
+        cb.on_validation_end(trainer, pl_module)
+
+        ckpt = torch.load(tmp_path / "checkpoint_best_regular.pth", weights_only=False)
+        assert ckpt["model_name"] is None
+
+    def test_ema_checkpoint_contains_model_name(self, tmp_path: Path) -> None:
+        """EMA checkpoint also includes model_name."""
+        cb = BestModelCallback(
+            output_dir=str(tmp_path),
+            monitor_ema="val/ema_mAP_50_95",
+        )
+        trainer = _make_trainer({"val/mAP_50_95": 0.4, "val/ema_mAP_50_95": 0.6})
+        pl_module = _make_pl_module()
+        pl_module.model_config = MagicMock()
+        pl_module.model_config.model_name = "RFDETRMedium"
+
+        cb.on_validation_end(trainer, pl_module)
+
+        ckpt = torch.load(tmp_path / "checkpoint_best_ema.pth", weights_only=False)
+        assert ckpt["model_name"] == "RFDETRMedium"

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -18,7 +18,7 @@ from pytorch_lightning import __version__ as ptl_version
 from pytorch_lightning.trainer.states import TrainerFn
 from torch.utils.data import DataLoader, TensorDataset
 
-from rfdetr.config import RFDETRMediumConfig
+from rfdetr.config import RFDETRLargeDeprecatedConfig, RFDETRMediumConfig
 from rfdetr.training.callbacks.best_model import BestModelCallback, RFDETREarlyStopping
 
 # ---------------------------------------------------------------------------
@@ -1007,8 +1007,8 @@ class TestCheckpointModelName:
         ckpt = torch.load(tmp_path / "checkpoint_best_regular.pth", weights_only=False)
         assert ckpt["model_name"] == "RFDETRLarge"
 
-    def test_regular_checkpoint_model_name_none_when_not_set(self, tmp_path: Path) -> None:
-        """model_name is None when model_config has no model_name attribute."""
+    def test_regular_checkpoint_model_name_absent_when_not_set(self, tmp_path: Path) -> None:
+        """model_name key is absent when model_config has no model_name attribute."""
         cb = BestModelCallback(output_dir=str(tmp_path))
         trainer = _make_trainer({"val/mAP_50_95": 0.5})
         pl_module = _make_pl_module()
@@ -1016,7 +1016,7 @@ class TestCheckpointModelName:
         cb.on_validation_end(trainer, pl_module)
 
         ckpt = torch.load(tmp_path / "checkpoint_best_regular.pth", weights_only=False)
-        assert ckpt["model_name"] is None
+        assert "model_name" not in ckpt
 
     def test_regular_checkpoint_infers_model_name_from_model_config_type(self, tmp_path: Path) -> None:
         """When model_name is unset, infer class name from concrete ModelConfig type."""
@@ -1045,3 +1045,19 @@ class TestCheckpointModelName:
 
         ckpt = torch.load(tmp_path / "checkpoint_best_ema.pth", weights_only=False)
         assert ckpt["model_name"] == "RFDETRMedium"
+
+    def test_deprecated_config_infers_canonical_class_name(self, tmp_path: Path) -> None:
+        """RFDETRLargeDeprecatedConfig resolves to 'RFDETRLarge', not 'RFDETRLargeDeprecated'.
+
+        Ensures consistency with the RFDETR.train() path which uses
+        type(self).__name__ (the user-facing class), not the config type name.
+        """
+        cb = BestModelCallback(output_dir=str(tmp_path))
+        trainer = _make_trainer({"val/mAP_50_95": 0.5})
+        pl_module = _make_pl_module()
+        pl_module.model_config = RFDETRLargeDeprecatedConfig(model_name=None)
+
+        cb.on_validation_end(trainer, pl_module)
+
+        ckpt = torch.load(tmp_path / "checkpoint_best_regular.pth", weights_only=False)
+        assert ckpt["model_name"] == "RFDETRLarge"

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -1046,18 +1046,12 @@ class TestCheckpointModelName:
         ckpt = torch.load(tmp_path / "checkpoint_best_ema.pth", weights_only=False)
         assert ckpt["model_name"] == "RFDETRMedium"
 
-    def test_deprecated_config_infers_canonical_class_name(self, tmp_path: Path) -> None:
-        """RFDETRLargeDeprecatedConfig resolves to 'RFDETRLarge', not 'RFDETRLargeDeprecated'.
-
-        Ensures consistency with the RFDETR.train() path which uses
-        type(self).__name__ (the user-facing class), not the config type name.
-        """
+    def test_deprecated_config_raises_runtime_error(self, tmp_path: Path) -> None:
+        """RFDETRLargeDeprecatedConfig raises RuntimeError — deprecated configs are unsupported."""
         cb = BestModelCallback(output_dir=str(tmp_path))
         trainer = _make_trainer({"val/mAP_50_95": 0.5})
         pl_module = _make_pl_module()
         pl_module.model_config = RFDETRLargeDeprecatedConfig(model_name=None)
 
-        cb.on_validation_end(trainer, pl_module)
-
-        ckpt = torch.load(tmp_path / "checkpoint_best_regular.pth", weights_only=False)
-        assert ckpt["model_name"] == "RFDETRLarge"
+        with pytest.raises(RuntimeError, match="Deprecated model config"):
+            cb.on_validation_end(trainer, pl_module)

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -18,6 +18,7 @@ from pytorch_lightning import __version__ as ptl_version
 from pytorch_lightning.trainer.states import TrainerFn
 from torch.utils.data import DataLoader, TensorDataset
 
+from rfdetr.config import RFDETRMediumConfig
 from rfdetr.training.callbacks.best_model import BestModelCallback, RFDETREarlyStopping
 
 # ---------------------------------------------------------------------------
@@ -1016,6 +1017,18 @@ class TestCheckpointModelName:
 
         ckpt = torch.load(tmp_path / "checkpoint_best_regular.pth", weights_only=False)
         assert ckpt["model_name"] is None
+
+    def test_regular_checkpoint_infers_model_name_from_model_config_type(self, tmp_path: Path) -> None:
+        """When model_name is unset, infer class name from concrete ModelConfig type."""
+        cb = BestModelCallback(output_dir=str(tmp_path))
+        trainer = _make_trainer({"val/mAP_50_95": 0.5})
+        pl_module = _make_pl_module()
+        pl_module.model_config = RFDETRMediumConfig(model_name=None)
+
+        cb.on_validation_end(trainer, pl_module)
+
+        ckpt = torch.load(tmp_path / "checkpoint_best_regular.pth", weights_only=False)
+        assert ckpt["model_name"] == "RFDETRMedium"
 
     def test_ema_checkpoint_contains_model_name(self, tmp_path: Path) -> None:
         """EMA checkpoint also includes model_name."""

--- a/tests/utilities/test_misc.py
+++ b/tests/utilities/test_misc.py
@@ -29,6 +29,40 @@ class TestStripCheckpoint:
         stripped = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
         assert set(stripped.keys()) == {"model", "args"}
 
+    def test_strip_checkpoint_preserves_model_name_when_present(self, tmp_path):
+        checkpoint_path = tmp_path / "checkpoint_best_total.pth"
+        torch.save(
+            {
+                "model": {"weight": torch.tensor([1.0])},
+                "args": SimpleNamespace(class_names=["a"]),
+                "model_name": "RFDETRSmall",
+                "optimizer": {"lr": 1e-4},
+            },
+            checkpoint_path,
+        )
+
+        strip_checkpoint(str(checkpoint_path))
+
+        stripped = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+        assert set(stripped.keys()) == {"model", "args", "model_name"}
+        assert stripped["model_name"] == "RFDETRSmall"
+
+    def test_strip_checkpoint_omits_model_name_when_absent(self, tmp_path):
+        checkpoint_path = tmp_path / "checkpoint_best_total.pth"
+        torch.save(
+            {
+                "model": {"weight": torch.tensor([1.0])},
+                "args": SimpleNamespace(class_names=["a"]),
+                "optimizer": {"lr": 1e-4},
+            },
+            checkpoint_path,
+        )
+
+        strip_checkpoint(str(checkpoint_path))
+
+        stripped = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+        assert "model_name" not in stripped
+
     def test_strip_checkpoint_is_atomic_when_save_fails(self, tmp_path, monkeypatch):
         checkpoint_path = tmp_path / "checkpoint_best_total.pth"
         original_checkpoint = {


### PR DESCRIPTION
## What does this PR do?

Stores the model class name (e.g. `"RFDETRLarge"`) as `model_name` in the checkpoint dictionary during training. `from_checkpoint()` now uses this key to resolve the correct model class directly, falling back to `pretrain_weights` filename parsing for older checkpoints.

Also preserves `model_name` in `strip_checkpoint()` so it isn't lost when stripping.

This PR also hardens deprecated variant behavior: `RFDETRBase`, `RFDETRLargeDeprecated`, and `RFDETRSegPreview` now raise `RuntimeError` on instantiation (in addition to deprecation metadata/warnings), enforcing migration to supported variants.

**Related Issue(s):** Fixes #887

## Type of Change

- New feature (non-breaking change that adds functionality)
- Refactoring (no functional changes)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

Added `TestFromCheckpointModelName` in `tests/models/test_from_checkpoint.py`:
- All supported model variants resolve correctly from `model_name`
- `model_name` takes priority over `pretrain_weights`
- Old checkpoints without `model_name` still work (backward compat)
- Unknown `model_name` falls back to `pretrain_weights` parsing
- Deprecated variants raise `RuntimeError` when resolved from checkpoint metadata

Added checkpoint metadata tests in `tests/training/test_best_model_callback.py`:
- Regular checkpoint contains `model_name`
- EMA checkpoint contains `model_name`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

## Additional Context

Files changed:
- `src/rfdetr/config.py` - Added `model_name` field to `ModelConfig`
- `src/rfdetr/detr.py` - Set `model_name` in `train()`, use it in `from_checkpoint()`
- `src/rfdetr/training/callbacks/best_model.py` - Include `model_name` in checkpoint payload
- `src/rfdetr/utilities/state_dict.py` - Preserve `model_name` in `strip_checkpoint()`
- `src/rfdetr/variants.py` - Deprecated variant classes now raise on instantiation and deprecation wording aligned
- `CHANGELOG.md` - Documented checkpoint `model_name` behavior and deprecated-variant runtime enforcement
