### PR TITLE
releasing `1.6.3` [rebase & merge]

### DIFF
--- a/.github/workflows/ci-typing.yml
+++ b/.github/workflows/ci-typing.yml
@@ -1,0 +1,66 @@
+name: Mypy Type Check
+
+on:
+  push:
+    branches: ["main", "release/*", "develop"]
+  pull_request:
+
+permissions:
+  contents: read
+defaults:
+  run:
+    shell: bash
+
+env:
+  # UV_TORCH_BACKEND only works with 'uv pip' commands, not 'uv sync'.
+  # Used by 'uv pip install torch torchvision' step to install CPU-only PyTorch.
+  UV_TORCH_BACKEND: "cpu"
+
+concurrency:
+  group: mypy-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  type-check:
+    name: Type Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: 📥 Checkout the repository
+        uses: actions/checkout@v6.0.1
+
+      - name: 🐍 Install uv and set Python version
+        uses: astral-sh/setup-uv@v7.2.0
+        with:
+          python-version: "3.12"
+          activate-environment: true
+
+      - name: 🚀 Install Packages
+        timeout-minutes: 5
+        run: uv pip install -e ".[train,cli,visual]" --group typing
+
+      - name: 🔍 Run mypy
+        run: uv run --no-sync mypy src/rfdetr/ --no-error-summary
+
+      - name: Minimize uv cache
+        continue-on-error: true
+        run: uv cache prune --ci
+
+  type-check-guardian:
+    runs-on: ubuntu-latest
+    needs: type-check
+    if: always()
+    steps:
+      - name: 📋 Display type-check result
+        run: echo "${{ needs.type-check.result }}"
+      - name: ❌ Fail guardian on type-check failure
+        if: needs.type-check.result == 'failure'
+        run: exit 1
+      - name: ⚠️ cancelled or skipped...
+        if: contains(fromJSON('["cancelled", "skipped"]'), needs.type-check.result)
+        run: |
+          echo "type-check job result is '${{ needs.type-check.result }}'; failing explicitly."
+          exit 1
+      - name: ✅ type check succeeded
+        if: needs.type-check.result == 'success'
+        run: echo "All type checks passed in job 'type-check'."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,17 @@ repos:
       - id: ruff-format
         exclude: ^notebooks/.*\.py$
 
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.19.1
+    hooks:
+      - id: mypy
+        # --ignore-missing-imports: the hook runs in an isolated env without torch/torchvision/etc.
+        # Full strict checking (matching pyproject.toml) runs in CI via ci-typing.yml.
+        # args: ["--ignore-missing-imports"]
+        additional_dependencies:
+          - "types-PyYAML"
+          - "types-requests"
+
   - repo: https://github.com/executablebooks/mdformat
     rev: 1.0.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+### Deprecated
+
+### Fixed
+
+- Fixed `RFDETR.optimize_for_inference()` leaking a CUDA context on multi-GPU setups: the deep-copy, export, and JIT-trace steps now run inside `torch.cuda.device(device)` to pin the context to the correct device. `optimize_for_inference()` also now accepts dtype as a string name (e.g. `"float16"`) in addition to a `torch.dtype` object, and all invalid dtype inputs uniformly raise `TypeError`. (#899)
+
 ---
 
 ## [1.6.2] — 2026-03-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
 ### Deprecated
 
 ### Fixed
 
-- Fixed `models/lwdetr.py`: `reinitialize_detection_head` now replaces `nn.Linear` modules instead of mutating `.data` tensors in-place, ensuring `out_features` metadata stays consistent with the actual weight shape. This prevents ONNX export and `torch.jit.trace` from emitting stale (pre-fine-tuning) class counts for fine-tuned models. (#904)
-- Fixed `RFDETR.optimize_for_inference()` leaking a CUDA context on multi-GPU setups: the deep-copy, export, and JIT-trace steps now run inside `torch.cuda.device(device)` to pin the context to the correct device. `optimize_for_inference()` also now accepts dtype as a string name (e.g. `"float16"`) in addition to a `torch.dtype` object, and all invalid dtype inputs uniformly raise `TypeError`. (#899)
-
 ---
+
+## [1.6.3] — 2026-04-02
+
+### Changed
+
+- `predict()` now stores the original image and its shape on returned `sv.Detections` objects — `detections.data["source_image"]` (NumPy array) and `detections.data["source_shape"]` (height, width) let you annotate results without loading the image separately. (#892)
+- `RFDETR.train()` auto-detects `num_classes` from the dataset directory when not explicitly set, reinitializing the detection head to the correct class count automatically. A warning is emitted when the configured value differs from the dataset count. (#893)
+- `optimize_for_inference()` now accepts dtype as a string name (e.g. `"float16"`) in addition to a `torch.dtype` object; invalid dtype inputs uniformly raise `TypeError`. (#899)
+
+### Fixed
+
+- Fixed `models/lwdetr.py`: `reinitialize_detection_head` now replaces `nn.Linear` modules instead of mutating `.data` tensors in-place, ensuring `out_features` metadata stays consistent with the actual weight shape. This prevents ONNX export and `torch.jit.trace` from emitting stale (pre-fine-tuning) class counts for fine-tuned models. (#904)
+- Fixed `RFDETR.optimize_for_inference()` leaking a CUDA context on multi-GPU setups: the deep-copy, export, and JIT-trace steps now run inside `torch.cuda.device(device)` to pin the context to the correct device. (#899)
+- Fixed `optimize_for_inference()` leaving inconsistent state on failure: prior optimized state is now reset and flags are committed only after a successful build/trace; temp download files use unique per-process paths to avoid parallel worker collisions.
+- Fixed `deploy_to_roboflow` failing with `FileNotFoundError` after PyTorch Lightning migration: `class_names.txt` is now written to the upload directory and `args.class_names` is populated before saving the checkpoint. (#890)
 
 ## [1.6.2] — 2026-03-27
 
@@ -33,8 +47,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed ONNX export ignoring an explicit `patch_size` argument: `export()` and `predict()` now resolve `patch_size` from `model_config` by default, validate it strictly (positive integer, not bool), and enforce that `(H, W)` dimensions are divisible by `patch_size × num_windows`. (#876)
 - Fixed ONNX export for models with dynamic batch dimensions — replaced `H_.expand(N_)` with `torch.full` for Python-int spatial dims to eliminate tracer failures. (#871)
 
----
-
 ## [1.6.1] — 2026-03-25
 
 ### Deprecated
@@ -49,8 +61,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `BestModelCallback` and checkpoint monitor raising `MisconfigurationException` on non-eval epochs when `eval_interval > 1` — monitor key absence is now handled gracefully. (#848)
 - Fixed `protobuf` version constraint in the `loggers` extra to guard against TensorBoard descriptor crash (`TypeError: Descriptors cannot be created directly`) with protobuf ≥ 4. (#846)
 - Fixed duplicate `ModelCheckpoint` state keys when `checkpoint_interval=1`; `last.ckpt` is omitted in that configuration to avoid collision. (#859)
-
----
 
 ## [1.6.0] — 2026-03-20
 
@@ -93,6 +103,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `ValueError: matrix entries are not finite` in `HungarianMatcher` when the cost matrix contains NaN or Inf — non-finite entries are replaced with a finite sentinel before `linear_sum_assignment`, warning emitted at most once per matcher instance. (#787, closes #784)
 - Fixed YOLO dataset validation rejecting `data.yml` — both `.yaml` and `.yml` are now accepted. (#777, closes #775)
 - Silently dropped degenerate bounding boxes (zero width or height) before Albumentations validation instead of raising `ValueError`. (#825)
+
+---
 
 ## [1.5.2] — 2026-03-04
 
@@ -159,3 +171,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `np.argwhere` → `np.argmax` misuse. (#536)
 - Fixed COCO sparse category ID remapping for non-contiguous or offset category IDs. (#712)
 - Fixed segmentation mask filtering when using aggressive augmentations. (#717)
+
+---
+
+## [1.4.3] — 2026-02-16
+
+### Changed
+
+- Pretrained weight downloads now validate against an MD5 checksum to detect corrupted files. (#679)
+
+### Fixed
+
+- Fixed `deploy_to_roboflow` failing for segmentation model exports. (#578)
+- Fixed missing `info` key in COCO export format. (#681)
+
+## [1.4.2] — 2026-02-12
+
+### Added
+
+- Added `generate_coco_dataset()` utility for generating synthetic COCO-format datasets with configurable class counts, split ratios, and bounding box annotations. (#617)
+- Added `run_test=False` to `TrainConfig` — skip test-split evaluation when your dataset has no test set. (#628)
+
+### Changed
+
+- `model.predict()` now accepts image URLs directly — no need to download images before inference. (#629)
+- Plus models (`RFDETRXLarge`, `RFDETR2XLarge`) are now distributed as a separate `rfdetr_plus` package under the Roboflow Model License. (#645)
+
+### Fixed
+
+- Fixed segmentation ONNX export failure. (#626)
+
+## [1.4.1] — 2026-01-30
+
+### Added
+
+- Added native YOLO dataset format support alongside COCO. (#74)
+- Added `--print-freq` CLI argument to control training log frequency. (#603)
+
+### Changed
+
+- Pinned `transformers` to `<5.0.0` to prevent incompatibility with the transformers v5 API. (#599)
+
+### Fixed
+
+- Fixed class count mismatch in `train_from_config` for Roboflow-uploaded datasets. (#588)
+- Improved `num_classes` mismatch warning messages to be actionable rather than misleading. (#261)
+- Fixed CLI crash when specifying the `device` argument. (#246)
+
+## [1.4.0] — 2026-01-22
+
+Foundation release that aligns box operations with the `supervision` library, drops Python 3.9, and fixes per-class precision/recall/F1 metrics for multi-class models. Introduced initial YOLO dataset format support and resolved several training stability issues around multiprocessing, path validation, and inference mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `models/lwdetr.py`: `reinitialize_detection_head` now replaces `nn.Linear` modules instead of mutating `.data` tensors in-place, ensuring `out_features` metadata stays consistent with the actual weight shape. This prevents ONNX export and `torch.jit.trace` from emitting stale (pre-fine-tuning) class counts for fine-tuned models. (#904)
 - Fixed `RFDETR.optimize_for_inference()` leaking a CUDA context on multi-GPU setups: the deep-copy, export, and JIT-trace steps now run inside `torch.cuda.device(device)` to pin the context to the correct device. `optimize_for_inference()` also now accepts dtype as a string name (e.g. `"float16"`) in addition to a `torch.dtype` object, and all invalid dtype inputs uniformly raise `TypeError`. (#899)
 
 ---

--- a/README.md
+++ b/README.md
@@ -125,20 +125,17 @@ RF-DETR achieves state-of-the-art results in both object detection and instance 
 RF-DETR provides multiple model sizes, ranging from Nano to 2XLarge. To use a different model size, replace the class name in the code snippet below with another class from the table.
 
 ```python
-import requests
 import supervision as sv
-from PIL import Image
 from rfdetr import RFDETRMedium
 from rfdetr.assets.coco_classes import COCO_CLASSES
 
 model = RFDETRMedium()
 
-image = Image.open(requests.get("https://media.roboflow.com/dog.jpg", stream=True).raw)
-detections = model.predict(image, threshold=0.5)
+detections = model.predict("https://media.roboflow.com/dog.jpg", threshold=0.5)
 
 labels = [f"{COCO_CLASSES[class_id]}" for class_id in detections.class_id]
 
-annotated_image = sv.BoxAnnotator().annotate(image, detections)
+annotated_image = sv.BoxAnnotator().annotate(detections.data["source_image"], detections)
 annotated_image = sv.LabelAnnotator().annotate(annotated_image, detections, labels)
 ```
 
@@ -183,20 +180,17 @@ annotated_image = sv.LabelAnnotator().annotate(annotated_image, detections)
 RF-DETR supports instance segmentation with model sizes from Nano to 2XLarge. To use a different model size, replace the class name in the code snippet below with another class from the table.
 
 ```python
-import requests
 import supervision as sv
-from PIL import Image
 from rfdetr import RFDETRSegMedium
 from rfdetr.assets.coco_classes import COCO_CLASSES
 
 model = RFDETRSegMedium()
 
-image = Image.open(requests.get("https://media.roboflow.com/dog.jpg", stream=True).raw)
-detections = model.predict(image, threshold=0.5)
+detections = model.predict("https://media.roboflow.com/dog.jpg", threshold=0.5)
 
 labels = [f"{COCO_CLASSES[class_id]}" for class_id in detections.class_id]
 
-annotated_image = sv.MaskAnnotator().annotate(image, detections)
+annotated_image = sv.MaskAnnotator().annotate(detections.data["source_image"], detections)
 annotated_image = sv.LabelAnnotator().annotate(annotated_image, detections, labels)
 ```
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ from rfdetr.assets.coco_classes import COCO_CLASSES
 
 model = RFDETRMedium()
 
-image = Image.open("https://media.roboflow.com/dog.jpg")
+image = Image.open(requests.get("https://media.roboflow.com/dog.jpg", stream=True).raw)
 detections = model.predict(image, threshold=0.5)
 
 labels = [f"{COCO_CLASSES[class_id]}" for class_id in detections.class_id]
@@ -157,7 +157,7 @@ from inference import get_model
 
 model = get_model("rfdetr-medium")
 
-image = Image.open("https://media.roboflow.com/dog.jpg")
+image = Image.open(requests.get("https://media.roboflow.com/dog.jpg", stream=True).raw)
 predictions = model.infer(image, confidence=0.5)[0]
 detections = sv.Detections.from_inference(predictions)
 
@@ -191,7 +191,7 @@ from rfdetr.assets.coco_classes import COCO_CLASSES
 
 model = RFDETRSegMedium()
 
-image = Image.open("https://media.roboflow.com/dog.jpg")
+image = Image.open(requests.get("https://media.roboflow.com/dog.jpg", stream=True).raw)
 detections = model.predict(image, threshold=0.5)
 
 labels = [f"{COCO_CLASSES[class_id]}" for class_id in detections.class_id]
@@ -215,7 +215,7 @@ from inference import get_model
 
 model = get_model("rfdetr-seg-medium")
 
-image = Image.open("https://media.roboflow.com/dog.jpg")
+image = Image.open(requests.get("https://media.roboflow.com/dog.jpg", stream=True).raw)
 predictions = model.infer(image, confidence=0.5)[0]
 detections = sv.Detections.from_inference(predictions)
 

--- a/docs/learn/run/detection.md
+++ b/docs/learn/run/detection.md
@@ -24,20 +24,17 @@ Perform inference on an image using either the `rfdetr` package or the `inferenc
 === "rfdetr"
 
     ```python
-    import requests
     import supervision as sv
-    from PIL import Image
     from rfdetr import RFDETRMedium
     from rfdetr.assets.coco_classes import COCO_CLASSES
 
     model = RFDETRMedium()
 
-    image = Image.open(requests.get("https://media.roboflow.com/dog.jpg", stream=True).raw)
-    detections = model.predict(image, threshold=0.5)
+    detections = model.predict("https://media.roboflow.com/dog.jpg", threshold=0.5)
 
     labels = [f"{COCO_CLASSES[class_id]}" for class_id in detections.class_id]
 
-    annotated_image = sv.BoxAnnotator().annotate(image, detections)
+    annotated_image = sv.BoxAnnotator().annotate(detections.data["source_image"], detections)
     annotated_image = sv.LabelAnnotator().annotate(annotated_image, detections, labels)
     ```
 

--- a/docs/learn/run/segmentation.md
+++ b/docs/learn/run/segmentation.md
@@ -22,20 +22,17 @@ Perform inference on an image using either the `rfdetr` package or the `inferenc
 === "rfdetr"
 
     ```python
-    import requests
     import supervision as sv
-    from PIL import Image
     from rfdetr import RFDETRSegMedium
     from rfdetr.assets.coco_classes import COCO_CLASSES
 
     model = RFDETRSegMedium()
 
-    image = Image.open(requests.get("https://media.roboflow.com/dog.jpg", stream=True).raw)
-    detections = model.predict(image, threshold=0.5)
+    detections = model.predict("https://media.roboflow.com/dog.jpg", threshold=0.5)
 
     labels = [f"{COCO_CLASSES[class_id]}" for class_id in detections.class_id]
 
-    annotated_image = sv.MaskAnnotator().annotate(image, detections)
+    annotated_image = sv.MaskAnnotator().annotate(detections.data["source_image"], detections)
     annotated_image = sv.LabelAnnotator().annotate(annotated_image, detections, labels)
     ```
 

--- a/docs/learn/train/augmentations.md
+++ b/docs/learn/train/augmentations.md
@@ -123,7 +123,7 @@ Any Albumentations transform works by name. If your custom transform is geometri
 
 ```python
 GEOMETRIC_TRANSFORMS = {
-    ...
+    ...,
     "YourCustomTransform",
 }
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,15 @@ tests = [
   "tomli>=2.0; python_version < '3.11'",
 ]
 
+typing = [
+    "mypy>=1.0",
+    # mypy 1.19.x can crash while processing NumPy 2.4 symbols in strict mode.
+    "numpy<2.4",
+    "types-PyYAML",
+    "types-requests",
+    "types-tqdm",
+]
+
 docs = [
     "mkdocs-material[imaging]>=9.7",
     "mkdocstrings>=0.25.2,<0.30.0",
@@ -175,3 +184,88 @@ filterwarnings = [
 
 [tool.codespell]
 skip = "*.pth"
+
+[tool.mypy]
+python_version = "3.10"
+ignore_missing_imports = false
+explicit_package_bases = true
+strict = true
+mypy_path = "src"
+overrides = [
+  { module = [
+    "tests.*",
+    "einops", "einops.*",
+    "matplotlib", "matplotlib.*",
+    "pandas", "pandas.*",
+    "seaborn", "seaborn.*",
+  ], ignore_errors = true },
+  { module = [
+    "torchvision", "torchvision.*",
+    "pycocotools", "pycocotools.*",
+    "timm", "timm.*",
+    "einops", "einops.*",
+    "deprecate", "deprecate.*",
+    "matplotlib", "matplotlib.*",
+    "pandas", "pandas.*",
+    "requests", "requests.*",
+    "seaborn", "seaborn.*",
+    "tqdm", "tqdm.*",
+  ], ignore_missing_imports = true },
+  # Modules with pre-existing type errors — ignored until incrementally fixed.
+  { module = [
+    "rfdetr",
+    "rfdetr._namespace",
+    "rfdetr.assets.model_weights",
+    "rfdetr.config",
+    "rfdetr.datasets._develop",
+    "rfdetr.datasets.coco",
+    "rfdetr.datasets.save_grids",
+    "rfdetr.datasets.synthetic",
+    "rfdetr.datasets.transforms",
+    "rfdetr.datasets.yolo",
+    "rfdetr.detr",
+    "rfdetr.evaluation.coco_eval",
+    "rfdetr.evaluation.matching",
+    "rfdetr.export._onnx.exporter",
+    "rfdetr.export._onnx.symbolic",
+    "rfdetr.export.benchmark",
+    "rfdetr.export.main",
+    "rfdetr.export.tensorrt",
+    "rfdetr.models.backbone",
+    "rfdetr.models.backbone.backbone",
+    "rfdetr.models.backbone.base",
+    "rfdetr.models.backbone.dinov2",
+    "rfdetr.models.backbone.dinov2_with_windowed_attn",
+    "rfdetr.models.backbone.projector",
+    "rfdetr.models.criterion",
+    "rfdetr.models.heads.detection",
+    "rfdetr.models.heads.segmentation",
+    "rfdetr.models.lwdetr",
+    "rfdetr.models.math",
+    "rfdetr.models.matcher",
+    "rfdetr.models.ops.functions.ms_deform_attn_func",
+    "rfdetr.models.ops.modules.ms_deform_attn",
+    "rfdetr.models.position_encoding",
+    "rfdetr.models.postprocess",
+    "rfdetr.models.transformer",
+    "rfdetr.models.weights",
+    "rfdetr.platform",
+    "rfdetr.platform.downloads",
+    "rfdetr.platform.models",
+    "rfdetr.training.callbacks.best_model",
+    "rfdetr.training.callbacks.coco_eval",
+    "rfdetr.training.callbacks.drop_schedule",
+    "rfdetr.training.callbacks.ema",
+    "rfdetr.training.cli",
+    "rfdetr.training.drop_schedule",
+    "rfdetr.training.model_ema",
+    "rfdetr.training.module_data",
+    "rfdetr.training.module_model",
+    "rfdetr.training.trainer",
+    "rfdetr.utilities.distributed",
+    "rfdetr.utilities.logger",
+    "rfdetr.utilities.state_dict",
+    "rfdetr.utilities.tensors",
+    "rfdetr.variants",
+  ], ignore_errors = true },
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rfdetr"
-version = "1.6.2"
+version = "1.6.3"
 description = "RF-DETR"
 readme = "README.md"
 authors = [

--- a/src/rfdetr/datasets/__init__.py
+++ b/src/rfdetr/datasets/__init__.py
@@ -17,17 +17,17 @@
 from pathlib import Path
 from typing import Any, Optional
 
-import torch.utils.data
 import torchvision
+from torch.utils.data import Dataset, Subset
 
 from rfdetr.datasets.coco import build_coco, build_roboflow_from_coco
 from rfdetr.datasets.o365 import build_o365
 from rfdetr.datasets.yolo import YoloDetection, build_roboflow_from_yolo
 
 
-def get_coco_api_from_dataset(dataset: torch.utils.data.Dataset) -> Optional[Any]:
+def get_coco_api_from_dataset(dataset: Dataset[Any]) -> Optional[Any]:
     for _ in range(10):
-        if isinstance(dataset, torch.utils.data.Subset):
+        if isinstance(dataset, Subset):
             dataset = dataset.dataset
     if isinstance(dataset, torchvision.datasets.CocoDetection):
         return dataset.coco
@@ -67,7 +67,7 @@ def detect_roboflow_format(dataset_dir: Path) -> str:
     )
 
 
-def build_roboflow(image_set: str, args: Any, resolution: int) -> torch.utils.data.Dataset:
+def build_roboflow(image_set: str, args: Any, resolution: int) -> Dataset[Any]:
     """Build a Roboflow dataset, auto-detecting COCO or YOLO format.
 
     This function detects the dataset format and delegates to the
@@ -83,7 +83,7 @@ def build_roboflow(image_set: str, args: Any, resolution: int) -> torch.utils.da
     return build_roboflow_from_yolo(image_set, args, resolution)
 
 
-def build_dataset(image_set: str, args: Any, resolution: int) -> torch.utils.data.Dataset:
+def build_dataset(image_set: str, args: Any, resolution: int) -> Dataset[Any]:
     if args.dataset_file == "coco":
         return build_coco(image_set, args, resolution)
     if args.dataset_file == "o365":

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -487,6 +487,14 @@ class RFDETR:
                 config.grad_accum_steps,
                 auto_batch.effective_batch_size,
             )
+
+        # Auto-detect num_classes from the training dataset and align model_config.
+        # This must run before RFDETRModelModule is constructed so that weight loading
+        # inside the module uses the correct (dataset-derived) class count.
+        dataset_dir = getattr(config, "dataset_dir", None)
+        if dataset_dir:
+            self._align_num_classes_from_dataset(dataset_dir)
+
         module = RFDETRModelModule(self.model_config, config)
         datamodule = RFDETRDataModule(self.model_config, config)
         trainer_kwargs = {"accelerator": _accelerator}
@@ -687,7 +695,7 @@ class RFDETR:
         """Load class names from a COCO or YOLO dataset directory."""
         if is_valid_coco_dataset(dataset_dir):
             coco_path = os.path.join(dataset_dir, "train", "_annotations.coco.json")
-            with open(coco_path) as f:
+            with open(coco_path, encoding="utf-8") as f:
                 anns = json.load(f)
             categories = sorted(anns["categories"], key=lambda category: category.get("id", float("inf")))
 
@@ -726,6 +734,87 @@ class RFDETR:
             f"Could not find class names in {dataset_dir}."
             " Checked for COCO (train/_annotations.coco.json) and YOLO (data.yaml, data.yml) styles.",
         )
+
+    @staticmethod
+    def _detect_num_classes_for_training(dataset_dir: str) -> int:
+        """Detect the class count using the same category basis as training labels.
+
+        For COCO-style datasets this counts all categories by ``id`` from
+        ``train/_annotations.coco.json`` (matching the remapping based on
+        ``coco.cats`` used by the training datamodule). For YOLO-style datasets
+        it falls back to ``_load_classes``.
+        """
+        if is_valid_coco_dataset(dataset_dir):
+            coco_path = os.path.join(dataset_dir, "train", "_annotations.coco.json")
+            with open(coco_path, encoding="utf-8") as f:
+                anns = json.load(f)
+            categories = anns["categories"]
+            cat_by_id = {category["id"]: category for category in categories}
+            return len(cat_by_id)
+
+        return len(RFDETR._load_classes(dataset_dir))
+
+    def _align_num_classes_from_dataset(self, dataset_dir: str) -> None:
+        """Auto-detect the dataset class count and align ``model_config.num_classes`` in-place.
+
+        Must be called before ``RFDETRModelModule`` is constructed so that weight loading inside
+        the module uses the correct (dataset-derived) class count.
+
+        When the user did **not** explicitly override ``num_classes`` (or passed the class-config
+        default), ``model_config.num_classes`` and ``self.model.args.num_classes`` are updated
+        to match the dataset.  When the user *did* set a non-default value that differs from the
+        dataset, the configured value is preserved and a warning is emitted.
+
+        Failures from ``_detect_num_classes_for_training`` are caught and logged at DEBUG level
+        so that training is never blocked by detection errors.
+
+        Args:
+            dataset_dir: Path to the training dataset root directory.
+        """
+        try:
+            dataset_num_classes = RFDETR._detect_num_classes_for_training(dataset_dir)
+        except (FileNotFoundError, ValueError, KeyError, OSError) as exc:
+            # Best-effort only; do not block training if detection fails.
+            logger.debug("Could not auto-detect num_classes from dataset '%s': %s", dataset_dir, exc)
+            return
+
+        model_num_classes = self.model_config.num_classes
+
+        if dataset_num_classes == model_num_classes:
+            return
+
+        # Determine whether the user explicitly overrode num_classes to a non-default value.
+        # "num_classes" in model_fields_set is True when the field was explicitly set at
+        # construction time; comparing against the class default filters out cases where the
+        # user passed the default value explicitly (treat those like "not set").
+        user_set = "num_classes" in getattr(self.model_config, "model_fields_set", set())
+        default_nc = type(self.model_config).model_fields["num_classes"].default
+        user_overrode = user_set and model_num_classes != default_nc
+
+        if not user_overrode:
+            logger.debug(
+                "Detected %d classes in dataset '%s'; auto-adjusting model num_classes from %d to %d.",
+                dataset_num_classes,
+                dataset_dir,
+                model_num_classes,
+                dataset_num_classes,
+            )
+            self.model_config.num_classes = dataset_num_classes
+            # Keep serialized checkpoint metadata in sync with the updated class count.
+            model_args = getattr(self.model, "args", None)
+            if model_args is not None:
+                model_args.num_classes = dataset_num_classes
+        else:
+            logger.warning(
+                "Dataset '%s' has %d classes but model was initialized with num_classes=%d. "
+                "Using the model's configured value (%d). If this is unintentional, "
+                "reinitialize the model with num_classes=%d.",
+                dataset_dir,
+                dataset_num_classes,
+                model_num_classes,
+                model_num_classes,
+                dataset_num_classes,
+            )
 
     def get_train_config(self, **kwargs) -> TrainConfig:
         """Retrieve the configuration parameters that will be used for training."""

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -14,7 +14,7 @@ import warnings
 from collections import defaultdict
 from copy import deepcopy
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional
 
 import numpy as np
 import requests
@@ -254,6 +254,7 @@ def _validate_shape_dims(
         ValueError: If ``shape`` cannot be unpacked as a two-element sequence, if either
             dimension is a bool, float, or other non-integer type, if either dimension is
             not positive, or if either dimension is not divisible by ``block_size``.
+
     """
     try:
         height, width = shape  # type: ignore[misc]
@@ -266,7 +267,7 @@ def _validate_shape_dims(
             operator.index(dim)
         except TypeError:
             raise ValueError(
-                f"shape {dim_name} must be an integer, got {type(dim).__name__} (shape={shape!r})."
+                f"shape {dim_name} must be an integer, got {type(dim).__name__} (shape={shape!r}).",
             ) from None
         if dim <= 0:
             raise ValueError(f"shape must contain positive integers for height and width, got {shape!r}.")
@@ -275,7 +276,7 @@ def _validate_shape_dims(
     if height % block_size != 0 or width % block_size != 0:
         raise ValueError(
             f"shape must have both dimensions divisible by {block_size} "
-            f"(patch_size={patch_size} * num_windows={num_windows}), got {shape!r}."
+            f"(patch_size={patch_size} * num_windows={num_windows}), got {shape!r}.",
         )
     return height, width
 
@@ -297,6 +298,7 @@ def _resolve_patch_size(patch_size: int | None, model_config: object, caller: st
     Raises:
         ValueError: If the resolved or provided ``patch_size`` is not a positive integer,
             or if a caller-provided value disagrees with ``model_config.patch_size``.
+
     """
     if patch_size is None:
         patch_size = getattr(model_config, "patch_size", 14)
@@ -308,7 +310,7 @@ def _resolve_patch_size(patch_size: int | None, model_config: object, caller: st
             raise ValueError(
                 f"{caller}(patch_size={patch_size}) does not match the instantiated model's "
                 f"patch_size={model_patch_size}. Patch size is an architectural parameter; "
-                f"omit patch_size to use the model's configured value."
+                f"omit patch_size to use the model's configured value.",
             )
     if isinstance(patch_size, bool) or not isinstance(patch_size, int) or patch_size <= 0:
         raise ValueError(f"patch_size must be a positive integer, got {patch_size!r}")
@@ -316,8 +318,7 @@ def _resolve_patch_size(patch_size: int | None, model_config: object, caller: st
 
 
 class RFDETR:
-    """
-    The base RF-DETR class implements the core methods for training RF-DETR models,
+    """The base RF-DETR class implements the core methods for training RF-DETR models,
     running inference on the models, optimising models, and uploading trained
     models for deployment.
     """
@@ -343,18 +344,14 @@ class RFDETR:
         self._optimized_dtype = None
 
     def maybe_download_pretrain_weights(self):
-        """
-        Download pre-trained weights if they are not already downloaded.
-        """
+        """Download pre-trained weights if they are not already downloaded."""
         pretrain_weights = self.model_config.pretrain_weights
         if pretrain_weights is None:
             return
         download_pretrain_weights(pretrain_weights)
 
     def get_model_config(self, **kwargs) -> ModelConfig:
-        """
-        Retrieve the configuration parameters used by the model.
-        """
+        """Retrieve the configuration parameters used by the model."""
         return self._model_config_class(**kwargs)
 
     @staticmethod
@@ -370,6 +367,7 @@ class RFDETR:
 
         Raises:
             ValueError: If ``device`` is not a valid torch device specifier.
+
         """
         if device is None:
             return None, None
@@ -378,7 +376,7 @@ class RFDETR:
         except (TypeError, ValueError, RuntimeError) as exc:
             raise ValueError(
                 f"Invalid device specifier for train(): {device!r}. "
-                "Expected values like 'cpu', 'cuda', 'cuda:0', or torch.device(...)."
+                "Expected values like 'cpu', 'cuda', 'cuda:0', or torch.device(...).",
             ) from exc
 
         if resolved_device.type == "cpu":
@@ -423,6 +421,7 @@ class RFDETR:
         Raises:
             ImportError: If training dependencies are not installed. Install with
                 ``pip install "rfdetr[train,loggers]"``.
+
         """
         # Both imports are grouped in a single try block because they both live in
         # the `rfdetr[train]` extras group — a missing `pytorch_lightning` (or any
@@ -438,7 +437,7 @@ class RFDETR:
                 raise
             raise ImportError(
                 "RF-DETR training dependencies are missing. "
-                'Install them with `pip install "rfdetr[train,loggers]"` and try again.'
+                'Install them with `pip install "rfdetr[train,loggers]"` and try again.',
             ) from exc
 
         # Absorb legacy `callbacks` dict — warn if non-empty, then discard.
@@ -524,7 +523,12 @@ class RFDETR:
             self.model.inference_model = torch.jit.trace(
                 self.model.inference_model,
                 torch.randn(
-                    batch_size, 3, self.model.resolution, self.model.resolution, device=self.model.device, dtype=dtype
+                    batch_size,
+                    3,
+                    self.model.resolution,
+                    self.model.resolution,
+                    device=self.model.device,
+                    dtype=dtype,
                 ),
             )
             self._optimized_has_been_compiled = True
@@ -588,6 +592,7 @@ class RFDETR:
                 explicitly it must match the instantiated model's patch size.
                 Shape divisibility is validated against ``patch_size * num_windows``.
             **kwargs: Additional keyword arguments forwarded to export_onnx.
+
         """
         logger.info("Exporting model to ONNX format")
         try:
@@ -595,7 +600,7 @@ class RFDETR:
         except ImportError:
             logger.error(
                 "It seems some dependencies for ONNX export are missing."
-                " Please run `pip install rfdetr[onnx]` and try again."
+                " Please run `pip install rfdetr[onnx]` and try again.",
             )
             raise
 
@@ -616,7 +621,7 @@ class RFDETR:
                 raise ValueError(
                     f"Model's default resolution ({self.model.resolution}) is not divisible by "
                     f"block_size={block_size} (patch_size={patch_size} * num_windows={num_windows}). "
-                    f"Provide an explicit shape divisible by {block_size}."
+                    f"Provide an explicit shape divisible by {block_size}.",
                 )
         else:
             shape = _validate_shape_dims(shape, block_size, patch_size, num_windows)
@@ -647,7 +652,7 @@ class RFDETR:
                 if isinstance(masks, torch.Tensor):
                     logger.debug(
                         f"PyTorch inference output shapes - Boxes: {dets.shape}, Labels: {labels.shape}, "
-                        f"Masks: {masks.shape}"
+                        f"Masks: {masks.shape}",
                     )
                 else:
                     logger.debug(f"PyTorch inference output shapes - Boxes: {dets.shape}, Labels: {labels.shape}")
@@ -678,11 +683,11 @@ class RFDETR:
         self.model.model = self.model.model.to(device)
 
     @staticmethod
-    def _load_classes(dataset_dir: str) -> List[str]:
+    def _load_classes(dataset_dir: str) -> list[str]:
         """Load class names from a COCO or YOLO dataset directory."""
         if is_valid_coco_dataset(dataset_dir):
             coco_path = os.path.join(dataset_dir, "train", "_annotations.coco.json")
-            with open(coco_path, "r") as f:
+            with open(coco_path) as f:
                 anns = json.load(f)
             categories = sorted(anns["categories"], key=lambda category: category.get("id", float("inf")))
 
@@ -710,23 +715,20 @@ class RFDETR:
             # any YAML file starting with data e.g. data.yaml, dataset.yaml
             yaml_data_files = [yp for yp in yaml_paths if os.path.basename(yp).startswith("data")]
             yaml_path = yaml_data_files[0]
-            with open(yaml_path, "r") as f:
+            with open(yaml_path) as f:
                 data = yaml.safe_load(f)
             if "names" in data:
                 if isinstance(data["names"], dict):
                     return [data["names"][i] for i in sorted(data["names"].keys())]
                 return data["names"]
-            else:
-                raise ValueError(f"Found {yaml_path} but it does not contain 'names' field.")
+            raise ValueError(f"Found {yaml_path} but it does not contain 'names' field.")
         raise FileNotFoundError(
             f"Could not find class names in {dataset_dir}."
-            " Checked for COCO (train/_annotations.coco.json) and YOLO (data.yaml, data.yml) styles."
+            " Checked for COCO (train/_annotations.coco.json) and YOLO (data.yaml, data.yml) styles.",
         )
 
     def get_train_config(self, **kwargs) -> TrainConfig:
-        """
-        Retrieve the configuration parameters that will be used for training.
-        """
+        """Retrieve the configuration parameters that will be used for training."""
         return self._train_config_class(**kwargs)
 
     def get_model(self, config: ModelConfig) -> "ModelContext":
@@ -738,17 +740,19 @@ class RFDETR:
         Returns:
             ModelContext with model, postprocess, device, resolution, args,
             and class_names attributes.
+
         """
         return _build_model_context(config)
 
     @property
-    def class_names(self) -> List[str]:
+    def class_names(self) -> list[str]:
         """Retrieve the class names supported by the loaded model.
 
         Returns:
             A list of class name strings, 0-indexed.  When no custom class
             names are embedded in the checkpoint, returns the standard 80
             COCO class names.
+
         """
         if hasattr(self.model, "class_names") and self.model.class_names is not None:
             return list(self.model.class_names)
@@ -757,14 +761,12 @@ class RFDETR:
 
     def predict(
         self,
-        images: Union[
-            str, Image.Image, np.ndarray, torch.Tensor, List[Union[str, np.ndarray, Image.Image, torch.Tensor]]
-        ],
+        images: str | Image.Image | np.ndarray | torch.Tensor | list[str | np.ndarray | Image.Image | torch.Tensor],
         threshold: float = 0.5,
         shape: tuple[int, int] | None = None,
         patch_size: int | None = None,
         **kwargs,
-    ) -> Union[sv.Detections, List[sv.Detections]]:
+    ) -> sv.Detections | list[sv.Detections]:
         """Performs object detection on the input images and returns bounding box
         predictions.
 
@@ -805,6 +807,7 @@ class RFDETR:
                 negative, if either dimension is not divisible by
                 ``patch_size * num_windows``, or if ``patch_size`` is not a positive
                 integer.
+
         """
         import supervision as sv
 
@@ -820,7 +823,7 @@ class RFDETR:
                 raise ValueError(
                     f"Model's default resolution ({default_res}) is not divisible by "
                     f"block_size={block_size} (patch_size={patch_size} * num_windows={num_windows}). "
-                    f"Provide an explicit shape divisible by {block_size}."
+                    f"Provide an explicit shape divisible by {block_size}.",
                 )
         else:
             shape = _validate_shape_dims(shape, block_size, patch_size, num_windows)
@@ -828,7 +831,7 @@ class RFDETR:
         if not self._is_optimized_for_inference and not self._has_warned_about_not_being_optimized_for_inference:
             logger.warning(
                 "Model is not optimized for inference. Latency may be higher than expected."
-                " You can optimize the model for inference by calling model.optimize_for_inference()."
+                " You can optimize the model for inference by calling model.optimize_for_inference().",
             )
             self._has_warned_about_not_being_optimized_for_inference = True
 
@@ -851,7 +854,7 @@ class RFDETR:
 
             if (img > 1).any():
                 raise ValueError(
-                    "Image has pixel values above 1. Please ensure the image is normalized (scaled to [0, 1])."
+                    "Image has pixel values above 1. Please ensure the image is normalized (scaled to [0, 1]).",
                 )
             if img.shape[0] != 3:
                 raise ValueError(f"Invalid image shape. Expected 3 channels (RGB), but got {img.shape[0]} channels.")
@@ -880,7 +883,7 @@ class RFDETR:
                     f"Resolution mismatch. "
                     f"Model was optimized for resolution {self._optimized_resolution}x{self._optimized_resolution}, "
                     f"but got {batch_tensor.shape[2]}x{batch_tensor.shape[3]}."
-                    " You can explicitly remove the optimized model by calling model.remove_optimized_model()."
+                    " You can explicitly remove the optimized model by calling model.remove_optimized_model().",
                 )
             if self._optimized_has_been_compiled:
                 if self._optimized_batch_size != batch_tensor.shape[0]:
@@ -890,7 +893,7 @@ class RFDETR:
                         f"but got {batch_tensor.shape[0]}."
                         " You can explicitly remove the optimized model by calling model.remove_optimized_model()."
                         " Alternatively, you can recompile the optimized model for a different batch size"
-                        " by calling model.optimize_for_inference(batch_size=<new_batch_size>)."
+                        " by calling model.optimize_for_inference(batch_size=<new_batch_size>).",
                     )
 
         with torch.no_grad():
@@ -945,12 +948,11 @@ class RFDETR:
         self,
         workspace: str,
         project_id: str,
-        version: str,
-        api_key: Optional[str] = None,
-        size: Optional[str] = None,
+        version: int | str,
+        api_key: str | None = None,
+        size: str | None = None,
     ) -> None:
-        """
-        Deploy the trained RF-DETR model to Roboflow.
+        """Deploy the trained RF-DETR model to Roboflow.
 
         Deploying with Roboflow will create a Serverless API to which you can make requests.
 
@@ -970,6 +972,7 @@ class RFDETR:
             ValueError: If the `api_key` is not provided and not found in the
                 environment variable `ROBOFLOW_API_KEY`, or if the `size` is
                 not set for custom architectures.
+
         """
         import shutil
 
@@ -989,12 +992,29 @@ class RFDETR:
         size = self.size or size
         tmp_out_dir = ".roboflow_temp_upload"
         os.makedirs(tmp_out_dir, exist_ok=True)
-        outpath = os.path.join(tmp_out_dir, "weights.pt")
-        torch.save({"model": self.model.model.state_dict(), "args": self.model.args}, outpath)
-        project = workspace.project(project_id)
-        version = project.version(version)
-        version.deploy(model_type=size, model_path=tmp_out_dir, filename="weights.pt")
-        shutil.rmtree(tmp_out_dir)
+        try:
+            # Write class_names.txt so the Roboflow upload pipeline can discover
+            # the class labels without relying on args.class_names in the checkpoint.
+            class_names_path = os.path.join(tmp_out_dir, "class_names.txt")
+            with open(class_names_path, "w", encoding="utf-8", newline="\n") as f:
+                f.write("\n".join(self.class_names))
+
+            # Also embed class_names in the args namespace so that any code path
+            # that loads the checkpoint directly (e.g. roboflow-python's second
+            # fallback) can find them.  Mutating the shared SimpleNamespace is
+            # intentional here: this mirrors reinitialize_detection_head(), which
+            # already mutates args.num_classes in-place.
+            args = self.model.args
+            if not hasattr(args, "class_names") or args.class_names is None:
+                args.class_names = self.class_names
+
+            outpath = os.path.join(tmp_out_dir, "weights.pt")
+            torch.save({"model": self.model.model.state_dict(), "args": args}, outpath)
+            project = workspace.project(project_id)
+            project_version = project.version(version)
+            project_version.deploy(model_type=size, model_path=tmp_out_dir, filename="weights.pt")
+        finally:
+            shutil.rmtree(tmp_out_dir, ignore_errors=True)
 
 
 class RFDETRBase(RFDETR):

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -5,6 +5,7 @@
 # ------------------------------------------------------------------------
 from __future__ import annotations
 
+import contextlib
 import functools
 import glob
 import json
@@ -514,35 +515,84 @@ class RFDETR:
             if dataset_class_names is not None:
                 self.model.class_names = dataset_class_names
 
-    def optimize_for_inference(self, compile=True, batch_size=1, dtype=torch.float32):
-        self.remove_optimized_model()
+    def optimize_for_inference(
+            self, compile: bool = True, batch_size: int = 1, dtype: torch.dtype | str = torch.float32
+    ) -> None:
+        """Optimize the model for inference with optional JIT compilation and dtype casting.
 
-        self.model.inference_model = deepcopy(self.model.model)
-        self.model.inference_model.eval()
-        self.model.inference_model.export()
+        Operations are wrapped in the correct CUDA device context to prevent context
+        leaks on multi-GPU setups. When ``compile=True`` the model is traced with
+        ``torch.jit.trace`` using a dummy input of ``batch_size`` images at the
+        model's current resolution.
 
-        self._optimized_resolution = self.model.resolution
-        self._is_optimized_for_inference = True
+        Args:
+            compile: If ``True``, trace the model with ``torch.jit.trace`` to obtain
+                a JIT-compiled ``ScriptModule``. Set to ``False`` for broader
+                compatibility (e.g. models with dynamic control flow).
+            batch_size: Number of images the traced model will be optimized for.
+                Ignored when ``compile=False``.
+            dtype: Target floating-point dtype for the inference model. Accepts a
+                ``torch.dtype`` directly (e.g. ``torch.float16``) or its string name
+                (e.g. ``"float16"``). Defaults to ``torch.float32``.
 
-        self.model.inference_model = self.model.inference_model.to(dtype=dtype)
-        self._optimized_dtype = dtype
+        Raises:
+            TypeError: If ``dtype`` is not a ``torch.dtype``, or if ``dtype`` is a
+                string that does not correspond to a valid ``torch.dtype`` attribute.
 
-        if compile:
-            self.model.inference_model = torch.jit.trace(
-                self.model.inference_model,
-                torch.randn(
-                    batch_size,
-                    3,
-                    self.model.resolution,
-                    self.model.resolution,
-                    device=self.model.device,
-                    dtype=dtype,
-                ),
-            )
-            self._optimized_has_been_compiled = True
-            self._optimized_batch_size = batch_size
+        Examples:
+            >>> model = RFDETRNano()
+            >>> model.optimize_for_inference(compile=False, dtype="float16", batch_size=4)
+        """
+        if isinstance(dtype, str):
+            try:
+                dtype = getattr(torch, dtype)
+            except AttributeError:
+                raise TypeError(f"dtype must be a torch.dtype or a string name of a dtype, got {dtype!r}") from None
+        if not isinstance(dtype, torch.dtype):
+            raise TypeError(f"dtype must be a torch.dtype or a string name of a dtype, got {type(dtype)!r}")
 
-    def remove_optimized_model(self):
+        device = self.model.device
+        cuda_ctx = torch.cuda.device(device) if device.type == "cuda" else contextlib.nullcontext()
+        with cuda_ctx:
+
+            self.model.inference_model = deepcopy(self.model.model)
+            self.model.inference_model.eval()
+            self.model.inference_model.export()
+
+            self._optimized_resolution = self.model.resolution
+            self._is_optimized_for_inference = True
+
+            self.model.inference_model = self.model.inference_model.to(dtype=dtype)
+            self._optimized_dtype = dtype
+
+            if compile:
+                self.model.inference_model = torch.jit.trace(
+                    self.model.inference_model,
+                    torch.randn(
+                        batch_size,
+                        3,
+                        self.model.resolution,
+                        self.model.resolution,
+                        device=self.model.device,
+                        dtype=dtype,
+                    ),
+                )
+                self._optimized_has_been_compiled = True
+                self._optimized_batch_size = batch_size
+
+    def remove_optimized_model(self) -> None:
+        """Remove the optimized inference model and reset all optimization flags.
+
+        Clears ``model.inference_model`` and resets all internal state set by
+        :meth:`optimize_for_inference`. Safe to call even if the model has not
+        been optimized.
+
+        Examples:
+            >>> model = RFDETRSmall()
+            >>> model.optimize_for_inference(compile=False)
+            >>> model.remove_optimized_model()
+            >>> assert not model._is_optimized_for_inference
+        """
         self.model.inference_model = None
         self._is_optimized_for_inference = False
         self._optimized_has_been_compiled = False

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -842,6 +842,7 @@ class RFDETR:
 
         orig_sizes = []
         processed_images = []
+        source_images = []
 
         for img in images:
             if isinstance(img, str):
@@ -850,11 +851,21 @@ class RFDETR:
                 img = Image.open(img)
 
             if not isinstance(img, torch.Tensor):
+                src = np.array(img)
+                if src.dtype != np.uint8:
+                    src = (src * 255).clip(0, 255).astype(np.uint8)
+                source_images.append(src)
                 img = F.to_tensor(img)
+            else:
+                source_images.append((img.permute(1, 2, 0).cpu().numpy() * 255).astype(np.uint8))
 
             if (img > 1).any():
                 raise ValueError(
                     "Image has pixel values above 1. Please ensure the image is normalized (scaled to [0, 1]).",
+                )
+            if (img < 0).any():
+                raise ValueError(
+                    "Image has pixel values below 0. Please ensure the image is normalized (scaled to [0, 1]).",
                 )
             if img.shape[0] != 3:
                 raise ValueError(f"Invalid image shape. Expected 3 channels (RGB), but got {img.shape[0]} channels.")
@@ -913,7 +924,7 @@ class RFDETR:
             results = self.model.postprocess(predictions, target_sizes=target_sizes)
 
         detections_list = []
-        for result in results:
+        for i, result in enumerate(results):
             scores = result["scores"]
             labels = result["labels"]
             boxes = result["boxes"]
@@ -939,6 +950,9 @@ class RFDETR:
                     confidence=scores.float().cpu().numpy(),
                     class_id=labels.cpu().numpy(),
                 )
+
+            detections.data["source_image"] = source_images[i]
+            detections.data["source_shape"] = orig_sizes[i]
 
             detections_list.append(detections)
 

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -516,7 +516,7 @@ class RFDETR:
                 self.model.class_names = dataset_class_names
 
     def optimize_for_inference(
-            self, compile: bool = True, batch_size: int = 1, dtype: torch.dtype | str = torch.float32
+        self, compile: bool = True, batch_size: int = 1, dtype: torch.dtype | str = torch.float32
     ) -> None:
         """Optimize the model for inference with optional JIT compilation and dtype casting.
 
@@ -554,7 +554,6 @@ class RFDETR:
         device = self.model.device
         cuda_ctx = torch.cuda.device(device) if device.type == "cuda" else contextlib.nullcontext()
         with cuda_ctx:
-
             self.model.inference_model = deepcopy(self.model.model)
             self.model.inference_model.eval()
             self.model.inference_model.export()

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -551,22 +551,19 @@ class RFDETR:
         if not isinstance(dtype, torch.dtype):
             raise TypeError(f"dtype must be a torch.dtype or a string name of a dtype, got {type(dtype)!r}")
 
+        self.remove_optimized_model()
+
         device = self.model.device
         cuda_ctx = torch.cuda.device(device) if device.type == "cuda" else contextlib.nullcontext()
         with cuda_ctx:
-            self.model.inference_model = deepcopy(self.model.model)
-            self.model.inference_model.eval()
-            self.model.inference_model.export()
-
-            self._optimized_resolution = self.model.resolution
-            self._is_optimized_for_inference = True
-
-            self.model.inference_model = self.model.inference_model.to(dtype=dtype)
-            self._optimized_dtype = dtype
+            inference_model = deepcopy(self.model.model)
+            inference_model.eval()
+            inference_model.export()
+            inference_model = inference_model.to(dtype=dtype)
 
             if compile:
-                self.model.inference_model = torch.jit.trace(
-                    self.model.inference_model,
+                inference_model = torch.jit.trace(
+                    inference_model,
                     torch.randn(
                         batch_size,
                         3,
@@ -576,6 +573,12 @@ class RFDETR:
                         dtype=dtype,
                     ),
                 )
+
+            self.model.inference_model = inference_model
+            self._optimized_resolution = self.model.resolution
+            self._is_optimized_for_inference = True
+            self._optimized_dtype = dtype
+            if compile:
                 self._optimized_has_been_compiled = True
                 self._optimized_batch_size = batch_size
 

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -554,33 +554,43 @@ class RFDETR:
         self.remove_optimized_model()
 
         device = self.model.device
+        # Clear any previously optimized state before starting a new optimization run.
+        self.remove_optimized_model()
+
+        device = self.model.device
         cuda_ctx = torch.cuda.device(device) if device.type == "cuda" else contextlib.nullcontext()
-        with cuda_ctx:
-            inference_model = deepcopy(self.model.model)
-            inference_model.eval()
-            inference_model.export()
-            inference_model = inference_model.to(dtype=dtype)
 
-            if compile:
-                inference_model = torch.jit.trace(
-                    inference_model,
-                    torch.randn(
-                        batch_size,
-                        3,
-                        self.model.resolution,
-                        self.model.resolution,
-                        device=self.model.device,
-                        dtype=dtype,
-                    ),
-                )
+        try:
+            with cuda_ctx:
+                self.model.inference_model = deepcopy(self.model.model)
+                self.model.inference_model.eval()
+                self.model.inference_model.export()
 
-            self.model.inference_model = inference_model
-            self._optimized_resolution = self.model.resolution
-            self._is_optimized_for_inference = True
-            self._optimized_dtype = dtype
-            if compile:
-                self._optimized_has_been_compiled = True
-                self._optimized_batch_size = batch_size
+                self._optimized_resolution = self.model.resolution
+                self._is_optimized_for_inference = True
+
+                self.model.inference_model = self.model.inference_model.to(dtype=dtype)
+                self._optimized_dtype = dtype
+
+                if compile:
+                    self.model.inference_model = torch.jit.trace(
+                        self.model.inference_model,
+                        torch.randn(
+                            batch_size,
+                            3,
+                            self.model.resolution,
+                            self.model.resolution,
+                            device=self.model.device,
+                            dtype=dtype,
+                        ),
+                    )
+                    self._optimized_has_been_compiled = True
+                    self._optimized_batch_size = batch_size
+        except Exception:
+            # Ensure the object is left in a consistent, unoptimized state if optimization fails.
+            with contextlib.suppress(Exception):
+                self.remove_optimized_model()
+            raise
 
     def remove_optimized_model(self) -> None:
         """Remove the optimized inference model and reset all optimization flags.

--- a/src/rfdetr/models/lwdetr.py
+++ b/src/rfdetr/models/lwdetr.py
@@ -67,8 +67,8 @@ def _resize_linear(linear: nn.Linear, num_classes: int) -> nn.Linear:
     """
     base = linear.weight.shape[0]
     num_repeats = int(math.ceil(num_classes / base))
-    new_weight = linear.weight.data.repeat(num_repeats, 1)[:num_classes]
-    new_bias = linear.bias.data.repeat(num_repeats)[:num_classes] if linear.bias is not None else None
+    new_weight = linear.weight.detach().repeat(num_repeats, 1)[:num_classes]
+    new_bias = linear.bias.detach().repeat(num_repeats)[:num_classes] if linear.bias is not None else None
     new_linear = nn.Linear(linear.in_features, num_classes, bias=new_bias is not None)
     # Copy resized weights/bias into the new layer while preserving requires_grad flags.
     with torch.no_grad():

--- a/src/rfdetr/models/lwdetr.py
+++ b/src/rfdetr/models/lwdetr.py
@@ -48,6 +48,39 @@ from rfdetr.models.transformer import build_transformer
 from rfdetr.utilities.tensors import NestedTensor, nested_tensor_from_tensor_list
 
 
+def _resize_linear(linear: nn.Linear, num_classes: int) -> nn.Linear:
+    """Return a new :class:`~torch.nn.Linear` resized to *num_classes* outputs.
+
+    Tiles the existing weight rows when *num_classes* is larger than the current
+    output size, or truncates them when smaller.  The returned module has
+    ``out_features == num_classes`` so that ``nn.Linear`` metadata stays
+    consistent with the actual weight shape — a requirement for correct ONNX
+    export and ``torch.jit.trace`` serialisation.
+
+    Args:
+        linear: Source linear layer whose weights are used as the starting point.
+        num_classes: Target number of output features.
+
+    Returns:
+        A new :class:`~torch.nn.Linear` with ``in_features`` unchanged and
+        ``out_features == num_classes``.
+    """
+    base = linear.weight.shape[0]
+    num_repeats = int(math.ceil(num_classes / base))
+    new_weight = linear.weight.data.repeat(num_repeats, 1)[:num_classes]
+    new_bias = linear.bias.data.repeat(num_repeats)[:num_classes] if linear.bias is not None else None
+    new_linear = nn.Linear(linear.in_features, num_classes, bias=new_bias is not None)
+    # Copy resized weights/bias into the new layer while preserving requires_grad flags.
+    with torch.no_grad():
+        new_linear.weight.copy_(new_weight)
+        if new_bias is not None and new_linear.bias is not None:
+            new_linear.bias.copy_(new_bias)
+    new_linear.weight.requires_grad = linear.weight.requires_grad
+    if linear.bias is not None and new_linear.bias is not None:
+        new_linear.bias.requires_grad = linear.bias.requires_grad
+    return new_linear
+
+
 class LWDETR(nn.Module):
     """This is the Group DETR v3 module that performs object detection"""
 
@@ -122,20 +155,26 @@ class LWDETR(nn.Module):
 
         self._export = False
 
-    def reinitialize_detection_head(self, num_classes):
-        base = self.class_embed.weight.shape[0]
-        num_repeats = int(math.ceil(num_classes / base))
-        self.class_embed.weight.data = self.class_embed.weight.data.repeat(num_repeats, 1)
-        self.class_embed.weight.data = self.class_embed.weight.data[:num_classes]
-        self.class_embed.bias.data = self.class_embed.bias.data.repeat(num_repeats)
-        self.class_embed.bias.data = self.class_embed.bias.data[:num_classes]
+    def reinitialize_detection_head(self, num_classes: int) -> None:
+        """Resize the detection classification head to *num_classes* outputs.
+
+        Replaces ``self.class_embed`` (and each ``enc_out_class_embed`` when the
+        model uses two-stage detection) with a new :class:`torch.nn.Linear` whose
+        ``out_features`` equals *num_classes*.  When *num_classes* is larger than
+        the current head the existing weights are tiled; when smaller they are
+        truncated.  Replacing the module (rather than mutating ``.data``) keeps
+        ``nn.Linear.out_features`` consistent with the actual weight shape, which
+        is required for correct ONNX export.
+
+        Args:
+            num_classes: Target number of output classes (including background).
+        """
+        self.class_embed = _resize_linear(self.class_embed, num_classes)
 
         if self.two_stage:
-            for enc_out_class_embed in self.transformer.enc_out_class_embed:
-                enc_out_class_embed.weight.data = enc_out_class_embed.weight.data.repeat(num_repeats, 1)
-                enc_out_class_embed.weight.data = enc_out_class_embed.weight.data[:num_classes]
-                enc_out_class_embed.bias.data = enc_out_class_embed.bias.data.repeat(num_repeats)
-                enc_out_class_embed.bias.data = enc_out_class_embed.bias.data[:num_classes]
+            self.transformer.enc_out_class_embed = nn.ModuleList(
+                [_resize_linear(m, num_classes) for m in self.transformer.enc_out_class_embed]
+            )
 
     def export(self):
         self._export = True

--- a/src/rfdetr/training/auto_batch.py
+++ b/src/rfdetr/training/auto_batch.py
@@ -128,11 +128,8 @@ def _probe_step(
             loss_dict = cast(dict[str, torch.Tensor], criterion(outputs, targets))
             weight_dict = cast(dict[str, float], getattr(criterion, "weight_dict"))
             weighted_losses = [loss_dict[name] * weight_dict[name] for name in loss_dict if name in weight_dict]
-            loss = (
-                torch.stack(weighted_losses).sum()
-                if weighted_losses
-                else torch.tensor(0.0, dtype=torch.float32, device=device)
-            )
+            base_loss = torch.zeros((), dtype=torch.float32, device=device, requires_grad=True)
+            loss = base_loss + torch.stack(weighted_losses).sum() if weighted_losses else base_loss
 
         if not torch.isfinite(loss):
             raise RuntimeError("auto-batch probe produced a non-finite training loss.")

--- a/src/rfdetr/training/auto_batch.py
+++ b/src/rfdetr/training/auto_batch.py
@@ -334,7 +334,7 @@ def resolve_auto_batch_config(
     max_targets_per_image = getattr(train_config, "auto_batch_max_targets_per_image", 100)
 
     args = build_namespace(model_config, train_config)
-    criterion, _ = build_criterion_and_postprocessors(args)
+    criterion, _ = build_criterion_and_postprocessors(args)  # type: ignore[no-untyped-call]
     criterion = criterion.to(device)
 
     safe_micro_batch = probe_max_micro_batch(

--- a/src/rfdetr/training/auto_batch.py
+++ b/src/rfdetr/training/auto_batch.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 import torch
 
@@ -125,14 +125,19 @@ def _probe_step(
 
         with torch.autocast(device_type="cuda", enabled=amp):
             outputs = model(samples, targets)
-            loss_dict = criterion(outputs, targets)
-            weight_dict = criterion.weight_dict
-            loss = sum(loss_dict[name] * weight_dict[name] for name in loss_dict if name in weight_dict)
+            loss_dict = cast(dict[str, torch.Tensor], criterion(outputs, targets))
+            weight_dict = cast(dict[str, float], getattr(criterion, "weight_dict"))
+            weighted_losses = [loss_dict[name] * weight_dict[name] for name in loss_dict if name in weight_dict]
+            loss = (
+                torch.stack(weighted_losses).sum()
+                if weighted_losses
+                else torch.tensor(0.0, dtype=torch.float32, device=device)
+            )
 
         if not torch.isfinite(loss):
             raise RuntimeError("auto-batch probe produced a non-finite training loss.")
 
-        loss.backward()
+        torch.autograd.backward(loss)
         model.zero_grad(set_to_none=True)
         criterion.zero_grad(set_to_none=True)
         return True

--- a/src/rfdetr/training/param_groups.py
+++ b/src/rfdetr/training/param_groups.py
@@ -8,7 +8,7 @@
 # ------------------------------------------------------------------------
 """Functions to get params dict"""
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, cast
 
 import torch.nn as nn
 
@@ -57,7 +57,7 @@ def get_vit_weight_decay_rate(name: str, weight_decay_rate: float = 1.0) -> floa
 
 def get_param_dict(args: Any, model_without_ddp: nn.Module) -> List[Dict[str, Any]]:
     assert isinstance(model_without_ddp.backbone, Joiner)
-    backbone = model_without_ddp.backbone[0]
+    backbone = cast(Any, model_without_ddp.backbone[0])
     backbone_named_param_lr_pairs = backbone.get_named_param_lr_pairs(args, prefix="backbone.0")
     backbone_param_lr_pairs = [param_dict for _, param_dict in backbone_named_param_lr_pairs.items()]
 

--- a/src/rfdetr/utilities/box_ops.py
+++ b/src/rfdetr/utilities/box_ops.py
@@ -128,11 +128,11 @@ def batch_dice_loss(inputs: torch.Tensor, targets: torch.Tensor) -> torch.Tensor
     inputs = inputs.flatten(1)
     numerator = 2 * torch.einsum("nc,mc->nm", inputs, targets)
     denominator = inputs.sum(-1)[:, None] + targets.sum(-1)[None, :]
-    loss = 1 - (numerator + 1) / (denominator + 1)
+    loss: torch.Tensor = 1 - (numerator + 1) / (denominator + 1)
     return loss
 
 
-batch_dice_loss_jit = torch.jit.script(batch_dice_loss)  # type: torch.jit.ScriptModule
+batch_dice_loss_jit = torch.jit.script(batch_dice_loss)
 
 
 def batch_sigmoid_ce_loss(inputs: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
@@ -157,4 +157,4 @@ def batch_sigmoid_ce_loss(inputs: torch.Tensor, targets: torch.Tensor) -> torch.
     return loss / hw
 
 
-batch_sigmoid_ce_loss_jit = torch.jit.script(batch_sigmoid_ce_loss)  # type: torch.jit.ScriptModule
+batch_sigmoid_ce_loss_jit = torch.jit.script(batch_sigmoid_ce_loss)

--- a/src/rfdetr/utilities/files.py
+++ b/src/rfdetr/utilities/files.py
@@ -8,7 +8,7 @@
 
 import hashlib
 import os
-import shutil
+import tempfile
 from typing import Optional
 
 import requests
@@ -87,8 +87,15 @@ def _download_file(
     except (TypeError, ValueError):
         total_size = None
 
-    # Download to temporary file first
-    temp_filename = f"{filename}.tmp"
+    # Download to a unique temporary file in the destination directory first.
+    # This avoids collisions when multiple workers download the same weight file.
+    target_dir = os.path.dirname(filename) or "."
+    fd, temp_filename = tempfile.mkstemp(
+        prefix=f"{os.path.basename(filename)}.",
+        suffix=".tmp",
+        dir=target_dir,
+    )
+    os.close(fd)
     try:
         with (
             open(temp_filename, "wb") as f,
@@ -118,5 +125,5 @@ def _download_file(
         else:
             logger.info(f"MD5 validation successful for {filename}")
 
-    # shutil.move handles cross-device moves (e.g. tmpfs → ext4 on Colab).
-    shutil.move(temp_filename, filename)
+    # Atomic replace in target directory.
+    os.replace(temp_filename, filename)

--- a/tests/benchmarks/test_training_synthetic.py
+++ b/tests/benchmarks/test_training_synthetic.py
@@ -24,7 +24,7 @@ import torch
 from pytorch_lightning import LightningModule
 
 from rfdetr import RFDETRNano
-from rfdetr.config import RFDETRBaseConfig, RFDETRSegNanoConfig, SegmentationTrainConfig, TrainConfig
+from rfdetr.config import RFDETRBaseConfig, RFDETRNanoConfig, RFDETRSegNanoConfig, SegmentationTrainConfig, TrainConfig
 from rfdetr.detr import RFDETR
 from rfdetr.training import RFDETRDataModule, RFDETRModelModule, build_trainer
 
@@ -84,7 +84,7 @@ def test_train_fast_dev_run(
     with open(synthetic_shape_dataset_dir / "train" / "_annotations.coco.json") as f:
         num_classes = len(json.load(f)["categories"])
 
-    mc = RFDETRBaseConfig(num_classes=num_classes, pretrain_weights=None)
+    mc = RFDETRNanoConfig(num_classes=num_classes, pretrain_weights=None, amp=False)
     tc = TrainConfig(
         dataset_dir=str(synthetic_shape_dataset_dir),
         output_dir=str(output_dir),

--- a/tests/models/test_detection_head.py
+++ b/tests/models/test_detection_head.py
@@ -1,0 +1,139 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Regression tests for _resize_linear() and LWDETR.reinitialize_detection_head().
+
+These tests guard against the out_features staleness bug where in-place .data
+mutation did not update nn.Linear.out_features, causing ONNX export to emit
+stale (pre-fine-tuning) class counts.
+"""
+
+from unittest.mock import MagicMock
+
+import torch
+from torch import nn
+
+from rfdetr.models.lwdetr import LWDETR, _resize_linear
+
+
+def _make_minimal_lwdetr(num_classes: int = 91, two_stage: bool = False) -> LWDETR:
+    """Construct the smallest viable LWDETR without loading pretrained weights.
+
+    Uses a MagicMock backbone and transformer with hidden_dim=4 so the model
+    can be constructed in milliseconds without any network I/O.
+
+    Args:
+        num_classes: Initial number of output classes passed to LWDETR.
+        two_stage: Whether to enable two-stage mode (creates enc_out_class_embed).
+
+    Returns:
+        An LWDETR instance with hidden_dim=4, num_queries=2, group_detr=1.
+
+    Examples:
+        >>> model = _make_minimal_lwdetr(num_classes=91)
+        >>> isinstance(model, LWDETR)
+        True
+    """
+    hidden_dim = 4
+    backbone = MagicMock()
+    transformer = MagicMock()
+    transformer.d_model = hidden_dim
+    transformer.decoder = MagicMock()
+    transformer.decoder.bbox_embed = None
+    return LWDETR(
+        backbone=backbone,
+        transformer=transformer,
+        segmentation_head=None,
+        num_classes=num_classes,
+        num_queries=2,
+        group_detr=1,
+        two_stage=two_stage,
+    )
+
+
+class TestResizeLinear:
+    """Unit tests for _resize_linear() — verifies out_features, weight shape, and bias shape."""
+
+    def test_shrink_out_features(self) -> None:
+        """Shrink: out_features equals the requested smaller class count."""
+        result = _resize_linear(nn.Linear(256, 91), 8)
+        assert result.out_features == 8, f"Expected out_features=8, got {result.out_features}"
+        assert result.weight.shape == (8, 256), f"Expected weight (8, 256), got {result.weight.shape}"
+        assert result.bias is not None
+        assert result.bias.shape == (8,), f"Expected bias (8,), got {result.bias.shape}"
+
+    def test_expand_out_features(self) -> None:
+        """Expand: out_features equals the requested larger class count via tiling."""
+        result = _resize_linear(nn.Linear(256, 10), 25)
+        assert result.out_features == 25, f"Expected out_features=25, got {result.out_features}"
+        assert result.weight.shape == (25, 256), f"Expected weight (25, 256), got {result.weight.shape}"
+        assert result.bias is not None
+        assert result.bias.shape == (25,), f"Expected bias (25,), got {result.bias.shape}"
+
+    def test_same_size_preserves_values(self) -> None:
+        """Same size: shapes and weight/bias values are preserved exactly."""
+        linear = nn.Linear(256, 91)
+        result = _resize_linear(linear, 91)
+        assert result.out_features == 91
+        assert result.weight.shape == (91, 256)
+        assert result.bias is not None
+        assert result.bias.shape == (91,)
+        assert torch.allclose(result.weight.data, linear.weight.data)
+        assert torch.allclose(result.bias.data, linear.bias.data)
+
+    def test_no_bias_returns_no_bias(self) -> None:
+        """bias=False input: returned module has bias=None and out_features is correct."""
+        linear = nn.Linear(256, 91, bias=False)
+        result = _resize_linear(linear, 8)
+        assert result.out_features == 8, f"Expected out_features=8, got {result.out_features}"
+        assert result.bias is None, "Expected bias=None for bias=False input"
+
+
+class TestReinitializeDetectionHead:
+    """Integration tests for LWDETR.reinitialize_detection_head().
+
+    Uses a minimal LWDETR (hidden_dim=4, no real backbone) to verify that
+    out_features is updated on the replaced nn.Linear modules — the core
+    invariant required for correct ONNX export.
+    """
+
+    def test_updates_class_embed_out_features(self) -> None:
+        """class_embed.out_features must reflect num_classes after reinitialize.
+
+        The `num_outputs_including_background` argument represents the total number
+        of classifier outputs (foreground classes plus background).
+        """
+        num_outputs_including_background = 8
+        model = _make_minimal_lwdetr(num_classes=91)
+        model.reinitialize_detection_head(num_outputs_including_background)
+        assert model.class_embed.out_features == num_outputs_including_background, (
+            f"Expected class_embed.out_features={num_outputs_including_background}, "
+            f"got {model.class_embed.out_features}"
+        )
+        assert model.class_embed.weight.shape == (num_outputs_including_background, 4), (
+            f"Expected weight ({num_outputs_including_background}, 4), got {model.class_embed.weight.shape}"
+        )
+
+    def test_two_stage_updates_enc_out_class_embed(self) -> None:
+        """enc_out_class_embed entries must also have updated out_features in two-stage mode.
+
+        The `num_outputs_including_background` argument represents the total number
+        of classifier outputs (foreground classes plus background).
+        """
+        num_outputs_including_background = 8
+        model = _make_minimal_lwdetr(num_classes=91, two_stage=True)
+        model.reinitialize_detection_head(num_outputs_including_background)
+        enc_embeds = model.transformer.enc_out_class_embed
+        assert len(enc_embeds) > 0, "enc_out_class_embed should be non-empty in two-stage mode"
+        for i, embed in enumerate(enc_embeds):
+            assert embed.out_features == num_outputs_including_background, (
+                f"enc_out_class_embed[{i}].out_features={embed.out_features}, "
+                f"expected {num_outputs_including_background}"
+            )
+            assert embed.weight.shape == (num_outputs_including_background, 4), (
+                f"enc_out_class_embed[{i}].weight.shape={embed.weight.shape}, "
+                f"expected ({num_outputs_including_background}, 4)"
+            )

--- a/tests/models/test_optimize_for_inference.py
+++ b/tests/models/test_optimize_for_inference.py
@@ -1,0 +1,315 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Tests for RFDETR.optimize_for_inference()."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from rfdetr.detr import RFDETR
+
+
+class _FakeModel(torch.nn.Module):
+    """Minimal nn.Module that satisfies the optimize_for_inference contract."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = torch.nn.Linear(1, 1)
+
+    def forward(self, x: torch.Tensor) -> dict[str, torch.Tensor]:
+        return {"pred_boxes": self.linear(x[:, :1, :1, :1].squeeze(-1).squeeze(-1))}
+
+    def export(self) -> None:
+        pass
+
+
+class _FakeModelContext:
+    def __init__(self, device: torch.device | str = torch.device("cpu"), resolution: int = 28) -> None:
+        self.device = torch.device(device) if not isinstance(device, torch.device) else device
+        self.resolution = resolution
+        self.model = _FakeModel()
+        self.inference_model = None
+
+
+class _FakeRFDETR(RFDETR):
+    def maybe_download_pretrain_weights(self) -> None:
+        return None
+
+    def get_model_config(self, **kwargs) -> SimpleNamespace:
+        return SimpleNamespace()
+
+    def get_model(self, config: SimpleNamespace) -> _FakeModelContext:
+        return _FakeModelContext()
+
+
+class TestOptimizeForInferenceDtype:
+    """dtype coercion and validation tests."""
+
+    def test_string_dtype_float32_is_accepted(self) -> None:
+        """Passing dtype='float32' (str) should be coerced to torch.float32."""
+        rfdetr = _FakeRFDETR()
+
+        with patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model):
+            rfdetr.optimize_for_inference(compile=False, dtype="float32")
+
+        assert rfdetr._optimized_dtype == torch.float32
+
+    def test_string_dtype_float16_is_accepted(self) -> None:
+        """Passing dtype='float16' (str) should be coerced to torch.float16."""
+        rfdetr = _FakeRFDETR()
+
+        with patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model):
+            rfdetr.optimize_for_inference(compile=False, dtype="float16")
+
+        assert rfdetr._optimized_dtype == torch.float16
+
+    def test_torch_dtype_is_passed_through(self) -> None:
+        """Passing dtype=torch.float32 directly should work as before."""
+        rfdetr = _FakeRFDETR()
+
+        with patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model):
+            rfdetr.optimize_for_inference(compile=False, dtype=torch.float32)
+
+        assert rfdetr._optimized_dtype == torch.float32
+
+    def test_invalid_dtype_type_raises_type_error(self) -> None:
+        """Passing an invalid dtype type (e.g. int) should raise TypeError."""
+        rfdetr = _FakeRFDETR()
+
+        with pytest.raises(TypeError, match="dtype must be a torch.dtype or a string name of a dtype"):
+            rfdetr.optimize_for_inference(compile=False, dtype=42)  # type: ignore[arg-type]
+
+    def test_invalid_dtype_string_raises_type_error(self) -> None:
+        """Passing a non-existent dtype string should raise TypeError with a descriptive message."""
+        rfdetr = _FakeRFDETR()
+
+        with pytest.raises(TypeError, match="dtype must be a torch.dtype or a string name of a dtype"):
+            rfdetr.optimize_for_inference(compile=False, dtype="not_a_dtype")
+
+    def test_valid_torch_attr_that_is_not_dtype_raises_type_error(self) -> None:
+        """'Tensor' is a valid torch attribute but not a torch.dtype — should raise TypeError."""
+        rfdetr = _FakeRFDETR()
+
+        with pytest.raises(TypeError, match="dtype must be a torch.dtype or a string name of a dtype"):
+            rfdetr.optimize_for_inference(compile=False, dtype="Tensor")  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("dtype_str", ["float32", "float16", "bfloat16"])
+    def test_string_dtype_variants_are_accepted(self, dtype_str: str) -> None:
+        """Common dtype string names should be accepted and coerced to the matching torch.dtype."""
+        rfdetr = _FakeRFDETR()
+        expected = getattr(torch, dtype_str)
+
+        with patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model):
+            rfdetr.optimize_for_inference(compile=False, dtype=dtype_str)
+
+        assert rfdetr._optimized_dtype == expected
+
+
+class TestOptimizeForInferenceCudaDeviceContext:
+    """Verify that optimize_for_inference wraps operations in the correct device context."""
+
+    def test_cuda_device_context_manager_is_used_for_cuda_device(self) -> None:
+        """torch.cuda.device() context should be entered when model is on CUDA."""
+        rfdetr = _FakeRFDETR()
+        # Simulate a CUDA device without actually requiring CUDA hardware
+        rfdetr.model.device = torch.device("cuda", 0)
+
+        entered_devices: list[torch.device] = []
+
+        class _CapturingDeviceCtx:
+            def __init__(self, captured_device):
+                entered_devices.append(captured_device)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        with (
+            patch("torch.cuda.device", side_effect=_CapturingDeviceCtx),
+            patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model),
+        ):
+            rfdetr.optimize_for_inference(compile=False, dtype=torch.float32)
+
+        assert len(entered_devices) == 1
+        assert entered_devices[0] == torch.device("cuda", 0)
+
+    def test_nullcontext_used_for_cpu_device(self) -> None:
+        """contextlib.nullcontext() should be used when model is on CPU (no CUDA init)."""
+        rfdetr = _FakeRFDETR()
+        rfdetr.model.device = torch.device("cpu")
+
+        # torch.cuda.device should NOT be called for CPU devices
+        with (
+            patch("torch.cuda.device") as mock_cuda_device,
+            patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model),
+        ):
+            rfdetr.optimize_for_inference(compile=False, dtype=torch.float32)
+
+        mock_cuda_device.assert_not_called()
+
+    def test_cuda_device_context_uses_model_device(self) -> None:
+        """The device passed to torch.cuda.device() should match self.model.device."""
+        rfdetr = _FakeRFDETR()
+        expected_device = torch.device("cuda", 2)
+        rfdetr.model.device = expected_device
+
+        captured: dict[str, torch.device] = {}
+
+        class _CapturingCtx:
+            def __init__(self, captured_device):
+                captured["device"] = captured_device
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        with (
+            patch("torch.cuda.device", side_effect=_CapturingCtx),
+            patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model),
+        ):
+            rfdetr.optimize_for_inference(compile=False)
+
+        assert captured.get("device") == expected_device
+
+
+class TestOptimizeForInferenceCompile:
+    """Tests for the compile=True path (JIT trace)."""
+
+    def test_compile_true_calls_jit_trace(self) -> None:
+        """torch.jit.trace should be called with the model and a correctly-shaped dummy input."""
+        rfdetr = _FakeRFDETR()
+        mock_traced = rfdetr.model.model
+
+        with (
+            patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model),
+            patch("torch.jit.trace", return_value=mock_traced) as mock_trace,
+        ):
+            rfdetr.optimize_for_inference(compile=True, batch_size=2)
+
+        assert mock_trace.called
+        dummy_input: torch.Tensor = mock_trace.call_args.args[1]
+        resolution = rfdetr.model.resolution
+        assert dummy_input.shape == (2, 3, resolution, resolution)
+
+    def test_compile_true_sets_compiled_flags(self) -> None:
+        """_optimized_has_been_compiled=True and _optimized_batch_size should be set after compile=True."""
+        rfdetr = _FakeRFDETR()
+
+        with (
+            patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model),
+            patch("torch.jit.trace", return_value=rfdetr.model.model),
+        ):
+            rfdetr.optimize_for_inference(compile=True, batch_size=4)
+
+        assert rfdetr._optimized_has_been_compiled is True
+        assert rfdetr._optimized_batch_size == 4
+
+    def test_compile_false_skips_jit_trace(self) -> None:
+        """torch.jit.trace should NOT be called when compile=False."""
+        rfdetr = _FakeRFDETR()
+
+        with (
+            patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model),
+            patch("torch.jit.trace") as mock_trace,
+        ):
+            rfdetr.optimize_for_inference(compile=False)
+
+        mock_trace.assert_not_called()
+        assert rfdetr._optimized_has_been_compiled is False
+        assert rfdetr._optimized_batch_size is None
+
+
+class TestOptimizeForInferenceState:
+    """Verify that optimize_for_inference correctly sets internal state flags."""
+
+    def test_is_optimized_flag_set(self) -> None:
+        """_is_optimized_for_inference should be True after optimization."""
+        rfdetr = _FakeRFDETR()
+
+        with patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model):
+            rfdetr.optimize_for_inference(compile=False)
+
+        assert rfdetr._is_optimized_for_inference is True
+
+    def test_inference_model_set(self) -> None:
+        """model.inference_model should be set after optimization."""
+        rfdetr = _FakeRFDETR()
+
+        with patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model):
+            rfdetr.optimize_for_inference(compile=False)
+
+        assert rfdetr.model.inference_model is not None
+
+    def test_remove_optimized_model_clears_state(self) -> None:
+        """remove_optimized_model() should clear all optimization flags."""
+        rfdetr = _FakeRFDETR()
+
+        with patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model):
+            rfdetr.optimize_for_inference(compile=False)
+
+        rfdetr.remove_optimized_model()
+
+        assert rfdetr._is_optimized_for_inference is False
+        assert rfdetr.model.inference_model is None
+        assert rfdetr._optimized_dtype is None
+        assert rfdetr._optimized_resolution is None
+        assert rfdetr._optimized_has_been_compiled is False
+        assert rfdetr._optimized_batch_size is None
+
+
+class TestOptimizeForInferenceExceptionRecovery:
+    """Verify state consistency when optimization fails mid-execution."""
+
+    def test_deepcopy_failure_leaves_clean_state(self) -> None:
+        """If deepcopy raises, inference_model should be None and _is_optimized_for_inference False."""
+        rfdetr = _FakeRFDETR()
+        # Simulate a previously-optimized state to confirm remove_optimized_model ran
+        rfdetr._is_optimized_for_inference = True
+        rfdetr.model.inference_model = rfdetr.model.model
+
+        with (
+            patch("rfdetr.detr.deepcopy", side_effect=RuntimeError("deepcopy failed")),
+            pytest.raises(RuntimeError, match="deepcopy failed"),
+        ):
+            rfdetr.optimize_for_inference(compile=False)
+
+        assert rfdetr.model.inference_model is None
+        assert rfdetr._is_optimized_for_inference is False
+
+    def test_export_failure_leaves_is_optimized_false(self) -> None:
+        """If export() raises after deepcopy succeeds, _is_optimized_for_inference stays False."""
+        rfdetr = _FakeRFDETR()
+        fake_copy = _FakeModel()
+
+        with (
+            patch("rfdetr.detr.deepcopy", return_value=fake_copy),
+            patch.object(fake_copy, "export", side_effect=RuntimeError("export failed")),
+            pytest.raises(RuntimeError, match="export failed"),
+        ):
+            rfdetr.optimize_for_inference(compile=False)
+
+        assert rfdetr._is_optimized_for_inference is False
+
+    def test_jit_trace_failure_leaves_compiled_flags_false(self) -> None:
+        """If jit.trace raises, _optimized_has_been_compiled and _optimized_batch_size stay unset."""
+        rfdetr = _FakeRFDETR()
+
+        with (
+            patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model),
+            patch("torch.jit.trace", side_effect=RuntimeError("trace failed")),
+            pytest.raises(RuntimeError, match="trace failed"),
+        ):
+            rfdetr.optimize_for_inference(compile=True, batch_size=2)
+
+        assert rfdetr._optimized_has_been_compiled is False
+        assert rfdetr._optimized_batch_size is None

--- a/tests/models/test_predict.py
+++ b/tests/models/test_predict.py
@@ -95,6 +95,56 @@ def test_predict_accepts_image_url() -> None:
     assert detections.xyxy.shape == (1, 4)
 
 
+class TestPredictSourceData:
+    """Verify that ``predict()`` populates ``source_image`` and ``source_shape``."""
+
+    def test_source_image_from_pil(self) -> None:
+        """PIL input stores the original image as a numpy array."""
+        img = PIL.Image.new("RGB", (64, 48), color=(128, 128, 128))
+        model = _DummyRFDETR()
+        detections = model.predict(img)
+        assert "source_image" in detections.data
+        assert isinstance(detections.data["source_image"], np.ndarray)
+        assert detections.data["source_image"].shape == (48, 64, 3)
+
+    def test_source_shape_from_pil(self) -> None:
+        """PIL input stores the original (height, width) tuple."""
+        img = PIL.Image.new("RGB", (64, 48), color=(128, 128, 128))
+        model = _DummyRFDETR()
+        detections = model.predict(img)
+        assert "source_shape" in detections.data
+        assert detections.data["source_shape"] == (48, 64)
+
+    def test_source_image_from_tensor(self) -> None:
+        """Tensor input stores the original image as a uint8 numpy array."""
+        tensor = torch.rand(3, 48, 64)
+        model = _DummyRFDETR()
+        detections = model.predict(tensor)
+        assert "source_image" in detections.data
+        assert isinstance(detections.data["source_image"], np.ndarray)
+        assert detections.data["source_image"].dtype == np.uint8
+        assert detections.data["source_image"].shape == (48, 64, 3)
+
+    def test_tensor_with_negative_values_raises(self) -> None:
+        """Tensor with negative pixel values raises ValueError."""
+        tensor = torch.full((3, 48, 64), -0.1)
+        model = _DummyRFDETR()
+        with pytest.raises(ValueError, match="below 0"):
+            model.predict(tensor)
+
+    def test_source_image_batch(self) -> None:
+        """Batch predict stores a source_image per detection."""
+        img1 = PIL.Image.new("RGB", (64, 48), color=(100, 100, 100))
+        img2 = PIL.Image.new("RGB", (32, 24), color=(200, 200, 200))
+        model = _DummyRFDETR()
+        detections_list = model.predict([img1, img2])
+        assert isinstance(detections_list, list)
+        assert detections_list[0].data["source_image"].shape == (48, 64, 3)
+        assert detections_list[1].data["source_image"].shape == (24, 32, 3)
+        assert detections_list[0].data["source_shape"] == (48, 64)
+        assert detections_list[1].data["source_shape"] == (24, 32)
+
+
 class TestPredictShape:
     """Verify that ``predict(shape=...)`` controls the resize target.
 

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -18,7 +18,7 @@ import builtins
 import warnings
 from collections import defaultdict
 from types import SimpleNamespace
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -303,7 +303,7 @@ class TestRFDETRTrainPTL:
         assert not any(issubclass(x.category, DeprecationWarning) for x in w)
 
     def test_callbacks_all_empty_lists_no_warning(self, tmp_path):
-        """callbacks dict with all-empty lists produces no DeprecationWarning."""
+        """Callbacks dict with all-empty lists produces no DeprecationWarning."""
         mock_self = _make_rfdetr_self(tmp_path)
         callbacks = defaultdict(list)
         p_mod, p_dm, p_bt, *_ = _patch_lit()
@@ -313,7 +313,7 @@ class TestRFDETRTrainPTL:
         assert not any(issubclass(x.category, DeprecationWarning) for x in w)
 
     def test_callbacks_non_empty_emits_deprecation_warning(self, tmp_path):
-        """callbacks dict with a non-empty list emits DeprecationWarning."""
+        """Callbacks dict with a non-empty list emits DeprecationWarning."""
         mock_self = _make_rfdetr_self(tmp_path)
         callbacks = {"on_fit_epoch_end": [lambda: None]}
         p_mod, p_dm, p_bt, *_ = _patch_lit()
@@ -493,7 +493,7 @@ class TestRFDETRTrainPTLAbsorption:
             RFDETR.train(mock_self, callbacks={})  # must not raise
 
     def test_callbacks_non_empty_emits_deprecation_warning(self, tmp_path):
-        """callbacks with non-empty lists emits DeprecationWarning."""
+        """Callbacks with non-empty lists emits DeprecationWarning."""
         mock_self = _make_rfdetr_self(tmp_path)
         callbacks = {"on_fit_epoch_end": [lambda: None]}
         p_mod, p_dm, p_bt, *_ = _patch_lit()
@@ -553,7 +553,7 @@ def _make_legacy_pth(tmp_path, epoch=5, include_ema=False, args_value="namespace
         "layer.weight": torch.ones(2, 3),
         "layer.bias": torch.zeros(3),
     }
-    ckpt: Dict[str, Any] = {"model": state, "epoch": epoch}
+    ckpt: dict[str, Any] = {"model": state, "epoch": epoch}
 
     if args_value == "namespace":
         ns = argparse.Namespace(lr=1e-4, epochs=100)
@@ -725,7 +725,7 @@ class TestConvertLegacyCheckpoint:
             convert_legacy_checkpoint(path, dst)
 
     def test_args_primitive_type_falls_back_to_empty_dict(self, tmp_path):
-        """args of a non-dict, non-Namespace type (e.g. string) falls back to {} with a warning."""
+        """Args of a non-dict, non-Namespace type (e.g. string) falls back to {} with a warning."""
         path = str(tmp_path / "prim_args.pth")
         torch.save({"model": {"w": torch.zeros(1)}, "args": "legacy_string_value"}, path)
         dst = str(tmp_path / "out.ckpt")
@@ -811,7 +811,7 @@ class TestOnLoadCheckpoint:
     def test_empty_checkpoint_is_noop(self):
         """Completely empty checkpoint {} triggers no mutation and no error."""
         fake = _FakeModule()
-        ckpt: Dict[str, Any] = {}
+        ckpt: dict[str, Any] = {}
         RFDETRModelModule.on_load_checkpoint(fake, ckpt)  # must not raise
         assert ckpt == {}
         assert not hasattr(fake, "_pending_legacy_ema_state")
@@ -888,7 +888,7 @@ class TestPublicAPIExports:
         monkeypatch.delitem(rfdetr.__dict__, "RFDETRXLarge", raising=False)
 
         original_all = list(rfdetr.__all__)
-        assert getattr(rfdetr, "RFDETRXLarge") is sentinel
+        assert rfdetr.RFDETRXLarge is sentinel
         assert rfdetr.__all__ == original_all
 
     def test_existing_exports_still_present(self):
@@ -1092,3 +1092,203 @@ class TestClassNamesProperty:
 
         assert result == ["cat", "dog", "bird"]
         assert mock_self.model.class_names == ["cat", "dog"]
+
+
+# ---------------------------------------------------------------------------
+# 8. RFDETR.deploy_to_roboflow — class_names.txt and args.class_names
+# ---------------------------------------------------------------------------
+
+
+class TestDeployToRoboflow:
+    """deploy_to_roboflow writes class_names.txt and embeds class_names in args.
+
+    Regression tests for the bug where RFDETRSeg models (and any model whose
+    args namespace lacks a ``class_names`` attribute) failed to upload to
+    Roboflow with a FileNotFoundError from the Roboflow client library.
+    """
+
+    def _make_mock_self(self, class_names, size="rfdetr-small"):
+        """Return a minimal RFDETR-like mock suitable for deploy_to_roboflow."""
+        mock_self = MagicMock(spec=RFDETR)
+        mock_self.size = size
+        mock_self.class_names = class_names  # the property, resolved to a plain list
+        # `model` is an instance attribute (set in __init__), not a class attribute, so
+        # MagicMock(spec=RFDETR).__getattr__ would raise AttributeError for it.  Assign
+        # it directly via __setattr__ so sub-attribute chaining works correctly.
+        mock_self.model = MagicMock()
+        mock_self.model.model.state_dict.return_value = {}
+        mock_self.model.args = SimpleNamespace(num_classes=len(class_names))
+        return mock_self
+
+    def test_class_names_txt_written_with_correct_content(self, tmp_path, monkeypatch):
+        """deploy_to_roboflow must write class_names.txt with one name per line.
+
+        Regression: RFDETRSeg models were failing with FileNotFoundError from
+        the Roboflow client library because class_names.txt was absent.
+        """
+        monkeypatch.chdir(tmp_path)
+
+        class_names = ["cat", "dog", "bird"]
+        mock_self = self._make_mock_self(class_names)
+        mock_rf = MagicMock()
+
+        captured: dict = {}
+
+        def deploy_side_effect(model_type, model_path, filename, **kwargs):
+            # Inspect class_names.txt while the temp dir still exists (before cleanup).
+            f = (tmp_path / model_path / "class_names.txt").resolve()
+            if f.exists():
+                captured["content"] = f.read_text()
+
+        mock_rf.workspace.return_value.project.return_value.version.return_value.deploy.side_effect = deploy_side_effect
+
+        with patch("roboflow.Roboflow", return_value=mock_rf):
+            RFDETR.deploy_to_roboflow(
+                mock_self,
+                workspace="test-workspace",
+                project_id="test-project",
+                version=1,
+                api_key="dummy-key",
+            )
+
+        assert "content" in captured, "class_names.txt was not present in the upload directory during deploy"
+        assert captured["content"] == "cat\ndog\nbird"
+
+    def test_args_class_names_set_in_checkpoint(self, tmp_path, monkeypatch):
+        """The saved checkpoint args must contain class_names when args lacks it.
+
+        Regression: args.class_names was absent after switching to PTL training,
+        causing the Roboflow client library to raise FileNotFoundError.
+        """
+        monkeypatch.chdir(tmp_path)
+
+        class_names = ["cat", "dog"]
+        mock_self = self._make_mock_self(class_names)
+        # Ensure class_names is absent from args (mimics the regression scenario).
+        assert not hasattr(mock_self.model.args, "class_names")
+
+        saved_checkpoints: list = []
+
+        def capturing_save(obj, path, *args, **kwargs):
+            # Only capture the object; skip actual disk I/O for this unit test.
+            saved_checkpoints.append(obj)
+
+        mock_rf = MagicMock()
+        mock_rf.workspace.return_value.project.return_value.version.return_value.deploy.return_value = None
+
+        with patch("roboflow.Roboflow", return_value=mock_rf), patch("torch.save", side_effect=capturing_save):
+            RFDETR.deploy_to_roboflow(
+                mock_self,
+                workspace="test-workspace",
+                project_id="test-project",
+                version=1,
+                api_key="dummy-key",
+            )
+
+        assert saved_checkpoints, "torch.save must have been called"
+        checkpoint = saved_checkpoints[0]
+        assert "args" in checkpoint
+        saved_args = checkpoint["args"]
+        assert hasattr(saved_args, "class_names"), "class_names must be present in saved args"
+        assert saved_args.class_names == class_names
+
+    def test_args_class_names_set_when_none_in_checkpoint(self, tmp_path, monkeypatch):
+        """class_names must be set when args has the attribute but its value is None."""
+        monkeypatch.chdir(tmp_path)
+
+        class_names = ["cat", "dog"]
+        mock_self = self._make_mock_self(class_names)
+        # Simulate the case where args has class_names but it is explicitly None.
+        mock_self.model.args.class_names = None
+
+        saved_checkpoints: list = []
+
+        def capturing_save(obj, path, *args, **kwargs):
+            saved_checkpoints.append(obj)
+
+        mock_rf = MagicMock()
+        mock_rf.workspace.return_value.project.return_value.version.return_value.deploy.return_value = None
+
+        with patch("roboflow.Roboflow", return_value=mock_rf), patch("torch.save", side_effect=capturing_save):
+            RFDETR.deploy_to_roboflow(
+                mock_self,
+                workspace="test-workspace",
+                project_id="test-project",
+                version=1,
+                api_key="dummy-key",
+            )
+
+        assert saved_checkpoints, "torch.save must have been called"
+        saved_args = saved_checkpoints[0]["args"]
+        assert saved_args.class_names == class_names, "class_names must be populated when args.class_names is None"
+
+    def test_existing_args_class_names_not_overwritten(self, tmp_path, monkeypatch):
+        """If args already has class_names set, deploy_to_roboflow must not overwrite it."""
+        monkeypatch.chdir(tmp_path)
+
+        existing_names = ["existing_cat", "existing_dog"]
+        mock_self = self._make_mock_self(["cat", "dog"])
+        mock_self.model.args.class_names = existing_names
+
+        saved_checkpoints: list = []
+
+        def capturing_save(obj, path, *args, **kwargs):
+            saved_checkpoints.append(obj)
+
+        mock_rf = MagicMock()
+        mock_rf.workspace.return_value.project.return_value.version.return_value.deploy.return_value = None
+
+        with patch("roboflow.Roboflow", return_value=mock_rf), patch("torch.save", side_effect=capturing_save):
+            RFDETR.deploy_to_roboflow(
+                mock_self,
+                workspace="test-workspace",
+                project_id="test-project",
+                version=1,
+                api_key="dummy-key",
+            )
+
+        assert saved_checkpoints
+        saved_args = saved_checkpoints[0]["args"]
+        assert saved_args.class_names == existing_names, "existing args.class_names must not be overwritten"
+
+    def test_temp_dir_cleaned_up_after_deploy(self, tmp_path, monkeypatch):
+        """The temporary upload directory must be removed after a successful deploy."""
+        monkeypatch.chdir(tmp_path)
+
+        mock_self = self._make_mock_self(["cat"])
+        mock_rf = MagicMock()
+        mock_rf.workspace.return_value.project.return_value.version.return_value.deploy.return_value = None
+
+        with patch("roboflow.Roboflow", return_value=mock_rf):
+            RFDETR.deploy_to_roboflow(
+                mock_self,
+                workspace="test-workspace",
+                project_id="test-project",
+                version=1,
+                api_key="dummy-key",
+            )
+
+        assert not (tmp_path / ".roboflow_temp_upload").exists(), "Temp upload dir must be removed after deploy"
+
+    def test_temp_dir_cleaned_up_after_deploy_failure(self, tmp_path, monkeypatch):
+        """Temp upload dir must be removed even when deploy() raises an exception."""
+        monkeypatch.chdir(tmp_path)
+
+        mock_self = self._make_mock_self(["cat"])
+        mock_rf = MagicMock()
+        mock_rf.workspace.return_value.project.return_value.version.return_value.deploy.side_effect = RuntimeError(
+            "upload failed",
+        )
+
+        with patch("roboflow.Roboflow", return_value=mock_rf), pytest.raises(RuntimeError, match="upload failed"):
+            RFDETR.deploy_to_roboflow(
+                mock_self,
+                workspace="test-workspace",
+                project_id="test-project",
+                version=1,
+                api_key="dummy-key",
+            )
+
+        assert not (tmp_path / ".roboflow_temp_upload").exists(), (
+            "Temp upload dir must be removed even after a failed deploy"
+        )

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -26,6 +26,7 @@ import torch
 
 from rfdetr.config import RFDETRBaseConfig, TrainConfig
 from rfdetr.detr import RFDETR, RFDETRLarge
+from rfdetr.detr import logger as detr_logger
 from rfdetr.training.auto_batch import AutoBatchResult
 from rfdetr.training.checkpoint import convert_legacy_checkpoint
 from rfdetr.training.module_model import RFDETRModelModule
@@ -65,8 +66,9 @@ def _make_rfdetr_self(tmp_path, **train_overrides):
     return mock
 
 
-def _patch_lit():
-    """Context manager that patches all three rfdetr.training entry points."""
+@pytest.fixture
+def patch_lit():
+    """Provide patched rfdetr.training entry points for tests."""
     mock_module_cls = MagicMock(name="RFDETRModule_cls")
     mock_dm_cls = MagicMock(name="RFDETRDataModule_cls")
     mock_build_trainer = MagicMock(name="build_trainer")
@@ -89,20 +91,20 @@ def _patch_lit():
 class TestRFDETRTrainPTL:
     """RFDETR.train() delegates to PTL build_trainer().fit()."""
 
-    def test_build_trainer_called_with_config_and_model_config(self, tmp_path):
+    def test_build_trainer_called_with_config_and_model_config(self, tmp_path, patch_lit):
         """build_trainer receives (train_config, model_config) in the right order."""
         mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = _patch_lit()
+        p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = patch_lit
         with p_mod, p_dm, p_bt:
             RFDETR.train(mock_self)
 
         config = mock_self.get_train_config.return_value
         mock_bt.assert_called_once_with(config, mock_self.model_config, accelerator=None)
 
-    def test_trainer_fit_called_with_module_and_datamodule(self, tmp_path):
+    def test_trainer_fit_called_with_module_and_datamodule(self, tmp_path, patch_lit):
         """trainer.fit() is called with (module_instance, datamodule_instance)."""
         mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, mcls, dmcls, mock_bt = _patch_lit()
+        p_mod, p_dm, p_bt, mcls, dmcls, mock_bt = patch_lit
         with p_mod, p_dm, p_bt:
             RFDETR.train(mock_self)
 
@@ -111,27 +113,27 @@ class TestRFDETRTrainPTL:
         assert fit_args[0][0] is mcls.return_value  # module instance
         assert fit_args[0][1] is dmcls.return_value  # datamodule instance
 
-    def test_ckpt_path_none_when_resume_not_set(self, tmp_path):
+    def test_ckpt_path_none_when_resume_not_set(self, tmp_path, patch_lit):
         """trainer.fit receives ckpt_path=None when config.resume is None."""
         mock_self = _make_rfdetr_self(tmp_path)  # resume defaults to None
-        p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = _patch_lit()
+        p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = patch_lit
         with p_mod, p_dm, p_bt:
             RFDETR.train(mock_self)
 
         trainer = mock_bt.return_value
         trainer.fit.assert_called_once_with(_mcls.return_value, _dmcls.return_value, ckpt_path=None)
 
-    def test_ckpt_path_forwarded_when_resume_set(self, tmp_path):
+    def test_ckpt_path_forwarded_when_resume_set(self, tmp_path, patch_lit):
         """trainer.fit receives ckpt_path when config.resume is a path string."""
         mock_self = _make_rfdetr_self(tmp_path, resume="/some/checkpoint.ckpt")
-        p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = _patch_lit()
+        p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = patch_lit
         with p_mod, p_dm, p_bt:
             RFDETR.train(mock_self)
 
         trainer = mock_bt.return_value
         trainer.fit.assert_called_once_with(_mcls.return_value, _dmcls.return_value, ckpt_path="/some/checkpoint.ckpt")
 
-    def test_ckpt_path_none_when_resume_is_empty_string(self, tmp_path):
+    def test_ckpt_path_none_when_resume_is_empty_string(self, tmp_path, patch_lit):
         """config.resume='' is coerced to ckpt_path=None via `resume or None`."""
         mock_self = _make_rfdetr_self(tmp_path)
         # Create a real TrainConfig-like object where resume is ""
@@ -140,7 +142,7 @@ class TestRFDETRTrainPTL:
         mock_config.batch_size = 4  # int so auto-batch branch is not taken
         mock_self.get_train_config.return_value = mock_config
 
-        p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = _patch_lit()
+        p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = patch_lit
         with p_mod, p_dm, p_bt:
             RFDETR.train(mock_self)
 
@@ -148,10 +150,10 @@ class TestRFDETRTrainPTL:
         _, fit_kwargs = trainer.fit.call_args
         assert fit_kwargs["ckpt_path"] is None
 
-    def test_model_model_synced_back_by_identity(self, tmp_path):
+    def test_model_model_synced_back_by_identity(self, tmp_path, patch_lit):
         """self.model.model is reassigned to module.model (identity, not copy)."""
         mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, mcls, _dmcls, mock_bt = _patch_lit()
+        p_mod, p_dm, p_bt, mcls, _dmcls, mock_bt = patch_lit
         sentinel_nn_module = object()
         mcls.return_value.model = sentinel_nn_module
 
@@ -160,15 +162,15 @@ class TestRFDETRTrainPTL:
 
         assert mock_self.model.model is sentinel_nn_module
 
-    def test_returns_none(self, tmp_path):
+    def test_returns_none(self, tmp_path, patch_lit):
         """RFDETR.train() has no return value."""
         mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, *_ = _patch_lit()
+        p_mod, p_dm, p_bt, *_ = patch_lit
         with p_mod, p_dm, p_bt:
             result = RFDETR.train(mock_self)
         assert result is None
 
-    def test_missing_training_extra_raises_install_hint(self, tmp_path, monkeypatch):
+    def test_missing_training_extra_raises_install_hint(self, tmp_path, monkeypatch, patch_lit):
         """Missing training dependencies should raise ImportError with extras install hint."""
         mock_self = _make_rfdetr_self(tmp_path)
         real_import = builtins.__import__
@@ -189,7 +191,7 @@ class TestRFDETRTrainPTL:
         ["rfdetr.training", "rfdetr.training.auto_batch"],
         ids=["training-package", "training-submodule"],
     )
-    def test_internal_training_module_import_error_preserved(self, tmp_path, monkeypatch, missing_name):
+    def test_internal_training_module_import_error_preserved(self, tmp_path, monkeypatch, missing_name, patch_lit):
         """Missing internal training modules should keep original ModuleNotFoundError."""
         mock_self = _make_rfdetr_self(tmp_path)
         real_import = builtins.__import__
@@ -204,7 +206,7 @@ class TestRFDETRTrainPTL:
         with pytest.raises(ModuleNotFoundError, match=missing_name.replace(".", r"\.")):
             RFDETR.train(mock_self)
 
-    def test_class_names_synced_from_datamodule_after_training(self, tmp_path):
+    def test_class_names_synced_from_datamodule_after_training(self, tmp_path, patch_lit):
         """self.model.class_names is set from RFDETRDataModule.class_names after train().
 
         Regression test for #509: custom class names were not synced back from
@@ -212,7 +214,7 @@ class TestRFDETRTrainPTL:
         instead of the dataset's class labels.
         """
         mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, _mcls, dmcls, _mock_bt = _patch_lit()
+        p_mod, p_dm, p_bt, _mcls, dmcls, _mock_bt = patch_lit
         custom_class_names = ["cat", "dog", "bird"]
         dmcls.return_value.class_names = custom_class_names
 
@@ -221,7 +223,7 @@ class TestRFDETRTrainPTL:
 
         assert mock_self.model.class_names == custom_class_names
 
-    def test_class_names_not_synced_when_datamodule_returns_none(self, tmp_path):
+    def test_class_names_not_synced_when_datamodule_returns_none(self, tmp_path, patch_lit):
         """self.model.class_names is NOT overwritten when datamodule.class_names is None.
 
         Ensures the sync-back guard does not clobber existing class names
@@ -230,7 +232,7 @@ class TestRFDETRTrainPTL:
         mock_self = _make_rfdetr_self(tmp_path)
         sentinel_names = ["existing_class"]
         mock_self.model.class_names = sentinel_names
-        p_mod, p_dm, p_bt, _mcls, dmcls, _mock_bt = _patch_lit()
+        p_mod, p_dm, p_bt, _mcls, dmcls, _mock_bt = patch_lit
         dmcls.return_value.class_names = None  # datamodule has no class names
 
         with p_mod, p_dm, p_bt:
@@ -238,7 +240,7 @@ class TestRFDETRTrainPTL:
 
         assert mock_self.model.class_names == sentinel_names
 
-    def test_empty_class_names_synced_from_datamodule_after_training(self, tmp_path):
+    def test_empty_class_names_synced_from_datamodule_after_training(self, tmp_path, patch_lit):
         """Empty class name lists are synced and overwrite stale model labels.
 
         Empty list is a valid explicit value and should not be treated as missing.
@@ -246,7 +248,7 @@ class TestRFDETRTrainPTL:
         mock_self = _make_rfdetr_self(tmp_path)
         sentinel_names = ["stale_label"]
         mock_self.model.class_names = sentinel_names
-        p_mod, p_dm, p_bt, _mcls, dmcls, _mock_bt = _patch_lit()
+        p_mod, p_dm, p_bt, _mcls, dmcls, _mock_bt = patch_lit
         dmcls.return_value.class_names = []
 
         with p_mod, p_dm, p_bt:
@@ -254,69 +256,69 @@ class TestRFDETRTrainPTL:
 
         assert mock_self.model.class_names == []
 
-    def test_device_kwarg_cpu_no_warning(self, tmp_path):
+    def test_device_kwarg_cpu_no_warning(self, tmp_path, patch_lit):
         """device='cpu' is consumed without a DeprecationWarning."""
         mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, *_ = _patch_lit()
+        p_mod, p_dm, p_bt, *_ = patch_lit
         with p_mod, p_dm, p_bt, warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             RFDETR.train(mock_self, device="cpu")
         assert not any(issubclass(x.category, DeprecationWarning) for x in w)
         mock_self.get_train_config.assert_called_once_with()
 
-    def test_device_kwarg_cuda_forwards_gpu_accelerator_without_devices(self, tmp_path):
+    def test_device_kwarg_cuda_forwards_gpu_accelerator_without_devices(self, tmp_path, patch_lit):
         """device='cuda' is mapped to accelerator='gpu' without explicit devices override."""
         mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, *_ = _patch_lit()
+        p_mod, p_dm, p_bt, *_ = patch_lit
         with p_mod, p_dm, p_bt, warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             RFDETR.train(mock_self, device="cuda")
         assert not any(issubclass(x.category, DeprecationWarning) for x in w)
         mock_self.get_train_config.assert_called_once_with()
 
-    def test_device_kwarg_torch_device_cuda_index_forwards_gpu_accelerator_and_devices(self, tmp_path):
+    def test_device_kwarg_torch_device_cuda_index_forwards_gpu_accelerator_and_devices(self, tmp_path, patch_lit):
         """torch.device('cuda:1') is mapped to accelerator='gpu' and devices=[1]."""
         mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, *_ = _patch_lit()
+        p_mod, p_dm, p_bt, *_ = patch_lit
         with p_mod, p_dm, p_bt, warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             RFDETR.train(mock_self, device=torch.device("cuda:1"))
         assert not any(issubclass(x.category, DeprecationWarning) for x in w)
         mock_self.get_train_config.assert_called_once_with()
 
-    def test_callbacks_none_no_warning(self, tmp_path):
+    def test_callbacks_none_no_warning(self, tmp_path, patch_lit):
         """callbacks=None produces no DeprecationWarning."""
         mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, *_ = _patch_lit()
+        p_mod, p_dm, p_bt, *_ = patch_lit
         with p_mod, p_dm, p_bt, warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             RFDETR.train(mock_self, callbacks=None)
         assert not any(issubclass(x.category, DeprecationWarning) for x in w)
 
-    def test_callbacks_empty_dict_no_warning(self, tmp_path):
+    def test_callbacks_empty_dict_no_warning(self, tmp_path, patch_lit):
         """callbacks={} (falsy dict) produces no DeprecationWarning."""
         mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, *_ = _patch_lit()
+        p_mod, p_dm, p_bt, *_ = patch_lit
         with p_mod, p_dm, p_bt, warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             RFDETR.train(mock_self, callbacks={})
         assert not any(issubclass(x.category, DeprecationWarning) for x in w)
 
-    def test_callbacks_all_empty_lists_no_warning(self, tmp_path):
+    def test_callbacks_all_empty_lists_no_warning(self, tmp_path, patch_lit):
         """Callbacks dict with all-empty lists produces no DeprecationWarning."""
         mock_self = _make_rfdetr_self(tmp_path)
         callbacks = defaultdict(list)
-        p_mod, p_dm, p_bt, *_ = _patch_lit()
+        p_mod, p_dm, p_bt, *_ = patch_lit
         with p_mod, p_dm, p_bt, warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             RFDETR.train(mock_self, callbacks=callbacks)
         assert not any(issubclass(x.category, DeprecationWarning) for x in w)
 
-    def test_callbacks_non_empty_emits_deprecation_warning(self, tmp_path):
+    def test_callbacks_non_empty_emits_deprecation_warning(self, tmp_path, patch_lit):
         """Callbacks dict with a non-empty list emits DeprecationWarning."""
         mock_self = _make_rfdetr_self(tmp_path)
         callbacks = {"on_fit_epoch_end": [lambda: None]}
-        p_mod, p_dm, p_bt, *_ = _patch_lit()
+        p_mod, p_dm, p_bt, *_ = patch_lit
         with p_mod, p_dm, p_bt, warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             RFDETR.train(mock_self, callbacks=callbacks)
@@ -324,30 +326,30 @@ class TestRFDETRTrainPTL:
         assert len(depr) >= 1
         assert "PTL" in str(depr[0].message)
 
-    def test_callbacks_mixed_emits_deprecation_warning(self, tmp_path):
+    def test_callbacks_mixed_emits_deprecation_warning(self, tmp_path, patch_lit):
         """Mixed callbacks (some empty, some non-empty) triggers DeprecationWarning."""
         mock_self = _make_rfdetr_self(tmp_path)
         callbacks = {"on_fit_epoch_end": [], "on_train_end": [lambda: None]}
-        p_mod, p_dm, p_bt, *_ = _patch_lit()
+        p_mod, p_dm, p_bt, *_ = patch_lit
         with p_mod, p_dm, p_bt, warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             RFDETR.train(mock_self, callbacks=callbacks)
         assert any(issubclass(x.category, DeprecationWarning) for x in w)
 
-    def test_do_benchmark_false_no_warning(self, tmp_path):
+    def test_do_benchmark_false_no_warning(self, tmp_path, patch_lit):
         """do_benchmark=False (default) emits no DeprecationWarning."""
         mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, *_ = _patch_lit()
+        p_mod, p_dm, p_bt, *_ = patch_lit
         with p_mod, p_dm, p_bt, warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             RFDETR.train(mock_self, do_benchmark=False)
         assert not any(issubclass(x.category, DeprecationWarning) for x in w)
 
     @pytest.mark.parametrize("truthy_value", [True, 1, "yes"], ids=["bool_true", "int_1", "str_yes"])
-    def test_do_benchmark_truthy_emits_deprecation_warning(self, tmp_path, truthy_value):
+    def test_do_benchmark_truthy_emits_deprecation_warning(self, tmp_path, truthy_value, patch_lit):
         """Any truthy do_benchmark value emits DeprecationWarning."""
         mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, *_ = _patch_lit()
+        p_mod, p_dm, p_bt, *_ = patch_lit
         with p_mod, p_dm, p_bt, warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             RFDETR.train(mock_self, do_benchmark=truthy_value)
@@ -355,25 +357,25 @@ class TestRFDETRTrainPTL:
         assert len(depr) >= 1
         assert "rfdetr benchmark" in str(depr[0].message)
 
-    def test_do_benchmark_not_forwarded_to_get_train_config(self, tmp_path):
+    def test_do_benchmark_not_forwarded_to_get_train_config(self, tmp_path, patch_lit):
         """do_benchmark is popped before calling get_train_config."""
         mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, *_ = _patch_lit()
+        p_mod, p_dm, p_bt, *_ = patch_lit
         with p_mod, p_dm, p_bt, warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
             RFDETR.train(mock_self, do_benchmark=True)
         mock_self.get_train_config.assert_called_once_with()
 
-    def test_device_not_forwarded_to_get_train_config(self, tmp_path):
+    def test_device_not_forwarded_to_get_train_config(self, tmp_path, patch_lit):
         """device= is popped and not passed on to get_train_config."""
         mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, *_ = _patch_lit()
+        p_mod, p_dm, p_bt, *_ = patch_lit
         with p_mod, p_dm, p_bt:
             RFDETR.train(mock_self, device="cpu")
         # get_train_config must have been called without device=
         assert "device" not in mock_self.get_train_config.call_args.kwargs
 
-    def test_batch_size_auto_resolved_before_module_and_datamodule_build(self, tmp_path):
+    def test_batch_size_auto_resolved_before_module_and_datamodule_build(self, tmp_path, patch_lit):
         """batch_size='auto' is resolved to ints before module/datamodule init."""
         mock_self = _make_rfdetr_self(tmp_path, batch_size="auto", grad_accum_steps=99)
         auto_result = AutoBatchResult(
@@ -382,7 +384,7 @@ class TestRFDETRTrainPTL:
             effective_batch_size=18,
             device_name="Fake GPU",
         )
-        p_mod, p_dm, p_bt, mcls, dmcls, _mock_bt = _patch_lit()
+        p_mod, p_dm, p_bt, mcls, dmcls, _mock_bt = patch_lit
         with p_mod, p_dm, p_bt, patch("rfdetr.training.auto_batch.resolve_auto_batch_config", return_value=auto_result):
             RFDETR.train(mock_self)
 
@@ -392,7 +394,7 @@ class TestRFDETRTrainPTL:
         mcls.assert_called_once_with(mock_self.model_config, config)
         dmcls.assert_called_once_with(mock_self.model_config, config)
 
-    def test_batch_size_auto_calls_resolver_with_expected_context(self, tmp_path):
+    def test_batch_size_auto_calls_resolver_with_expected_context(self, tmp_path, patch_lit):
         """Auto-batch resolver receives model context, model config, and train config."""
         mock_self = _make_rfdetr_self(tmp_path, batch_size="auto")
         auto_result = AutoBatchResult(
@@ -401,7 +403,7 @@ class TestRFDETRTrainPTL:
             effective_batch_size=16,
             device_name="Fake GPU",
         )
-        p_mod, p_dm, p_bt, *_ = _patch_lit()
+        p_mod, p_dm, p_bt, *_ = patch_lit
         with (
             p_mod,
             p_dm,
@@ -426,47 +428,47 @@ class TestRFDETRTrainPTL:
 class TestRFDETRTrainPTLAbsorption:
     """RFDETR.train() absorbs legacy kwargs and routes through PTL build_trainer()."""
 
-    def test_device_cpu_absorbed_as_accelerator_cpu(self, tmp_path):
+    def test_device_cpu_absorbed_as_accelerator_cpu(self, tmp_path, patch_lit):
         """device='cpu' is absorbed and forwarded to build_trainer as accelerator='cpu'."""
         mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = _patch_lit()
+        p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = patch_lit
         with p_mod, p_dm, p_bt:
             RFDETR.train(mock_self, device="cpu")
         config = mock_self.get_train_config.return_value
         mock_bt.assert_called_once_with(config, mock_self.model_config, accelerator="cpu")
 
-    def test_device_cuda_absorbed_as_accelerator_gpu(self, tmp_path):
+    def test_device_cuda_absorbed_as_accelerator_gpu(self, tmp_path, patch_lit):
         """device='cuda' forwards accelerator='gpu' without a devices kwarg."""
         mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = _patch_lit()
+        p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = patch_lit
         with p_mod, p_dm, p_bt:
             RFDETR.train(mock_self, device="cuda")
         config = mock_self.get_train_config.return_value
         mock_bt.assert_called_once_with(config, mock_self.model_config, accelerator="gpu")
         assert "devices" not in mock_bt.call_args.kwargs
 
-    def test_device_cuda_index_absorbed_as_accelerator_gpu_devices_list(self, tmp_path):
+    def test_device_cuda_index_absorbed_as_accelerator_gpu_devices_list(self, tmp_path, patch_lit):
         """device='cuda:1' forwards accelerator='gpu' and devices=[1]."""
         mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = _patch_lit()
+        p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = patch_lit
         with p_mod, p_dm, p_bt:
             RFDETR.train(mock_self, device="cuda:1")
         config = mock_self.get_train_config.return_value
         mock_bt.assert_called_once_with(config, mock_self.model_config, accelerator="gpu", devices=[1])
 
-    def test_device_torch_device_cuda_index_absorbed_as_accelerator_gpu_devices_list(self, tmp_path):
+    def test_device_torch_device_cuda_index_absorbed_as_accelerator_gpu_devices_list(self, tmp_path, patch_lit):
         """device=torch.device('cuda:2') forwards accelerator='gpu' and devices=[2]."""
         mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = _patch_lit()
+        p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = patch_lit
         with p_mod, p_dm, p_bt:
             RFDETR.train(mock_self, device=torch.device("cuda:2"))
         config = mock_self.get_train_config.return_value
         mock_bt.assert_called_once_with(config, mock_self.model_config, accelerator="gpu", devices=[2])
 
-    def test_device_invalid_raises_value_error_with_expected_message(self, tmp_path):
+    def test_device_invalid_raises_value_error_with_expected_message(self, tmp_path, patch_lit):
         """Invalid device strings raise a ValueError with the train() device hint."""
         mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, *_ = _patch_lit()
+        p_mod, p_dm, p_bt, *_ = patch_lit
         with (
             p_mod,
             p_dm,
@@ -475,38 +477,38 @@ class TestRFDETRTrainPTLAbsorption:
         ):
             RFDETR.train(mock_self, device="notadevice")
 
-    def test_device_unmapped_valid_type_warns_and_falls_back_to_auto_detection(self, tmp_path):
+    def test_device_unmapped_valid_type_warns_and_falls_back_to_auto_detection(self, tmp_path, patch_lit):
         """Valid but unmapped torch device types warn and use PTL auto-detection."""
         mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = _patch_lit()
+        p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = patch_lit
         with p_mod, p_dm, p_bt, pytest.warns(UserWarning, match="auto-detection"):
             RFDETR.train(mock_self, device="meta")
         config = mock_self.get_train_config.return_value
         mock_bt.assert_called_once_with(config, mock_self.model_config, accelerator=None)
         assert "devices" not in mock_bt.call_args.kwargs
 
-    def test_callbacks_empty_dict_no_error(self, tmp_path):
+    def test_callbacks_empty_dict_no_error(self, tmp_path, patch_lit):
         """callbacks={} is accepted without error."""
         mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, *_ = _patch_lit()
+        p_mod, p_dm, p_bt, *_ = patch_lit
         with p_mod, p_dm, p_bt:
             RFDETR.train(mock_self, callbacks={})  # must not raise
 
-    def test_callbacks_non_empty_emits_deprecation_warning(self, tmp_path):
+    def test_callbacks_non_empty_emits_deprecation_warning(self, tmp_path, patch_lit):
         """Callbacks with non-empty lists emits DeprecationWarning."""
         mock_self = _make_rfdetr_self(tmp_path)
         callbacks = {"on_fit_epoch_end": [lambda: None]}
-        p_mod, p_dm, p_bt, *_ = _patch_lit()
+        p_mod, p_dm, p_bt, *_ = patch_lit
         with p_mod, p_dm, p_bt, warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             RFDETR.train(mock_self, callbacks=callbacks)
         depr = [x for x in w if issubclass(x.category, DeprecationWarning)]
         assert len(depr) >= 1
 
-    def test_start_epoch_emits_deprecation_warning(self, tmp_path):
+    def test_start_epoch_emits_deprecation_warning(self, tmp_path, patch_lit):
         """start_epoch=1 emits DeprecationWarning and is dropped."""
         mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, *_ = _patch_lit()
+        p_mod, p_dm, p_bt, *_ = patch_lit
         with p_mod, p_dm, p_bt, warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             RFDETR.train(mock_self, start_epoch=1)
@@ -515,20 +517,20 @@ class TestRFDETRTrainPTLAbsorption:
         # start_epoch must not reach get_train_config
         assert "start_epoch" not in mock_self.get_train_config.call_args.kwargs
 
-    def test_do_benchmark_true_emits_deprecation_warning(self, tmp_path):
+    def test_do_benchmark_true_emits_deprecation_warning(self, tmp_path, patch_lit):
         """do_benchmark=True emits DeprecationWarning."""
         mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, *_ = _patch_lit()
+        p_mod, p_dm, p_bt, *_ = patch_lit
         with p_mod, p_dm, p_bt, warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             RFDETR.train(mock_self, do_benchmark=True)
         depr = [x for x in w if issubclass(x.category, DeprecationWarning)]
         assert any("do_benchmark" in str(d.message) or "rfdetr benchmark" in str(d.message) for d in depr)
 
-    def test_returns_none(self, tmp_path):
+    def test_returns_none(self, tmp_path, patch_lit):
         """RFDETR.train() returns None."""
         mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, *_ = _patch_lit()
+        p_mod, p_dm, p_bt, *_ = patch_lit
         with p_mod, p_dm, p_bt:
             result = RFDETR.train(mock_self)
         assert result is None
@@ -577,7 +579,7 @@ def _make_legacy_pth(tmp_path, epoch=5, include_ema=False, args_value="namespace
 class TestConvertLegacyCheckpoint:
     """convert_legacy_checkpoint() produces a valid PTL .ckpt file."""
 
-    def test_state_dict_keys_prefixed_with_model(self, tmp_path):
+    def test_state_dict_keys_prefixed_with_model(self, tmp_path, patch_lit):
         """All state_dict keys must be prefixed with 'model.'."""
         src = _make_legacy_pth(tmp_path)
         dst = str(tmp_path / "out.ckpt")
@@ -585,7 +587,7 @@ class TestConvertLegacyCheckpoint:
         ckpt = torch.load(dst, map_location="cpu", weights_only=False)
         assert all(k.startswith("model.") for k in ckpt["state_dict"])
 
-    def test_state_dict_keys_dot_containing_names_prefixed_once(self, tmp_path):
+    def test_state_dict_keys_dot_containing_names_prefixed_once(self, tmp_path, patch_lit):
         """Keys already containing dots are prefixed exactly once."""
         path = str(tmp_path / "dot_keys.pth")
         torch.save({"model": {"backbone.layer.weight": torch.zeros(1)}, "epoch": 0}, path)
@@ -595,7 +597,7 @@ class TestConvertLegacyCheckpoint:
         assert "model.backbone.layer.weight" in ckpt["state_dict"]
         assert "model.model.backbone.layer.weight" not in ckpt["state_dict"]
 
-    def test_epoch_preserved(self, tmp_path):
+    def test_epoch_preserved(self, tmp_path, patch_lit):
         """Epoch value is copied from the source checkpoint."""
         src = _make_legacy_pth(tmp_path, epoch=42)
         dst = str(tmp_path / "out.ckpt")
@@ -603,7 +605,7 @@ class TestConvertLegacyCheckpoint:
         ckpt = torch.load(dst, map_location="cpu", weights_only=False)
         assert ckpt["epoch"] == 42
 
-    def test_epoch_defaults_to_zero_when_missing(self, tmp_path):
+    def test_epoch_defaults_to_zero_when_missing(self, tmp_path, patch_lit):
         """Missing epoch key in source defaults to 0."""
         path = str(tmp_path / "no_epoch.pth")
         torch.save({"model": {"w": torch.zeros(1)}}, path)
@@ -612,7 +614,7 @@ class TestConvertLegacyCheckpoint:
         ckpt = torch.load(dst, map_location="cpu", weights_only=False)
         assert ckpt["epoch"] == 0
 
-    def test_global_step_always_zero(self, tmp_path):
+    def test_global_step_always_zero(self, tmp_path, patch_lit):
         """global_step is always written as 0."""
         src = _make_legacy_pth(tmp_path)
         dst = str(tmp_path / "out.ckpt")
@@ -620,7 +622,7 @@ class TestConvertLegacyCheckpoint:
         ckpt = torch.load(dst, map_location="cpu", weights_only=False)
         assert ckpt["global_step"] == 0
 
-    def test_legacy_checkpoint_format_flag_set(self, tmp_path):
+    def test_legacy_checkpoint_format_flag_set(self, tmp_path, patch_lit):
         """legacy_checkpoint_format is always True in output."""
         src = _make_legacy_pth(tmp_path)
         dst = str(tmp_path / "out.ckpt")
@@ -628,7 +630,7 @@ class TestConvertLegacyCheckpoint:
         ckpt = torch.load(dst, map_location="cpu", weights_only=False)
         assert ckpt["legacy_checkpoint_format"] is True
 
-    def test_args_as_namespace_converted_to_dict(self, tmp_path):
+    def test_args_as_namespace_converted_to_dict(self, tmp_path, patch_lit):
         """argparse.Namespace args are converted to a plain dict via vars()."""
         src = _make_legacy_pth(tmp_path, args_value="namespace")
         dst = str(tmp_path / "out.ckpt")
@@ -637,7 +639,7 @@ class TestConvertLegacyCheckpoint:
         assert isinstance(ckpt["hyper_parameters"], dict)
         assert ckpt["hyper_parameters"]["lr"] == pytest.approx(1e-4)
 
-    def test_args_as_dict_kept_as_dict(self, tmp_path):
+    def test_args_as_dict_kept_as_dict(self, tmp_path, patch_lit):
         """Plain dict args is preserved as-is."""
         src = _make_legacy_pth(tmp_path, args_value="dict")
         dst = str(tmp_path / "out.ckpt")
@@ -645,7 +647,7 @@ class TestConvertLegacyCheckpoint:
         ckpt = torch.load(dst, map_location="cpu", weights_only=False)
         assert ckpt["hyper_parameters"] == {"lr": pytest.approx(1e-4), "epochs": 100}
 
-    def test_args_none_gives_empty_hyper_parameters(self, tmp_path):
+    def test_args_none_gives_empty_hyper_parameters(self, tmp_path, patch_lit):
         """args=None produces an empty hyper_parameters dict."""
         src = _make_legacy_pth(tmp_path, args_value=None)
         dst = str(tmp_path / "out.ckpt")
@@ -653,7 +655,7 @@ class TestConvertLegacyCheckpoint:
         ckpt = torch.load(dst, map_location="cpu", weights_only=False)
         assert ckpt["hyper_parameters"] == {}
 
-    def test_args_missing_key_gives_empty_hyper_parameters(self, tmp_path):
+    def test_args_missing_key_gives_empty_hyper_parameters(self, tmp_path, patch_lit):
         """No 'args' key at all also produces empty hyper_parameters."""
         src = _make_legacy_pth(tmp_path, args_value="missing")
         dst = str(tmp_path / "out.ckpt")
@@ -661,7 +663,7 @@ class TestConvertLegacyCheckpoint:
         ckpt = torch.load(dst, map_location="cpu", weights_only=False)
         assert ckpt["hyper_parameters"] == {}
 
-    def test_args_custom_object_with_dict_converted_via_vars(self, tmp_path):
+    def test_args_custom_object_with_dict_converted_via_vars(self, tmp_path, patch_lit):
         """A custom object with __dict__ is converted via vars()."""
         opts = _CustomArgs()
         opts.lr = 2e-4
@@ -674,7 +676,7 @@ class TestConvertLegacyCheckpoint:
         ckpt = torch.load(dst, map_location="cpu", weights_only=False)
         assert ckpt["hyper_parameters"]["lr"] == pytest.approx(2e-4)
 
-    def test_ema_model_preserved_as_legacy_ema_state_dict(self, tmp_path):
+    def test_ema_model_preserved_as_legacy_ema_state_dict(self, tmp_path, patch_lit):
         """ema_model present in source is written as legacy_ema_state_dict."""
         src = _make_legacy_pth(tmp_path, include_ema=True)
         dst = str(tmp_path / "out.ckpt")
@@ -683,7 +685,7 @@ class TestConvertLegacyCheckpoint:
         assert "legacy_ema_state_dict" in ckpt
         assert "layer.weight" in ckpt["legacy_ema_state_dict"]
 
-    def test_no_ema_model_no_legacy_ema_state_dict(self, tmp_path):
+    def test_no_ema_model_no_legacy_ema_state_dict(self, tmp_path, patch_lit):
         """No ema_model in source means legacy_ema_state_dict is absent."""
         src = _make_legacy_pth(tmp_path, include_ema=False)
         dst = str(tmp_path / "out.ckpt")
@@ -691,7 +693,7 @@ class TestConvertLegacyCheckpoint:
         ckpt = torch.load(dst, map_location="cpu", weights_only=False)
         assert "legacy_ema_state_dict" not in ckpt
 
-    def test_round_trip_with_on_load_checkpoint(self, tmp_path):
+    def test_round_trip_with_on_load_checkpoint(self, tmp_path, patch_lit):
         """convert_legacy_checkpoint output is handled correctly by on_load_checkpoint.
 
         After conversion, loading the .ckpt via on_load_checkpoint must NOT
@@ -715,7 +717,7 @@ class TestConvertLegacyCheckpoint:
         # EMA stashed
         assert hasattr(fake, "_pending_legacy_ema_state")
 
-    def test_missing_model_key_raises_value_error(self, tmp_path):
+    def test_missing_model_key_raises_value_error(self, tmp_path, patch_lit):
         """Source file with no 'model' key raises ValueError with a clear message."""
         path = str(tmp_path / "no_model.pth")
         torch.save({"epoch": 5}, path)
@@ -724,7 +726,7 @@ class TestConvertLegacyCheckpoint:
         with pytest.raises(ValueError, match="'model' key"):
             convert_legacy_checkpoint(path, dst)
 
-    def test_args_primitive_type_falls_back_to_empty_dict(self, tmp_path):
+    def test_args_primitive_type_falls_back_to_empty_dict(self, tmp_path, patch_lit):
         """Args of a non-dict, non-Namespace type (e.g. string) falls back to {} with a warning."""
         path = str(tmp_path / "prim_args.pth")
         torch.save({"model": {"w": torch.zeros(1)}, "args": "legacy_string_value"}, path)
@@ -747,7 +749,7 @@ class _FakeModule:
 class TestOnLoadCheckpoint:
     """RFDETRModule.on_load_checkpoint auto-detects legacy formats."""
 
-    def test_raw_pth_writes_state_dict_with_prefix(self):
+    def test_raw_pth_writes_state_dict_with_prefix(self, patch_lit):
         """'model' key without 'state_dict' → state_dict written with 'model.' prefix."""
         fake = _FakeModule()
         ckpt = {"model": {"backbone.weight": torch.zeros(2)}}
@@ -755,21 +757,21 @@ class TestOnLoadCheckpoint:
         assert "state_dict" in ckpt
         assert "model.backbone.weight" in ckpt["state_dict"]
 
-    def test_raw_pth_original_model_key_preserved(self):
+    def test_raw_pth_original_model_key_preserved(self, patch_lit):
         """Original 'model' key is not deleted after state_dict is written."""
         fake = _FakeModule()
         ckpt = {"model": {"w": torch.zeros(1)}}
         RFDETRModelModule.on_load_checkpoint(fake, ckpt)
         assert "model" in ckpt  # PTL may inspect it; must not be deleted
 
-    def test_empty_model_dict_produces_empty_state_dict(self):
+    def test_empty_model_dict_produces_empty_state_dict(self, patch_lit):
         """Empty 'model' dict without 'state_dict' → empty state_dict written."""
         fake = _FakeModule()
         ckpt = {"model": {}}
         RFDETRModelModule.on_load_checkpoint(fake, ckpt)
         assert ckpt["state_dict"] == {}
 
-    def test_native_ptl_format_no_op(self):
+    def test_native_ptl_format_no_op(self, patch_lit):
         """Native PTL checkpoint (has 'state_dict', no 'model') → no mutation."""
         fake = _FakeModule()
         sentinel = {"model.layer.weight": torch.zeros(1)}
@@ -778,7 +780,7 @@ class TestOnLoadCheckpoint:
         assert ckpt["state_dict"] is sentinel  # not replaced
         assert not hasattr(fake, "_pending_legacy_ema_state")
 
-    def test_both_model_and_state_dict_present_state_dict_not_overwritten(self):
+    def test_both_model_and_state_dict_present_state_dict_not_overwritten(self, patch_lit):
         """'state_dict' is NOT overwritten when both 'model' and 'state_dict' exist."""
         fake = _FakeModule()
         existing_sd = {"model.existing": torch.zeros(1)}
@@ -790,7 +792,7 @@ class TestOnLoadCheckpoint:
         assert ckpt["state_dict"] is existing_sd
         assert "model.new_key" not in ckpt["state_dict"]
 
-    def test_legacy_ema_state_dict_stashed(self):
+    def test_legacy_ema_state_dict_stashed(self, patch_lit):
         """'legacy_ema_state_dict' in checkpoint → stashed on _pending_legacy_ema_state."""
         fake = _FakeModule()
         ema_weights = {"layer.weight": torch.ones(2)}
@@ -801,14 +803,14 @@ class TestOnLoadCheckpoint:
         RFDETRModelModule.on_load_checkpoint(fake, ckpt)
         assert fake._pending_legacy_ema_state is ema_weights
 
-    def test_no_legacy_ema_attribute_not_set(self):
+    def test_no_legacy_ema_attribute_not_set(self, patch_lit):
         """No 'legacy_ema_state_dict' → _pending_legacy_ema_state not set on module."""
         fake = _FakeModule()
         ckpt = {"state_dict": {"model.w": torch.zeros(1)}}
         RFDETRModelModule.on_load_checkpoint(fake, ckpt)
         assert not hasattr(fake, "_pending_legacy_ema_state")
 
-    def test_empty_checkpoint_is_noop(self):
+    def test_empty_checkpoint_is_noop(self, patch_lit):
         """Completely empty checkpoint {} triggers no mutation and no error."""
         fake = _FakeModule()
         ckpt: dict[str, Any] = {}
@@ -816,7 +818,7 @@ class TestOnLoadCheckpoint:
         assert ckpt == {}
         assert not hasattr(fake, "_pending_legacy_ema_state")
 
-    def test_second_call_overwrites_pending_ema(self):
+    def test_second_call_overwrites_pending_ema(self, patch_lit):
         """Calling on_load_checkpoint twice with EMA overwrites the stash."""
         fake = _FakeModule()
         first_ema = {"w": torch.zeros(1)}
@@ -825,7 +827,7 @@ class TestOnLoadCheckpoint:
         RFDETRModelModule.on_load_checkpoint(fake, {"state_dict": {}, "legacy_ema_state_dict": second_ema})
         assert fake._pending_legacy_ema_state is second_ema
 
-    def test_second_call_without_ema_leaves_first_stash(self):
+    def test_second_call_without_ema_leaves_first_stash(self, patch_lit):
         """Second call without 'legacy_ema_state_dict' does not clear the stash."""
         fake = _FakeModule()
         first_ema = {"w": torch.zeros(1)}
@@ -847,7 +849,7 @@ class TestPublicAPIExports:
         ["RFDETRModelModule", "RFDETRDataModule", "build_trainer"],
         ids=["RFDETRModelModule", "RFDETRDataModule", "build_trainer"],
     )
-    def test_symbol_importable_from_rfdetr(self, name):
+    def test_symbol_importable_from_rfdetr(self, name, patch_lit):
         """Each PTL export is accessible as rfdetr.<name> via lazy __getattr__."""
         import rfdetr
 
@@ -858,27 +860,27 @@ class TestPublicAPIExports:
         ["RFDETRModelModule", "RFDETRDataModule", "build_trainer"],
         ids=["RFDETRModelModule", "RFDETRDataModule", "build_trainer"],
     )
-    def test_symbol_is_same_object_as_rfdetr_training(self, name):
+    def test_symbol_is_same_object_as_rfdetr_training(self, name, patch_lit):
         """rfdetr.<name> is the identical object to rfdetr.training.<name>."""
         import rfdetr
         import rfdetr.training
 
         assert getattr(rfdetr, name) is getattr(rfdetr.training, name)
 
-    def test_ptl_names_not_in_all(self):
+    def test_ptl_names_not_in_all(self, patch_lit):
         """PTL exports are optional (rfdetr[train]) and must not be in rfdetr.__all__."""
         import rfdetr
 
         for name in ("RFDETRModelModule", "RFDETRDataModule", "build_trainer"):
             assert name not in rfdetr.__all__, f"{name} must not be in __all__ (optional extra)"
 
-    def test_rfdetr_all_no_duplicates(self):
+    def test_rfdetr_all_no_duplicates(self, patch_lit):
         """rfdetr.__all__ contains no duplicate names."""
         import rfdetr
 
         assert len(rfdetr.__all__) == len(set(rfdetr.__all__))
 
-    def test_plus_symbol_resolution_does_not_mutate_all(self, monkeypatch):
+    def test_plus_symbol_resolution_does_not_mutate_all(self, monkeypatch, patch_lit):
         """Top-level __all__ remains static when plus-only symbols resolve lazily."""
         import rfdetr
         import rfdetr.platform.models
@@ -891,14 +893,14 @@ class TestPublicAPIExports:
         assert rfdetr.RFDETRXLarge is sentinel
         assert rfdetr.__all__ == original_all
 
-    def test_existing_exports_still_present(self):
+    def test_existing_exports_still_present(self, patch_lit):
         """Original RFDETR* class exports are unchanged."""
         import rfdetr
 
         for name in ["RFDETRNano", "RFDETRSmall", "RFDETRMedium", "RFDETRLarge"]:
             assert hasattr(rfdetr, name), f"rfdetr.{name} unexpectedly missing"
 
-    def test_convert_legacy_checkpoint_not_in_rfdetr_namespace(self):
+    def test_convert_legacy_checkpoint_not_in_rfdetr_namespace(self, patch_lit):
         """convert_legacy_checkpoint is in rfdetr.training but not the top-level rfdetr namespace."""
         import rfdetr
         from rfdetr.training import convert_legacy_checkpoint  # noqa: F401
@@ -915,7 +917,7 @@ class TestPublicAPIExports:
 class TestRFDETRLargeFallback:
     """RFDETRLarge retries only for deprecated-weight compatibility errors."""
 
-    def test_cuda_oom_runtime_error_does_not_retry(self, monkeypatch):
+    def test_cuda_oom_runtime_error_does_not_retry(self, monkeypatch, patch_lit):
         """CUDA OOM should fail fast without deprecated-config retry."""
         call_count = 0
 
@@ -932,7 +934,7 @@ class TestRFDETRLargeFallback:
 
         assert call_count == 1
 
-    def test_state_dict_runtime_error_retries_once_with_deprecated_config(self, monkeypatch):
+    def test_state_dict_runtime_error_retries_once_with_deprecated_config(self, monkeypatch, patch_lit):
         """State-dict mismatch errors trigger exactly one deprecated-config retry."""
         call_count = 0
 
@@ -1047,7 +1049,7 @@ class TestLoadPretrainWeightsInto:
 class TestClassNamesProperty:
     """RFDETR.class_names property returns List[str] (0-indexed)."""
 
-    def test_empty_class_names_returns_empty_list_not_coco(self):
+    def test_empty_class_names_returns_empty_list_not_coco(self, patch_lit):
         """class_names property returns [] when model.class_names is [], NOT COCO fallback.
 
         Regression test for #509: the truthiness check `and self.model.class_names:`
@@ -1062,7 +1064,7 @@ class TestClassNamesProperty:
 
         assert result == [], "class_names=[] must return [] (empty list), not COCO fallback"
 
-    def test_none_class_names_returns_coco(self):
+    def test_none_class_names_returns_coco(self, patch_lit):
         """class_names property falls back to COCO_CLASS_NAMES when model.class_names is None."""
         from rfdetr.assets.coco_classes import COCO_CLASS_NAMES
 
@@ -1073,7 +1075,7 @@ class TestClassNamesProperty:
 
         assert result is COCO_CLASS_NAMES
 
-    def test_custom_class_names_returned_as_list(self):
+    def test_custom_class_names_returned_as_list(self, patch_lit):
         """Non-empty class_names are returned as a 0-indexed list."""
         mock_self = MagicMock()
         mock_self.model.class_names = ["cat", "dog"]
@@ -1082,7 +1084,7 @@ class TestClassNamesProperty:
 
         assert result == ["cat", "dog"]
 
-    def test_custom_class_names_returns_shallow_copy(self):
+    def test_custom_class_names_returns_shallow_copy(self, patch_lit):
         """Mutating the returned class_names list must not mutate model state."""
         mock_self = MagicMock()
         mock_self.model.class_names = ["cat", "dog"]
@@ -1107,10 +1109,12 @@ class TestDeployToRoboflow:
     Roboflow with a FileNotFoundError from the Roboflow client library.
     """
 
-    def _make_mock_self(self, class_names, size="rfdetr-small"):
-        """Return a minimal RFDETR-like mock suitable for deploy_to_roboflow."""
+    @pytest.fixture
+    def mock_self(self):
+        """Return a minimal RFDETR-like mock for deploy_to_roboflow tests."""
+        class_names = ["cat", "dog"]
         mock_self = MagicMock(spec=RFDETR)
-        mock_self.size = size
+        mock_self.size = "rfdetr-small"
         mock_self.class_names = class_names  # the property, resolved to a plain list
         # `model` is an instance attribute (set in __init__), not a class attribute, so
         # MagicMock(spec=RFDETR).__getattr__ would raise AttributeError for it.  Assign
@@ -1120,7 +1124,13 @@ class TestDeployToRoboflow:
         mock_self.model.args = SimpleNamespace(num_classes=len(class_names))
         return mock_self
 
-    def test_class_names_txt_written_with_correct_content(self, tmp_path, monkeypatch):
+    @staticmethod
+    def _set_class_names(mock_self: MagicMock, class_names: list[str]) -> None:
+        """Update class names and keep args.num_classes in sync."""
+        mock_self.class_names = class_names
+        mock_self.model.args.num_classes = len(class_names)
+
+    def test_class_names_txt_written_with_correct_content(self, tmp_path, monkeypatch, mock_self, patch_lit):
         """deploy_to_roboflow must write class_names.txt with one name per line.
 
         Regression: RFDETRSeg models were failing with FileNotFoundError from
@@ -1129,7 +1139,7 @@ class TestDeployToRoboflow:
         monkeypatch.chdir(tmp_path)
 
         class_names = ["cat", "dog", "bird"]
-        mock_self = self._make_mock_self(class_names)
+        self._set_class_names(mock_self, class_names)
         mock_rf = MagicMock()
 
         captured: dict = {}
@@ -1154,7 +1164,7 @@ class TestDeployToRoboflow:
         assert "content" in captured, "class_names.txt was not present in the upload directory during deploy"
         assert captured["content"] == "cat\ndog\nbird"
 
-    def test_args_class_names_set_in_checkpoint(self, tmp_path, monkeypatch):
+    def test_args_class_names_set_in_checkpoint(self, tmp_path, monkeypatch, mock_self, patch_lit):
         """The saved checkpoint args must contain class_names when args lacks it.
 
         Regression: args.class_names was absent after switching to PTL training,
@@ -1163,7 +1173,6 @@ class TestDeployToRoboflow:
         monkeypatch.chdir(tmp_path)
 
         class_names = ["cat", "dog"]
-        mock_self = self._make_mock_self(class_names)
         # Ensure class_names is absent from args (mimics the regression scenario).
         assert not hasattr(mock_self.model.args, "class_names")
 
@@ -1192,12 +1201,11 @@ class TestDeployToRoboflow:
         assert hasattr(saved_args, "class_names"), "class_names must be present in saved args"
         assert saved_args.class_names == class_names
 
-    def test_args_class_names_set_when_none_in_checkpoint(self, tmp_path, monkeypatch):
+    def test_args_class_names_set_when_none_in_checkpoint(self, tmp_path, monkeypatch, mock_self, patch_lit):
         """class_names must be set when args has the attribute but its value is None."""
         monkeypatch.chdir(tmp_path)
 
         class_names = ["cat", "dog"]
-        mock_self = self._make_mock_self(class_names)
         # Simulate the case where args has class_names but it is explicitly None.
         mock_self.model.args.class_names = None
 
@@ -1222,12 +1230,11 @@ class TestDeployToRoboflow:
         saved_args = saved_checkpoints[0]["args"]
         assert saved_args.class_names == class_names, "class_names must be populated when args.class_names is None"
 
-    def test_existing_args_class_names_not_overwritten(self, tmp_path, monkeypatch):
+    def test_existing_args_class_names_not_overwritten(self, tmp_path, monkeypatch, mock_self, patch_lit):
         """If args already has class_names set, deploy_to_roboflow must not overwrite it."""
         monkeypatch.chdir(tmp_path)
 
         existing_names = ["existing_cat", "existing_dog"]
-        mock_self = self._make_mock_self(["cat", "dog"])
         mock_self.model.args.class_names = existing_names
 
         saved_checkpoints: list = []
@@ -1251,11 +1258,11 @@ class TestDeployToRoboflow:
         saved_args = saved_checkpoints[0]["args"]
         assert saved_args.class_names == existing_names, "existing args.class_names must not be overwritten"
 
-    def test_temp_dir_cleaned_up_after_deploy(self, tmp_path, monkeypatch):
+    def test_temp_dir_cleaned_up_after_deploy(self, tmp_path, monkeypatch, mock_self, patch_lit):
         """The temporary upload directory must be removed after a successful deploy."""
         monkeypatch.chdir(tmp_path)
 
-        mock_self = self._make_mock_self(["cat"])
+        self._set_class_names(mock_self, ["cat"])
         mock_rf = MagicMock()
         mock_rf.workspace.return_value.project.return_value.version.return_value.deploy.return_value = None
 
@@ -1270,11 +1277,11 @@ class TestDeployToRoboflow:
 
         assert not (tmp_path / ".roboflow_temp_upload").exists(), "Temp upload dir must be removed after deploy"
 
-    def test_temp_dir_cleaned_up_after_deploy_failure(self, tmp_path, monkeypatch):
+    def test_temp_dir_cleaned_up_after_deploy_failure(self, tmp_path, monkeypatch, mock_self, patch_lit):
         """Temp upload dir must be removed even when deploy() raises an exception."""
         monkeypatch.chdir(tmp_path)
 
-        mock_self = self._make_mock_self(["cat"])
+        self._set_class_names(mock_self, ["cat"])
         mock_rf = MagicMock()
         mock_rf.workspace.return_value.project.return_value.version.return_value.deploy.side_effect = RuntimeError(
             "upload failed",

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -26,7 +26,6 @@ import torch
 
 from rfdetr.config import RFDETRBaseConfig, TrainConfig
 from rfdetr.detr import RFDETR, RFDETRLarge
-from rfdetr.detr import logger as detr_logger
 from rfdetr.training.auto_batch import AutoBatchResult
 from rfdetr.training.checkpoint import convert_legacy_checkpoint
 from rfdetr.training.module_model import RFDETRModelModule


### PR DESCRIPTION
## 🌱 Changed

- **`predict()` returns source image and shape on detections.** Returned `sv.Detections` objects now include `detections.data["source_image"]` (the original image as a NumPy array) and `detections.data["source_shape"]` (a `(height, width)` tuple), so you can annotate results without loading the image separately. (#892)

    ```python
    detections = model.predict("https://media.roboflow.com/dog.jpg", threshold=0.5)
    annotated = sv.BoxAnnotator().annotate(detections.data["source_image"], detections)
    ```

- **`RFDETR.train()` auto-detects `num_classes` from the dataset.** When `num_classes` is not explicitly set, RF-DETR reads the class count from the dataset directory and reinitializes the detection head automatically. A warning is emitted when your configured value differs from the dataset count. (#893)

    ```python
    model = RFDETRSmall()
    model.train(dataset_dir="./dataset")  # num_classes inferred from dataset
    ```

- **`optimize_for_inference()` accepts dtype as a string.** Pass `"float16"` or `"bfloat16"` in addition to `torch.float16`; invalid inputs now raise `TypeError` uniformly. (#899)

## 🔧 Fixed

- Fixed fine-tuned models exporting wrong class counts to ONNX: `reinitialize_detection_head` now replaces `nn.Linear` modules instead of mutating tensor data in-place, keeping `out_features` consistent with the actual weight shape after fine-tuning. (#904)
- Fixed `optimize_for_inference()` leaking a CUDA context on multi-GPU setups — deep-copy, export, and JIT-trace now run inside the correct device context. Also fixed: state is rolled back cleanly if optimization fails mid-way, and temp download files now use unique per-process paths to prevent parallel worker collisions. (#899)
- Fixed `deploy_to_roboflow` raising `FileNotFoundError` after PyTorch Lightning migration — `class_names.txt` is now written to the upload directory and `args.class_names` is populated before saving the checkpoint, restoring uploads for all model types including segmentation. (#890)

---

## 🏆 Contributors

Welcome to our new contributors, and thank you to everyone who helped with this release:

- **Md Faruk Alam** (@farukalamai) ([LinkedIn](https://www.linkedin.com/in/farukalamai/)) — *predict source image and shape*
- **Jirka Borovec** (@Borda) ([LinkedIn](https://www.linkedin.com/in/jirka-borovec/)) — *release coordination, reviews*

*Automated contributions: @copilot-swe-agent[bot], @pre-commit-ci[bot]*

---

**Full changelog**: https://github.com/roboflow/rf-detr/compare/1.6.2...1.6.3
