### PR TITLE
deprecate RFDETRBase and RFDETRSegPreview

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "transformers>=5.1.0,<6.0.0",     # DINOv2 backbone loading
     "pydantic>=2.0,<3",               # ModelConfig / TrainConfig validation
     "supervision",                     # inference output (Detections, Masks)
-    "pyDeprecate>=0.3,<0.6",           # deprecation warnings for legacy APIs
+    "pyDeprecate>=0.6,<0.8",             # deprecation warnings for legacy APIs; >=0.6 for deprecated_class
 ]
 
 [project.optional-dependencies]

--- a/src/rfdetr/variants.py
+++ b/src/rfdetr/variants.py
@@ -32,7 +32,7 @@ __all__ = [
 
 import warnings
 
-from deprecate import deprecated
+from deprecate import deprecated_class
 
 from rfdetr.config import (
     ModelConfig,
@@ -57,14 +57,10 @@ from rfdetr.utilities.logger import get_logger
 logger = get_logger()
 
 
-@deprecated(
+@deprecated_class(
     target=None,
     deprecated_in="1.7.0",
     remove_in="2.0.0",
-    template_mgs=(
-        "`%(source_name)s` is deprecated since v%(deprecated_in)s and will be removed "
-        "in v%(remove_in)s. Use RFDETRNano, RFDETRSmall, RFDETRMedium, or RFDETRLarge instead."
-    ),
 )
 class RFDETRBase(RFDETR):
     """RF-DETR Base model — deprecated since v1.7.0.
@@ -192,14 +188,10 @@ class RFDETRSeg(RFDETR):
     _train_config_class = SegmentationTrainConfig
 
 
-@deprecated(
+@deprecated_class(
     target=None,
     deprecated_in="1.7.0",
     remove_in="2.0.0",
-    template_mgs=(
-        "`%(source_name)s` is deprecated since v%(deprecated_in)s and will be removed "
-        "in v%(remove_in)s. Use RFDETRSegNano, RFDETRSegSmall, RFDETRSegMedium, or RFDETRSegLarge instead."
-    ),
 )
 class RFDETRSegPreview(RFDETRSeg):
     """RF-DETR Segmentation Preview model — deprecated since v1.7.0.

--- a/src/rfdetr/variants.py
+++ b/src/rfdetr/variants.py
@@ -57,6 +57,15 @@ from rfdetr.utilities.logger import get_logger
 logger = get_logger()
 
 
+@deprecated(
+    target=None,
+    deprecated_in="1.7.0",
+    remove_in="2.0.0",
+    template_mgs=(
+        "`%(source_name)s` is deprecated since v%(deprecated_in)s and will be removed "
+        "in v%(remove_in)s. Use RFDETRNano, RFDETRSmall, RFDETRMedium, or RFDETRLarge instead."
+    ),
+)
 class RFDETRBase(RFDETR):
     """RF-DETR Base model — deprecated since v1.7.0.
 
@@ -67,26 +76,6 @@ class RFDETRBase(RFDETR):
 
     size = "rfdetr-base"
     _model_config_class = RFDETRBaseConfig
-
-    @deprecated(
-        target=None,
-        deprecated_in="1.7.0",
-        remove_in="2.0.0",
-        template_mgs=(
-            "`%(source_name)s` is deprecated since v%(deprecated_in)s and will be removed "
-            "in v%(remove_in)s. Use RFDETRNano, RFDETRSmall, RFDETRMedium, or RFDETRLarge instead."
-        ),
-    )
-    def __init__(self, **kwargs) -> None:
-        """Initialize a deprecated RFDETRBase instance.
-
-        Args:
-            **kwargs: Forwarded to :class:`~rfdetr.detr.RFDETR`.
-
-        Examples:
-            >>> RFDETRBase()  # doctest: +SKIP
-        """
-        super().__init__(**kwargs)
 
 
 class RFDETRNano(RFDETR):
@@ -203,6 +192,15 @@ class RFDETRSeg(RFDETR):
     _train_config_class = SegmentationTrainConfig
 
 
+@deprecated(
+    target=None,
+    deprecated_in="1.7.0",
+    remove_in="2.0.0",
+    template_mgs=(
+        "`%(source_name)s` is deprecated since v%(deprecated_in)s and will be removed "
+        "in v%(remove_in)s. Use RFDETRSegNano, RFDETRSegSmall, RFDETRSegMedium, or RFDETRSegLarge instead."
+    ),
+)
 class RFDETRSegPreview(RFDETRSeg):
     """RF-DETR Segmentation Preview model — deprecated since v1.7.0.
 
@@ -213,26 +211,6 @@ class RFDETRSegPreview(RFDETRSeg):
 
     size = "rfdetr-seg-preview"
     _model_config_class = RFDETRSegPreviewConfig
-
-    @deprecated(
-        target=None,
-        deprecated_in="1.7.0",
-        remove_in="2.0.0",
-        template_mgs=(
-            "`%(source_name)s` is deprecated since v%(deprecated_in)s and will be removed "
-            "in v%(remove_in)s. Use RFDETRSegNano, RFDETRSegSmall, RFDETRSegMedium, or RFDETRSegLarge instead."
-        ),
-    )
-    def __init__(self, **kwargs) -> None:
-        """Initialize a deprecated RFDETRSegPreview instance.
-
-        Args:
-            **kwargs: Forwarded to :class:`~rfdetr.variants.RFDETRSeg`.
-
-        Examples:
-            >>> RFDETRSegPreview()  # doctest: +SKIP
-        """
-        super().__init__(**kwargs)
 
 
 class RFDETRSegNano(RFDETRSeg):

--- a/src/rfdetr/variants.py
+++ b/src/rfdetr/variants.py
@@ -56,12 +56,22 @@ logger = get_logger()
 
 
 class RFDETRBase(RFDETR):
-    """
-    Train an RF-DETR Base model (29M parameters).
+    """RF-DETR Base model — deprecated, raises on instantiation.
+
+    .. deprecated::
+        ``RFDETRBase`` is deprecated and will be removed in a future release.
+        Use one of the supported variants: :class:`RFDETRNano`, :class:`RFDETRSmall`,
+        :class:`RFDETRMedium`, or :class:`RFDETRLarge`.
     """
 
     size = "rfdetr-base"
     _model_config_class = RFDETRBaseConfig
+
+    def __init__(self, **kwargs) -> None:
+        raise RuntimeError(
+            "RFDETRBase is deprecated and will be removed in a future release. "
+            "Use one of the supported variants: RFDETRNano, RFDETRSmall, RFDETRMedium, or RFDETRLarge."
+        )
 
 
 class RFDETRNano(RFDETR):
@@ -179,8 +189,23 @@ class RFDETRSeg(RFDETR):
 
 
 class RFDETRSegPreview(RFDETRSeg):
+    """RF-DETR Segmentation Preview model — deprecated, raises on instantiation.
+
+    .. deprecated::
+        ``RFDETRSegPreview`` is deprecated and will be removed in a future release.
+        Use one of the supported segmentation variants: :class:`RFDETRSegNano`, :class:`RFDETRSegSmall`,
+        :class:`RFDETRSegMedium`, or :class:`RFDETRSegLarge`.
+    """
+
     size = "rfdetr-seg-preview"
     _model_config_class = RFDETRSegPreviewConfig
+
+    def __init__(self, **kwargs) -> None:
+        raise RuntimeError(
+            "RFDETRSegPreview is deprecated and will be removed in a future release. "
+            "Use one of the supported segmentation variants: RFDETRSegNano, RFDETRSegSmall, "
+            "RFDETRSegMedium, or RFDETRSegLarge."
+        )
 
 
 class RFDETRSegNano(RFDETRSeg):

--- a/src/rfdetr/variants.py
+++ b/src/rfdetr/variants.py
@@ -32,6 +32,8 @@ __all__ = [
 
 import warnings
 
+from deprecate import deprecated
+
 from rfdetr.config import (
     ModelConfig,
     RFDETRBaseConfig,
@@ -56,10 +58,9 @@ logger = get_logger()
 
 
 class RFDETRBase(RFDETR):
-    """RF-DETR Base model — deprecated, raises on instantiation.
+    """RF-DETR Base model — deprecated since v1.7.0.
 
-    .. deprecated::
-        ``RFDETRBase`` is deprecated and will be removed in a future release.
+    .. deprecated:: 1.7.0
         Use one of the supported variants: :class:`RFDETRNano`, :class:`RFDETRSmall`,
         :class:`RFDETRMedium`, or :class:`RFDETRLarge`.
     """
@@ -67,11 +68,25 @@ class RFDETRBase(RFDETR):
     size = "rfdetr-base"
     _model_config_class = RFDETRBaseConfig
 
+    @deprecated(
+        target=None,
+        deprecated_in="1.7.0",
+        remove_in="2.0.0",
+        template_mgs=(
+            "`%(source_name)s` is deprecated since v%(deprecated_in)s and will be removed "
+            "in v%(remove_in)s. Use RFDETRNano, RFDETRSmall, RFDETRMedium, or RFDETRLarge instead."
+        ),
+    )
     def __init__(self, **kwargs) -> None:
-        raise RuntimeError(
-            "RFDETRBase is deprecated and will be removed in a future release. "
-            "Use one of the supported variants: RFDETRNano, RFDETRSmall, RFDETRMedium, or RFDETRLarge."
-        )
+        """Initialize a deprecated RFDETRBase instance.
+
+        Args:
+            **kwargs: Forwarded to :class:`~rfdetr.detr.RFDETR`.
+
+        Examples:
+            >>> RFDETRBase()  # doctest: +SKIP
+        """
+        super().__init__(**kwargs)
 
 
 class RFDETRNano(RFDETR):
@@ -189,10 +204,9 @@ class RFDETRSeg(RFDETR):
 
 
 class RFDETRSegPreview(RFDETRSeg):
-    """RF-DETR Segmentation Preview model — deprecated, raises on instantiation.
+    """RF-DETR Segmentation Preview model — deprecated since v1.7.0.
 
-    .. deprecated::
-        ``RFDETRSegPreview`` is deprecated and will be removed in a future release.
+    .. deprecated:: 1.7.0
         Use one of the supported segmentation variants: :class:`RFDETRSegNano`, :class:`RFDETRSegSmall`,
         :class:`RFDETRSegMedium`, or :class:`RFDETRSegLarge`.
     """
@@ -200,12 +214,25 @@ class RFDETRSegPreview(RFDETRSeg):
     size = "rfdetr-seg-preview"
     _model_config_class = RFDETRSegPreviewConfig
 
+    @deprecated(
+        target=None,
+        deprecated_in="1.7.0",
+        remove_in="2.0.0",
+        template_mgs=(
+            "`%(source_name)s` is deprecated since v%(deprecated_in)s and will be removed "
+            "in v%(remove_in)s. Use RFDETRSegNano, RFDETRSegSmall, RFDETRSegMedium, or RFDETRSegLarge instead."
+        ),
+    )
     def __init__(self, **kwargs) -> None:
-        raise RuntimeError(
-            "RFDETRSegPreview is deprecated and will be removed in a future release. "
-            "Use one of the supported segmentation variants: RFDETRSegNano, RFDETRSegSmall, "
-            "RFDETRSegMedium, or RFDETRSegLarge."
-        )
+        """Initialize a deprecated RFDETRSegPreview instance.
+
+        Args:
+            **kwargs: Forwarded to :class:`~rfdetr.variants.RFDETRSeg`.
+
+        Examples:
+            >>> RFDETRSegPreview()  # doctest: +SKIP
+        """
+        super().__init__(**kwargs)
 
 
 class RFDETRSegNano(RFDETRSeg):


### PR DESCRIPTION
## What does this PR do?

This pull request introduces formal deprecation warnings for legacy model classes in the `rfdetr` package, ensuring users are notified about outdated variants and guided toward supported alternatives. It also updates a dependency to support this new deprecation mechanism.

**Deprecation of legacy model classes:**

* Added the `@deprecated_class` decorator to `RFDETRBase` and `RFDETRSegPreview` to emit deprecation warnings starting from version 1.7.0, with removal planned for 2.0.0. The docstrings for these classes now direct users to supported variants such as `RFDETRNano`, `RFDETRSmall`, `RFDETRMedium`, and `RFDETRLarge` for detection, and `RFDETRSegNano`, `RFDETRSegSmall`, `RFDETRSegMedium`, and `RFDETRSegLarge` for segmentation. [[1]](diffhunk://#diff-2fc230229291353efd14839925b6b9b6904dd34561c210c8e0bb03409f2eadabR60-R70) [[2]](diffhunk://#diff-2fc230229291353efd14839925b6b9b6904dd34561c210c8e0bb03409f2eadabR191-R203)

**Dependency updates:**

* Increased the minimum required version of `pyDeprecate` to `0.6` in `pyproject.toml` to enable use of the `deprecated_class` decorator.

**Imports:**

* Added import of `deprecated_class` from `deprecate` in `variants.py` to support the new deprecation mechanism.

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Refactoring (no functional changes)

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have tested this change locally
- [x] I have added/updated tests for this change

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
