### PR TITLE
chore: update `pyproject.toml` for linting refinements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,4 +202,10 @@ docs/versions.json
 notebooks/*.py
 
 # tracking work in progress
+.codex/logs
+.reports/
+.temp/
+cache-gh/
+checkpoints/
+releases/
 tasks/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,12 +157,14 @@ select = [
     "W",  # pycodestyle warnings
     "F",  # pyflakes
     "I",  # isort
+    "N",  # pep8-naming: lowercase variables (N806) and arguments (N803)
 ]
 extend-select = [
     "RUF100",  # yesqa
 ]
 ignore = [
     "E722",  # todo: Do not use bare `except`
+    "N812",  # torch convention: `import torch.nn.functional as F`
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,7 @@ extend-select = [
 ]
 ignore = [
     "E722",  # todo: Do not use bare `except`
+    "N806",  # allow conventional uppercase local tensor-shape variables (e.g. N, C, H, W)
     "N812",  # torch convention: `import torch.nn.functional as F`
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,8 +164,6 @@ extend-select = [
 ]
 ignore = [
     "E722",  # todo: Do not use bare `except`
-    "N806",  # allow conventional uppercase local tensor-shape variables (e.g. N, C, H, W)
-    "N812",  # torch convention: `import torch.nn.functional as F`
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/rfdetr/datasets/_develop.py
+++ b/src/rfdetr/datasets/_develop.py
@@ -55,12 +55,12 @@ class _SimpleDataset:
         transforms: Optional transforms to apply (e.g., Compose of AlbumentationsWrapper).
 
     Examples:
-        >>> import albumentations as A
+        >>> from albumentations import HorizontalFlip
         >>> from torchvision.transforms.v2 import Compose
         >>> from rfdetr.datasets.transforms import AlbumentationsWrapper
         >>>
         >>> transforms = Compose([
-        ...     AlbumentationsWrapper(A.HorizontalFlip(p=0.5)),
+        ...     AlbumentationsWrapper(HorizontalFlip(p=0.5)),
         ... ])
         >>> dataset = _SimpleDataset(num_samples=10, transforms=transforms)
         >>> image, target = dataset[0]

--- a/src/rfdetr/datasets/coco.py
+++ b/src/rfdetr/datasets/coco.py
@@ -543,7 +543,7 @@ def build_coco(image_set: str, args: Any, resolution: int) -> CocoDetection:
         raise FileNotFoundError(f"COCO path {root} does not exist")
 
     mode = "instances"
-    PATHS = {
+    PATHS = {  # noqa: N806
         "train": (root / "train2017", root / "annotations" / f"{mode}_train2017.json"),
         "val": (root / "val2017", root / "annotations" / f"{mode}_val2017.json"),
         "test": (root / "test2017", root / "annotations" / "image_info_test-dev2017.json"),
@@ -603,7 +603,7 @@ def build_roboflow_from_coco(image_set: str, args: Any, resolution: int) -> Coco
         logger.error(f"Roboflow dataset path {root} does not exist")
         raise FileNotFoundError(f"Roboflow dataset path {root} does not exist")
 
-    PATHS = {
+    PATHS = {  # noqa: N806
         "train": (root / "train", root / "train" / "_annotations.coco.json"),
         "val": (root / "valid", root / "valid" / "_annotations.coco.json"),
         "test": (root / "test", root / "test" / "_annotations.coco.json"),

--- a/src/rfdetr/datasets/o365.py
+++ b/src/rfdetr/datasets/o365.py
@@ -21,7 +21,7 @@ Image.MAX_IMAGE_PIXELS = None
 
 def build_o365_raw(image_set: str, args: Any, resolution: int) -> CocoDetection:
     root = Path(getattr(args, "dataset_dir", None) or args.coco_path)
-    PATHS = {
+    PATHS = {  # noqa: N806
         "train": (root, root / "zhiyuan_objv2_train_val_wo_5k.json"),
         "val": (root, root / "zhiyuan_objv2_minival5k.json"),
     }

--- a/src/rfdetr/datasets/save_grids.py
+++ b/src/rfdetr/datasets/save_grids.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import supervision as sv
 import torch
-import torchvision.transforms as T
+import torchvision.transforms as T  # noqa: N812
 from matplotlib.axes import Axes
 from torch.utils.data import DataLoader
 

--- a/src/rfdetr/datasets/transforms.py
+++ b/src/rfdetr/datasets/transforms.py
@@ -25,9 +25,9 @@ from functools import lru_cache
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 try:
-    import albumentations as A
+    import albumentations as alb
 except ImportError:
-    A = None  # type: ignore[assignment]
+    alb = None  # type: ignore[assignment]
 import numpy as np
 import PIL
 import torch
@@ -120,7 +120,7 @@ GEOMETRIC_TRANSFORMS = {
 ALBUMENTATIONS_CONTAINERS = frozenset({"OneOf", "SomeOf", "Sequential"})
 
 
-def _is_geometric_transform(transform: A.BasicTransform) -> bool:
+def _is_geometric_transform(transform: alb.BasicTransform) -> bool:
     """Return True if transform (or any nested transform) affects spatial coordinates.
 
     For container transforms such as ``A.OneOf`` or ``A.Sequential``, returns
@@ -150,7 +150,7 @@ def _is_geometric_transform(transform: A.BasicTransform) -> bool:
     return False
 
 
-def _build_albu_transform(name: str, params: Dict[str, Any]) -> A.BasicTransform:
+def _build_albu_transform(name: str, params: Dict[str, Any]) -> alb.BasicTransform:
     """Build a single Albumentations transform from its name and parameter dict.
 
     Handles container transforms (``OneOf``, ``SomeOf``, ``Sequential``) by
@@ -190,7 +190,7 @@ def _build_albu_transform(name: str, params: Dict[str, Any]) -> A.BasicTransform
         raw_nested = params.get("transforms", [])
         if not isinstance(raw_nested, list):
             raise ValueError(f"'{name}.transforms' must be a list, got {type(raw_nested).__name__}")
-        nested_transforms: List[A.BasicTransform] = []
+        nested_transforms: List[alb.BasicTransform] = []
         for entry in raw_nested:
             if not isinstance(entry, dict) or len(entry) != 1:
                 raise ValueError(f"Each nested transform entry must be a single-key dict, got {entry!r}")
@@ -213,12 +213,12 @@ def _build_albu_transform(name: str, params: Dict[str, Any]) -> A.BasicTransform
         else:
             other_params = {k: v for k, v in params.items() if k != "transforms"}
 
-        container_cls = getattr(A, name, None)
+        container_cls = getattr(alb, name, None)
         if container_cls is None:
             raise ValueError(f"Unknown Albumentations container: {name!r}")
         return container_cls(transforms=nested_transforms, **other_params)
 
-    aug_cls = getattr(A, name, None)
+    aug_cls = getattr(alb, name, None)
     if aug_cls is None:
         raise ValueError(f"Unknown Albumentations transform: {name!r}")
     return aug_cls(**_normalize_albu_params(name, params, aug_cls))
@@ -372,16 +372,16 @@ class AlbumentationsWrapper:
         GEOMETRIC_TRANSFORMS set at module level.
     """
 
-    def __init__(self, transform: A.BasicTransform) -> None:
+    def __init__(self, transform: alb.BasicTransform) -> None:
         # Auto-detect if transform is geometric (recursively for containers)
         self._is_geometric = _is_geometric_transform(transform)
 
         if self._is_geometric:
             # Wrap geometric transform with bbox handling capabilities
             # bbox_params configure how Albumentations should transform bounding boxes:
-            self.transform = A.Compose(
+            self.transform = alb.Compose(
                 [transform],
-                bbox_params=A.BboxParams(
+                bbox_params=alb.BboxParams(
                     format="pascal_voc",  # Boxes are in (x1, y1, x2, y2) format
                     label_fields=["category_ids", "idxs"],  # Track labels and indices for per-instance field sync
                     min_visibility=0.0,  # Remove boxes with zero visibility/area after transformation
@@ -391,7 +391,7 @@ class AlbumentationsWrapper:
         else:
             # Wrap non-geometric transform without bbox handling
             # Simpler composition since boxes don't need transformation
-            self.transform = A.Compose([transform])
+            self.transform = alb.Compose([transform])
 
     def __repr__(self) -> str:
         """Return a readable string representation of the wrapper.
@@ -400,12 +400,12 @@ class AlbumentationsWrapper:
             Representation including the wrapped transform and type.
         """
         transform = None
-        if isinstance(self.transform, A.Compose):
+        if isinstance(self.transform, alb.Compose):
             for candidate in self.transform.transforms:
-                if isinstance(candidate, A.BasicTransform):
+                if isinstance(candidate, alb.BasicTransform):
                     transform = candidate
                     break
-        elif isinstance(self.transform, A.BasicTransform):
+        elif isinstance(self.transform, alb.BasicTransform):
             transform = self.transform
 
         if transform is None:

--- a/src/rfdetr/datasets/transforms.py
+++ b/src/rfdetr/datasets/transforms.py
@@ -356,7 +356,7 @@ class AlbumentationsWrapper:
         transform: Albumentations transform to apply (e.g., alb.HorizontalFlip, alb.GaussianBlur).
 
     Examples:
-        >>> from albumentations import HorizontalFlip
+        >>> from albumentations import GaussianBlur, HorizontalFlip
         >>> # Geometric transform - automatically transforms boxes
         >>> wrapper = AlbumentationsWrapper(HorizontalFlip(p=1.0))
         >>> image = Image.new("RGB", (300, 400))
@@ -364,7 +364,7 @@ class AlbumentationsWrapper:
         >>> aug_image, aug_target = wrapper(image, target)
 
         >>> # Pixel-level transform - automatically preserves boxes
-        >>> wrapper = AlbumentationsWrapper(A.GaussianBlur(p=1.0))
+        >>> wrapper = AlbumentationsWrapper(GaussianBlur(p=1.0))
         >>> aug_image, aug_target = wrapper(image, target)
 
     Note:

--- a/src/rfdetr/datasets/transforms.py
+++ b/src/rfdetr/datasets/transforms.py
@@ -134,12 +134,12 @@ def _is_geometric_transform(transform: alb.BasicTransform) -> bool:
         ``True`` if the transform modifies spatial layout; ``False`` otherwise.
 
     Examples:
-        >>> import albumentations as A
-        >>> _is_geometric_transform(A.HorizontalFlip())
+        >>> from albumentations import GaussianBlur, HorizontalFlip, OneOf
+        >>> _is_geometric_transform(HorizontalFlip())
         True
-        >>> _is_geometric_transform(A.GaussianBlur())
+        >>> _is_geometric_transform(GaussianBlur())
         False
-        >>> _is_geometric_transform(A.OneOf([A.HorizontalFlip(), A.GaussianBlur()]))
+        >>> _is_geometric_transform(OneOf([HorizontalFlip(), GaussianBlur()]))
         True
     """
     if type(transform).__name__ in GEOMETRIC_TRANSFORMS:
@@ -175,15 +175,15 @@ def _build_albu_transform(name: str, params: Dict[str, Any]) -> alb.BasicTransfo
         ValueError: If ``name`` is unknown or ``params`` is malformed.
 
     Examples:
-        >>> import albumentations as A
+        >>> from albumentations import HorizontalFlip, OneOf
         >>> t = _build_albu_transform("HorizontalFlip", {"p": 0.5})
-        >>> isinstance(t, A.HorizontalFlip)
+        >>> isinstance(t, HorizontalFlip)
         True
         >>> container = _build_albu_transform(
         ...     "OneOf",
         ...     {"transforms": [{"HorizontalFlip": {"p": 1.0}}, {"VerticalFlip": {"p": 1.0}}]},
         ... )
-        >>> isinstance(container, A.OneOf)
+        >>> isinstance(container, OneOf)
         True
     """
     if name in ALBUMENTATIONS_CONTAINERS:
@@ -353,12 +353,12 @@ class AlbumentationsWrapper:
     invalid boxes.
 
     Args:
-        transform: Albumentations transform to apply (e.g., A.HorizontalFlip, A.GaussianBlur).
+        transform: Albumentations transform to apply (e.g., alb.HorizontalFlip, alb.GaussianBlur).
 
     Examples:
-        >>> import albumentations as A
+        >>> from albumentations import HorizontalFlip
         >>> # Geometric transform - automatically transforms boxes
-        >>> wrapper = AlbumentationsWrapper(A.HorizontalFlip(p=1.0))
+        >>> wrapper = AlbumentationsWrapper(HorizontalFlip(p=1.0))
         >>> image = Image.new("RGB", (300, 400))
         >>> target = {"boxes": torch.tensor([[10, 20, 100, 200]]), "labels": torch.tensor([1])}
         >>> aug_image, aug_target = wrapper(image, target)
@@ -495,9 +495,9 @@ class AlbumentationsWrapper:
         Returns:
             Tuple of (transformed PIL Image, transformed target dict).
 
-        >>> import albumentations as A
         >>> import torch
-        >>> wrapper = AlbumentationsWrapper(A.HorizontalFlip(p=1.0))
+        >>> from albumentations import HorizontalFlip
+        >>> wrapper = AlbumentationsWrapper(HorizontalFlip(p=1.0))
         >>> img = np.ones((100, 100, 3), dtype=np.uint8)
         >>> tgt = {"boxes": torch.tensor([[10, 20, 30, 40]]), "labels": torch.tensor([1])}
         >>> img_out, tgt_out = wrapper._apply_geometric_transform(img, tgt, [1])
@@ -605,7 +605,8 @@ class AlbumentationsWrapper:
             ValueError: If boxes don't have shape (N, 4).
 
         Examples:
-            >>> wrapper = AlbumentationsWrapper(A.HorizontalFlip(p=1.0))
+            >>> from albumentations import HorizontalFlip
+            >>> wrapper = AlbumentationsWrapper(HorizontalFlip(p=1.0))
             >>> image = Image.new('RGB', (100, 100))
             >>> target = {"boxes": torch.tensor([[10, 20, 90, 80]]), "labels": torch.tensor([1])}
             >>> aug_image, aug_target = wrapper(image, target)

--- a/src/rfdetr/datasets/yolo.py
+++ b/src/rfdetr/datasets/yolo.py
@@ -691,7 +691,7 @@ def build_roboflow_from_yolo(image_set: str, args: Any, resolution: int) -> Yolo
     assert root.exists(), f"provided Roboflow path {root} does not exist"
 
     # YOLO format uses images/ and labels/ subdirectories
-    PATHS = {
+    PATHS = {  # noqa: N806
         "train": (root / "train" / "images", root / "train" / "labels"),
         "val": (root / "valid" / "images", root / "valid" / "labels"),
         "test": (root / "test" / "images", root / "test" / "labels"),

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -26,7 +26,7 @@ import torch
 if TYPE_CHECKING:
     import supervision as sv
 
-import torchvision.transforms.functional as F
+import torchvision.transforms.functional as F  # noqa: N812
 import yaml
 from PIL import Image
 

--- a/src/rfdetr/evaluation/coco_eval.py
+++ b/src/rfdetr/evaluation/coco_eval.py
@@ -282,22 +282,25 @@ def evaluate(self: COCOeval) -> tuple[list[int], np.ndarray]:
     self.params = p
 
     self._prepare()
-    catIds = p.catIds if p.useCats else [-1]
+    category_ids = p.catIds if p.useCats else [-1]
 
     if p.iouType == "segm" or p.iouType == "bbox":
-        computeIoU = self.computeIoU
+        compute_iou = self.computeIoU
     elif p.iouType == "keypoints":
-        computeIoU = self.computeOks
-    self.ious = {(imgId, catId): computeIoU(imgId, catId) for imgId in p.imgIds for catId in catIds}
+        compute_iou = self.computeOks
+    self.ious = {(imgId, catId): compute_iou(imgId, catId) for imgId in p.imgIds for catId in category_ids}
 
-    evaluateImg = self.evaluateImg
-    maxDet = p.maxDets[-1]
-    evalImgs = [
-        evaluateImg(imgId, catId, areaRng, maxDet) for catId in catIds for areaRng in p.areaRng for imgId in p.imgIds
+    evaluate_image = self.evaluateImg
+    max_det = p.maxDets[-1]
+    eval_images = [
+        evaluate_image(imgId, catId, areaRng, max_det)
+        for catId in category_ids
+        for areaRng in p.areaRng
+        for imgId in p.imgIds
     ]
-    evalImgs = np.asarray(evalImgs).reshape(len(catIds), len(p.areaRng), len(p.imgIds))
+    eval_images = np.asarray(eval_images).reshape(len(category_ids), len(p.areaRng), len(p.imgIds))
     self._paramsEval = copy.deepcopy(self.params)
-    return p.imgIds, evalImgs
+    return p.imgIds, eval_images
 
 
 #################################################################
@@ -307,66 +310,68 @@ def evaluate(self: COCOeval) -> tuple[list[int], np.ndarray]:
 def patched_pycocotools_summarize(self: COCOeval) -> None:
     """Compute and display summary metrics for evaluation results."""
 
-    def _summarize(ap: int = 1, iouThr: float | None = None, areaRng: str = "all", maxDets: int = 100) -> float:
+    def _summarize(ap: int = 1, iou_thr: float | None = None, area_rng: str = "all", max_dets: int = 100) -> float:
         p = self.params
-        iStr = " {:<18} {} @[ IoU={:<9} | area={:>6s} | maxDets={:>3d} ] = {:0.3f}"
-        titleStr = "Average Precision" if ap == 1 else "Average Recall"
-        typeStr = "(AP)" if ap == 1 else "(AR)"
-        iouStr = "{:0.2f}:{:0.2f}".format(p.iouThrs[0], p.iouThrs[-1]) if iouThr is None else "{:0.2f}".format(iouThr)
+        log_template = " {:<18} {} @[ IoU={:<9} | area={:>6s} | maxDets={:>3d} ] = {:0.3f}"
+        title_str = "Average Precision" if ap == 1 else "Average Recall"
+        type_str = "(AP)" if ap == 1 else "(AR)"
+        iou_str = (
+            "{:0.2f}:{:0.2f}".format(p.iouThrs[0], p.iouThrs[-1]) if iou_thr is None else "{:0.2f}".format(iou_thr)
+        )
 
-        aind = [i for i, aRng in enumerate(p.areaRngLbl) if aRng == areaRng]
-        mind = [i for i, mDet in enumerate(p.maxDets) if mDet == maxDets]
+        aind = [i for i, aRng in enumerate(p.areaRngLbl) if aRng == area_rng]
+        mind = [i for i, mDet in enumerate(p.maxDets) if mDet == max_dets]
         if ap == 1:
             s = self.eval["precision"]
-            if iouThr is not None:
-                t = np.where(iouThr == p.iouThrs)[0]
+            if iou_thr is not None:
+                t = np.where(iou_thr == p.iouThrs)[0]
                 s = s[t]
             s = s[:, :, :, aind, mind]
         else:
             s = self.eval["recall"]
-            if iouThr is not None:
-                t = np.where(iouThr == p.iouThrs)[0]
+            if iou_thr is not None:
+                t = np.where(iou_thr == p.iouThrs)[0]
                 s = s[t]
             s = s[:, :, aind, mind]
         mean_s = -1 if len(s[s > -1]) == 0 else float(np.mean(s[s > -1]))
-        logger.info(iStr.format(titleStr, typeStr, iouStr, areaRng, maxDets, mean_s))
+        logger.info(log_template.format(title_str, type_str, iou_str, area_rng, max_dets, mean_s))
         return mean_s
 
-    def _summarizeDets() -> np.ndarray:
+    def _summarizeDets() -> np.ndarray:  # noqa: N802
         stats = np.zeros((12,))
-        stats[0] = _summarize(1, maxDets=self.params.maxDets[2])
-        stats[1] = _summarize(1, iouThr=0.5, maxDets=self.params.maxDets[2])
-        stats[2] = _summarize(1, iouThr=0.75, maxDets=self.params.maxDets[2])
-        stats[3] = _summarize(1, areaRng="small", maxDets=self.params.maxDets[2])
-        stats[4] = _summarize(1, areaRng="medium", maxDets=self.params.maxDets[2])
-        stats[5] = _summarize(1, areaRng="large", maxDets=self.params.maxDets[2])
-        stats[6] = _summarize(0, maxDets=self.params.maxDets[0])
-        stats[7] = _summarize(0, maxDets=self.params.maxDets[1])
-        stats[8] = _summarize(0, maxDets=self.params.maxDets[2])
-        stats[9] = _summarize(0, areaRng="small", maxDets=self.params.maxDets[2])
-        stats[10] = _summarize(0, areaRng="medium", maxDets=self.params.maxDets[2])
-        stats[11] = _summarize(0, areaRng="large", maxDets=self.params.maxDets[2])
+        stats[0] = _summarize(1, max_dets=self.params.maxDets[2])
+        stats[1] = _summarize(1, iou_thr=0.5, max_dets=self.params.maxDets[2])
+        stats[2] = _summarize(1, iou_thr=0.75, max_dets=self.params.maxDets[2])
+        stats[3] = _summarize(1, area_rng="small", max_dets=self.params.maxDets[2])
+        stats[4] = _summarize(1, area_rng="medium", max_dets=self.params.maxDets[2])
+        stats[5] = _summarize(1, area_rng="large", max_dets=self.params.maxDets[2])
+        stats[6] = _summarize(0, max_dets=self.params.maxDets[0])
+        stats[7] = _summarize(0, max_dets=self.params.maxDets[1])
+        stats[8] = _summarize(0, max_dets=self.params.maxDets[2])
+        stats[9] = _summarize(0, area_rng="small", max_dets=self.params.maxDets[2])
+        stats[10] = _summarize(0, area_rng="medium", max_dets=self.params.maxDets[2])
+        stats[11] = _summarize(0, area_rng="large", max_dets=self.params.maxDets[2])
         return stats
 
-    def _summarizeKps() -> np.ndarray:
+    def _summarizeKps() -> np.ndarray:  # noqa: N802
         stats = np.zeros((10,))
-        stats[0] = _summarize(1, maxDets=20)
-        stats[1] = _summarize(1, maxDets=20, iouThr=0.5)
-        stats[2] = _summarize(1, maxDets=20, iouThr=0.75)
-        stats[3] = _summarize(1, maxDets=20, areaRng="medium")
-        stats[4] = _summarize(1, maxDets=20, areaRng="large")
-        stats[5] = _summarize(0, maxDets=20)
-        stats[6] = _summarize(0, maxDets=20, iouThr=0.5)
-        stats[7] = _summarize(0, maxDets=20, iouThr=0.75)
-        stats[8] = _summarize(0, maxDets=20, areaRng="medium")
-        stats[9] = _summarize(0, maxDets=20, areaRng="large")
+        stats[0] = _summarize(1, max_dets=20)
+        stats[1] = _summarize(1, max_dets=20, iou_thr=0.5)
+        stats[2] = _summarize(1, max_dets=20, iou_thr=0.75)
+        stats[3] = _summarize(1, max_dets=20, area_rng="medium")
+        stats[4] = _summarize(1, max_dets=20, area_rng="large")
+        stats[5] = _summarize(0, max_dets=20)
+        stats[6] = _summarize(0, max_dets=20, iou_thr=0.5)
+        stats[7] = _summarize(0, max_dets=20, iou_thr=0.75)
+        stats[8] = _summarize(0, max_dets=20, area_rng="medium")
+        stats[9] = _summarize(0, max_dets=20, area_rng="large")
         return stats
 
     if not self.eval:
         raise Exception("Please run accumulate() first")
-    iouType = self.params.iouType
-    if iouType == "segm" or iouType == "bbox":
+    iou_type = self.params.iouType
+    if iou_type == "segm" or iou_type == "bbox":
         summarize = _summarizeDets
-    elif iouType == "keypoints":
+    elif iou_type == "keypoints":
         summarize = _summarizeKps
     self.stats = summarize()

--- a/src/rfdetr/evaluation/matching.py
+++ b/src/rfdetr/evaluation/matching.py
@@ -20,7 +20,7 @@ from typing import Any
 
 import numpy as np
 import torch
-import torch.nn.functional as F
+import torch.nn.functional as F  # noqa: N812
 from torchvision.ops import box_iou
 
 from rfdetr.utilities import all_gather

--- a/src/rfdetr/export/_onnx/exporter.py
+++ b/src/rfdetr/export/_onnx/exporter.py
@@ -257,7 +257,7 @@ class OnnxOptimizer:
                 Shape->Slice----^     subgraph to the graph to extract the shape of the output tensor.
         This fix is required for the dynamic shape support.
         """
-        mResizeNodes = 0
+        resized_node_count = 0
         for node in self.graph.nodes:
             if node.op == "Resize" and len(node.inputs) == 3:
                 name = node.name + "/"
@@ -319,26 +319,26 @@ class OnnxOptimizer:
                 node.inputs = []
                 node.outputs = []
 
-                mResizeNodes += 1
+                resized_node_count += 1
 
         self.cleanup()
-        return mResizeNodes
+        return resized_node_count
 
-    def adjustAddNode(self):
-        nAdjustAddNode = 0
+    def adjustAddNode(self):  # noqa: N802
+        adjusted_add_node_count = 0
         for node in self.graph.nodes:
             # Change the bias const to the second input to allow Gemm+BiasAdd fusion in TRT.
             if node.op in ["Add"] and isinstance(node.inputs[0], gs.ir.tensor.Constant):
                 tensor = node.inputs[1]
                 bias = node.inputs[0]
                 node.inputs = [tensor, bias]
-                nAdjustAddNode += 1
+                adjusted_add_node_count += 1
 
         self.cleanup()
-        return nAdjustAddNode
+        return adjusted_add_node_count
 
     def decompose_instancenorms(self):
-        nRemoveInstanceNorm = 0
+        removed_instance_norm_count = 0
         for node in self.graph.nodes:
             if node.op == "InstanceNormalization":
                 name = node.name + "/"
@@ -388,33 +388,33 @@ class OnnxOptimizer:
                 div_node = gs.Node(
                     op="Div", name=name + "div_node", attrs={}, inputs=[sub_out, sqrt_out], outputs=[div_out]
                 )
-                constantScale = gs.Constant(
-                    "InstanceNormScaleV-" + str(nRemoveInstanceNorm),
+                constant_scale = gs.Constant(
+                    "InstanceNormScaleV-" + str(removed_instance_norm_count),
                     np.ascontiguousarray(node.inputs[1].inputs[0].attrs["value"].values.reshape(1, 32, 1)),
                 )
-                constantBias = gs.Constant(
-                    "InstanceBiasV-" + str(nRemoveInstanceNorm),
+                constant_bias = gs.Constant(
+                    "InstanceBiasV-" + str(removed_instance_norm_count),
                     np.ascontiguousarray(node.inputs[2].inputs[0].attrs["value"].values.reshape(1, 32, 1)),
                 )
                 mul_out = gs.Variable(name=name + "mul_out")
                 mul_node = gs.Node(
-                    op="Mul", name=name + "mul_node", attrs={}, inputs=[div_out, constantScale], outputs=[mul_out]
+                    op="Mul", name=name + "mul_node", attrs={}, inputs=[div_out, constant_scale], outputs=[mul_out]
                 )
                 add_node = gs.Node(
-                    op="Add", name=name + "add_node", attrs={}, inputs=[mul_out, constantBias], outputs=[output_tensor]
+                    op="Add", name=name + "add_node", attrs={}, inputs=[mul_out, constant_bias], outputs=[output_tensor]
                 )
                 self.graph.nodes.extend(
                     [mean_node, sub_node, pow_node, mean2_node, epsilon_node, sqrt_node, div_node, mul_node, add_node]
                 )
                 node.inputs = []
                 node.outputs = []
-                nRemoveInstanceNorm += 1
+                removed_instance_norm_count += 1
 
         self.cleanup()
-        return nRemoveInstanceNorm
+        return removed_instance_norm_count
 
     def insert_groupnorm_plugin(self):
-        nGroupNormPlugin = 0
+        group_norm_plugin_count = 0
         for node in self.graph.nodes:
             if (
                 node.op == "Reshape"
@@ -428,57 +428,59 @@ class OnnxOptimizer:
             ):
                 # "node.outputs != []" is added for VAE
 
-                inputTensor = node.inputs[0]
+                input_tensor = node.inputs[0]
 
-                gammaNode = node.o().o().o().o().o().o().o().o().o().o().o()
-                index = [isinstance(inp, gs.ir.tensor.Constant) for inp in gammaNode.inputs].index(True)
-                gamma = np.array(deepcopy(gammaNode.inputs[index].values.tolist()), dtype=np.float32)
-                constantGamma = gs.Constant(
-                    "groupNormGamma-" + str(nGroupNormPlugin), np.ascontiguousarray(gamma.reshape(-1))
+                gamma_node = node.o().o().o().o().o().o().o().o().o().o().o()
+                index = [isinstance(inp, gs.ir.tensor.Constant) for inp in gamma_node.inputs].index(True)
+                gamma = np.array(deepcopy(gamma_node.inputs[index].values.tolist()), dtype=np.float32)
+                constant_gamma = gs.Constant(
+                    "groupNormGamma-" + str(group_norm_plugin_count), np.ascontiguousarray(gamma.reshape(-1))
                 )  # MUST use np.ascontiguousarray, or TRT will regard the shape of this Constant as (0) !!!
 
-                betaNode = gammaNode.o()
-                index = [isinstance(inp, gs.ir.tensor.Constant) for inp in betaNode.inputs].index(True)
-                beta = np.array(deepcopy(betaNode.inputs[index].values.tolist()), dtype=np.float32)
-                constantBeta = gs.Constant(
-                    "groupNormBeta-" + str(nGroupNormPlugin), np.ascontiguousarray(beta.reshape(-1))
+                beta_node = gamma_node.o()
+                index = [isinstance(inp, gs.ir.tensor.Constant) for inp in beta_node.inputs].index(True)
+                beta = np.array(deepcopy(beta_node.inputs[index].values.tolist()), dtype=np.float32)
+                constant_beta = gs.Constant(
+                    "groupNormBeta-" + str(group_norm_plugin_count), np.ascontiguousarray(beta.reshape(-1))
                 )
 
                 epsilon = node.o().o().o().o().o().inputs[1].values.tolist()[0]
 
-                if betaNode.o().op == "Sigmoid":  # need Swish
-                    bSwish = True
-                    lastNode = betaNode.o().o()  # Mul node of Swish
+                if beta_node.o().op == "Sigmoid":  # need Swish
+                    use_swish = True
+                    last_node = beta_node.o().o()  # Mul node of Swish
                 else:
-                    bSwish = False
-                    lastNode = betaNode  # Cast node after Group Norm
+                    use_swish = False
+                    last_node = beta_node  # Cast node after Group Norm
 
-                if lastNode.o().op == "Cast":
-                    lastNode = lastNode.o()
-                inputList = [inputTensor, constantGamma, constantBeta]
-                groupNormV = gs.Variable("GroupNormV-" + str(nGroupNormPlugin), np.dtype(np.float16), inputTensor.shape)
-                groupNormN = gs.Node(
-                    "GroupNorm",
-                    "GroupNormN-" + str(nGroupNormPlugin),
-                    inputs=inputList,
-                    outputs=[groupNormV],
-                    attrs=OrderedDict([("epsilon", epsilon), ("bSwish", int(bSwish))]),
+                if last_node.o().op == "Cast":
+                    last_node = last_node.o()
+                input_list = [input_tensor, constant_gamma, constant_beta]
+                group_norm_v = gs.Variable(
+                    "GroupNormV-" + str(group_norm_plugin_count), np.dtype(np.float16), input_tensor.shape
                 )
-                self.graph.nodes.append(groupNormN)
+                group_norm_n = gs.Node(
+                    "GroupNorm",
+                    "GroupNormN-" + str(group_norm_plugin_count),
+                    inputs=input_list,
+                    outputs=[group_norm_v],
+                    attrs=OrderedDict([("epsilon", epsilon), ("bSwish", int(use_swish))]),
+                )
+                self.graph.nodes.append(group_norm_n)
 
-                for subNode in self.graph.nodes:
-                    if lastNode.outputs[0] in subNode.inputs:
-                        index = subNode.inputs.index(lastNode.outputs[0])
-                        subNode.inputs[index] = groupNormV
+                for sub_node in self.graph.nodes:
+                    if last_node.outputs[0] in sub_node.inputs:
+                        index = sub_node.inputs.index(last_node.outputs[0])
+                        sub_node.inputs[index] = group_norm_v
                 node.inputs = []
-                lastNode.outputs = []
-                nGroupNormPlugin += 1
+                last_node.outputs = []
+                group_norm_plugin_count += 1
 
         self.cleanup()
-        return nGroupNormPlugin
+        return group_norm_plugin_count
 
     def insert_layernorm_plugin(self):
-        nLayerNormPlugin = 0
+        layer_norm_plugin_count = 0
         for node in self.graph.nodes:
             if (
                 node.op == "ReduceMean"
@@ -496,52 +498,54 @@ class OnnxOptimizer:
                 and len(node.o().o(0).o().o().o().o().o().inputs[1].values.shape) == 1
             ):
                 if node.i().op == "Add":
-                    inputTensor = node.inputs[0]  # CLIP
+                    input_tensor = node.inputs[0]  # CLIP
                 else:
-                    inputTensor = node.i().inputs[0]  # UNet and VAE
+                    input_tensor = node.i().inputs[0]  # UNet and VAE
 
-                gammaNode = node.o().o().o().o().o().o().o()
-                index = [isinstance(inp, gs.ir.tensor.Constant) for inp in gammaNode.inputs].index(True)
-                gamma = np.array(deepcopy(gammaNode.inputs[index].values.tolist()), dtype=np.float32)
-                constantGamma = gs.Constant(
-                    "LayerNormGamma-" + str(nLayerNormPlugin), np.ascontiguousarray(gamma.reshape(-1))
+                gamma_node = node.o().o().o().o().o().o().o()
+                index = [isinstance(inp, gs.ir.tensor.Constant) for inp in gamma_node.inputs].index(True)
+                gamma = np.array(deepcopy(gamma_node.inputs[index].values.tolist()), dtype=np.float32)
+                constant_gamma = gs.Constant(
+                    "LayerNormGamma-" + str(layer_norm_plugin_count), np.ascontiguousarray(gamma.reshape(-1))
                 )  # MUST use np.ascontiguousarray, or TRT will regard the shape of this Constant as (0) !!!
 
-                betaNode = gammaNode.o()
-                index = [isinstance(inp, gs.ir.tensor.Constant) for inp in betaNode.inputs].index(True)
-                beta = np.array(deepcopy(betaNode.inputs[index].values.tolist()), dtype=np.float32)
-                constantBeta = gs.Constant(
-                    "LayerNormBeta-" + str(nLayerNormPlugin), np.ascontiguousarray(beta.reshape(-1))
+                beta_node = gamma_node.o()
+                index = [isinstance(inp, gs.ir.tensor.Constant) for inp in beta_node.inputs].index(True)
+                beta = np.array(deepcopy(beta_node.inputs[index].values.tolist()), dtype=np.float32)
+                constant_beta = gs.Constant(
+                    "LayerNormBeta-" + str(layer_norm_plugin_count), np.ascontiguousarray(beta.reshape(-1))
                 )
 
-                inputList = [inputTensor, constantGamma, constantBeta]
-                layerNormV = gs.Variable("LayerNormV-" + str(nLayerNormPlugin), np.dtype(np.float32), inputTensor.shape)
-                layerNormN = gs.Node(
+                input_list = [input_tensor, constant_gamma, constant_beta]
+                layer_norm_v = gs.Variable(
+                    "LayerNormV-" + str(layer_norm_plugin_count), np.dtype(np.float32), input_tensor.shape
+                )
+                layer_norm_n = gs.Node(
                     "LayerNorm",
-                    "LayerNormN-" + str(nLayerNormPlugin),
-                    inputs=inputList,
+                    "LayerNormN-" + str(layer_norm_plugin_count),
+                    inputs=input_list,
                     attrs=OrderedDict([("epsilon", 1.0e-5)]),
-                    outputs=[layerNormV],
+                    outputs=[layer_norm_v],
                 )
-                self.graph.nodes.append(layerNormN)
-                nLayerNormPlugin += 1
+                self.graph.nodes.append(layer_norm_n)
+                layer_norm_plugin_count += 1
 
-                if betaNode.outputs[0] in self.graph.outputs:
-                    index = self.graph.outputs.index(betaNode.outputs[0])
-                    self.graph.outputs[index] = layerNormV
+                if beta_node.outputs[0] in self.graph.outputs:
+                    index = self.graph.outputs.index(beta_node.outputs[0])
+                    self.graph.outputs[index] = layer_norm_v
                 else:
-                    if betaNode.o().op == "Cast":
-                        lastNode = betaNode.o()
+                    if beta_node.o().op == "Cast":
+                        last_node = beta_node.o()
                     else:
-                        lastNode = betaNode
-                    for subNode in self.graph.nodes:
-                        if lastNode.outputs[0] in subNode.inputs:
-                            index = subNode.inputs.index(lastNode.outputs[0])
-                            subNode.inputs[index] = layerNormV
-                    lastNode.outputs = []
+                        last_node = beta_node
+                    for sub_node in self.graph.nodes:
+                        if last_node.outputs[0] in sub_node.inputs:
+                            index = sub_node.inputs.index(last_node.outputs[0])
+                            sub_node.inputs[index] = layer_norm_v
+                    last_node.outputs = []
 
         self.cleanup()
-        return nLayerNormPlugin
+        return layer_norm_plugin_count
 
     def fuse_kv(self, node_k, node_v, fused_kv_idx, heads, num_dynamic=0):
         # Get weights of K
@@ -549,14 +553,19 @@ class OnnxOptimizer:
         # Get weights of V
         weights_v = node_v.inputs[1].values
         # Input number of channels to K and V
-        C = weights_k.shape[0]
+        channel_count = weights_k.shape[0]
         # Number of heads
-        H = heads
+        num_heads = heads
         # Dimension per head
-        D = weights_k.shape[1] // H
+        head_dim = weights_k.shape[1] // num_heads
 
         # Concat and interleave weights such that the output of fused KV GEMM has [b, s_kv, h, 2, d] shape
-        weights_kv = np.dstack([weights_k.reshape(C, H, D), weights_v.reshape(C, H, D)]).reshape(C, 2 * H * D)
+        weights_kv = np.dstack(
+            [
+                weights_k.reshape(channel_count, num_heads, head_dim),
+                weights_v.reshape(channel_count, num_heads, head_dim),
+            ]
+        ).reshape(channel_count, 2 * num_heads * head_dim)
 
         # K and V have the same input
         input_tensor = node_k.inputs[0]
@@ -661,16 +670,20 @@ class OnnxOptimizer:
         weights_v = node_v.inputs[1].values
 
         # Input number of channels to Q, K and V
-        C = weights_k.shape[0]
+        channel_count = weights_k.shape[0]
         # Number of heads
-        H = heads
+        num_heads = heads
         # Hidden dimension per head
-        D = weights_k.shape[1] // H
+        head_dim = weights_k.shape[1] // num_heads
 
         # Concat and interleave weights such that the output of fused QKV GEMM has [b, s, h, 3, d] shape
         weights_qkv = np.dstack(
-            [weights_q.reshape(C, H, D), weights_k.reshape(C, H, D), weights_v.reshape(C, H, D)]
-        ).reshape(C, 3 * H * D)
+            [
+                weights_q.reshape(channel_count, num_heads, head_dim),
+                weights_k.reshape(channel_count, num_heads, head_dim),
+                weights_v.reshape(channel_count, num_heads, head_dim),
+            ]
+        ).reshape(channel_count, 3 * num_heads * head_dim)
 
         input_tensor = node_k.inputs[0]  # K and V have the same input
         # Q, K and V must have the same output which we feed into fmha plugin

--- a/src/rfdetr/export/benchmark.py
+++ b/src/rfdetr/export/benchmark.py
@@ -307,10 +307,10 @@ class TRTInference(object):
         """Takes an ONNX file and creates a TensorRT engine to run inference with
         http://gitlab.baidu.com/paddle-inference/benchmark/blob/main/backend_trt.py#L57
         """
-        EXPLICIT_BATCH = 1 << (int)(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH)
+        explicit_batch_flag = 1 << (int)(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH)
         with (
             trt.Builder(self.logger) as builder,
-            builder.create_network(EXPLICIT_BATCH) as network,
+            builder.create_network(explicit_batch_flag) as network,
             trt.OnnxParser(network, self.logger) as parser,
             builder.create_builder_config() as config,
         ):

--- a/src/rfdetr/models/backbone/backbone.py
+++ b/src/rfdetr/models/backbone/backbone.py
@@ -18,7 +18,7 @@ Backbone modules.
 """
 
 import torch
-import torch.nn.functional as F
+import torch.nn.functional as F  # noqa: N812
 
 from rfdetr.models.backbone.base import BackboneBase
 from rfdetr.models.backbone.dinov2 import DinoV2

--- a/src/rfdetr/models/backbone/dinov2.py
+++ b/src/rfdetr/models/backbone/dinov2.py
@@ -11,7 +11,7 @@ import types
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
+import torch.nn.functional as F  # noqa: N812
 from transformers import AutoBackbone
 
 from rfdetr.models.backbone.dinov2_with_windowed_attn import (

--- a/src/rfdetr/models/backbone/dinov2_with_windowed_attn.py
+++ b/src/rfdetr/models/backbone/dinov2_with_windowed_attn.py
@@ -752,9 +752,11 @@ class WindowedDinov2WithRegistersLayer(nn.Module):
         shortcut = hidden_states
         if run_full_attention:
             # reshape x to remove windows
-            B, HW, C = hidden_states.shape
+            batch_windows, tokens_per_window, channels = hidden_states.shape
             num_windows_squared = self.num_windows**2
-            hidden_states = hidden_states.view(B // num_windows_squared, num_windows_squared * HW, C)
+            hidden_states = hidden_states.view(
+                batch_windows // num_windows_squared, num_windows_squared * tokens_per_window, channels
+            )
 
         self_attention_outputs = self.attention(
             self.norm1(hidden_states),  # in Dinov2WithRegisters, layernorm is applied before self-attention
@@ -764,10 +766,12 @@ class WindowedDinov2WithRegistersLayer(nn.Module):
 
         if run_full_attention:
             # reshape x to add windows back
-            B, HW, C = hidden_states.shape
+            batch_windows, tokens_per_window, channels = hidden_states.shape
             num_windows_squared = self.num_windows**2
             # hidden_states = hidden_states.view(B * num_windows_squared, HW // num_windows_squared, C)
-            attention_output = attention_output.view(B * num_windows_squared, HW // num_windows_squared, C)
+            attention_output = attention_output.view(
+                batch_windows * num_windows_squared, tokens_per_window // num_windows_squared, channels
+            )
 
         attention_output = self.layer_scale1(attention_output)
         outputs = self_attention_outputs[1:]  # add self attentions if we output attention weights
@@ -1281,16 +1285,20 @@ class WindowedDinov2WithRegistersBackbone(WindowedDinov2WithRegistersPreTrainedM
                     if self.config.num_windows > 1:
                         # undo windowing
                         num_windows_squared = self.config.num_windows**2
-                        B, HW, C = hidden_state.shape
+                        batch_windows, tokens_per_window, channels = hidden_state.shape
                         num_h_patches_per_window = num_h_patches // self.config.num_windows
                         num_w_patches_per_window = num_w_patches // self.config.num_windows
-                        hidden_state = hidden_state.reshape(B // num_windows_squared, num_windows_squared * HW, C)
                         hidden_state = hidden_state.reshape(
-                            (B // num_windows_squared) * self.config.num_windows,
+                            batch_windows // num_windows_squared,
+                            num_windows_squared * tokens_per_window,
+                            channels,
+                        )
+                        hidden_state = hidden_state.reshape(
+                            (batch_windows // num_windows_squared) * self.config.num_windows,
                             self.config.num_windows,
                             num_h_patches_per_window,
                             num_w_patches_per_window,
-                            C,
+                            channels,
                         )
                         hidden_state = hidden_state.permute(0, 2, 1, 3, 4)
 

--- a/src/rfdetr/models/backbone/projector.py
+++ b/src/rfdetr/models/backbone/projector.py
@@ -19,7 +19,7 @@ from typing import Callable, Optional, Sequence, Union
 import numpy as np
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
+import torch.nn.functional as F  # noqa: N812
 
 
 class LayerNorm(nn.Module):

--- a/src/rfdetr/models/criterion.py
+++ b/src/rfdetr/models/criterion.py
@@ -11,7 +11,7 @@
 """Loss functions and criterion for RF-DETR training."""
 
 import torch
-import torch.nn.functional as F
+import torch.nn.functional as F  # noqa: N812
 from torch import nn
 
 from rfdetr.models.heads.segmentation import (

--- a/src/rfdetr/models/heads/segmentation.py
+++ b/src/rfdetr/models/heads/segmentation.py
@@ -8,7 +8,7 @@ from typing import Any, Callable
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
+import torch.nn.functional as F  # noqa: N812
 
 from rfdetr.utilities.tensors import _bilinear_grid_sample
 

--- a/src/rfdetr/models/matcher.py
+++ b/src/rfdetr/models/matcher.py
@@ -22,7 +22,7 @@ Modules to compute the matching cost and solve the corresponding LSAP.
 
 import numpy as np
 import torch
-import torch.nn.functional as F
+import torch.nn.functional as F  # noqa: N812
 from scipy.optimize import linear_sum_assignment
 from torch import nn
 

--- a/src/rfdetr/models/matcher.py
+++ b/src/rfdetr/models/matcher.py
@@ -78,7 +78,7 @@ class HungarianMatcher(nn.Module):
         self._warned_non_finite_costs = False
 
     @staticmethod
-    def _sanitize_cost_matrix(C: torch.Tensor) -> torch.Tensor:
+    def _sanitize_cost_matrix(cost_matrix: torch.Tensor) -> torch.Tensor:
         """Replace non-finite cost entries with a large finite sentinel.
 
         >>> HungarianMatcher._sanitize_cost_matrix(
@@ -87,35 +87,35 @@ class HungarianMatcher(nn.Module):
         [[1.0, 4.0], [4.0, -2.0]]
 
         Args:
-            C: Cost matrix to sanitize before Hungarian assignment.
+            cost_matrix: Cost matrix to sanitize before Hungarian assignment.
 
         Returns:
             Cost matrix with all non-finite entries replaced by a finite
             sentinel that is no smaller than any valid entry.
         """
-        finite_mask = torch.isfinite(C)
+        finite_mask = torch.isfinite(cost_matrix)
         if finite_mask.all():
-            return C
+            return cost_matrix
 
-        dtype_info = torch.finfo(C.dtype)
+        dtype_info = torch.finfo(cost_matrix.dtype)
         if finite_mask.any():
-            finite_costs = C[finite_mask]
+            finite_costs = cost_matrix[finite_mask]
             max_cost = finite_costs.max()
             # Add the largest absolute finite cost so the replacement stays
             # strictly larger than every valid entry, even if all costs are negative.
             replacement_cost = max_cost + finite_costs.abs().max() + _SANITIZED_COST_MARGIN
             # Guard against overflow to inf/NaN and clamp to the maximum finite value.
             if not torch.isfinite(replacement_cost):
-                replacement_cost = C.new_tensor(dtype_info.max)
+                replacement_cost = cost_matrix.new_tensor(dtype_info.max)
             else:
                 replacement_cost = torch.clamp(replacement_cost, max=dtype_info.max)
         else:
             # If all entries are non-finite, fall back to a large finite sentinel.
-            replacement_cost = C.new_tensor(dtype_info.max)
+            replacement_cost = cost_matrix.new_tensor(dtype_info.max)
 
-        sanitized_C = C.clone()
-        sanitized_C[~finite_mask] = replacement_cost
-        return sanitized_C
+        sanitized_cost_matrix = cost_matrix.clone()
+        sanitized_cost_matrix[~finite_mask] = replacement_cost
+        return sanitized_cost_matrix
 
     @torch.no_grad()
     def forward(self, outputs, targets, group_detr=1):
@@ -209,14 +209,16 @@ class HungarianMatcher(nn.Module):
             cost_mask_dice = batch_dice_loss(pred_masks_logits, tgt_masks_flat)
 
         # Final cost matrix
-        C = self.cost_bbox * cost_bbox + self.cost_class * cost_class + self.cost_giou * cost_giou
+        cost_matrix = self.cost_bbox * cost_bbox + self.cost_class * cost_class + self.cost_giou * cost_giou
         if masks_present:
-            C = C + self.cost_mask_ce * cost_mask_ce + self.cost_mask_dice * cost_mask_dice
-        C = C.view(bs, num_queries, -1).float().cpu()  # convert to float because bfloat16 doesn't play nicely with CPU
+            cost_matrix = cost_matrix + self.cost_mask_ce * cost_mask_ce + self.cost_mask_dice * cost_mask_dice
+        cost_matrix = (
+            cost_matrix.view(bs, num_queries, -1).float().cpu()
+        )  # convert to float because bfloat16 doesn't play nicely with CPU
 
         # We assume any good match will not cause NaN or Inf, so replace invalid
         # entries with a finite value that is larger than every valid cost.
-        finite_mask = torch.isfinite(C)
+        finite_mask = torch.isfinite(cost_matrix)
         if not finite_mask.all():
             if not self._warned_non_finite_costs:
                 logger.warning(
@@ -225,15 +227,15 @@ class HungarianMatcher(nn.Module):
                     "Check for numerical instability."
                 )
                 self._warned_non_finite_costs = True
-            C = self._sanitize_cost_matrix(C)
+            cost_matrix = self._sanitize_cost_matrix(cost_matrix)
 
         sizes = [len(v["boxes"]) for v in targets]
         indices = []
         g_num_queries = num_queries // group_detr
-        C_list = C.split(g_num_queries, dim=1)
+        cost_matrix_list = cost_matrix.split(g_num_queries, dim=1)
         for g_i in range(group_detr):
-            C_g = C_list[g_i]
-            indices_g = [linear_sum_assignment(c[i]) for i, c in enumerate(C_g.split(sizes, -1))]
+            grouped_cost_matrix = cost_matrix_list[g_i]
+            indices_g = [linear_sum_assignment(c[i]) for i, c in enumerate(grouped_cost_matrix.split(sizes, -1))]
             if g_i == 0:
                 indices = indices_g
             else:

--- a/src/rfdetr/models/math.py
+++ b/src/rfdetr/models/math.py
@@ -13,7 +13,7 @@
 from typing import List, Optional, Tuple
 
 import torch
-import torch.nn.functional as F
+import torch.nn.functional as F  # noqa: N812
 import torchvision
 from torch import Tensor, nn
 

--- a/src/rfdetr/models/ops/functions/ms_deform_attn_func.py
+++ b/src/rfdetr/models/ops/functions/ms_deform_attn_func.py
@@ -30,27 +30,33 @@ def ms_deform_attn_core_pytorch(
     value_spatial_shapes_hw: list[tuple[int, int]] | None = None,
 ) -> torch.Tensor:
     """For debug and test only, need to use cuda version instead."""
-    # B, n_heads, head_dim, N
-    B, n_heads, head_dim, _ = value.shape
-    _, Len_q, n_heads, L, P, _ = sampling_locations.shape
+    # batch_size, n_heads, head_dim, spatial_size
+    batch_size, n_heads, head_dim, _ = value.shape
+    _, len_query, n_heads, num_levels, num_points, _ = sampling_locations.shape
     # Use Python int pairs when available (required for torch.export compatibility,
     # since iterating over a tensor and using scalar elements as split/view sizes
     # fails during FakeTensor tracing).
     shapes = value_spatial_shapes_hw if value_spatial_shapes_hw is not None else value_spatial_shapes
-    value_list = value.split([H * W for H, W in shapes], dim=3)
+    value_list = value.split([height * width for height, width in shapes], dim=3)
     sampling_grids = 2 * sampling_locations - 1
     sampling_value_list = []
-    for lid_, (H, W) in enumerate(shapes):
-        # B, n_heads, head_dim, H, W
-        value_l_ = value_list[lid_].view(B * n_heads, head_dim, H, W)
-        # B, Len_q, n_heads, P, 2 -> B, n_heads, Len_q, P, 2 -> B*n_heads, Len_q, P, 2
-        sampling_grid_l_ = sampling_grids[:, :, :, lid_].transpose(1, 2).flatten(0, 1)
-        # B*n_heads, head_dim, Len_q, P
+    for level_index, (height, width) in enumerate(shapes):
+        # batch_size, n_heads, head_dim, height, width
+        value_l_ = value_list[level_index].view(batch_size * n_heads, head_dim, height, width)
+        # batch_size, len_query, n_heads, num_points, 2
+        # -> batch_size, n_heads, len_query, num_points, 2
+        # -> batch_size*n_heads, len_query, num_points, 2
+        sampling_grid_l_ = sampling_grids[:, :, :, level_index].transpose(1, 2).flatten(0, 1)
+        # batch_size*n_heads, head_dim, len_query, num_points
         sampling_value_l_ = _bilinear_grid_sample(value_l_, sampling_grid_l_, padding_mode="zeros", align_corners=False)
         sampling_value_list.append(sampling_value_l_)
-    # (B, Len_q, n_heads, L * P) -> (B, n_heads, Len_q, L, P) -> (B*n_heads, 1, Len_q, L*P)
-    attention_weights = attention_weights.transpose(1, 2).reshape(B * n_heads, 1, Len_q, L * P)
-    # B*n_heads, head_dim, Len_q, L*P
+    # (batch_size, len_query, n_heads, num_levels * num_points)
+    # -> (batch_size, n_heads, len_query, num_levels, num_points)
+    # -> (batch_size*n_heads, 1, len_query, num_levels*num_points)
+    attention_weights = attention_weights.transpose(1, 2).reshape(
+        batch_size * n_heads, 1, len_query, num_levels * num_points
+    )
+    # batch_size*n_heads, head_dim, len_query, num_levels*num_points
     sampling_value_list = torch.stack(sampling_value_list, dim=-2).flatten(-2)
-    output = (sampling_value_list * attention_weights).sum(-1).view(B, n_heads * head_dim, Len_q)
+    output = (sampling_value_list * attention_weights).sum(-1).view(batch_size, n_heads * head_dim, len_query)
     return output.transpose(1, 2).contiguous()

--- a/src/rfdetr/models/ops/functions/ms_deform_attn_func.py
+++ b/src/rfdetr/models/ops/functions/ms_deform_attn_func.py
@@ -24,23 +24,28 @@ from rfdetr.utilities.tensors import _bilinear_grid_sample
 
 def ms_deform_attn_core_pytorch(value, value_spatial_shapes, sampling_locations, attention_weights):
     """ "for debug and test only, need to use cuda version instead"""
-    # B, n_heads, head_dim, N
-    B, n_heads, head_dim, _ = value.shape
-    _, Len_q, n_heads, L, P, _ = sampling_locations.shape
-    value_list = value.split([H * W for H, W in value_spatial_shapes], dim=3)
+    # batch_size, n_heads, head_dim, token_count
+    batch_size, n_heads, head_dim, _ = value.shape
+    _, query_length, n_heads, num_levels, num_points, _ = sampling_locations.shape
+    value_list = value.split([height * width for height, width in value_spatial_shapes], dim=3)
     sampling_grids = 2 * sampling_locations - 1
     sampling_value_list = []
-    for lid_, (H, W) in enumerate(value_spatial_shapes):
-        # B, n_heads, head_dim, H, W
-        value_l_ = value_list[lid_].view(B * n_heads, head_dim, H, W)
-        # B, Len_q, n_heads, P, 2 -> B, n_heads, Len_q, P, 2 -> B*n_heads, Len_q, P, 2
+    for lid_, (height, width) in enumerate(value_spatial_shapes):
+        # batch_size, n_heads, head_dim, height, width
+        value_l_ = value_list[lid_].view(batch_size * n_heads, head_dim, height, width)
+        # batch_size, query_length, n_heads, num_points, 2 -> batch_size, n_heads, query_length, num_points, 2
+        # -> batch_size*n_heads, query_length, num_points, 2
         sampling_grid_l_ = sampling_grids[:, :, :, lid_].transpose(1, 2).flatten(0, 1)
-        # B*n_heads, head_dim, Len_q, P
+        # batch_size*n_heads, head_dim, query_length, num_points
         sampling_value_l_ = _bilinear_grid_sample(value_l_, sampling_grid_l_, padding_mode="zeros", align_corners=False)
         sampling_value_list.append(sampling_value_l_)
-    # (B, Len_q, n_heads, L * P) -> (B, n_heads, Len_q, L, P) -> (B*n_heads, 1, Len_q, L*P)
-    attention_weights = attention_weights.transpose(1, 2).reshape(B * n_heads, 1, Len_q, L * P)
-    # B*n_heads, head_dim, Len_q, L*P
+    # (batch_size, query_length, n_heads, num_levels * num_points)
+    # -> (batch_size, n_heads, query_length, num_levels, num_points)
+    # -> (batch_size*n_heads, 1, query_length, num_levels*num_points)
+    attention_weights = attention_weights.transpose(1, 2).reshape(
+        batch_size * n_heads, 1, query_length, num_levels * num_points
+    )
+    # batch_size*n_heads, head_dim, query_length, num_levels*num_points
     sampling_value_list = torch.stack(sampling_value_list, dim=-2).flatten(-2)
-    output = (sampling_value_list * attention_weights).sum(-1).view(B, n_heads * head_dim, Len_q)
+    output = (sampling_value_list * attention_weights).sum(-1).view(batch_size, n_heads * head_dim, query_length)
     return output.transpose(1, 2).contiguous()

--- a/src/rfdetr/models/ops/modules/ms_deform_attn.py
+++ b/src/rfdetr/models/ops/modules/ms_deform_attn.py
@@ -21,7 +21,7 @@ import math
 import warnings
 
 import torch
-import torch.nn.functional as F
+import torch.nn.functional as F  # noqa: N812
 from torch import nn
 from torch.nn.init import constant_, xavier_uniform_
 

--- a/src/rfdetr/models/ops/modules/ms_deform_attn.py
+++ b/src/rfdetr/models/ops/modules/ms_deform_attn.py
@@ -122,16 +122,20 @@ class MSDeformAttn(nn.Module):
 
         :return output                     (N, Length_{query}, C)
         """
-        N, Len_q, _ = query.shape
-        N, Len_in, _ = input_flatten.shape
-        assert (input_spatial_shapes[:, 0] * input_spatial_shapes[:, 1]).sum() == Len_in
+        batch_size, query_length, _ = query.shape
+        batch_size, input_length, _ = input_flatten.shape
+        assert (input_spatial_shapes[:, 0] * input_spatial_shapes[:, 1]).sum() == input_length
 
         value = self.value_proj(input_flatten)
         if input_padding_mask is not None:
             value = value.masked_fill(input_padding_mask[..., None], float(0))
 
-        sampling_offsets = self.sampling_offsets(query).view(N, Len_q, self.n_heads, self.n_levels, self.n_points, 2)
-        attention_weights = self.attention_weights(query).view(N, Len_q, self.n_heads, self.n_levels * self.n_points)
+        sampling_offsets = self.sampling_offsets(query).view(
+            batch_size, query_length, self.n_heads, self.n_levels, self.n_points, 2
+        )
+        attention_weights = self.attention_weights(query).view(
+            batch_size, query_length, self.n_heads, self.n_levels * self.n_points
+        )
 
         # N, Len_q, n_heads, n_levels, n_points, 2
         if reference_points.shape[-1] == 2:
@@ -151,7 +155,11 @@ class MSDeformAttn(nn.Module):
             )
         attention_weights = F.softmax(attention_weights, -1)
 
-        value = value.transpose(1, 2).contiguous().view(N, self.n_heads, self.d_model // self.n_heads, Len_in)
+        value = (
+            value.transpose(1, 2)
+            .contiguous()
+            .view(batch_size, self.n_heads, self.d_model // self.n_heads, input_length)
+        )
         output = ms_deform_attn_core_pytorch(value, input_spatial_shapes, sampling_locations, attention_weights)
         output = self.output_proj(output)
         return output

--- a/src/rfdetr/models/ops/modules/ms_deform_attn.py
+++ b/src/rfdetr/models/ops/modules/ms_deform_attn.py
@@ -129,21 +129,25 @@ class MSDeformAttn(nn.Module):
         Returns:
             Output tensor of shape (N, Length_{query}, C).
         """
-        N, Len_q, _ = query.shape
-        N, Len_in, _ = input_flatten.shape
+        batch_size, len_query, _ = query.shape
+        batch_size, len_input, _ = input_flatten.shape
         expected_len_in = (input_spatial_shapes[:, 0] * input_spatial_shapes[:, 1]).sum()
         error_msg = "input_spatial_shapes must match the flattened input length"
         if self._export:
-            torch._assert(expected_len_in == Len_in, error_msg)
+            torch._assert(expected_len_in == len_input, error_msg)
         else:
-            assert expected_len_in == Len_in, error_msg
+            assert expected_len_in == len_input, error_msg
 
         value = self.value_proj(input_flatten)
         if input_padding_mask is not None:
             value = value.masked_fill(input_padding_mask[..., None], float(0))
 
-        sampling_offsets = self.sampling_offsets(query).view(N, Len_q, self.n_heads, self.n_levels, self.n_points, 2)
-        attention_weights = self.attention_weights(query).view(N, Len_q, self.n_heads, self.n_levels * self.n_points)
+        sampling_offsets = self.sampling_offsets(query).view(
+            batch_size, len_query, self.n_heads, self.n_levels, self.n_points, 2
+        )
+        attention_weights = self.attention_weights(query).view(
+            batch_size, len_query, self.n_heads, self.n_levels * self.n_points
+        )
 
         # N, Len_q, n_heads, n_levels, n_points, 2
         if reference_points.shape[-1] == 2:
@@ -163,7 +167,9 @@ class MSDeformAttn(nn.Module):
             )
         attention_weights = F.softmax(attention_weights, -1)
 
-        value = value.transpose(1, 2).contiguous().view(N, self.n_heads, self.d_model // self.n_heads, Len_in)
+        value = value.transpose(1, 2).contiguous().view(
+            batch_size, self.n_heads, self.d_model // self.n_heads, len_input
+        )
         output = ms_deform_attn_core_pytorch(
             value,
             input_spatial_shapes,

--- a/src/rfdetr/models/ops/modules/ms_deform_attn.py
+++ b/src/rfdetr/models/ops/modules/ms_deform_attn.py
@@ -167,8 +167,8 @@ class MSDeformAttn(nn.Module):
             )
         attention_weights = F.softmax(attention_weights, -1)
 
-        value = value.transpose(1, 2).contiguous().view(
-            batch_size, self.n_heads, self.d_model // self.n_heads, len_input
+        value = (
+            value.transpose(1, 2).contiguous().view(batch_size, self.n_heads, self.d_model // self.n_heads, len_input)
         )
         output = ms_deform_attn_core_pytorch(
             value,

--- a/src/rfdetr/models/position_encoding.py
+++ b/src/rfdetr/models/position_encoding.py
@@ -143,12 +143,12 @@ class PositionEmbeddingLearned(nn.Module):
 
 
 def build_position_encoding(hidden_dim, position_embedding):
-    N_steps = hidden_dim // 2
+    num_steps = hidden_dim // 2
     if position_embedding in ("v2", "sine"):
         # TODO find a better way of exposing other arguments
-        position_embedding = PositionEmbeddingSine(N_steps, normalize=True)
+        position_embedding = PositionEmbeddingSine(num_steps, normalize=True)
     elif position_embedding in ("v3", "learned"):
-        position_embedding = PositionEmbeddingLearned(N_steps)
+        position_embedding = PositionEmbeddingLearned(num_steps)
     else:
         raise ValueError(f"not supported {position_embedding}")
 

--- a/src/rfdetr/models/postprocess.py
+++ b/src/rfdetr/models/postprocess.py
@@ -11,7 +11,7 @@
 """Post-processing module for converting model outputs to COCO API format."""
 
 import torch
-import torch.nn.functional as F
+import torch.nn.functional as F  # noqa: N812
 from torch import nn
 
 from rfdetr.utilities import box_ops

--- a/src/rfdetr/models/transformer.py
+++ b/src/rfdetr/models/transformer.py
@@ -81,39 +81,39 @@ def gen_encoder_output_proposals(memory, memory_padding_mask, spatial_shapes, un
         - output_memory: bs, \sum{hw}, d_model
         - output_proposals: bs, \sum{hw}, 4
     """
-    N_, S_, C_ = memory.shape
+    batch_size, _, _ = memory.shape
     proposals = []
     _cur = 0
-    for lvl, (H_, W_) in enumerate(spatial_shapes):
+    for lvl, (height, width) in enumerate(spatial_shapes):
         if memory_padding_mask is not None:
-            mask_flatten_ = memory_padding_mask[:, _cur : (_cur + H_ * W_)].view(N_, H_, W_, 1)
-            valid_H = torch.sum(~mask_flatten_[:, :, 0, 0], 1)
-            valid_W = torch.sum(~mask_flatten_[:, 0, :, 0], 1)
+            mask_flatten_ = memory_padding_mask[:, _cur : (_cur + height * width)].view(batch_size, height, width, 1)
+            valid_height = torch.sum(~mask_flatten_[:, :, 0, 0], 1)
+            valid_width = torch.sum(~mask_flatten_[:, 0, :, 0], 1)
         else:
-            if isinstance(H_, torch.Tensor):
-                valid_H = H_.expand(N_).to(dtype=torch.long, device=memory.device)
+            if isinstance(height, torch.Tensor):
+                valid_height = height.expand(batch_size).to(dtype=torch.long, device=memory.device)
             else:
-                valid_H = torch.full((N_,), H_, dtype=torch.long, device=memory.device)
-            if isinstance(W_, torch.Tensor):
-                valid_W = W_.expand(N_).to(dtype=torch.long, device=memory.device)
+                valid_height = torch.full((batch_size,), height, dtype=torch.long, device=memory.device)
+            if isinstance(width, torch.Tensor):
+                valid_width = width.expand(batch_size).to(dtype=torch.long, device=memory.device)
             else:
-                valid_W = torch.full((N_,), W_, dtype=torch.long, device=memory.device)
+                valid_width = torch.full((batch_size,), width, dtype=torch.long, device=memory.device)
 
         grid_y, grid_x = torch.meshgrid(
-            torch.linspace(0, H_ - 1, H_, dtype=torch.float32, device=memory.device),
-            torch.linspace(0, W_ - 1, W_, dtype=torch.float32, device=memory.device),
+            torch.linspace(0, height - 1, height, dtype=torch.float32, device=memory.device),
+            torch.linspace(0, width - 1, width, dtype=torch.float32, device=memory.device),
             indexing="ij",
         )
-        grid = torch.cat([grid_x.unsqueeze(-1), grid_y.unsqueeze(-1)], -1)  # H_, W_, 2
+        grid = torch.cat([grid_x.unsqueeze(-1), grid_y.unsqueeze(-1)], -1)  # height, width, 2
 
-        scale = torch.cat([valid_W.unsqueeze(-1), valid_H.unsqueeze(-1)], 1).view(N_, 1, 1, 2)
-        grid = (grid.unsqueeze(0).expand(N_, -1, -1, -1) + 0.5) / scale
+        scale = torch.cat([valid_width.unsqueeze(-1), valid_height.unsqueeze(-1)], 1).view(batch_size, 1, 1, 2)
+        grid = (grid.unsqueeze(0).expand(batch_size, -1, -1, -1) + 0.5) / scale
 
         wh = torch.ones_like(grid) * 0.05 * (2.0**lvl)
 
-        proposal = torch.cat((grid, wh), -1).view(N_, -1, 4)
+        proposal = torch.cat((grid, wh), -1).view(batch_size, -1, 4)
         proposals.append(proposal)
-        _cur += H_ * W_
+        _cur += height * width
 
     output_proposals = torch.cat(proposals, 1)
     output_proposals_valid = ((output_proposals > 0.01) & (output_proposals < 0.99)).all(-1, keepdim=True)
@@ -218,11 +218,11 @@ class Transformer(nn.Module):
                 m._reset_parameters()
 
     def get_valid_ratio(self, mask):
-        _, H, W = mask.shape
-        valid_H = torch.sum(~mask[:, :, 0], 1)
-        valid_W = torch.sum(~mask[:, 0, :], 1)
-        valid_ratio_h = valid_H.float() / H
-        valid_ratio_w = valid_W.float() / W
+        _, height, width = mask.shape
+        valid_height = torch.sum(~mask[:, :, 0], 1)
+        valid_width = torch.sum(~mask[:, 0, :], 1)
+        valid_ratio_h = valid_height.float() / height
+        valid_ratio_w = valid_width.float() / width
         valid_ratio = torch.stack([valid_ratio_w, valid_ratio_h], -1)
         return valid_ratio
 
@@ -629,8 +629,8 @@ class TransformerDecoderLayer(nn.Module):
         )
 
 
-def _get_clones(module, N):
-    return nn.ModuleList([copy.deepcopy(module) for i in range(N)])
+def _get_clones(module, num_layers):
+    return nn.ModuleList([copy.deepcopy(module) for i in range(num_layers)])
 
 
 def build_transformer(args):

--- a/src/rfdetr/models/transformer.py
+++ b/src/rfdetr/models/transformer.py
@@ -21,7 +21,7 @@ import math
 from typing import Optional
 
 import torch
-import torch.nn.functional as F
+import torch.nn.functional as F  # noqa: N812
 from torch import Tensor, nn
 
 from rfdetr.models.ops.modules import MSDeformAttn

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -626,15 +626,17 @@ class COCOEvalCallback(Callback):
             return sum(widths[start : end + 1]) + (end - start)
 
         # Box-drawing character sets
-        BH, BL = "━", "─"
-        VH, VL = "┃", "│"
-        TL, TR = "┏", "┓"
-        T_DN = "┳"  # heavy T-down: top-border internal group separator
-        TR_L, TR_R = "┡", "┩"  # transition-row left/right edges
-        GRP_J = "╇"  # transition-row at group boundary: heavy-up, heavy-horiz, light-down
-        SUB_J = "┯"  # transition-row within group: no-up, heavy-horiz, light-down
-        ML, MR, MX = "├", "┤", "┼"
-        BL_C, BR_C, BT = "└", "┘", "┴"
+        heavy_horizontal = "━"
+        light_horizontal = "─"
+        heavy_vertical = "┃"
+        light_vertical = "│"
+        top_left_corner, top_right_corner = "┏", "┓"
+        top_t_down = "┳"  # heavy T-down: top-border internal group separator
+        transition_left, transition_right = "┡", "┩"  # transition-row left/right edges
+        group_join = "╇"  # transition-row at group boundary: heavy-up, heavy-horiz, light-down
+        subgroup_join = "┯"  # transition-row within group: no-up, heavy-horiz, light-down
+        mid_left, mid_right, mid_cross = "├", "┤", "┼"
+        bottom_left_corner, bottom_right_corner, bottom_t_up = "└", "┘", "┴"
 
         # Title (centred over the full table width)
         inner_w = sum(widths) + n - 1
@@ -642,45 +644,45 @@ class COCOEvalCallback(Callback):
         title_line = title.center(inner_w + 2)
 
         # Row 1: top border — group-level separators only
-        r1 = TL
+        r1 = top_left_corner
         for i, (s, e, _) in enumerate(spans):
-            r1 += BH * grp_w(s, e)
-            r1 += T_DN if i < len(spans) - 1 else TR
+            r1 += heavy_horizontal * grp_w(s, e)
+            r1 += top_t_down if i < len(spans) - 1 else top_right_corner
 
         # Row 2: group labels centred in merged cells
-        r2 = VH
+        r2 = heavy_vertical
         for s, e, grp in spans:
-            r2 += grp.center(grp_w(s, e)) + VH
+            r2 += grp.center(grp_w(s, e)) + heavy_vertical
 
         # Row 3: transition row — heavy horizontal; ╇ at group ends, ┯ within groups
-        r3 = TR_L
+        r3 = transition_left
         for i, w in enumerate(widths):
-            r3 += BH * w
+            r3 += heavy_horizontal * w
             if i < n - 1:
-                r3 += GRP_J if i in grp_ends else SUB_J
-        r3 += TR_R
+                r3 += group_join if i in grp_ends else subgroup_join
+        r3 += transition_right
 
         # Row 4: sub-labels with light borders
-        r4 = VL
+        r4 = light_vertical
         for i, (sub, _) in enumerate(flat):
-            r4 += sub.center(widths[i]) + VL
+            r4 += sub.center(widths[i]) + light_vertical
 
         # Row 5: light separator between sub-labels and values
-        r5 = ML
+        r5 = mid_left
         for i, w in enumerate(widths):
-            r5 += BL * w
-            r5 += MX if i < n - 1 else MR
+            r5 += light_horizontal * w
+            r5 += mid_cross if i < n - 1 else mid_right
 
         # Row 6: values
-        r6 = VL
+        r6 = light_vertical
         for i, (_, val) in enumerate(flat):
-            r6 += val.center(widths[i]) + VL
+            r6 += val.center(widths[i]) + light_vertical
 
         # Row 7: bottom border
-        r7 = BL_C
+        r7 = bottom_left_corner
         for i, w in enumerate(widths):
-            r7 += BL * w
-            r7 += BT if i < n - 1 else BR_C
+            r7 += light_horizontal * w
+            r7 += bottom_t_up if i < n - 1 else bottom_right_corner
 
         return "\n".join([title_line, r1, r2, r3, r4, r5, r6, r7])
 

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import numpy as np
 import torch
-import torch.nn.functional as F
+import torch.nn.functional as F  # noqa: N812
 from pytorch_lightning import Callback
 from torchmetrics.detection import MeanAveragePrecision
 

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -14,7 +14,7 @@ import warnings
 from typing import Any, Dict, Optional, Tuple
 
 import torch
-import torch.nn.functional as F
+import torch.nn.functional as F  # noqa: N812
 from pytorch_lightning import LightningModule, seed_everything
 
 from rfdetr._namespace import _namespace_from_configs

--- a/src/rfdetr/utilities/box_ops.py
+++ b/src/rfdetr/utilities/box_ops.py
@@ -18,7 +18,7 @@
 """Utilities for bounding box manipulation and GIoU."""
 
 import torch
-import torch.nn.functional as F
+import torch.nn.functional as F  # noqa: N812
 from torchvision.ops.boxes import box_area
 
 

--- a/src/rfdetr/utilities/tensors.py
+++ b/src/rfdetr/utilities/tensors.py
@@ -187,7 +187,7 @@ def _bilinear_grid_sample(
     Returns:
         Sampled tensor of shape ``(N, C, Hg, Wg)``.
     """
-    import torch.nn.functional as F
+    import torch.nn.functional as F  # noqa: N812
 
     if input.device.type != "mps":
         return F.grid_sample(input, grid, mode="bilinear", padding_mode=padding_mode, align_corners=align_corners)

--- a/src/rfdetr/utilities/tensors.py
+++ b/src/rfdetr/utilities/tensors.py
@@ -199,16 +199,16 @@ def _bilinear_grid_sample(
         )
         raise ValueError(msg)
 
-    N, C, H, W = input.shape
-    Hg, Wg = grid.shape[1], grid.shape[2]
+    batch_size, channels, height, width = input.shape
+    grid_height, grid_width = grid.shape[1], grid.shape[2]
 
     # Unnormalize [-1, 1] → floating-point pixel coordinates
     if align_corners:
-        ix = (grid[..., 0] + 1) * (W - 1) / 2  # [N, Hg, Wg]
-        iy = (grid[..., 1] + 1) * (H - 1) / 2
+        ix = (grid[..., 0] + 1) * (width - 1) / 2  # [batch_size, grid_height, grid_width]
+        iy = (grid[..., 1] + 1) * (height - 1) / 2
     else:
-        ix = (grid[..., 0] + 1) * W / 2 - 0.5
-        iy = (grid[..., 1] + 1) * H / 2 - 0.5
+        ix = (grid[..., 0] + 1) * width / 2 - 0.5
+        iy = (grid[..., 1] + 1) * height / 2 - 0.5
 
     ix0 = ix.floor().long()  # top-left corner
     iy0 = iy.floor().long()
@@ -224,25 +224,25 @@ def _bilinear_grid_sample(
     wy0 = one - wy1
 
     if padding_mode == "border":
-        ix0 = ix0.clamp(0, W - 1)
-        iy0 = iy0.clamp(0, H - 1)
-        ix1 = ix1.clamp(0, W - 1)
-        iy1 = iy1.clamp(0, H - 1)
+        ix0 = ix0.clamp(0, width - 1)
+        iy0 = iy0.clamp(0, height - 1)
+        ix1 = ix1.clamp(0, width - 1)
+        iy1 = iy1.clamp(0, height - 1)
     else:  # zeros: record which corners fall inside the image before clamping
-        in_x0 = (ix0 >= 0) & (ix0 < W)  # [N, Hg, Wg]
-        in_x1 = (ix1 >= 0) & (ix1 < W)
-        in_y0 = (iy0 >= 0) & (iy0 < H)
-        in_y1 = (iy1 >= 0) & (iy1 < H)
-        ix0 = ix0.clamp(0, W - 1)
-        iy0 = iy0.clamp(0, H - 1)
-        ix1 = ix1.clamp(0, W - 1)
-        iy1 = iy1.clamp(0, H - 1)
+        in_x0 = (ix0 >= 0) & (ix0 < width)  # [batch_size, grid_height, grid_width]
+        in_x1 = (ix1 >= 0) & (ix1 < width)
+        in_y0 = (iy0 >= 0) & (iy0 < height)
+        in_y1 = (iy1 >= 0) & (iy1 < height)
+        ix0 = ix0.clamp(0, width - 1)
+        iy0 = iy0.clamp(0, height - 1)
+        ix1 = ix1.clamp(0, width - 1)
+        iy1 = iy1.clamp(0, height - 1)
 
-    flat = input.flatten(2)  # [N, C, H*W]
+    flat = input.flatten(2)  # [batch_size, channels, height*width]
 
     def _gather(iy_: torch.Tensor, ix_: torch.Tensor) -> torch.Tensor:
-        idx = (iy_ * W + ix_).flatten(1).unsqueeze(1).expand(N, C, -1)  # [N, C, Hg*Wg]
-        return flat.gather(2, idx).view(N, C, Hg, Wg)
+        idx = (iy_ * width + ix_).flatten(1).unsqueeze(1).expand(batch_size, channels, -1)
+        return flat.gather(2, idx).view(batch_size, channels, grid_height, grid_width)
 
     v00 = _gather(iy0, ix0)  # top-left
     v10 = _gather(iy0, ix1)  # top-right

--- a/tests/datasets/test_augmentations.py
+++ b/tests/datasets/test_augmentations.py
@@ -6,6 +6,8 @@
 
 """Tests for Albumentations augmentation wrappers."""
 
+from unittest import mock
+
 import albumentations as alb
 import numpy as np
 import pytest
@@ -19,6 +21,25 @@ from rfdetr.datasets.aug_config import AUG_AGGRESSIVE, AUG_CONFIG
 from rfdetr.datasets.coco import make_coco_transforms, make_coco_transforms_square_div_64
 from rfdetr.datasets.transforms import AlbumentationsWrapper, _build_albu_transform
 from rfdetr.utilities import collate_fn
+
+
+class _FakeRandomSizedCropV2:
+    """Test double for Albumentations 2.x-style RandomSizedCrop API."""
+
+    def __init__(self, *, min_max_height, size, p=1.0):
+        self.min_max_height = min_max_height
+        self.size = size
+        self.p = p
+
+
+class _FakeRandomSizedCropV1:
+    """Test double for Albumentations 1.x-style RandomSizedCrop API."""
+
+    def __init__(self, *, min_max_height, height, width, p=1.0):
+        self.min_max_height = min_max_height
+        self.height = height
+        self.width = width
+        self.p = p
 
 
 class TestAlbumentationsWrapper:
@@ -731,13 +752,8 @@ class TestRandomSizedCropCompat:
             ),
         ],
     )
-    def test_errors_on_partial_hw_with_v2_api(self, monkeypatch, params, expected_missing):
-        class FakeV2:
-            def __init__(self, *, min_max_height, size, p=1.0):
-                pass
-
-        monkeypatch.setattr("rfdetr.datasets.transforms.A.RandomSizedCrop", FakeV2)
-
+    @mock.patch("rfdetr.datasets.transforms.alb.RandomSizedCrop", new=_FakeRandomSizedCropV2)
+    def test_errors_on_partial_hw_with_v2_api(self, params, expected_missing):
         with pytest.raises(ValueError, match=f"missing '{expected_missing}'"):
             _build_albu_transform("RandomSizedCrop", params)
 
@@ -763,25 +779,14 @@ class TestRandomSizedCropCompat:
             ),
         ],
     )
-    def test_size_takes_precedence_over_hw_on_v2_api(self, monkeypatch, params):
-        class FakeV2:
-            def __init__(self, *, min_max_height, size, p=1.0):
-                self.size = size
-
-        monkeypatch.setattr("rfdetr.datasets.transforms.A.RandomSizedCrop", FakeV2)
-
+    @mock.patch("rfdetr.datasets.transforms.alb.RandomSizedCrop", new=_FakeRandomSizedCropV2)
+    def test_size_takes_precedence_over_hw_on_v2_api(self, params):
         # No TypeError means height/width were correctly dropped before instantiation
         transform = _build_albu_transform("RandomSizedCrop", params)
         assert transform.size == (256, 256)
 
-    def test_scalar_size_passes_through_on_v1_legacy_path(self, monkeypatch):
-        class FakeV1:
-            def __init__(self, *, min_max_height, height, width, p=1.0):
-                self.height = height
-                self.width = width
-
-        monkeypatch.setattr("rfdetr.datasets.transforms.A.RandomSizedCrop", FakeV1)
-
+    @mock.patch("rfdetr.datasets.transforms.alb.RandomSizedCrop", new=_FakeRandomSizedCropV1)
+    def test_scalar_size_passes_through_on_v1_legacy_path(self):
         # Scalar size=640 does not match isinstance(size, Sequence), so the v1
         # legacy branch leaves it in the params dict. FakeV1 does not accept
         # ``size`` so this should raise a TypeError from the constructor — our
@@ -792,61 +797,41 @@ class TestRandomSizedCropCompat:
                 {"min_max_height": [100, 200], "size": 640},
             )
 
-    def test_adapts_height_width_for_v2_api(self, monkeypatch):
+    @mock.patch("rfdetr.datasets.transforms.alb.RandomSizedCrop", new=_FakeRandomSizedCropV2)
+    def test_adapts_height_width_for_v2_api(self):
         """RandomSizedCrop config with height/width is adapted to the Albumentations 2.x size API."""
-
-        class FakeV2:
-            def __init__(self, *, min_max_height, size, p=1.0):
-                self.min_max_height = min_max_height
-                self.size = size
-                self.p = p
-
-        monkeypatch.setattr("rfdetr.datasets.transforms.A.RandomSizedCrop", FakeV2)
 
         transform = _build_albu_transform(
             "RandomSizedCrop",
             {"min_max_height": [384, 600], "height": 640, "width": 640},
         )
 
-        assert isinstance(transform, FakeV2)
+        assert isinstance(transform, _FakeRandomSizedCropV2)
         assert transform.min_max_height == [384, 600]
         assert transform.size == (640, 640)
 
-    def test_adapts_size_for_v1_api(self, monkeypatch):
+    @mock.patch("rfdetr.datasets.transforms.alb.RandomSizedCrop", new=_FakeRandomSizedCropV1)
+    def test_adapts_size_for_v1_api(self):
         """RandomSizedCrop config with size is adapted to the Albumentations 1.x height/width API."""
-
-        class FakeV1:
-            def __init__(self, *, min_max_height, height, width, p=1.0):
-                self.min_max_height = min_max_height
-                self.height = height
-                self.width = width
-                self.p = p
-
-        monkeypatch.setattr("rfdetr.datasets.transforms.A.RandomSizedCrop", FakeV1)
 
         transform = _build_albu_transform(
             "RandomSizedCrop",
             {"min_max_height": [384, 600], "size": (640, 640)},
         )
 
-        assert isinstance(transform, FakeV1)
+        assert isinstance(transform, _FakeRandomSizedCropV1)
         assert transform.min_max_height == [384, 600]
         assert transform.height == 640
         assert transform.width == 640
 
-    def test_from_config_partial_height_is_silently_skipped(self, monkeypatch):
+    @mock.patch("rfdetr.datasets.transforms.alb.RandomSizedCrop", new=_FakeRandomSizedCropV2)
+    def test_from_config_partial_height_is_silently_skipped(self):
         """from_config swallows the ValueError for partial height-only config and skips the transform.
 
         This documents the intentional silent-skip behavior: from_config wraps
         _build_albu_transform in a broad except clause so bad configs produce a
         warning rather than an exception.
         """
-
-        class FakeV2:
-            def __init__(self, *, min_max_height, size, p=1.0):
-                pass
-
-        monkeypatch.setattr("rfdetr.datasets.transforms.A.RandomSizedCrop", FakeV2)
 
         config = {
             "HorizontalFlip": {"p": 0.5},

--- a/tests/datasets/test_augmentations.py
+++ b/tests/datasets/test_augmentations.py
@@ -6,7 +6,7 @@
 
 """Tests for Albumentations augmentation wrappers."""
 
-import albumentations as A
+import albumentations as alb
 import numpy as np
 import pytest
 import torch
@@ -27,8 +27,8 @@ class TestAlbumentationsWrapper:
     @pytest.mark.parametrize(
         "transform_class,params,box_in,box_out",
         [
-            (A.HorizontalFlip, {"p": 1.0}, [10.0, 20.0, 30.0, 40.0], [70.0, 20.0, 90.0, 40.0]),
-            (A.VerticalFlip, {"p": 1.0}, [10.0, 20.0, 30.0, 40.0], [10.0, 60.0, 30.0, 80.0]),
+            (alb.HorizontalFlip, {"p": 1.0}, [10.0, 20.0, 30.0, 40.0], [70.0, 20.0, 90.0, 40.0]),
+            (alb.VerticalFlip, {"p": 1.0}, [10.0, 20.0, 30.0, 40.0], [10.0, 60.0, 30.0, 80.0]),
         ],
     )
     def test_flip_transforms_with_boxes(self, transform_class, params, box_in, box_out):
@@ -47,7 +47,7 @@ class TestAlbumentationsWrapper:
 
     def test_non_geometric_transform_preserves_boxes(self):
         """Test that non-geometric transforms preserve bounding boxes."""
-        transform = A.GaussianBlur(blur_limit=3, p=1.0)
+        transform = alb.GaussianBlur(blur_limit=3, p=1.0)
         wrapper = AlbumentationsWrapper(transform)
 
         image = Image.new("RGB", (100, 100))
@@ -62,7 +62,7 @@ class TestAlbumentationsWrapper:
 
     def test_empty_boxes_handling(self):
         """Test wrapper handles empty boxes correctly."""
-        transform = A.HorizontalFlip(p=1.0)
+        transform = alb.HorizontalFlip(p=1.0)
         wrapper = AlbumentationsWrapper(transform)
 
         image = Image.new("RGB", (100, 100))
@@ -76,7 +76,7 @@ class TestAlbumentationsWrapper:
 
     def test_multiple_boxes(self):
         """Test wrapper handles multiple bounding boxes."""
-        transform = A.HorizontalFlip(p=1.0)
+        transform = alb.HorizontalFlip(p=1.0)
         wrapper = AlbumentationsWrapper(transform)
 
         image = Image.new("RGB", (100, 100))
@@ -99,7 +99,7 @@ class TestAlbumentationsWrapper:
 
     def test_none_target_inference_mode(self):
         """Test wrapper accepts None target for inference (no ground-truth annotations)."""
-        transform = A.Resize(height=64, width=64)
+        transform = alb.Resize(height=64, width=64)
         wrapper = AlbumentationsWrapper(transform)
 
         image = Image.new("RGB", (100, 100))
@@ -111,7 +111,7 @@ class TestAlbumentationsWrapper:
 
     def test_invalid_target_type(self):
         """Test wrapper raises error for invalid target type."""
-        transform = A.HorizontalFlip(p=1.0)
+        transform = alb.HorizontalFlip(p=1.0)
         wrapper = AlbumentationsWrapper(transform)
 
         image = Image.new("RGB", (100, 100))
@@ -121,7 +121,7 @@ class TestAlbumentationsWrapper:
 
     def test_missing_labels_key(self):
         """Test wrapper raises error when labels key is missing."""
-        transform = A.HorizontalFlip(p=1.0)
+        transform = alb.HorizontalFlip(p=1.0)
         wrapper = AlbumentationsWrapper(transform)
 
         image = Image.new("RGB", (100, 100))
@@ -132,7 +132,7 @@ class TestAlbumentationsWrapper:
 
     def test_invalid_boxes_shape(self):
         """Test wrapper raises error for invalid boxes shape."""
-        transform = A.HorizontalFlip(p=1.0)
+        transform = alb.HorizontalFlip(p=1.0)
         wrapper = AlbumentationsWrapper(transform)
 
         image = Image.new("RGB", (100, 100))
@@ -152,7 +152,7 @@ class TestAlbumentationsWrapper:
         orig_size to be filtered/indexed incorrectly and leading to inconsistent
         tensor shapes in batches.
         """
-        transform = A.HorizontalFlip(p=1.0)
+        transform = alb.HorizontalFlip(p=1.0)
         wrapper = AlbumentationsWrapper(transform)
 
         image = Image.new("RGB", (640, 480))
@@ -187,7 +187,7 @@ class TestAlbumentationsWrapper:
         - orig_size (shape [2]): global field, should NOT be filtered
         - masks (shape [2, H, W]): per-instance field, SHOULD be transformed
         """
-        transform = A.HorizontalFlip(p=1.0)
+        transform = alb.HorizontalFlip(p=1.0)
         wrapper = AlbumentationsWrapper(transform)
 
         image = Image.new("RGB", (640, 480))
@@ -238,9 +238,9 @@ class TestAlbumentationsWrapper:
     @pytest.mark.parametrize(
         "transform_class,params",
         [
-            (A.HorizontalFlip, {"p": 1.0}),
-            (A.VerticalFlip, {"p": 1.0}),
-            (A.Rotate, {"limit": 45, "p": 1.0}),
+            (alb.HorizontalFlip, {"p": 1.0}),
+            (alb.VerticalFlip, {"p": 1.0}),
+            (alb.Rotate, {"limit": 45, "p": 1.0}),
         ],
     )
     def test_various_geometric_transforms(self, transform_class, params):
@@ -261,7 +261,7 @@ class TestAlbumentationsWrapper:
 
     def test_masks_transform_with_horizontal_flip(self):
         """Masks should be transformed consistently with boxes for geometric transforms."""
-        transform = A.HorizontalFlip(p=1.0)
+        transform = alb.HorizontalFlip(p=1.0)
         wrapper = AlbumentationsWrapper(transform)
 
         # Create test image (100x100)
@@ -305,9 +305,9 @@ class TestAlbumentationsWrapper:
     @pytest.mark.parametrize(
         "transform_class,params",
         [
-            (A.HorizontalFlip, {"p": 1.0}),
-            (A.VerticalFlip, {"p": 1.0}),
-            (A.Rotate, {"limit": 15, "p": 1.0}),  # Small angle to avoid boxes going out
+            (alb.HorizontalFlip, {"p": 1.0}),
+            (alb.VerticalFlip, {"p": 1.0}),
+            (alb.Rotate, {"limit": 15, "p": 1.0}),  # Small angle to avoid boxes going out
         ],
     )
     def test_various_geometric_transforms_with_masks(self, transform_class, params):
@@ -341,9 +341,9 @@ class TestAlbumentationsWrapper:
     @pytest.mark.parametrize(
         "transform_class,params",
         [
-            (A.GaussianBlur, {"blur_limit": 3, "p": 1.0}),
-            (A.RandomBrightnessContrast, {"p": 1.0}),
-            (A.GaussNoise, {"p": 1.0}),
+            (alb.GaussianBlur, {"blur_limit": 3, "p": 1.0}),
+            (alb.RandomBrightnessContrast, {"p": 1.0}),
+            (alb.GaussNoise, {"p": 1.0}),
         ],
     )
     def test_pixel_transforms_preserve_masks(self, transform_class, params):
@@ -371,7 +371,7 @@ class TestAlbumentationsWrapper:
 
     def test_multiple_masks_with_geometric_transform(self):
         """Test multiple masks are correctly transformed together."""
-        transform = A.HorizontalFlip(p=1.0)
+        transform = alb.HorizontalFlip(p=1.0)
         wrapper = AlbumentationsWrapper(transform)
 
         height, width = 100, 100
@@ -401,7 +401,7 @@ class TestAlbumentationsWrapper:
 
     def test_empty_masks_handling(self):
         """Test wrapper correctly handles empty masks (no 'masks' key when empty)."""
-        transform = A.HorizontalFlip(p=1.0)
+        transform = alb.HorizontalFlip(p=1.0)
         wrapper = AlbumentationsWrapper(transform)
 
         height, width = 100, 100
@@ -426,7 +426,7 @@ class TestAlbumentationsWrapper:
         has shape (0, H, W). Passing an empty list to albumentations raises
         ValueError: masks cannot be empty.
         """
-        transform = A.HorizontalFlip(p=1.0)
+        transform = alb.HorizontalFlip(p=1.0)
         wrapper = AlbumentationsWrapper(transform)
 
         height, width = 100, 100
@@ -453,7 +453,7 @@ class TestAlbumentationsWrapper:
     def test_pixel_transform_with_masks_no_boxes(self):
         """Test that pixel transforms work with masks but no boxes."""
         # Use a non-geometric transform which doesn't need boxes
-        transform = A.GaussianBlur(blur_limit=3, p=1.0)
+        transform = alb.GaussianBlur(blur_limit=3, p=1.0)
         wrapper = AlbumentationsWrapper(transform)
 
         height, width = 100, 100
@@ -474,7 +474,7 @@ class TestAlbumentationsWrapper:
 
     def test_invalid_mask_shape_raises_error(self):
         """Test that invalid mask shape raises ValueError."""
-        transform = A.HorizontalFlip(p=1.0)
+        transform = alb.HorizontalFlip(p=1.0)
         wrapper = AlbumentationsWrapper(transform)
 
         height, width = 100, 100
@@ -493,7 +493,7 @@ class TestAlbumentationsWrapper:
     @pytest.mark.parametrize("mask_dtype", [torch.uint8, torch.float32])
     def test_mask_dtype_handling(self, mask_dtype):
         """Test wrapper handles different mask dtypes correctly (uint8, float32)."""
-        transform = A.HorizontalFlip(p=1.0)
+        transform = alb.HorizontalFlip(p=1.0)
         wrapper = AlbumentationsWrapper(transform)
 
         height, width = 100, 100
@@ -521,7 +521,7 @@ class TestAlbumentationsWrapper:
         # Original image 100x100
         # Box 1: [10, 10, 20, 20] (will be kept if we crop top-left)
         # Box 2: [80, 80, 90, 90] (will be dropped if we crop top-left to 50x50)
-        transform = A.Crop(x_min=0, y_min=0, x_max=50, y_max=50, p=1.0)
+        transform = alb.Crop(x_min=0, y_min=0, x_max=50, y_max=50, p=1.0)
         wrapper = AlbumentationsWrapper(transform)
 
         height, width = 100, 100
@@ -554,7 +554,7 @@ class TestAlbumentationsWrapper:
         Albumentations' check_bboxes rejects these with
         "x_max is less than or equal to x_min", crashing the DataLoader worker.
         """
-        transform = A.HorizontalFlip(p=1.0)
+        transform = alb.HorizontalFlip(p=1.0)
         wrapper = AlbumentationsWrapper(transform)
 
         width, height = 100, 100
@@ -585,7 +585,7 @@ class TestAlbumentationsWrapper:
 
     def test_degenerate_bbox_mixed_with_masks(self):
         """Degenerate boxes are dropped together with their corresponding masks."""
-        transform = A.HorizontalFlip(p=1.0)
+        transform = alb.HorizontalFlip(p=1.0)
         wrapper = AlbumentationsWrapper(transform)
 
         width, height = 100, 100
@@ -866,17 +866,17 @@ class TestAlbumentationsWrapperNestedConfig:
 
     def test_one_of_geometric_detection(self):
         """OneOf containing a geometric transform is treated as geometric."""
-        wrapper = AlbumentationsWrapper(A.OneOf([A.HorizontalFlip(p=1.0), A.GaussianBlur(p=1.0)]))
+        wrapper = AlbumentationsWrapper(alb.OneOf([alb.HorizontalFlip(p=1.0), alb.GaussianBlur(p=1.0)]))
         assert wrapper._is_geometric is True
 
     def test_one_of_pixel_detection(self):
         """OneOf containing only pixel transforms is treated as pixel-level."""
-        wrapper = AlbumentationsWrapper(A.OneOf([A.GaussianBlur(p=1.0), A.Blur(p=1.0)]))
+        wrapper = AlbumentationsWrapper(alb.OneOf([alb.GaussianBlur(p=1.0), alb.Blur(p=1.0)]))
         assert wrapper._is_geometric is False
 
     def test_sequential_geometric_detection(self):
         """Sequential containing a geometric transform is treated as geometric."""
-        wrapper = AlbumentationsWrapper(A.Sequential([A.Rotate(limit=45, p=1.0), A.GaussianBlur(p=1.0)]))
+        wrapper = AlbumentationsWrapper(alb.Sequential([alb.Rotate(limit=45, p=1.0), alb.GaussianBlur(p=1.0)]))
         assert wrapper._is_geometric is True
 
     def test_from_config_nested_one_of(self):
@@ -897,7 +897,7 @@ class TestAlbumentationsWrapperNestedConfig:
         assert wrapper._is_geometric is True
         # The inner Albumentations transform should be OneOf
         inner = wrapper.transform.transforms[0]
-        assert isinstance(inner, A.OneOf)
+        assert isinstance(inner, alb.OneOf)
         assert len(inner.transforms) == 2
 
     def test_from_config_nested_one_of_pixel_only(self):
@@ -937,8 +937,8 @@ class TestAlbumentationsWrapperNestedConfig:
         assert len(transforms) == 1
         assert transforms[0]._is_geometric is True
         inner = transforms[0].transform.transforms[0]
-        assert isinstance(inner, A.Sequential)
-        assert isinstance(inner.transforms[0], A.OneOf)
+        assert isinstance(inner, alb.Sequential)
+        assert isinstance(inner.transforms[0], alb.OneOf)
 
     def test_from_config_shorthand_list(self):
         """from_config supports shorthand {OneOf: [...]} without explicit transforms key."""
@@ -952,7 +952,7 @@ class TestAlbumentationsWrapperNestedConfig:
 
         assert len(transforms) == 1
         inner = transforms[0].transform.transforms[0]
-        assert isinstance(inner, A.OneOf)
+        assert isinstance(inner, alb.OneOf)
         assert len(inner.transforms) == 2
 
     def test_from_config_nested_sequential(self):
@@ -969,7 +969,7 @@ class TestAlbumentationsWrapperNestedConfig:
 
         assert len(transforms) == 1
         inner = transforms[0].transform.transforms[0]
-        assert isinstance(inner, A.Sequential)
+        assert isinstance(inner, alb.Sequential)
         assert len(inner.transforms) == 2
 
     def test_from_config_list_format(self):
@@ -989,7 +989,7 @@ class TestAlbumentationsWrapperNestedConfig:
 
         assert len(transforms) == 2
         assert isinstance(transforms[0], AlbumentationsWrapper)
-        assert isinstance(transforms[1].transform.transforms[0], A.OneOf)
+        assert isinstance(transforms[1].transform.transforms[0], alb.OneOf)
 
     def test_from_config_mixed_flat_and_nested(self):
         """from_config handles mix of flat and nested transforms."""
@@ -1065,7 +1065,7 @@ class TestAlbumentationsWrapperNestedConfig:
         }
         transforms = AlbumentationsWrapper.from_config(config)
         inner = transforms[0].transform.transforms[0]
-        assert isinstance(inner, A.OneOf)
+        assert isinstance(inner, alb.OneOf)
         assert inner.p == pytest.approx(1.0)
 
     def test_one_of_empty_transforms_raises(self):
@@ -1083,7 +1083,7 @@ class TestAlbumentationsWrapperNestedConfig:
         }
         transforms = AlbumentationsWrapper.from_config(config)
         inner = transforms[0].transform.transforms[0]
-        assert isinstance(inner, A.Sequential)
+        assert isinstance(inner, alb.Sequential)
         assert inner.p == pytest.approx(1.0)
 
     def test_some_of_single_p_still_works(self):
@@ -1101,7 +1101,7 @@ class TestAlbumentationsWrapperNestedConfig:
         transforms = AlbumentationsWrapper.from_config(config)
         inner = transforms[0].transform.transforms[0]
 
-        assert isinstance(inner, A.SomeOf)
+        assert isinstance(inner, alb.SomeOf)
         assert inner.p == pytest.approx(0.5)
 
 
@@ -1300,8 +1300,8 @@ class TestTrainingLoop:
         """
         # Create augmentations
         aug_transforms = [
-            AlbumentationsWrapper(A.HorizontalFlip(p=0.5)),
-            AlbumentationsWrapper(A.Rotate(limit=10, p=0.5)),
+            AlbumentationsWrapper(alb.HorizontalFlip(p=0.5)),
+            AlbumentationsWrapper(alb.Rotate(limit=10, p=0.5)),
         ]
         transforms = Compose(aug_transforms)
 
@@ -1341,7 +1341,7 @@ class TestTrainingLoop:
         This specifically tests the edge case where some samples have 2 boxes
         (which matches orig_size shape [2]), ensuring they don't get mixed up.
         """
-        aug_transforms = [AlbumentationsWrapper(A.HorizontalFlip(p=0.5))]
+        aug_transforms = [AlbumentationsWrapper(alb.HorizontalFlip(p=0.5))]
         transforms = Compose(aug_transforms)
 
         # Create dataset with samples that have different numbers of boxes
@@ -1376,9 +1376,9 @@ class TestTrainingLoop:
     @pytest.mark.parametrize(
         "transform_class,transform_kwargs",
         [
-            (A.HorizontalFlip, {"p": 1.0}),
-            (A.VerticalFlip, {"p": 1.0}),
-            (A.RandomRotate90, {"p": 1.0}),
+            (alb.HorizontalFlip, {"p": 1.0}),
+            (alb.VerticalFlip, {"p": 1.0}),
+            (alb.RandomRotate90, {"p": 1.0}),
         ],
         ids=["horizontal_flip", "vertical_flip", "random_rotate_90"],
     )

--- a/tests/models/test_predict.py
+++ b/tests/models/test_predict.py
@@ -186,7 +186,7 @@ class TestPredictShape:
         """Without ``shape=``, resize uses ``(resolution, resolution)``."""
         from unittest.mock import patch
 
-        import torchvision.transforms.functional as F
+        import torchvision.transforms.functional as F  # noqa: N812
 
         model = _DummyRFDETR()
         img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
@@ -201,7 +201,7 @@ class TestPredictShape:
         # Regression test for #682
         from unittest.mock import patch
 
-        import torchvision.transforms.functional as F
+        import torchvision.transforms.functional as F  # noqa: N812
 
         model = _DummyRFDETR()
         img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
@@ -220,7 +220,7 @@ class TestPredictShape:
         # Regression test for #682 — square shape different from model resolution.
         from unittest.mock import patch
 
-        import torchvision.transforms.functional as F
+        import torchvision.transforms.functional as F  # noqa: N812
 
         model = _DummyRFDETR()
         img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
@@ -247,7 +247,7 @@ class TestPredictShape:
         """predict() accepts integer-like types (numpy, torch) via the __index__ protocol."""
         from unittest.mock import patch
 
-        import torchvision.transforms.functional as F
+        import torchvision.transforms.functional as F  # noqa: N812
 
         model = _DummyRFDETR()
         img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))

--- a/tests/training/test_metrics_csv.py
+++ b/tests/training/test_metrics_csv.py
@@ -132,24 +132,24 @@ class TestDetectionMetricsCSV:
         value equals the raw weighted criterion output so both losses are on the
         same scale.
         """
-        FIXED_LOSS = 5.0
-        GRAD_ACCUM = 4
+        fixed_loss_value = 5.0
+        grad_accum_steps = 4
 
         class _FixedCriterion:
             weight_dict = {"loss_ce": 1.0}
 
             def __call__(self, outputs, targets):
-                # Loss is always FIXED_LOSS, connected to model params for gradient.
+                # Loss is always fixed_loss_value, connected to model params for gradient.
                 dummy = outputs.get("dummy", torch.zeros(1))
-                return {"loss_ce": dummy.mean() * 0 + FIXED_LOSS}
+                return {"loss_ce": dummy.mean() * 0 + fixed_loss_value}
 
         mc = base_model_config()
-        tc = base_train_config(use_ema=False, run_test=False, grad_accum_steps=GRAD_ACCUM)
+        tc = base_train_config(use_ema=False, run_test=False, grad_accum_steps=grad_accum_steps)
         df = _fit_and_read_csv(mc, tc, criterion=_FixedCriterion())
 
         logged = df["train/loss"].dropna().mean()
-        expected_unscaled = FIXED_LOSS
-        expected_if_divided = FIXED_LOSS / GRAD_ACCUM
+        expected_unscaled = fixed_loss_value
+        expected_if_divided = fixed_loss_value / grad_accum_steps
 
         assert abs(logged - expected_unscaled) < abs(logged - expected_if_divided), (
             f"train/loss={logged:.4f} is closer to the grad-accum-divided value "

--- a/tests/utilities/test_tensors.py
+++ b/tests/utilities/test_tensors.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 import pytest
 import torch
-import torch.nn.functional as F
+import torch.nn.functional as F  # noqa: N812
 import torch.testing
 
 from rfdetr.utilities.tensors import _bilinear_grid_sample


### PR DESCRIPTION
This pull request updates the linting configuration in `pyproject.toml` to improve code style enforcement and accommodate project-specific conventions. The main changes are:

**Linting rule updates:**

* Added `"N"` to the `select` list to enable `pep8-naming` checks, which enforce naming conventions for variables and arguments.
* Added `"N812"` to the `ignore` list to allow the common PyTorch import convention `import torch.nn.functional as F` without raising a naming warning.