### PR TITLE
fix: enable multi-GPU DDP training in Jupyter notebooks

### DIFF
--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -24,9 +24,11 @@ def _detect_device() -> str:
     when available — it queries the driver through NVML without creating a
     primary context.  On older builds we fall back to ``torch.cuda.is_available()``.
     """
-    if hasattr(torch.accelerator, "current_accelerator"):
+    accelerator = getattr(torch, "accelerator", None)
+    current_accelerator = getattr(accelerator, "current_accelerator", None)
+    if current_accelerator is not None:
         try:
-            accel = torch.accelerator.current_accelerator()
+            accel = current_accelerator()
             if accel is not None:
                 return str(accel)
             return "cpu"

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -24,7 +24,7 @@ def _detect_device() -> str:
     when available — it queries the driver through NVML without creating a
     primary context.  On older builds we fall back to ``torch.cuda.is_available()``.
     """
-    if hasattr(torch.accelerator, "current_accelerator"):
+    if hasattr(torch, "accelerator") and hasattr(torch.accelerator, "current_accelerator"):
         try:
             accel = torch.accelerator.current_accelerator()
             if accel is not None:

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -26,7 +26,10 @@ def _detect_device() -> str:
     """
     if hasattr(torch.accelerator, "current_accelerator"):
         try:
-            return str(torch.accelerator.current_accelerator())
+            accel = torch.accelerator.current_accelerator()
+            if accel is not None:
+                return str(accel)
+            return "cpu"
         except RuntimeError:
             return "cpu"
     # Fallback for PyTorch < 2.4 — this DOES create a CUDA driver context.

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -12,7 +12,32 @@ from typing import Any, ClassVar, Dict, List, Literal, Mapping, Optional, Union
 import torch
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-DEVICE = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
+
+def _detect_device() -> str:
+    """Detect the best available device **without** initialising the CUDA runtime.
+
+    ``torch.cuda.is_available()`` creates a CUDA driver context that makes
+    ``_is_in_bad_fork()`` return ``True`` in child processes.  This breaks
+    fork-based DDP strategies (e.g. ``ddp_notebook``) in notebook environments.
+
+    We defer to :func:`torch.accelerator.current_accelerator` (PyTorch ≥ 2.4)
+    when available — it queries the driver through NVML without creating a
+    primary context.  On older builds we fall back to ``torch.cuda.is_available()``.
+    """
+    if hasattr(torch.accelerator, "current_accelerator"):
+        try:
+            return str(torch.accelerator.current_accelerator())
+        except RuntimeError:
+            return "cpu"
+    # Fallback for PyTorch < 2.4 — this DOES create a CUDA driver context.
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+DEVICE: str = _detect_device()
 
 
 class BaseConfig(BaseModel):

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -510,6 +510,10 @@ class RFDETR:
 
         config = self.get_train_config(**kwargs)
         if config.batch_size == "auto":
+            # Auto-batch probing runs forward/backward on the actual model, which
+            # must be on the target device (typically CUDA).  Lazy placement keeps
+            # the model on CPU until first use — move it now.
+            _ensure_model_on_device(self.model)
             auto_batch = resolve_auto_batch_config(
                 model_context=self.model,
                 model_config=self.model_config,

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -182,6 +182,28 @@ def _resolve_patch_size(patch_size: int | None, model_config: object, caller: st
     return patch_size
 
 
+def _ensure_model_on_device(model_ctx) -> None:
+    """Move model weights to the target device recorded in *model_ctx*.
+
+    ``_build_model_context`` intentionally keeps the ``nn.Module`` on CPU so
+    that ``RFDETR.__init__`` does not initialise CUDA (which would prevent DDP
+    strategies from forking in notebook environments).  This helper performs
+    the deferred ``.to(device)`` on first use.
+
+    It is safe to call on duck-typed stand-ins (e.g. ``SimpleNamespace``); the
+    function silently returns when the expected attributes are missing.
+    """
+    target = getattr(model_ctx, "device", None)
+    inner = getattr(model_ctx, "model", None)
+    if target is None or inner is None or not hasattr(inner, "parameters"):
+        return
+    if isinstance(target, str):
+        target = torch.device(target)
+    first_param = next(inner.parameters(), None)
+    if first_param is not None and first_param.device != target:
+        model_ctx.model = inner.to(target)
+
+
 class RFDETR:
     """The base RF-DETR class implements the core methods for training RF-DETR models,
     running inference on the models, optimising models, and uploading trained
@@ -585,6 +607,7 @@ class RFDETR:
         # Clear any previously optimized state before starting a new optimization run.
         self.remove_optimized_model()
 
+        _ensure_model_on_device(self.model)
         device = self.model.device
         cuda_ctx = torch.cuda.device(device) if device.type == "cuda" else contextlib.nullcontext()
 
@@ -700,6 +723,7 @@ class RFDETR:
             )
             raise
 
+        _ensure_model_on_device(self.model)
         device = self.model.device
         model = deepcopy(self.model.model.to("cpu"))
         model.to(device)
@@ -1002,6 +1026,8 @@ class RFDETR:
 
         """
         import supervision as sv
+
+        _ensure_model_on_device(self.model)
 
         patch_size = _resolve_patch_size(patch_size, self.model_config, "predict")
         num_windows = getattr(self.model_config, "num_windows", 1)

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -727,7 +727,6 @@ class RFDETR:
             )
             raise
 
-        _ensure_model_on_device(self.model)
         device = self.model.device
         model = deepcopy(self.model.model.to("cpu"))
         model.to(device)

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -538,7 +538,20 @@ class RFDETR:
         if _devices is not None:
             trainer_kwargs["devices"] = _devices
         trainer = build_trainer(config, self.model_config, **trainer_kwargs)
+
+        # Fork-based DDP (``ddp_notebook``) inherits the parent's thread state.
+        # OpenMP/MKL threads and HuggingFace tokenizer parallelism become zombie
+        # locks in forked children, causing silent hangs during DDP setup.
+        _restore_num_threads = None
+        if config.strategy == "ddp_notebook":
+            _restore_num_threads = torch.get_num_threads()
+            torch.set_num_threads(1)
+            os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+
         trainer.fit(module, datamodule, ckpt_path=config.resume or None)
+
+        if _restore_num_threads is not None:
+            torch.set_num_threads(_restore_num_threads)
 
         # Sync the trained weights back so predict() / export() see the updated model.
         self.model.model = module.model

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -182,7 +182,7 @@ def _resolve_patch_size(patch_size: int | None, model_config: object, caller: st
     return patch_size
 
 
-def _ensure_model_on_device(model_ctx) -> None:
+def _ensure_model_on_device(model_ctx: Any) -> None:
     """Move model weights to the target device recorded in *model_ctx*.
 
     ``_build_model_context`` intentionally keeps the ``nn.Module`` on CPU so

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -538,20 +538,7 @@ class RFDETR:
         if _devices is not None:
             trainer_kwargs["devices"] = _devices
         trainer = build_trainer(config, self.model_config, **trainer_kwargs)
-
-        # Fork-based DDP (``ddp_notebook``) inherits the parent's thread state.
-        # OpenMP/MKL threads and HuggingFace tokenizer parallelism become zombie
-        # locks in forked children, causing silent hangs during DDP setup.
-        _restore_num_threads = None
-        if config.strategy == "ddp_notebook":
-            _restore_num_threads = torch.get_num_threads()
-            torch.set_num_threads(1)
-            os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
-
         trainer.fit(module, datamodule, ckpt_path=config.resume or None)
-
-        if _restore_num_threads is not None:
-            torch.set_num_threads(_restore_num_threads)
 
         # Sync the trained weights back so predict() / export() see the updated model.
         self.model.model = module.model

--- a/src/rfdetr/inference.py
+++ b/src/rfdetr/inference.py
@@ -99,7 +99,11 @@ def _build_model_context(model_config: ModelConfig) -> ModelContext:
         apply_lora(nn_model)
 
     device = torch.device(args.device)
-    nn_model = nn_model.to(device)
+    # Keep the model on CPU here; predict() / export() / optimize_for_inference()
+    # will lazily move it to the target device on first use.  Eagerly calling
+    # .to("cuda") would initialise the CUDA runtime during __init__(), which
+    # prevents DDP strategies (ddp_notebook, ddp_spawn) from forking/spawning
+    # child processes in notebook environments.
     postprocess = PostProcess(num_select=args.num_select)
 
     return ModelContext(

--- a/src/rfdetr/inference.py
+++ b/src/rfdetr/inference.py
@@ -71,13 +71,19 @@ def _build_model_context(model_config: ModelConfig) -> ModelContext:
     """Build a ModelContext from ModelConfig without using legacy main.py:Model.
 
     Replicates ``Model.__init__`` logic: builds the nn.Module, optionally loads
-    pretrain weights and applies LoRA, then moves the model to the target device.
+    pretrain weights and applies LoRA.  The model is intentionally kept on CPU;
+    :func:`_ensure_model_on_device` in ``detr.py`` performs the deferred
+    ``.to(device)`` on the first ``predict()`` / ``export()`` /
+    ``optimize_for_inference()`` call.  Keeping construction CPU-only prevents
+    CUDA initialisation during ``__init__``, which would block DDP strategies
+    (``ddp_notebook``, ``ddp_spawn``) from spawning child processes in notebook
+    environments.
 
     Args:
         model_config: Architecture configuration.
 
     Returns:
-        Fully initialised ModelContext ready for inference or training.
+        ModelContext with the model on CPU, ready for lazy device placement.
     """
     from rfdetr._namespace import _namespace_from_configs
 

--- a/src/rfdetr/training/module_data.py
+++ b/src/rfdetr/training/module_data.py
@@ -41,21 +41,7 @@ class RFDETRDataModule(LightningDataModule):
         self._dataset_val: Optional[torch.utils.data.Dataset] = None
         self._dataset_test: Optional[torch.utils.data.Dataset] = None
 
-        num_workers = self.train_config.num_workers
-        # ``ddp_notebook`` uses fork-based multiprocessing.  DataLoader workers
-        # forked from a CUDA-initialised DDP child inherit the CUDA driver
-        # context, which can cause hangs or "Cannot re-initialize CUDA in forked
-        # subprocess" errors.  Force num_workers=0 for safety.
-        if self.train_config.strategy == "ddp_notebook" and num_workers > 0:
-            logger.warning(
-                "Overriding num_workers=%d → 0 for ddp_notebook strategy.  "
-                "Fork-based DDP + multi-process DataLoader can deadlock "
-                "because DataLoader sub-forks inherit the CUDA driver context.",
-                num_workers,
-            )
-            num_workers = 0
-
-        self._num_workers: int = num_workers
+        self._num_workers: int = self.train_config.num_workers
 
         # Use the fork-safe DEVICE constant instead of torch.cuda.is_available(),
         # which creates a CUDA driver context that breaks fork-based DDP.
@@ -65,11 +51,11 @@ class RFDETRDataModule(LightningDataModule):
             (DEVICE == "cuda") if self.train_config.pin_memory is None else bool(self.train_config.pin_memory)
         )
         self._persistent_workers: bool = (
-            num_workers > 0
+            self._num_workers > 0
             if self.train_config.persistent_workers is None
             else bool(self.train_config.persistent_workers)
         )
-        if num_workers > 0:
+        if self._num_workers > 0:
             self._prefetch_factor = (
                 self.train_config.prefetch_factor if self.train_config.prefetch_factor is not None else 2
             )

--- a/src/rfdetr/training/module_data.py
+++ b/src/rfdetr/training/module_data.py
@@ -47,8 +47,12 @@ class RFDETRDataModule(LightningDataModule):
         # which creates a CUDA driver context that breaks fork-based DDP.
         from rfdetr.config import DEVICE
 
+        accelerator = str(self.train_config.accelerator).lower()
+        uses_cuda_accelerator = accelerator in {"auto", "gpu", "cuda"}
         self._pin_memory: bool = (
-            (DEVICE == "cuda") if self.train_config.pin_memory is None else bool(self.train_config.pin_memory)
+            (DEVICE == "cuda" and uses_cuda_accelerator)
+            if self.train_config.pin_memory is None
+            else bool(self.train_config.pin_memory)
         )
         self._persistent_workers: bool = (
             self._num_workers > 0

--- a/src/rfdetr/training/module_data.py
+++ b/src/rfdetr/training/module_data.py
@@ -42,8 +42,12 @@ class RFDETRDataModule(LightningDataModule):
         self._dataset_test: Optional[torch.utils.data.Dataset] = None
 
         num_workers = self.train_config.num_workers
+        # Use the fork-safe DEVICE constant instead of torch.cuda.is_available(),
+        # which creates a CUDA driver context that breaks fork-based DDP.
+        from rfdetr.config import DEVICE
+
         self._pin_memory: bool = (
-            torch.cuda.is_available() if self.train_config.pin_memory is None else bool(self.train_config.pin_memory)
+            (DEVICE == "cuda") if self.train_config.pin_memory is None else bool(self.train_config.pin_memory)
         )
         self._persistent_workers: bool = (
             num_workers > 0

--- a/src/rfdetr/training/module_data.py
+++ b/src/rfdetr/training/module_data.py
@@ -42,6 +42,21 @@ class RFDETRDataModule(LightningDataModule):
         self._dataset_test: Optional[torch.utils.data.Dataset] = None
 
         num_workers = self.train_config.num_workers
+        # ``ddp_notebook`` uses fork-based multiprocessing.  DataLoader workers
+        # forked from a CUDA-initialised DDP child inherit the CUDA driver
+        # context, which can cause hangs or "Cannot re-initialize CUDA in forked
+        # subprocess" errors.  Force num_workers=0 for safety.
+        if self.train_config.strategy == "ddp_notebook" and num_workers > 0:
+            logger.warning(
+                "Overriding num_workers=%d → 0 for ddp_notebook strategy.  "
+                "Fork-based DDP + multi-process DataLoader can deadlock "
+                "because DataLoader sub-forks inherit the CUDA driver context.",
+                num_workers,
+            )
+            num_workers = 0
+
+        self._num_workers: int = num_workers
+
         # Use the fork-safe DEVICE constant instead of torch.cuda.is_available(),
         # which creates a CUDA driver context that breaks fork-based DDP.
         from rfdetr.config import DEVICE
@@ -108,7 +123,7 @@ class RFDETRDataModule(LightningDataModule):
         dataset = self._dataset_train
         batch_size = self.train_config.batch_size
         effective_batch_size = batch_size * self.train_config.grad_accum_steps
-        num_workers = self.train_config.num_workers
+        num_workers = self._num_workers
 
         if len(dataset) < effective_batch_size * _MIN_TRAIN_BATCHES:
             logger.info(
@@ -156,7 +171,7 @@ class RFDETRDataModule(LightningDataModule):
             sampler=torch.utils.data.SequentialSampler(self._dataset_val),
             drop_last=False,
             collate_fn=collate_fn,
-            num_workers=self.train_config.num_workers,
+            num_workers=self._num_workers,
             pin_memory=self._pin_memory,
             persistent_workers=self._persistent_workers,
             prefetch_factor=self._prefetch_factor,
@@ -174,7 +189,7 @@ class RFDETRDataModule(LightningDataModule):
             sampler=torch.utils.data.SequentialSampler(self._dataset_test),
             drop_last=False,
             collate_fn=collate_fn,
-            num_workers=self.train_config.num_workers,
+            num_workers=self._num_workers,
             pin_memory=self._pin_memory,
             persistent_workers=self._persistent_workers,
             prefetch_factor=self._prefetch_factor,
@@ -192,7 +207,7 @@ class RFDETRDataModule(LightningDataModule):
             sampler=torch.utils.data.SequentialSampler(self._dataset_val),
             drop_last=False,
             collate_fn=collate_fn,
-            num_workers=self.train_config.num_workers,
+            num_workers=self._num_workers,
             pin_memory=self._pin_memory,
             persistent_workers=self._persistent_workers,
             prefetch_factor=self._prefetch_factor,

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -71,7 +71,11 @@ class RFDETRModelModule(LightningModule):
         # which creates a CUDA driver context that breaks fork-based DDP.
         from rfdetr.config import DEVICE
 
-        compile_enabled = model_config.compile and DEVICE == "cuda" and not train_config.multi_scale
+        accelerator = str(train_config.accelerator).lower()
+        uses_cuda_accelerator = accelerator in {"auto", "gpu", "cuda"}
+        compile_enabled = (
+            model_config.compile and DEVICE == "cuda" and uses_cuda_accelerator and not train_config.multi_scale
+        )
         if model_config.compile and train_config.multi_scale:
             logger.info("Disabling torch.compile because multi_scale=True introduces dynamic input shapes.")
         if compile_enabled:

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -67,7 +67,11 @@ class RFDETRModelModule(LightningModule):
 
         # torch.compile is opt-in: set model_config.compile=True to enable.
         # Only enabled on CUDA; MPS and CPU do not benefit from compilation.
-        compile_enabled = model_config.compile and torch.cuda.is_available() and not train_config.multi_scale
+        # Use the fork-safe DEVICE constant instead of torch.cuda.is_available(),
+        # which creates a CUDA driver context that breaks fork-based DDP.
+        from rfdetr.config import DEVICE
+
+        compile_enabled = model_config.compile and DEVICE == "cuda" and not train_config.multi_scale
         if model_config.compile and train_config.multi_scale:
             logger.info("Disabling torch.compile because multi_scale=True introduces dynamic input shapes.")
         if compile_enabled:

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -65,9 +65,7 @@ class _NotebookSpawnDDPStrategy(_DDPStrategy):
 
     def _configure_launcher(self) -> None:
         assert self.cluster_environment is not None
-        self._launcher = _InteractiveSpawnLauncher(
-            self, start_method=self._start_method
-        )
+        self._launcher = _InteractiveSpawnLauncher(self, start_method=self._start_method)
 
 
 def build_trainer(
@@ -138,11 +136,11 @@ def build_trainer(
     # for spawned children, so no ``if __name__ == "__main__"`` guard is needed.
     if strategy in ("ddp_notebook", "ddp_spawn"):
         strategy = _NotebookSpawnDDPStrategy(
-            start_method="spawn", find_unused_parameters=True,
+            start_method="spawn",
+            find_unused_parameters=True,
         )
         _logger.info(
-            "%s → spawn-based DDP to avoid OpenMP thread pool "
-            "corruption after fork.",
+            "%s → spawn-based DDP to avoid OpenMP thread pool corruption after fork.",
             tc.strategy,
         )
     sharded = any(s in str(strategy).lower() for s in ("fsdp", "deepspeed"))

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -87,6 +87,21 @@ def build_trainer(
 
     # --- Strategy + EMA sharding guard ---
     strategy = tc.strategy
+
+    # ``ddp_notebook`` maps to fork-based DDP which is fundamentally unsafe:
+    # PyTorch's OpenMP thread pool (created during model construction) cannot
+    # survive fork() — the worker threads become zombie handles, causing
+    # "Invalid thread pool!" SIGABRT when the autograd engine initialises in
+    # the forked child.  Use spawn-based DDP instead: children start as clean
+    # processes with their own OpenMP thread pools.
+    if strategy == "ddp_notebook":
+        from pytorch_lightning.strategies import DDPStrategy
+
+        strategy = DDPStrategy(start_method="spawn")
+        _logger.info(
+            "ddp_notebook: using spawn-based DDP to avoid OpenMP thread pool "
+            "corruption after fork."
+        )
     sharded = any(s in str(strategy).lower() for s in ("fsdp", "deepspeed"))
     enable_ema = bool(tc.use_ema) and not sharded
     if tc.use_ema and sharded:

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -121,6 +121,13 @@ def build_trainer(
         # BF16 is safe for fine-tuning (pretrained weights loaded by default).
         # Training from random init with very small LR may underflow; callers
         # can override via trainer_kwargs(precision="16-mixed") if needed.
+        #
+        # Note: torch.cuda.is_available() and torch.cuda.is_bf16_supported() both
+        # create a CUDA driver context in the parent process.  This is intentional
+        # and safe: all DDP paths use spawn-based strategies (see _NotebookSpawnDDPStrategy
+        # above) so spawned children start with a fresh CUDA state regardless of
+        # what the parent has initialised.  If a fork-based path is ever added,
+        # this precision check must be moved into the child process.
         if torch.cuda.is_available():
             if torch.cuda.is_bf16_supported():
                 return "bf16-mixed"

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -139,15 +139,8 @@ def build_trainer(
     # --- Strategy + EMA sharding guard ---
     strategy = tc.strategy
 
-    # ``ddp_notebook`` maps to fork-based DDP which is fundamentally unsafe:
-    # PyTorch's OpenMP thread pool (created during model construction) cannot
-    # survive fork() — the worker threads become zombie handles, causing
-    # "Invalid thread pool!" SIGABRT when the autograd engine initialises in
-    # the forked child.  ``ddp_spawn`` is safe but PTL blocks it in notebooks.
-    #
-    # Both are replaced with a spawn-based strategy whose launcher is marked
-    # interactive-compatible.  PTL's ``_wrapping_function`` is the entry-point
-    # for spawned children, so no ``if __name__ == "__main__"`` guard is needed.
+    # Transparently replace fork-based DDP with spawn-based DDP — see the
+    # module-level comment block above _InteractiveSpawnLauncher for rationale.
     if strategy in ("ddp_notebook", "ddp_spawn"):
         strategy = _NotebookSpawnDDPStrategy(
             start_method="spawn",

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -92,15 +92,13 @@ def build_trainer(
     # PyTorch's OpenMP thread pool (created during model construction) cannot
     # survive fork() — the worker threads become zombie handles, causing
     # "Invalid thread pool!" SIGABRT when the autograd engine initialises in
-    # the forked child.  Use spawn-based DDP instead: children start as clean
+    # the forked child.  Use ``ddp_spawn`` instead: children start as clean
     # processes with their own OpenMP thread pools.
     if strategy == "ddp_notebook":
-        from pytorch_lightning.strategies import DDPStrategy
-
-        strategy = DDPStrategy(start_method="spawn")
+        strategy = "ddp_spawn"
         _logger.info(
-            "ddp_notebook: using spawn-based DDP to avoid OpenMP thread pool "
-            "corruption after fork."
+            "ddp_notebook → ddp_spawn: using spawn-based DDP to avoid "
+            "OpenMP thread pool corruption after fork."
         )
     sharded = any(s in str(strategy).lower() for s in ("fsdp", "deepspeed"))
     enable_ema = bool(tc.use_ema) and not sharded

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -28,6 +28,48 @@ from rfdetr.utilities.logger import get_logger
 _logger = get_logger()
 
 
+# ---------------------------------------------------------------------------
+# Notebook-safe spawn-based DDP
+# ---------------------------------------------------------------------------
+# ``ddp_notebook`` maps to fork-based DDP which is fundamentally unsafe:
+# PyTorch's OpenMP thread pool (created during model construction) cannot
+# survive fork() — the worker threads become zombie handles, causing
+# "Invalid thread pool!" SIGABRT when the autograd engine initialises in
+# the forked child.
+#
+# PTL considers ``start_method="spawn"`` incompatible with interactive
+# environments and raises ``MisconfigurationException`` if used in Jupyter.
+# However, PTL's own ``_wrapping_function`` is the entry-point for spawned
+# children — no ``if __name__ == "__main__"`` guard is required — so spawn
+# is perfectly safe here.
+#
+# Classes MUST live at module level (not inside a function) so that Python's
+# pickle can serialise them for the spawned child processes.
+
+from pytorch_lightning.strategies import DDPStrategy as _DDPStrategy
+from pytorch_lightning.strategies.launchers.multiprocessing import (
+    _MultiProcessingLauncher,
+)
+
+
+class _InteractiveSpawnLauncher(_MultiProcessingLauncher):
+    """Spawn launcher that reports itself as interactive-compatible."""
+
+    @property
+    def is_interactive_compatible(self) -> bool:  # type: ignore[override]
+        return True
+
+
+class _NotebookSpawnDDPStrategy(_DDPStrategy):
+    """Spawn-based DDP strategy that works inside Jupyter / Kaggle notebooks."""
+
+    def _configure_launcher(self) -> None:
+        assert self.cluster_environment is not None
+        self._launcher = _InteractiveSpawnLauncher(
+            self, start_method=self._start_method
+        )
+
+
 def build_trainer(
     train_config: TrainConfig,
     model_config: ModelConfig,
@@ -75,7 +117,7 @@ def build_trainer(
         # crashing with "Cannot re-initialize CUDA in forked subprocess".
         # Return bf16-mixed immediately without touching the CUDA runtime;
         # pre-Ampere GPUs emulate bf16 transparently.
-        if tc.strategy == "ddp_notebook":
+        if tc.strategy in ("ddp_notebook", "ddp_spawn"):
             return "bf16-mixed"
         if torch.cuda.is_available():
             if torch.cuda.is_bf16_supported():
@@ -92,13 +134,19 @@ def build_trainer(
     # PyTorch's OpenMP thread pool (created during model construction) cannot
     # survive fork() — the worker threads become zombie handles, causing
     # "Invalid thread pool!" SIGABRT when the autograd engine initialises in
-    # the forked child.  Use ``ddp_spawn`` instead: children start as clean
-    # processes with their own OpenMP thread pools.
-    if strategy == "ddp_notebook":
-        strategy = "ddp_spawn"
+    # the forked child.  ``ddp_spawn`` is safe but PTL blocks it in notebooks.
+    #
+    # Both are replaced with a spawn-based strategy whose launcher is marked
+    # interactive-compatible.  PTL's ``_wrapping_function`` is the entry-point
+    # for spawned children, so no ``if __name__ == "__main__"`` guard is needed.
+    if strategy in ("ddp_notebook", "ddp_spawn"):
+        strategy = _NotebookSpawnDDPStrategy(
+            start_method="spawn", find_unused_parameters=True,
+        )
         _logger.info(
-            "ddp_notebook → ddp_spawn: using spawn-based DDP to avoid "
-            "OpenMP thread pool corruption after fork."
+            "%s → spawn-based DDP to avoid OpenMP thread pool "
+            "corruption after fork.",
+            tc.strategy,
         )
     sharded = any(s in str(strategy).lower() for s in ("fsdp", "deepspeed"))
     enable_ema = bool(tc.use_ema) and not sharded

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -111,14 +111,11 @@ def build_trainer(
     def _resolve_precision() -> str:
         if not model_config.amp:
             return "32-true"
-        # ``ddp_notebook`` uses fork-based multiprocessing.  ANY CUDA API
-        # call — even ``torch.cuda.is_available()`` — creates a CUDA driver
-        # context that makes ``_is_in_bad_fork()`` return True in the child,
-        # crashing with "Cannot re-initialize CUDA in forked subprocess".
-        # Return bf16-mixed immediately without touching the CUDA runtime;
-        # pre-Ampere GPUs emulate bf16 transparently.
-        if tc.strategy in ("ddp_notebook", "ddp_spawn"):
-            return "bf16-mixed"
+        # Ampere+ GPUs support bf16-mixed which is scaler-free —
+        # no GradScaler.scale/unscale/update overhead per optimizer step.
+        # BF16 is safe for fine-tuning (pretrained weights loaded by default).
+        # Training from random init with very small LR may underflow; callers
+        # can override via trainer_kwargs(precision="16-mixed") if needed.
         if torch.cuda.is_available():
             if torch.cuda.is_bf16_supported():
                 return "bf16-mixed"

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -63,7 +63,10 @@ class _NotebookSpawnDDPStrategy(_DDPStrategy):
     """Spawn-based DDP strategy that works inside Jupyter / Kaggle notebooks."""
 
     def _configure_launcher(self) -> None:
-        assert self.cluster_environment is not None
+        if self.cluster_environment is None:
+            raise RuntimeError(
+                "Cluster environment must be configured before creating the DDP launcher."
+            )
         self._launcher = _InteractiveSpawnLauncher(self, start_method=self._start_method)
 
 

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -122,10 +122,12 @@ def build_trainer(
         #
         # Note: torch.cuda.is_available() and torch.cuda.is_bf16_supported() both
         # create a CUDA driver context in the parent process.  This is intentional
-        # and safe: all DDP paths use spawn-based strategies (see _NotebookSpawnDDPStrategy
-        # above) so spawned children start with a fresh CUDA state regardless of
-        # what the parent has initialised.  If a fork-based path is ever added,
-        # this precision check must be moved into the child process.
+        # and safe for the multi-process launch modes we rely on here because we
+        # avoid fork-based launching in notebook contexts (see
+        # _NotebookSpawnDDPStrategy above), and spawn/subprocess-based launchers
+        # start child processes with a fresh CUDA state regardless of what the
+        # parent has initialised. If a fork-based path is ever added, this
+        # precision check must be moved into the child process.
         if torch.cuda.is_available():
             if torch.cuda.is_bf16_supported():
                 return "bf16-mixed"

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -140,10 +140,7 @@ def build_trainer(
     # Transparently replace fork-based DDP with spawn-based DDP — see the
     # module-level comment block above _InteractiveSpawnLauncher for rationale.
     if strategy in ("ddp_notebook", "ddp_spawn"):
-        strategy = _NotebookSpawnDDPStrategy(
-            start_method="spawn",
-            find_unused_parameters=True
-        )
+        strategy = _NotebookSpawnDDPStrategy(start_method="spawn", find_unused_parameters=True)
         _logger.info(
             "%s → spawn-based DDP to avoid OpenMP thread pool corruption after fork.",
             tc.strategy,

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -70,11 +70,14 @@ def build_trainer(
         if not model_config.amp:
             return "32-true"
         if torch.cuda.is_available():
-            # Ampere+ GPUs support bf16-mixed which is scaler-free —
-            # no GradScaler.scale/unscale/update overhead per optimizer step.
-            # BF16 is safe for fine-tuning (pretrained weights loaded by default).
-            # Training from random init with very small LR may underflow; callers
-            # can override via trainer_kwargs(precision="16-mixed") if needed.
+            # ``ddp_notebook`` uses fork-based multiprocessing.  Calling
+            # ``torch.cuda.is_bf16_supported()`` initialises the CUDA runtime
+            # in the parent process which makes the subsequent fork fail with
+            # "Cannot re-initialize CUDA in forked subprocess".  In that case
+            # we default to bf16-mixed (pre-Ampere GPUs emulate it
+            # transparently) and let PTL validate inside the child process.
+            if tc.strategy == "ddp_notebook":
+                return "bf16-mixed"
             if torch.cuda.is_bf16_supported():
                 return "bf16-mixed"
             return "16-mixed"

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -19,9 +19,7 @@ from pytorch_lightning.strategies import DDPStrategy as _DDPStrategy
 # _MultiProcessingLauncher is a private PTL API (leading underscore) that may change
 # in minor PTL releases within the >=2.6,<3 range.  No public equivalent exists in
 # PTL 2.x.  Monitor PTL changelogs when bumping the lower bound.
-from pytorch_lightning.strategies.launchers.multiprocessing import (
-    _MultiProcessingLauncher,
-)
+from pytorch_lightning.strategies.launchers.multiprocessing import _MultiProcessingLauncher
 
 from rfdetr.config import ModelConfig, TrainConfig
 from rfdetr.training.callbacks import (
@@ -144,7 +142,7 @@ def build_trainer(
     if strategy in ("ddp_notebook", "ddp_spawn"):
         strategy = _NotebookSpawnDDPStrategy(
             start_method="spawn",
-            find_unused_parameters=True,
+            find_unused_parameters=True
         )
         _logger.info(
             "%s → spawn-based DDP to avoid OpenMP thread pool corruption after fork.",

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -14,6 +14,10 @@ from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint, RichProgressBar, TQDMProgressBar
 from pytorch_lightning.callbacks.progress.rich_progress import RichProgressBarTheme
 from pytorch_lightning.loggers import CSVLogger, MLFlowLogger, TensorBoardLogger, WandbLogger
+from pytorch_lightning.strategies import DDPStrategy as _DDPStrategy
+from pytorch_lightning.strategies.launchers.multiprocessing import (
+    _MultiProcessingLauncher,
+)
 
 from rfdetr.config import ModelConfig, TrainConfig
 from rfdetr.training.callbacks import (
@@ -45,11 +49,6 @@ _logger = get_logger()
 #
 # Classes MUST live at module level (not inside a function) so that Python's
 # pickle can serialise them for the spawned child processes.
-
-from pytorch_lightning.strategies import DDPStrategy as _DDPStrategy
-from pytorch_lightning.strategies.launchers.multiprocessing import (
-    _MultiProcessingLauncher,
-)
 
 
 class _InteractiveSpawnLauncher(_MultiProcessingLauncher):

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -63,7 +63,11 @@ class _NotebookSpawnDDPStrategy(_DDPStrategy):
     """Spawn-based DDP strategy that works inside Jupyter / Kaggle notebooks."""
 
     def _configure_launcher(self) -> None:
-        assert self.cluster_environment is not None
+        if self.cluster_environment is None:
+            raise RuntimeError(
+                "_NotebookSpawnDDPStrategy requires a cluster environment; "
+                "ensure the strategy is initialised through PTL's Trainer."
+            )
         self._launcher = _InteractiveSpawnLauncher(self, start_method=self._start_method)
 
 

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -19,7 +19,10 @@ from pytorch_lightning.strategies import DDPStrategy as _DDPStrategy
 # _MultiProcessingLauncher is a private PTL API (leading underscore) that may change
 # in minor PTL releases within the >=2.6,<3 range.  No public equivalent exists in
 # PTL 2.x.  Monitor PTL changelogs when bumping the lower bound.
-from pytorch_lightning.strategies.launchers.multiprocessing import _MultiProcessingLauncher
+try:
+    from pytorch_lightning.strategies.launchers.multiprocessing import _MultiProcessingLauncher
+except ImportError:  # pragma: no cover - exercised in unit tests via monkeypatch
+    _MultiProcessingLauncher = None  # type: ignore[assignment]
 
 from rfdetr.config import ModelConfig, TrainConfig
 from rfdetr.training.callbacks import (
@@ -53,12 +56,17 @@ _logger = get_logger()
 # pickle can serialise them for the spawned child processes.
 
 
-class _InteractiveSpawnLauncher(_MultiProcessingLauncher):
-    """Spawn launcher that reports itself as interactive-compatible."""
+if _MultiProcessingLauncher is not None:
 
-    @property
-    def is_interactive_compatible(self) -> bool:  # type: ignore[override]
-        return True
+    class _InteractiveSpawnLauncher(_MultiProcessingLauncher):
+        """Spawn launcher that reports itself as interactive-compatible."""
+
+        @property
+        def is_interactive_compatible(self) -> bool:  # type: ignore[override]
+            return True
+
+else:
+    _InteractiveSpawnLauncher = None
 
 
 class _NotebookSpawnDDPStrategy(_DDPStrategy):
@@ -69,6 +77,13 @@ class _NotebookSpawnDDPStrategy(_DDPStrategy):
             raise RuntimeError(
                 "_NotebookSpawnDDPStrategy requires a cluster environment; "
                 "ensure the strategy is initialised through PTL's Trainer."
+            )
+        if _InteractiveSpawnLauncher is None:
+            raise RuntimeError(
+                "Notebook spawn strategy requires "
+                "pytorch_lightning.strategies.launchers.multiprocessing._MultiProcessingLauncher. "
+                "Your installed PyTorch Lightning version changed this private API; "
+                "pin/upgrade PTL to a compatible version in the supported >=2.6,<3 range."
             )
         self._launcher = _InteractiveSpawnLauncher(self, start_method=self._start_method)
 

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -64,9 +64,7 @@ class _NotebookSpawnDDPStrategy(_DDPStrategy):
 
     def _configure_launcher(self) -> None:
         if self.cluster_environment is None:
-            raise RuntimeError(
-                "Cluster environment must be configured before creating the DDP launcher."
-            )
+            raise RuntimeError("Cluster environment must be configured before creating the DDP launcher.")
         self._launcher = _InteractiveSpawnLauncher(self, start_method=self._start_method)
 
 

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -15,6 +15,10 @@ from pytorch_lightning.callbacks import ModelCheckpoint, RichProgressBar, TQDMPr
 from pytorch_lightning.callbacks.progress.rich_progress import RichProgressBarTheme
 from pytorch_lightning.loggers import CSVLogger, MLFlowLogger, TensorBoardLogger, WandbLogger
 from pytorch_lightning.strategies import DDPStrategy as _DDPStrategy
+
+# _MultiProcessingLauncher is a private PTL API (leading underscore) that may change
+# in minor PTL releases within the >=2.6,<3 range.  No public equivalent exists in
+# PTL 2.x.  Monitor PTL changelogs when bumping the lower bound.
 from pytorch_lightning.strategies.launchers.multiprocessing import (
     _MultiProcessingLauncher,
 )

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -69,15 +69,15 @@ def build_trainer(
     def _resolve_precision() -> str:
         if not model_config.amp:
             return "32-true"
+        # ``ddp_notebook`` uses fork-based multiprocessing.  ANY CUDA API
+        # call — even ``torch.cuda.is_available()`` — creates a CUDA driver
+        # context that makes ``_is_in_bad_fork()`` return True in the child,
+        # crashing with "Cannot re-initialize CUDA in forked subprocess".
+        # Return bf16-mixed immediately without touching the CUDA runtime;
+        # pre-Ampere GPUs emulate bf16 transparently.
+        if tc.strategy == "ddp_notebook":
+            return "bf16-mixed"
         if torch.cuda.is_available():
-            # ``ddp_notebook`` uses fork-based multiprocessing.  Calling
-            # ``torch.cuda.is_bf16_supported()`` initialises the CUDA runtime
-            # in the parent process which makes the subsequent fork fail with
-            # "Cannot re-initialize CUDA in forked subprocess".  In that case
-            # we default to bf16-mixed (pre-Ampere GPUs emulate it
-            # transparently) and let PTL validate inside the child process.
-            if tc.strategy == "ddp_notebook":
-                return "bf16-mixed"
             if torch.cuda.is_bf16_supported():
                 return "bf16-mixed"
             return "16-mixed"

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -4,7 +4,7 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -373,29 +373,27 @@ class TestDeprecatedModelConfigClsLossCoef:
         assert not depr_warnings, f"Unexpected DeprecationWarning: {depr_warnings}"
 
 
-def test_detect_device_falls_back_when_torch_accelerator_absent() -> None:
-    mock_torch = Mock(spec=["cuda", "backends"])
-    mock_torch.cuda.is_available.return_value = True
-    mock_torch.backends.mps.is_available.return_value = False
+class TestDetectDevice:
+    """Tests for _detect_device() covering PyTorch accelerator detection paths."""
 
-    with patch("rfdetr.config.torch", mock_torch):
+    @patch("rfdetr.config.torch")
+    def test_falls_back_to_cuda_when_accelerator_module_absent(self, mock_torch: MagicMock) -> None:
+        """Returns 'cuda' via legacy fallback when torch.accelerator lacks current_accelerator (PyTorch < 2.4)."""
+        mock_torch.accelerator = MagicMock(spec=[])  # no current_accelerator → hasattr returns False → fallback
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.backends.mps.is_available.return_value = False
         assert _detect_device() == "cuda"
 
-
-def test_detect_device_falls_back_when_current_accelerator_raises() -> None:
-    mock_torch = Mock(spec=["accelerator", "cuda", "backends"])
-    mock_torch.accelerator.current_accelerator.side_effect = RuntimeError("boom")
-    mock_torch.cuda.is_available.return_value = True
-    mock_torch.backends.mps.is_available.return_value = False
-
-    with patch("rfdetr.config.torch", mock_torch):
+    @patch("rfdetr.config.torch")
+    def test_returns_cpu_when_current_accelerator_raises(self, mock_torch: MagicMock) -> None:
+        """Returns 'cpu' directly from the except handler when current_accelerator() raises RuntimeError."""
+        mock_torch.accelerator.current_accelerator.side_effect = RuntimeError("no device")
         assert _detect_device() == "cpu"
 
-
-def test_detect_device_returns_cpu_when_no_gpu() -> None:
-    mock_torch = Mock(spec=["cuda", "backends"])
-    mock_torch.cuda.is_available.return_value = False
-    mock_torch.backends.mps.is_available.return_value = False
-
-    with patch("rfdetr.config.torch", mock_torch):
+    @patch("rfdetr.config.torch")
+    def test_returns_cpu_when_no_gpu_available(self, mock_torch: MagicMock) -> None:
+        """Returns 'cpu' when accelerator is absent and neither CUDA nor MPS is available."""
+        mock_torch.accelerator = MagicMock(spec=[])  # no current_accelerator → fallback branch
+        mock_torch.cuda.is_available.return_value = False
+        mock_torch.backends.mps.is_available.return_value = False
         assert _detect_device() == "cpu"

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -4,10 +4,11 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
+from unittest.mock import Mock, patch
+
 import pytest
 import torch
 from pydantic import ValidationError
-from unittest.mock import Mock, patch
 
 from rfdetr.config import (
     ModelConfig,

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -7,6 +7,7 @@
 import pytest
 import torch
 from pydantic import ValidationError
+from unittest.mock import Mock, patch
 
 from rfdetr.config import (
     ModelConfig,
@@ -19,6 +20,7 @@ from rfdetr.config import (
     RFDETRSegXLargeConfig,
     SegmentationTrainConfig,
     TrainConfig,
+    _detect_device,
 )
 
 
@@ -368,3 +370,31 @@ class TestDeprecatedModelConfigClsLossCoef:
         RFDETRBaseConfig(pretrain_weights=None, device="cpu")
         depr_warnings = [w for w in recwarn.list if issubclass(w.category, DeprecationWarning)]
         assert not depr_warnings, f"Unexpected DeprecationWarning: {depr_warnings}"
+
+
+def test_detect_device_falls_back_when_torch_accelerator_absent() -> None:
+    mock_torch = Mock(spec=["cuda", "backends"])
+    mock_torch.cuda.is_available.return_value = True
+    mock_torch.backends.mps.is_available.return_value = False
+
+    with patch("rfdetr.config.torch", mock_torch):
+        assert _detect_device() == "cuda"
+
+
+def test_detect_device_falls_back_when_current_accelerator_raises() -> None:
+    mock_torch = Mock(spec=["accelerator", "cuda", "backends"])
+    mock_torch.accelerator.current_accelerator.side_effect = RuntimeError("boom")
+    mock_torch.cuda.is_available.return_value = True
+    mock_torch.backends.mps.is_available.return_value = False
+
+    with patch("rfdetr.config.torch", mock_torch):
+        assert _detect_device() == "cpu"
+
+
+def test_detect_device_returns_cpu_when_no_gpu() -> None:
+    mock_torch = Mock(spec=["cuda", "backends"])
+    mock_torch.cuda.is_available.return_value = False
+    mock_torch.backends.mps.is_available.return_value = False
+
+    with patch("rfdetr.config.torch", mock_torch):
+        assert _detect_device() == "cpu"

--- a/tests/models/test_optimize_for_inference.py
+++ b/tests/models/test_optimize_for_inference.py
@@ -114,11 +114,20 @@ class TestOptimizeForInferenceDtype:
 class TestOptimizeForInferenceCudaDeviceContext:
     """Verify that optimize_for_inference wraps operations in the correct device context."""
 
-    def test_cuda_device_context_manager_is_used_for_cuda_device(self) -> None:
+    @patch("rfdetr.detr._ensure_model_on_device")
+    @patch("rfdetr.detr.deepcopy")
+    @patch("torch.cuda.device")
+    def test_cuda_device_context_manager_is_used_for_cuda_device(
+        self,
+        mock_cuda_device,
+        mock_deepcopy,
+        _mock_ensure_model_on_device,
+    ) -> None:
         """torch.cuda.device() context should be entered when model is on CUDA."""
         rfdetr = _FakeRFDETR()
         # Simulate a CUDA device without actually requiring CUDA hardware
         rfdetr.model.device = torch.device("cuda", 0)
+        mock_deepcopy.return_value = rfdetr.model.model
 
         entered_devices: list[torch.device] = []
 
@@ -132,11 +141,8 @@ class TestOptimizeForInferenceCudaDeviceContext:
             def __exit__(self, *args):
                 pass
 
-        with (
-            patch("torch.cuda.device", side_effect=_CapturingDeviceCtx),
-            patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model),
-        ):
-            rfdetr.optimize_for_inference(compile=False, dtype=torch.float32)
+        mock_cuda_device.side_effect = _CapturingDeviceCtx
+        rfdetr.optimize_for_inference(compile=False, dtype=torch.float32)
 
         assert len(entered_devices) == 1
         assert entered_devices[0] == torch.device("cuda", 0)
@@ -155,11 +161,20 @@ class TestOptimizeForInferenceCudaDeviceContext:
 
         mock_cuda_device.assert_not_called()
 
-    def test_cuda_device_context_uses_model_device(self) -> None:
+    @patch("rfdetr.detr._ensure_model_on_device")
+    @patch("rfdetr.detr.deepcopy")
+    @patch("torch.cuda.device")
+    def test_cuda_device_context_uses_model_device(
+        self,
+        mock_cuda_device,
+        mock_deepcopy,
+        _mock_ensure_model_on_device,
+    ) -> None:
         """The device passed to torch.cuda.device() should match self.model.device."""
         rfdetr = _FakeRFDETR()
         expected_device = torch.device("cuda", 2)
         rfdetr.model.device = expected_device
+        mock_deepcopy.return_value = rfdetr.model.model
 
         captured: dict[str, torch.device] = {}
 
@@ -173,11 +188,8 @@ class TestOptimizeForInferenceCudaDeviceContext:
             def __exit__(self, *args):
                 pass
 
-        with (
-            patch("torch.cuda.device", side_effect=_CapturingCtx),
-            patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model),
-        ):
-            rfdetr.optimize_for_inference(compile=False)
+        mock_cuda_device.side_effect = _CapturingCtx
+        rfdetr.optimize_for_inference(compile=False)
 
         assert captured.get("device") == expected_device
 

--- a/tests/training/test_auto_batch.py
+++ b/tests/training/test_auto_batch.py
@@ -140,7 +140,34 @@ def test_resolve_auto_batch_config_returns_expected_values():
     assert result.device_name == "Fake GPU"
 
 
-def test_train_auto_batch_ensures_model_on_device_before_resolve(tmp_path):
+@patch("rfdetr.detr.is_main_process", return_value=False)
+@patch("rfdetr.training.auto_batch.resolve_auto_batch_config")
+@patch("rfdetr.training.build_trainer")
+@patch("rfdetr.training.RFDETRDataModule")
+@patch("rfdetr.training.RFDETRModelModule")
+@patch("rfdetr.detr._ensure_model_on_device")
+def test_train_auto_batch_ensures_model_on_device_before_resolve(
+    mock_ensure: MagicMock,
+    _mock_module: MagicMock,
+    _mock_data_module: MagicMock,
+    _mock_build_trainer: MagicMock,
+    mock_resolve: MagicMock,
+    _mock_is_main: MagicMock,
+) -> None:
+    """_ensure_model_on_device must be called before resolve_auto_batch_config when batch_size='auto'."""
+    auto_result = SimpleNamespace(safe_micro_batch=4, recommended_grad_accum_steps=1, effective_batch_size=4)
+    call_order: list[str] = []
+
+    def _ensure_side_effect(model: object) -> None:
+        call_order.append("ensure")
+
+    def _resolve_side_effect(**_kwargs: object) -> object:
+        call_order.append("resolve")
+        return auto_result
+
+    mock_ensure.side_effect = _ensure_side_effect
+    mock_resolve.side_effect = _resolve_side_effect
+
     train_config = SimpleNamespace(
         batch_size="auto",
         grad_accum_steps=99,
@@ -149,36 +176,15 @@ def test_train_auto_batch_ensures_model_on_device_before_resolve(tmp_path):
         class_names=None,
     )
     mock_self = MagicMock()
-    mock_self.model = MagicMock()
     mock_self.model_config = SimpleNamespace(model_name=None)
     mock_self.get_train_config.return_value = train_config
 
-    auto_result = SimpleNamespace(
-        safe_micro_batch=4,
-        recommended_grad_accum_steps=1,
-        effective_batch_size=4,
-    )
-    call_order = []
-    mock_ensure_model_on_device = MagicMock(side_effect=lambda *_args, **_kwargs: call_order.append("ensure"))
-    mock_resolve_auto_batch_config = MagicMock(
-        side_effect=lambda **_kwargs: call_order.append("resolve") or auto_result,
-    )
-
-    with (
-        patch("rfdetr.training.RFDETRModelModule"),
-        patch("rfdetr.training.RFDETRDataModule"),
-        patch("rfdetr.training.build_trainer"),
-        patch("rfdetr.detr.is_main_process", return_value=False),
-        patch("rfdetr.detr._ensure_model_on_device", mock_ensure_model_on_device),
-        patch("rfdetr.training.auto_batch.resolve_auto_batch_config", mock_resolve_auto_batch_config),
-        patch("rfdetr.detr.resolve_auto_batch_config", mock_resolve_auto_batch_config, create=True),
-    ):
-        RFDETR.train(mock_self)
+    RFDETR.train(mock_self)
 
     assert train_config.batch_size == 4
     assert train_config.grad_accum_steps == 1
-    mock_ensure_model_on_device.assert_called_once_with(mock_self.model)
-    mock_resolve_auto_batch_config.assert_called_once_with(
+    mock_ensure.assert_called_once_with(mock_self.model)
+    mock_resolve.assert_called_once_with(
         model_context=mock_self.model,
         model_config=mock_self.model_config,
         train_config=train_config,

--- a/tests/training/test_auto_batch.py
+++ b/tests/training/test_auto_batch.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 
+from rfdetr.detr import RFDETR
 from rfdetr.training import auto_batch
 from rfdetr.training.auto_batch import AutoBatchResult
 
@@ -137,6 +138,52 @@ def test_resolve_auto_batch_config_returns_expected_values():
     assert result.recommended_grad_accum_steps == 4
     assert result.effective_batch_size == 20
     assert result.device_name == "Fake GPU"
+
+
+def test_train_auto_batch_ensures_model_on_device_before_resolve(tmp_path):
+    train_config = SimpleNamespace(
+        batch_size="auto",
+        grad_accum_steps=99,
+        dataset_dir=None,
+        resume=None,
+        class_names=None,
+    )
+    mock_self = MagicMock()
+    mock_self.model = MagicMock()
+    mock_self.model_config = SimpleNamespace(model_name=None)
+    mock_self.get_train_config.return_value = train_config
+
+    auto_result = SimpleNamespace(
+        safe_micro_batch=4,
+        recommended_grad_accum_steps=1,
+        effective_batch_size=4,
+    )
+    call_order = []
+    mock_ensure_model_on_device = MagicMock(side_effect=lambda *_args, **_kwargs: call_order.append("ensure"))
+    mock_resolve_auto_batch_config = MagicMock(
+        side_effect=lambda **_kwargs: call_order.append("resolve") or auto_result,
+    )
+
+    with (
+        patch("rfdetr.training.RFDETRModelModule"),
+        patch("rfdetr.training.RFDETRDataModule"),
+        patch("rfdetr.training.build_trainer"),
+        patch("rfdetr.detr.is_main_process", return_value=False),
+        patch("rfdetr.detr._ensure_model_on_device", mock_ensure_model_on_device),
+        patch("rfdetr.training.auto_batch.resolve_auto_batch_config", mock_resolve_auto_batch_config),
+        patch("rfdetr.detr.resolve_auto_batch_config", mock_resolve_auto_batch_config, create=True),
+    ):
+        RFDETR.train(mock_self)
+
+    assert train_config.batch_size == 4
+    assert train_config.grad_accum_steps == 1
+    mock_ensure_model_on_device.assert_called_once_with(mock_self.model)
+    mock_resolve_auto_batch_config.assert_called_once_with(
+        model_context=mock_self.model,
+        model_config=mock_self.model_config,
+        train_config=train_config,
+    )
+    assert call_order == ["ensure", "resolve"]
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for segmentation probe")

--- a/tests/training/test_build_trainer.py
+++ b/tests/training/test_build_trainer.py
@@ -298,15 +298,13 @@ class TestBuildTrainerPrecision:
         m_bf16.assert_not_called()
         assert captured["precision"] == "bf16-mixed"
 
-    def test_ddp_notebook_uses_spawn_start_method(self, tmp_path):
-        """ddp_notebook must be replaced with spawn-based DDPStrategy.
+    def test_ddp_notebook_uses_spawn_strategy(self, tmp_path):
+        """ddp_notebook must be replaced with ddp_spawn strategy.
 
         Fork-based DDP inherits the parent's OpenMP thread pool which is
         invalid after fork, causing SIGABRT in the autograd engine.
         """
         import unittest.mock as mock
-
-        from pytorch_lightning.strategies import DDPStrategy
 
         captured: dict = {}
 
@@ -319,9 +317,7 @@ class TestBuildTrainerPrecision:
                 _tc(tmp_path, use_ema=False, strategy="ddp_notebook"),
                 _mc(amp=True),
             )
-        strat = captured["strategy"]
-        assert isinstance(strat, DDPStrategy)
-        assert strat._start_method == "spawn"
+        assert captured["strategy"] == "ddp_spawn"
 
 
 class TestBuildTrainerEMAShardingGuard:

--- a/tests/training/test_build_trainer.py
+++ b/tests/training/test_build_trainer.py
@@ -321,10 +321,10 @@ class TestBuildTrainerPrecision:
                 _tc(tmp_path, use_ema=False, strategy=strategy_name),
                 _mc(amp=True),
             )
-        strat = captured["strategy"]
-        assert isinstance(strat, DDPStrategy)
-        assert strat._start_method == "spawn"
-        assert strat._ddp_kwargs.get("find_unused_parameters") is True
+        strategy_obj = captured["strategy"]
+        assert isinstance(strategy_obj, DDPStrategy)
+        assert strategy_obj._start_method == "spawn"
+        assert strategy_obj._ddp_kwargs.get("find_unused_parameters") is True
 
 
 class TestBuildTrainerEMAShardingGuard:

--- a/tests/training/test_build_trainer.py
+++ b/tests/training/test_build_trainer.py
@@ -325,6 +325,26 @@ class TestBuildTrainerPrecision:
         assert strategy_obj._start_method == "spawn"
         assert strategy_obj._ddp_kwargs.get("find_unused_parameters") is True
 
+    @patch("rfdetr.training.trainer._InteractiveSpawnLauncher", None)
+    def test_ddp_notebook_raises_clear_error_when_private_launcher_is_missing(self, tmp_path):
+        """Missing private PTL launcher should raise a targeted compatibility error."""
+        captured: dict = {}
+
+        def _fake_trainer(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        with patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer):
+            build_trainer(
+                _tc(tmp_path, use_ema=False, strategy="ddp_notebook"),
+                _mc(amp=True),
+            )
+
+        strategy = captured["strategy"]
+        strategy.cluster_environment = object()
+        with pytest.raises(RuntimeError, match="private API"):
+            strategy._configure_launcher()
+
 
 class TestBuildTrainerEMAShardingGuard:
     """EMA must be disabled and a UserWarning emitted for sharded strategies.

--- a/tests/training/test_build_trainer.py
+++ b/tests/training/test_build_trainer.py
@@ -7,6 +7,7 @@
 """Tests for build_trainer() — PTL Ch3/T5 (callbacks) and Ch4/T1 (precision, loggers, trainer kwargs)."""
 
 import warnings
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pytorch_lightning.callbacks import ModelCheckpoint
@@ -270,32 +271,30 @@ class TestBuildTrainerPrecision:
             build_trainer(_tc(tmp_path, use_ema=False), _mc(amp=True))
         assert captured["precision"] == "bf16-mixed"
 
-    def test_amp_true_ddp_notebook_probes_bf16_normally(self, tmp_path):
+    @patch("torch.cuda.is_available", return_value=True)
+    @patch("torch.cuda.is_bf16_supported", return_value=False)
+    @patch("rfdetr.training.trainer.Trainer")
+    def test_amp_true_ddp_notebook_probes_bf16_normally(
+        self, mock_trainer: MagicMock, _mock_bf16: MagicMock, _mock_cuda: MagicMock, tmp_path
+    ):
         """ddp_notebook uses standard precision probing (spawn makes CUDA init safe).
 
         With spawn-based DDP, child processes start fresh — CUDA init in the
         parent does not propagate.  So ``is_bf16_supported()`` is safe to call
         and pre-Ampere GPUs correctly get ``16-mixed`` instead of the slower
-        bf16 emulation path.
+        bf16 emulation path.  Simulates pre-Ampere GPU: CUDA available, bf16 NOT supported.
         """
-        import unittest.mock as mock
-
         captured: dict = {}
 
         def _fake_trainer(**kwargs):
             captured.update(kwargs)
-            return mock.MagicMock()
+            return MagicMock()
 
-        # Simulate pre-Ampere GPU: CUDA available but bf16 NOT supported.
-        with (
-            mock.patch("torch.cuda.is_available", return_value=True),
-            mock.patch("torch.cuda.is_bf16_supported", return_value=False),
-            mock.patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer),
-        ):
-            build_trainer(
-                _tc(tmp_path, use_ema=False, strategy="ddp_notebook"),
-                _mc(amp=True),
-            )
+        mock_trainer.side_effect = _fake_trainer
+        build_trainer(
+            _tc(tmp_path, use_ema=False, strategy="ddp_notebook"),
+            _mc(amp=True),
+        )
         assert captured["precision"] == "16-mixed"
 
     @pytest.mark.parametrize("strategy_name", ["ddp_notebook", "ddp_spawn"])

--- a/tests/training/test_build_trainer.py
+++ b/tests/training/test_build_trainer.py
@@ -298,6 +298,31 @@ class TestBuildTrainerPrecision:
         m_bf16.assert_not_called()
         assert captured["precision"] == "bf16-mixed"
 
+    def test_ddp_notebook_uses_spawn_start_method(self, tmp_path):
+        """ddp_notebook must be replaced with spawn-based DDPStrategy.
+
+        Fork-based DDP inherits the parent's OpenMP thread pool which is
+        invalid after fork, causing SIGABRT in the autograd engine.
+        """
+        import unittest.mock as mock
+
+        from pytorch_lightning.strategies import DDPStrategy
+
+        captured: dict = {}
+
+        def _fake_trainer(**kwargs):
+            captured.update(kwargs)
+            return mock.MagicMock()
+
+        with mock.patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer):
+            build_trainer(
+                _tc(tmp_path, use_ema=False, strategy="ddp_notebook"),
+                _mc(amp=True),
+            )
+        strat = captured["strategy"]
+        assert isinstance(strat, DDPStrategy)
+        assert strat._start_method == "spawn"
+
 
 class TestBuildTrainerEMAShardingGuard:
     """EMA must be disabled and a UserWarning emitted for sharded strategies.

--- a/tests/training/test_build_trainer.py
+++ b/tests/training/test_build_trainer.py
@@ -298,13 +298,17 @@ class TestBuildTrainerPrecision:
         m_bf16.assert_not_called()
         assert captured["precision"] == "bf16-mixed"
 
-    def test_ddp_notebook_uses_spawn_strategy(self, tmp_path):
-        """ddp_notebook must be replaced with ddp_spawn strategy.
+    @pytest.mark.parametrize("strategy_name", ["ddp_notebook", "ddp_spawn"])
+    def test_ddp_notebook_and_spawn_use_interactive_spawn(self, tmp_path, strategy_name):
+        """ddp_notebook and ddp_spawn must be replaced with interactive spawn DDPStrategy.
 
         Fork-based DDP inherits the parent's OpenMP thread pool which is
         invalid after fork, causing SIGABRT in the autograd engine.
+        ddp_spawn is blocked by PTL in notebooks without the override.
         """
         import unittest.mock as mock
+
+        from pytorch_lightning.strategies import DDPStrategy
 
         captured: dict = {}
 
@@ -314,10 +318,13 @@ class TestBuildTrainerPrecision:
 
         with mock.patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer):
             build_trainer(
-                _tc(tmp_path, use_ema=False, strategy="ddp_notebook"),
+                _tc(tmp_path, use_ema=False, strategy=strategy_name),
                 _mc(amp=True),
             )
-        assert captured["strategy"] == "ddp_spawn"
+        strat = captured["strategy"]
+        assert isinstance(strat, DDPStrategy)
+        assert strat._start_method == "spawn"
+        assert strat._ddp_kwargs.get("find_unused_parameters") is True
 
 
 class TestBuildTrainerEMAShardingGuard:

--- a/tests/training/test_build_trainer.py
+++ b/tests/training/test_build_trainer.py
@@ -235,13 +235,7 @@ class TestBuildTrainerPrecision:
         assert trainer.precision == "32-true"
 
     def test_amp_true_cuda_no_bf16_gives_16_mixed(self, tmp_path):
-        """amp=True with CUDA but no bf16 support must produce '16-mixed'.
-
-        We mock the Trainer constructor to capture the precision kwarg rather
-        than inspecting trainer.precision after construction: PTL may re-detect
-        hardware bf16 support during __init__ and normalise the precision string
-        on machines that happen to have a bf16-capable GPU.
-        """
+        """amp=True with CUDA but no bf16 support must produce '16-mixed'."""
         import unittest.mock as mock
 
         captured: dict = {}
@@ -259,12 +253,7 @@ class TestBuildTrainerPrecision:
         assert captured["precision"] == "16-mixed"
 
     def test_amp_true_cuda_bf16_supported_gives_bf16_mixed(self, tmp_path):
-        """amp=True with CUDA + bf16 hardware produces 'bf16-mixed' (scaler-free).
-
-        On Ampere+ GPUs (bf16 supported) we select bf16-mixed to eliminate
-        GradScaler overhead.  Fine-tuning from pretrained weights is safe with
-        BF16; callers training from scratch can override via trainer_kwargs.
-        """
+        """amp=True with CUDA + bf16 hardware produces 'bf16-mixed'."""
         import unittest.mock as mock
 
         captured: dict = {}
@@ -279,6 +268,34 @@ class TestBuildTrainerPrecision:
             mock.patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer),
         ):
             build_trainer(_tc(tmp_path, use_ema=False), _mc(amp=True))
+        assert captured["precision"] == "bf16-mixed"
+
+    def test_amp_true_ddp_notebook_skips_bf16_check(self, tmp_path):
+        """ddp_notebook strategy must not call is_bf16_supported() (CUDA init).
+
+        ``torch.cuda.is_bf16_supported()`` initialises the CUDA runtime which
+        prevents fork-based DDP from working in notebooks.  When strategy is
+        ``ddp_notebook`` we default to ``bf16-mixed`` without probing hardware.
+        """
+        import unittest.mock as mock
+
+        captured: dict = {}
+
+        def _fake_trainer(**kwargs):
+            captured.update(kwargs)
+            return mock.MagicMock()
+
+        bf16_mock = mock.patch("torch.cuda.is_bf16_supported")
+        with (
+            mock.patch("torch.cuda.is_available", return_value=True),
+            bf16_mock as m_bf16,
+            mock.patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer),
+        ):
+            build_trainer(
+                _tc(tmp_path, use_ema=False, strategy="ddp_notebook"),
+                _mc(amp=True),
+            )
+        m_bf16.assert_not_called()
         assert captured["precision"] == "bf16-mixed"
 
 

--- a/tests/training/test_build_trainer.py
+++ b/tests/training/test_build_trainer.py
@@ -270,12 +270,13 @@ class TestBuildTrainerPrecision:
             build_trainer(_tc(tmp_path, use_ema=False), _mc(amp=True))
         assert captured["precision"] == "bf16-mixed"
 
-    def test_amp_true_ddp_notebook_skips_bf16_check(self, tmp_path):
-        """ddp_notebook strategy must not call is_bf16_supported() (CUDA init).
+    def test_amp_true_ddp_notebook_probes_bf16_normally(self, tmp_path):
+        """ddp_notebook uses standard precision probing (spawn makes CUDA init safe).
 
-        ``torch.cuda.is_bf16_supported()`` initialises the CUDA runtime which
-        prevents fork-based DDP from working in notebooks.  When strategy is
-        ``ddp_notebook`` we default to ``bf16-mixed`` without probing hardware.
+        With spawn-based DDP, child processes start fresh — CUDA init in the
+        parent does not propagate.  So ``is_bf16_supported()`` is safe to call
+        and pre-Ampere GPUs correctly get ``16-mixed`` instead of the slower
+        bf16 emulation path.
         """
         import unittest.mock as mock
 
@@ -285,18 +286,17 @@ class TestBuildTrainerPrecision:
             captured.update(kwargs)
             return mock.MagicMock()
 
-        bf16_mock = mock.patch("torch.cuda.is_bf16_supported")
+        # Simulate pre-Ampere GPU: CUDA available but bf16 NOT supported.
         with (
             mock.patch("torch.cuda.is_available", return_value=True),
-            bf16_mock as m_bf16,
+            mock.patch("torch.cuda.is_bf16_supported", return_value=False),
             mock.patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer),
         ):
             build_trainer(
                 _tc(tmp_path, use_ema=False, strategy="ddp_notebook"),
                 _mc(amp=True),
             )
-        m_bf16.assert_not_called()
-        assert captured["precision"] == "bf16-mixed"
+        assert captured["precision"] == "16-mixed"
 
     @pytest.mark.parametrize("strategy_name", ["ddp_notebook", "ddp_spawn"])
     def test_ddp_notebook_and_spawn_use_interactive_spawn(self, tmp_path, strategy_name):

--- a/tests/training/test_module_data.py
+++ b/tests/training/test_module_data.py
@@ -184,6 +184,20 @@ class TestInit:
         dm = build_datamodule(train_config=tc)
         assert dm._persistent_workers is False
 
+    def test_ddp_notebook_forces_num_workers_zero(self, build_datamodule, base_train_config):
+        """ddp_notebook overrides num_workers to 0 to avoid nested-fork deadlocks."""
+        tc = base_train_config(num_workers=4, strategy="ddp_notebook")
+        dm = build_datamodule(train_config=tc)
+        assert dm._num_workers == 0
+        assert dm._prefetch_factor is None
+
+    def test_non_ddp_notebook_preserves_num_workers(self, build_datamodule, base_train_config):
+        """Non-ddp_notebook strategies keep num_workers as configured."""
+        tc = base_train_config(num_workers=4, strategy="ddp")
+        dm = build_datamodule(train_config=tc)
+        assert dm._num_workers == 4
+        assert dm._prefetch_factor == 2  # default prefetch_factor for num_workers>0
+
 
 class TestSetup:
     """setup(stage) builds the correct dataset(s) for each PTL stage."""

--- a/tests/training/test_module_data.py
+++ b/tests/training/test_module_data.py
@@ -184,15 +184,17 @@ class TestInit:
         dm = build_datamodule(train_config=tc)
         assert dm._persistent_workers is False
 
-    def test_ddp_notebook_forces_num_workers_zero(self, build_datamodule, base_train_config):
-        """ddp_notebook overrides num_workers to 0 to avoid nested-fork deadlocks."""
+    def test_ddp_notebook_preserves_num_workers(self, build_datamodule, base_train_config):
+        """ddp_notebook keeps num_workers as configured (spawn-based DDP
+        children initialise CUDA fresh; DataLoader fork workers are CPU-only
+        and never touch CUDA, so nested forks are safe)."""
         tc = base_train_config(num_workers=4, strategy="ddp_notebook")
         dm = build_datamodule(train_config=tc)
-        assert dm._num_workers == 0
-        assert dm._prefetch_factor is None
+        assert dm._num_workers == 4
+        assert dm._prefetch_factor == 2
 
-    def test_non_ddp_notebook_preserves_num_workers(self, build_datamodule, base_train_config):
-        """Non-ddp_notebook strategies keep num_workers as configured."""
+    def test_other_strategy_preserves_num_workers(self, build_datamodule, base_train_config):
+        """Non-ddp_notebook strategies also keep num_workers as configured."""
         tc = base_train_config(num_workers=4, strategy="ddp")
         dm = build_datamodule(train_config=tc)
         assert dm._num_workers == 4

--- a/tests/training/test_module_data.py
+++ b/tests/training/test_module_data.py
@@ -178,6 +178,13 @@ class TestInit:
         dm = build_datamodule(train_config=tc)
         assert dm._pin_memory is False
 
+    @patch("rfdetr.config.DEVICE", "cuda")
+    def test_pin_memory_defaults_to_false_when_accelerator_is_cpu(self, build_datamodule, base_train_config):
+        """Default pin_memory stays off when training is explicitly CPU-only."""
+        tc = base_train_config(pin_memory=None, accelerator="cpu")
+        dm = build_datamodule(train_config=tc)
+        assert dm._pin_memory is False
+
     def test_persistent_workers_override_is_respected(self, build_datamodule, base_train_config):
         """persistent_workers can be explicitly overridden from TrainConfig."""
         tc = base_train_config(num_workers=2, persistent_workers=False)

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -191,6 +191,15 @@ class TestInit:
             _build_module(model_config=mc, train_config=tc, tmp_path=tmp_path)
         mock_compile.assert_called_once()
 
+    @patch("rfdetr.training.module_model.torch.compile")
+    @patch("rfdetr.config.DEVICE", "cuda")
+    def test_compile_disabled_when_train_accelerator_is_cpu(self, _mock_compile: MagicMock, tmp_path):
+        """compile stays disabled when training is explicitly forced to CPU."""
+        mc = _base_model_config(compile=True)
+        tc = _base_train_config(tmp_path, multi_scale=False, accelerator="cpu")
+        _build_module(model_config=mc, train_config=tc, tmp_path=tmp_path)
+        _mock_compile.assert_not_called()
+
 
 class TestLoadPretrainWeights:
     """Tests for _load_pretrain_weights() — covers checkpoint validation, detection-head

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -185,7 +185,7 @@ class TestInit:
         mc = _base_model_config(compile=True)
         tc = _base_train_config(tmp_path, multi_scale=False)
         with (
-            patch("torch.cuda.is_available", return_value=True),
+            patch("rfdetr.config.DEVICE", "cuda"),
             patch("rfdetr.training.module_model.torch.compile", side_effect=lambda m, **_: m) as mock_compile,
         ):
             _build_module(model_config=mc, train_config=tc, tmp_path=tmp_path)


### PR DESCRIPTION
## What does this PR do?

Fixes multi-GPU DDP training (`strategy="ddp_notebook"` and `strategy="ddp_spawn"`) which was completely broken in Jupyter (e.g. Kaggle) notebook environments. The fix addresses two layers of issues:

1. **CUDA early initialization**: `RFDETRBase()` eagerly moved the model to CUDA during `__init__()`, and module-level `torch.cuda.is_available()` in `config.py` created a CUDA driver context at import time, making multi-process training impossible.

2. **OpenMP thread pool corruption after fork**: Even after fixing CUDA init, PyTorch's OpenMP thread pool (created during model construction) cannot survive `fork()`. The worker threads become zombie handles, causing `SIGABRT: Invalid thread pool!` when the autograd engine initializes in forked children. Fixed by transparently replacing fork-based DDP with a spawn-based strategy.

**Related Issue(s):** Fixes #923

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

### Unit tests (101 pass locally)

- `test_build_trainer.py`: 52 tests covering precision resolution, strategy selection, ddp_notebook→spawn mapping, EMA guards, logger wiring
- `test_module_data.py`: 49 tests including `test_ddp_notebook_preserves_num_workers` and `test_other_strategy_preserves_num_workers`

### Integration test (Kaggle T4 x2)

Validated on Kaggle GPU T4 x2 accelerator (Python 3.12, PyTorch 2.10.0+cu128, PTL 2.6.1):

| Test | Result | Time |
|------|--------|------|
| CUDA not initialized after `RFDETRBase()` | ✅ PASS | — |
| Model weights on CPU after construction | ✅ PASS | — |
| `strategy="ddp_notebook"` training (3 epochs, 2×T4) | ✅ PASS | 84.3s |
| `strategy="ddp_spawn"` training (3 epochs, 2×T4) | ✅ PASS | 77.4s |
| Inference after DDP training | ✅ PASS | — |

## What This Fixes

| Scenario | Before | After |
|---|---|---|
| `model.train(devices=2, strategy="ddp_notebook")` in notebook | ❌ CUDA re-init / SIGABRT | ✅ Works |
| `model.train(devices=2, strategy="ddp_spawn")` in notebook | ❌ CUDA re-init / MisconfigurationException | ✅ Works |
| `model.train(devices=1)` | ✅ Works | ✅ Works (no regression) |
| `model.predict(img)` | ✅ Works | ✅ Works (lazy device placement) |
| `model.train() → model.predict(img)` | ✅ Works | ✅ Works |
| `model.export_onnx()` / `model.optimize_for_inference()` | ✅ Works | ✅ Works |

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

The `ddp_notebook → spawn` conversion is transparent to users: they continue passing `strategy="ddp_notebook"` (or `strategy="ddp_spawn"`) and training just works. An INFO log message is emitted:

```
[INFO] rf-detr - ddp_notebook → spawn-based DDP to avoid OpenMP thread pool corruption after fork.
```

The `find_unused_parameters=True` flag is required because RF-DETR's architecture has parameters in the detection head that may not contribute to every loss term (e.g. encoder-only auxiliary losses).

### Technical Details

#### Two layers of CUDA initialization that had to be fixed

1. **Module-level** (`config.py`): `torch.cuda.is_available()` creates a CUDA driver context at import time. Fixed with `torch.accelerator.current_accelerator()` which queries NVML without creating a primary context.

2. **Model construction** (`inference.py`): `nn_model.to("cuda")` fully initializes the CUDA runtime. Fixed by keeping the model on CPU and deferring `.to(device)` to first `predict()`/`export()`/`batch_size="auto"` call via `_ensure_model_on_device()`.

#### Why spawn instead of fork

PyTorch creates an OpenMP thread pool (default 8 threads) during the first tensor operation (model construction). `fork()` only copies the calling thread, OMP worker threads become zombie handles. When the autograd engine in forked children calls `set_num_threads` during `thread_init`, the OMP runtime finds an invalid pool state and aborts:

```
terminate called after throwing an instance of 'c10::Error'
  what(): pool INTERNAL ASSERT FAILED at "/pytorch/aten/src/ATen/ParallelOpenMP.cpp":64
```

This is a **fundamental fork+OMP incompatibility**; as far as I know, there is no library-level workaround. The fix transparently replaces fork-based `ddp_notebook` with a spawn-based `_NotebookSpawnDDPStrategy` whose launcher is marked `is_interactive_compatible = True`, allowing PTL to accept it in notebook environments.

#### Performance impact

- **First `predict()` call**: ~50-200ms one-time latency from CPU→GPU model transfer. Strictly one-time, `_ensure_model_on_device()` checks `first_param.device != target` and becomes a no-op once the model is on GPU. After `train()`, the PTL-trained model is already on CUDA (synced at line 548), so even the first post-training `predict()` has zero transfer cost.
- **Subsequent `predict()` calls**: Zero overhead (single `next(parameters()).device` comparison)
- **Production inference** (`RFDETRBase() → predict()` without training): The one-time transfer happens on the very first call only. All subsequent calls, including batch evaluation loops, are zero-overhead.
- **Training**: Zero impact (PTL builds its own model on CPU and handles device placement)
- **DDP spawn vs fork**: ~12s additional startup for process spawn (one-time per training run)
