### PR TITLE
releasing `1.6.4` [rebase & merge]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
         args: ["--print-width=120"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.6
+    rev: v0.15.9
     hooks:
       - id: ruff-check
         args: ["--exit-non-zero-on-fix"]
@@ -41,7 +41,7 @@ repos:
         exclude: ^notebooks/.*\.py$
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.19.1
+    rev: v1.20.0
     hooks:
       - id: mypy
         # --ignore-missing-imports: the hook runs in an isolated env without torch/torchvision/etc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed segmentation multi-GPU DDP training crash: `build_trainer()` now wraps `strategy="ddp"` with `DDPStrategy(find_unused_parameters=True)` when `segmentation_head=True`. The segmentation head's `sparse_forward()` leaves parameters unused on some forward steps; plain `"ddp"` raised `RuntimeError: It looks like your LightningModule has parameters that were not used in producing the loss`. Non-segmentation DDP and other strategies are unchanged. (#942, #947)
+- Fixed fused AdamW crash under FP32 multi-GPU training: `configure_optimizers()` and `clip_gradients()` now gate fused AdamW on the trainer's actual precision (requiring a BF16 variant) rather than GPU capability alone. On Ampere+ hardware `torch.cuda.is_bf16_supported()` is always `True`, so the old code enabled fused AdamW even with `precision="32-true"`, causing `RuntimeError: params, grads, exp_avgs, and exp_avg_sqs must have same dtype, device, and layout` from DDP gradient bucket view stride mismatches. (#942, #947)
 - `download_pretrain_weights()` no longer overwrites fine-tuned checkpoints that share a filename with a registry model (e.g. `rf-detr-nano.pth`). Previously, an MD5 mismatch would fall through to `_download_file()` and silently replace the user's weights with the original COCO checkpoint. The function now returns early whenever the file exists and `redownload=False`, regardless of MD5 status — a warning is emitted when the hash differs. Pass `redownload=True` to force a fresh download. (#935)
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `download_pretrain_weights()` no longer overwrites fine-tuned checkpoints that share a filename with a registry model (e.g. `rf-detr-nano.pth`). Previously, an MD5 mismatch would fall through to `_download_file()` and silently replace the user's weights with the original COCO checkpoint. The function now returns early whenever the file exists and `redownload=False`, regardless of MD5 status — a warning is emitted when the hash differs. Pass `redownload=True` to force a fresh download. (#935)
+
 ---
 
 ## [1.6.3] — 2026-04-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+---
+
+## [1.6.4] — 2026-04-10
+
+### Changed
+
+- `predict()` now includes `class_name` in `detections.data`, mapping each detection's 0-indexed class ID to its human-readable name. (#914)
+
+### Fixed
+
 - Fixed segmentation multi-GPU DDP training crash: `build_trainer()` now wraps `strategy="ddp"` with `DDPStrategy(find_unused_parameters=True)` when `segmentation_head=True`. The segmentation head's `sparse_forward()` leaves parameters unused on some forward steps; plain `"ddp"` raised `RuntimeError: It looks like your LightningModule has parameters that were not used in producing the loss`. Non-segmentation DDP and other strategies are unchanged. (#942, #947)
 - Fixed fused AdamW crash under FP32 multi-GPU training: `configure_optimizers()` and `clip_gradients()` now gate fused AdamW on the trainer's actual precision (requiring a BF16 variant) rather than GPU capability alone. On Ampere+ hardware `torch.cuda.is_bf16_supported()` is always `True`, so the old code enabled fused AdamW even with `precision="32-true"`, causing `RuntimeError: params, grads, exp_avgs, and exp_avg_sqs must have same dtype, device, and layout` from DDP gradient bucket view stride mismatches. (#942, #947)
+- Fixed multi-GPU DDP training crashing in Jupyter notebooks and Kaggle: replaced fork-based `ddp_notebook` strategy with a spawn-based DDP strategy that avoids OpenMP thread pool corruption after `fork()`. (#928)
+- Fixed `RFDETR.train(resolution=...)` being silently ignored — the kwarg is now applied to `model_config` before training begins, with validation that the value is divisible by `patch_size * num_windows`. (#933)
+- Fixed `save_dataset_grids` being silently a no-op — `DatasetGridSaver` is now wired into the training loop, saving sample grids to `{output_dir}/dataset_grids/` when enabled. Grid save failures are caught without interrupting training. (#946)
+- Fixed partial gradient-accumulation windows at the tail of training epochs: the training dataset is now padded to an exact multiple of `effective_batch_size * world_size`, ensuring every optimizer step uses a full gradient window. Workaround for [pytorch-lightning#19987](https://github.com/Lightning-AI/pytorch-lightning/issues/19987). (#937)
+- Fixed `torch.export.export` failing on the transformer decoder by threading `spatial_shapes_hw` through all decoder layers. (#936)
 - `download_pretrain_weights()` no longer overwrites fine-tuned checkpoints that share a filename with a registry model (e.g. `rf-detr-nano.pth`). Previously, an MD5 mismatch would fall through to `_download_file()` and silently replace the user's weights with the original COCO checkpoint. The function now returns early whenever the file exists and `redownload=False`, regardless of MD5 status — a warning is emitted when the hash differs. Pass `redownload=True` to force a fresh download. (#935)
-
----
 
 ## [1.6.3] — 2026-04-02
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rfdetr"
-version = "1.6.3"
+version = "1.6.4"
 description = "RF-DETR"
 readme = "README.md"
 authors = [

--- a/src/rfdetr/assets/model_weights.py
+++ b/src/rfdetr/assets/model_weights.py
@@ -340,16 +340,19 @@ def download_pretrain_weights(
         except (ImportError, KeyError):
             return
 
-    # Check if file exists with correct hash
+    # Skip download when file already exists and redownload is disabled
     if os.path.exists(pretrain_weights) and not redownload:
         if expected_md5 and validate_md5:
             if not _validate_file_md5(pretrain_weights, expected_md5):
-                logger.warning(f"Existing file {pretrain_weights} has incorrect MD5 hash. Re-downloading...")
+                logger.warning(
+                    f"Existing file {pretrain_weights} has incorrect MD5 hash. "
+                    "It may be a user-provided checkpoint or a corrupted/tampered file — "
+                    "skipping re-download to avoid overwriting it. "
+                    "To force a fresh download of the original weights, pass redownload=True."
+                )
             else:
                 logger.info(f"File {pretrain_weights} already exists with correct MD5 hash.")
-                return
-        else:
-            return
+        return
 
     logger.info(f"Downloading pretrained weights for {pretrain_weights}")
     _download_file(

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -382,7 +382,7 @@ class TrainConfig(BaseModel):
     clearml: bool = False  # Not yet implemented — reserved for future use.
     project: Optional[str] = None
     run: Optional[str] = None
-    class_names: List[str] = None
+    class_names: Optional[List[str]] = None
     run_test: bool = False
     segmentation_head: bool = False
     eval_max_dets: int = 500

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -11,7 +11,37 @@ from typing import Any, ClassVar, Dict, List, Literal, Mapping, Optional, Union
 import torch
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-DEVICE = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
+
+def _detect_device() -> str:
+    """Detect the best available device **without** initialising the CUDA runtime.
+
+    ``torch.cuda.is_available()`` creates a CUDA driver context that makes
+    ``_is_in_bad_fork()`` return ``True`` in child processes.  This breaks
+    fork-based DDP strategies (e.g. ``ddp_notebook``) in notebook environments.
+
+    We defer to :func:`torch.accelerator.current_accelerator` (PyTorch ≥ 2.4)
+    when available — it queries the driver through NVML without creating a
+    primary context.  On older builds we fall back to ``torch.cuda.is_available()``.
+    """
+    accelerator = getattr(torch, "accelerator", None)
+    current_accelerator = getattr(accelerator, "current_accelerator", None)
+    if current_accelerator is not None:
+        try:
+            accel = current_accelerator()
+            if accel is not None:
+                return str(accel)
+            return "cpu"
+        except RuntimeError:
+            return "cpu"
+    # Fallback for PyTorch < 2.4 — this DOES create a CUDA driver context.
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+DEVICE: str = _detect_device()
 
 
 class BaseConfig(BaseModel):

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -4,8 +4,8 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
-
 import os
+import warnings
 from typing import Any, ClassVar, Dict, List, Literal, Mapping, Optional, Union
 
 import torch
@@ -523,3 +523,15 @@ class SegmentationTrainConfig(TrainConfig):
     mask_dice_loss_coef: float = 5.0
     cls_loss_coef: float = 5.0
     segmentation_head: bool = True
+
+    @model_validator(mode="after")
+    def warn_deprecated_num_select(self) -> "SegmentationTrainConfig":
+        """Warn when callers explicitly set the deprecated train-time ``num_select`` field."""
+        if "num_select" in self.model_fields_set and self.num_select is not None:
+            warnings.warn(
+                "TrainConfig.num_select is deprecated and ignored by "
+                "PTL/inference; set ModelConfig.num_select instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return self

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -419,6 +419,7 @@ class TrainConfig(BaseModel):
     eval_interval: int = 1
     log_per_class_metrics: bool = True
     aug_config: Optional[Dict[str, Any]] = None
+    save_dataset_grids: bool = False
 
     @field_validator("progress_bar", mode="before")
     @classmethod

--- a/src/rfdetr/datasets/_develop.py
+++ b/src/rfdetr/datasets/_develop.py
@@ -21,6 +21,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generator, Optional, Tuple
 from urllib.request import urlretrieve
 
+import numpy as np
+import torch
+from PIL import Image
+
 from rfdetr.util.logger import get_logger
 
 logger = get_logger()
@@ -70,10 +74,6 @@ class _SimpleDataset:
         return self.num_samples
 
     def __getitem__(self, idx: int) -> Tuple[torch.Tensor, dict]:
-        import numpy as np
-        import torch
-        from PIL import Image
-
         # Create synthetic image
         image = Image.new("RGB", (640, 480))
 

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -595,6 +595,25 @@ class RFDETR:
 
         module = RFDETRModelModule(self.model_config, config)
         datamodule = RFDETRDataModule(self.model_config, config)
+
+        # Guard with LOCAL_RANK env var rather than is_main_process() because torch.distributed
+        # is not yet initialized here (it is set up inside trainer.fit()).  In Lightning DDP
+        # subprocesses, LOCAL_RANK is set by the launcher before the subprocess calls train(),
+        # so this correctly identifies rank 0 even before dist.init_process_group() runs.
+        if config.save_dataset_grids and os.environ.get("LOCAL_RANK", "0") == "0":
+            try:
+                from rfdetr.datasets.save_grids import DatasetGridSaver
+
+                datamodule.setup("fit")
+                grids_output_dir = Path(config.output_dir) / "dataset_grids"
+                DatasetGridSaver(datamodule.train_dataloader(), grids_output_dir, dataset_type="train").save_grid()
+                DatasetGridSaver(datamodule.val_dataloader(), grids_output_dir, dataset_type="val").save_grid()
+            except Exception:
+                logger.warning(
+                    "Failed to save dataset grids; training will continue without them.",
+                    exc_info=True,
+                )
+
         trainer_kwargs = {"accelerator": _accelerator}
         if _devices is not None:
             trainer_kwargs["devices"] = _devices

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -192,17 +192,23 @@ def _apply_lora_to(nn_model: torch.nn.Module) -> None:
     nn_model.backbone[0].encoder = get_peft_model(nn_model.backbone[0].encoder, lora_config)
 
 
-def _build_model_context(model_config: ModelConfig) -> "ModelContext":
+def _build_model_context(model_config: ModelConfig) -> ModelContext:
     """Build a ModelContext from ModelConfig without using legacy main.py:Model.
 
     Replicates ``Model.__init__`` logic: builds the nn.Module, optionally loads
-    pretrain weights and applies LoRA, then moves the model to the target device.
+    pretrain weights and applies LoRA.  The model is intentionally kept on CPU;
+    :func:`_ensure_model_on_device` in ``detr.py`` performs the deferred
+    ``.to(device)`` on the first ``predict()`` / ``export()`` /
+    ``optimize_for_inference()`` call.  Keeping construction CPU-only prevents
+    CUDA initialisation during ``__init__``, which would block DDP strategies
+    (``ddp_notebook``, ``ddp_spawn``) from spawning child processes in notebook
+    environments.
 
     Args:
         model_config: Architecture configuration.
 
     Returns:
-        Fully initialised ModelContext ready for inference or training.
+        ModelContext with the model on CPU, ready for lazy device placement.
     """
     from rfdetr._namespace import build_namespace
 
@@ -219,7 +225,11 @@ def _build_model_context(model_config: ModelConfig) -> "ModelContext":
         _apply_lora_to(nn_model)
 
     device = torch.device(args.device)
-    nn_model = nn_model.to(device)
+    # Keep the model on CPU here; predict() / export() / optimize_for_inference()
+    # will lazily move it to the target device on first use.  Eagerly calling
+    # .to("cuda") would initialise the CUDA runtime during __init__(), which
+    # prevents DDP strategies (ddp_notebook, ddp_spawn) from forking/spawning
+    # child processes in notebook environments.
     postprocess = PostProcess(num_select=args.num_select)
 
     return ModelContext(
@@ -316,6 +326,28 @@ def _resolve_patch_size(patch_size: int | None, model_config: object, caller: st
     if isinstance(patch_size, bool) or not isinstance(patch_size, int) or patch_size <= 0:
         raise ValueError(f"patch_size must be a positive integer, got {patch_size!r}")
     return patch_size
+
+
+def _ensure_model_on_device(model_ctx: Any) -> None:
+    """Move model weights to the target device recorded in *model_ctx*.
+
+    ``_build_model_context`` intentionally keeps the ``nn.Module`` on CPU so
+    that ``RFDETR.__init__`` does not initialise CUDA (which would prevent DDP
+    strategies from forking in notebook environments).  This helper performs
+    the deferred ``.to(device)`` on first use.
+
+    It is safe to call on duck-typed stand-ins (e.g. ``SimpleNamespace``); the
+    function silently returns when the expected attributes are missing.
+    """
+    target = getattr(model_ctx, "device", None)
+    inner = getattr(model_ctx, "model", None)
+    if target is None or inner is None or not hasattr(inner, "parameters"):
+        return
+    if isinstance(target, str):
+        target = torch.device(target)
+    first_param = next(inner.parameters(), None)
+    if first_param is not None and first_param.device != target:
+        model_ctx.model = inner.to(target)
 
 
 class RFDETR:
@@ -475,6 +507,10 @@ class RFDETR:
 
         config = self.get_train_config(**kwargs)
         if config.batch_size == "auto":
+            # Auto-batch probing runs forward/backward on the actual model, which
+            # must be on the target device (typically CUDA).  Lazy placement keeps
+            # the model on CPU until first use — move it now.
+            _ensure_model_on_device(self.model)
             auto_batch = resolve_auto_batch_config(
                 model_context=self.model,
                 model_config=self.model_config,
@@ -557,6 +593,7 @@ class RFDETR:
         # Clear any previously optimized state before starting a new optimization run.
         self.remove_optimized_model()
 
+        _ensure_model_on_device(self.model)
         device = self.model.device
         cuda_ctx = torch.cuda.device(device) if device.type == "cuda" else contextlib.nullcontext()
 
@@ -971,6 +1008,8 @@ class RFDETR:
 
         """
         import supervision as sv
+
+        _ensure_model_on_device(self.model)
 
         patch_size = _resolve_patch_size(patch_size, self.model_config, "predict")
         num_windows = getattr(self.model_config, "num_windows", 1)

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -142,8 +142,19 @@ def _load_pretrain_weights_into(nn_model: torch.nn.Module, args: Any) -> List[st
 
     validate_checkpoint_compatibility(checkpoint, args)
 
+    user_set_num_classes = "num_classes" in getattr(args, "model_fields_set", set())
+    default_num_classes = getattr(type(args), "model_fields", {}).get("num_classes")
+    default_num_classes = getattr(default_num_classes, "default", 90)
+    num_classes = args.num_classes
+    user_overrode_default_num_classes = user_set_num_classes and num_classes != default_num_classes
+
     checkpoint_num_classes = checkpoint["model"]["class_embed.bias"].shape[0]
-    if checkpoint_num_classes != args.num_classes + 1:
+    configured_num_classes_plus_bg = num_classes + 1
+    if checkpoint_num_classes != configured_num_classes_plus_bg:
+        if checkpoint_num_classes < configured_num_classes_plus_bg and not user_overrode_default_num_classes:
+            num_classes = checkpoint_num_classes - 1
+            configured_num_classes_plus_bg = checkpoint_num_classes
+            args.num_classes = num_classes
         # Temporarily align the detection head size with the checkpoint so
         # that state_dict loading succeeds even when the configured
         # num_classes differs from the checkpoint.
@@ -159,8 +170,11 @@ def _load_pretrain_weights_into(nn_model: torch.nn.Module, args: Any) -> List[st
 
     # Only reinitialize back to configured size when intentionally reducing a
     # larger pretrain checkpoint to fewer task-specific classes.
-    if args.num_classes + 1 < checkpoint_num_classes:
-        nn_model.reinitialize_detection_head(args.num_classes + 1)
+    if checkpoint_num_classes < configured_num_classes_plus_bg and user_overrode_default_num_classes:
+        nn_model.reinitialize_detection_head(configured_num_classes_plus_bg)
+
+    if num_classes + 1 < checkpoint_num_classes:
+        nn_model.reinitialize_detection_head(num_classes + 1)
 
     return class_names
 

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -431,9 +431,20 @@ class RFDETR:
         """Train an RF-DETR model via the PyTorch Lightning stack.
 
         All keyword arguments are forwarded to :meth:`get_train_config` to build
-        a :class:`~rfdetr.config.TrainConfig`.  Several legacy kwargs are absorbed
-        so existing call-sites do not break:
+        a :class:`~rfdetr.config.TrainConfig`.  Several kwargs are absorbed and
+        handled specially so that existing call-sites do not break:
 
+        * ``resolution`` — updates the model's input resolution by mutating
+          :attr:`model_config.resolution` in place before the train config is
+          built. This change persists on :attr:`model_config` after
+          :meth:`train` returns. The value must be a positive integer divisible
+          by ``patch_size * num_windows`` for the model variant; a
+          :class:`ValueError` is raised otherwise.
+          :attr:`model_config.positional_encoding_size` is also updated when
+          the config derives it formulaically (``PE == resolution //
+          patch_size``); configs with a pretrained-specific PE value (e.g.
+          ``RFDETRBase`` uses DINOv2's PE=37 at 560 px) are left unchanged to
+          preserve checkpoint compatibility.
         * ``device`` — normalized via :class:`torch.device` and mapped to PyTorch
           Lightning trainer arguments. ``"cpu"`` becomes ``accelerator="cpu"``;
           ``"cuda"`` and ``"cuda:N"`` become ``accelerator="gpu"`` and optionally
@@ -454,6 +465,8 @@ class RFDETR:
         Raises:
             ImportError: If training dependencies are not installed. Install with
                 ``pip install "rfdetr[train,loggers]"``.
+            ValueError: If ``resolution`` is not a positive integer or is not
+                divisible by ``patch_size * num_windows`` for the model variant.
 
         """
         # Both imports are grouped in a single try block because they both live in
@@ -505,6 +518,54 @@ class RFDETR:
                 stacklevel=2,
             )
 
+        # Apply resolution override to model_config before building the train config.
+        # resolution is a ModelConfig field, not a TrainConfig field, so we pop it
+        # here to avoid it being silently ignored by TrainConfig.
+        _resolution = kwargs.pop("resolution", None)
+        if _resolution is not None:
+            if isinstance(_resolution, bool):
+                raise ValueError("resolution must be a positive integer")
+            try:
+                _resolution = operator.index(_resolution)
+            except TypeError as error:
+                raise ValueError("resolution must be a positive integer") from error
+            if _resolution <= 0:
+                raise ValueError("resolution must be a positive integer")
+            block_size = self.model_config.patch_size * self.model_config.num_windows
+            if _resolution % block_size != 0:
+                raise ValueError(
+                    f"resolution={_resolution} is not divisible by "
+                    f"patch_size ({self.model_config.patch_size}) * num_windows "
+                    f"({self.model_config.num_windows}) = {block_size}. "
+                    f"Choose a resolution that is a multiple of {block_size}."
+                )
+            # Smart PE update: only recompute positional_encoding_size when the
+            # current config derives it formulaically (PE == resolution // patch_size).
+            # Configs with a pretrained-specific PE (e.g. RFDETRBase uses DINOv2's
+            # PE=37 at 518 px, training at 560 px) must not have PE silently changed
+            # — doing so causes shape mismatches when loading pretrained checkpoints.
+            _current_pe = self.model_config.positional_encoding_size
+            _derived_pe = self.model_config.resolution // self.model_config.patch_size
+            if _current_pe == _derived_pe:
+                # Formula-derived: update PE proportionally to the new resolution.
+                new_pe = _resolution // self.model_config.patch_size
+                self.model_config.positional_encoding_size = new_pe
+            else:
+                # Pretrained-specific PE; leave it unchanged.
+                new_pe = _current_pe
+            self.model_config.resolution = _resolution
+
+            # Keep the cached inference/export context in sync with model_config so
+            # predict()/export()/deployment all see the same resolution metadata.
+            if hasattr(self, "model") and self.model is not None:
+                if hasattr(self.model, "resolution"):
+                    self.model.resolution = _resolution
+                model_args = getattr(self.model, "args", None)
+                if model_args is not None:
+                    if hasattr(model_args, "resolution"):
+                        model_args.resolution = _resolution
+                    if hasattr(model_args, "positional_encoding_size"):
+                        model_args.positional_encoding_size = new_pe
         config = self.get_train_config(**kwargs)
         if config.batch_size == "auto":
             # Auto-batch probing runs forward/backward on the actual model, which

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -949,7 +949,17 @@ class RFDETR:
 
         Returns:
             A single or multiple Detections objects, each containing bounding box
-            coordinates, confidence scores, and class IDs.
+            coordinates, confidence scores, and class IDs.  The ``data`` dict of
+            each :class:`~supervision.Detections` object contains:
+
+            * ``"class_name"`` – ``np.ndarray`` of string class names corresponding
+              to each detection (``class_names[class_id]``).  Class IDs are always
+              0-indexed; ``class_names[0]`` is the first class regardless of the
+              original dataset format (COCO category IDs are remapped to 0-based
+              indices during training).
+            * ``"source_image"`` – the original input image (only present when
+              ``include_source_image=True``, which is the default).
+            * ``"source_shape"`` – ``(height, width)`` tuple of the source image dimensions.
 
         Raises:
             ValueError: If ``shape`` cannot be unpacked as a two-element sequence,
@@ -1074,6 +1084,8 @@ class RFDETR:
             target_sizes = torch.tensor(orig_sizes, device=self.model.device)
             results = self.model.postprocess(predictions, target_sizes=target_sizes)
 
+        model_class_names = self.class_names
+        n = len(model_class_names)
         detections_list = []
         for i, result in enumerate(results):
             scores = result["scores"]
@@ -1104,6 +1116,23 @@ class RFDETR:
 
             detections.data["source_image"] = source_images[i]
             detections.data["source_shape"] = orig_sizes[i]
+
+            # Attach class names so callers can map class_id → name without a
+            # separate lookup.  class_id is always 0-indexed regardless of the
+            # original dataset format (COCO category IDs are remapped during
+            # training), so class_names[class_id] is the correct mapping.
+            # Always set data["class_name"] for a consistent interface.
+            class_ids = detections.class_id if detections.class_id is not None else np.array([], dtype=int)
+            oob_ids = [cid for cid in class_ids if not (0 <= cid < n)]
+            if oob_ids:
+                logger.warning_once(
+                    "predict() encountered class_id values out of range [0, %d): %s — mapping to empty string",
+                    n,
+                    oob_ids[:5],
+                )
+            detections.data["class_name"] = np.array(
+                [model_class_names[cid] if 0 <= cid < n else "" for cid in class_ids], dtype=object
+            )
 
             detections_list.append(detections)
 

--- a/src/rfdetr/models/ops/functions/ms_deform_attn_func.py
+++ b/src/rfdetr/models/ops/functions/ms_deform_attn_func.py
@@ -22,15 +22,25 @@ import torch
 from rfdetr.utilities.tensors import _bilinear_grid_sample
 
 
-def ms_deform_attn_core_pytorch(value, value_spatial_shapes, sampling_locations, attention_weights):
-    """ "for debug and test only, need to use cuda version instead"""
+def ms_deform_attn_core_pytorch(
+    value: torch.Tensor,
+    value_spatial_shapes: torch.Tensor,
+    sampling_locations: torch.Tensor,
+    attention_weights: torch.Tensor,
+    value_spatial_shapes_hw: list[tuple[int, int]] | None = None,
+) -> torch.Tensor:
+    """For debug and test only, need to use cuda version instead."""
     # B, n_heads, head_dim, N
     B, n_heads, head_dim, _ = value.shape
     _, Len_q, n_heads, L, P, _ = sampling_locations.shape
-    value_list = value.split([H * W for H, W in value_spatial_shapes], dim=3)
+    # Use Python int pairs when available (required for torch.export compatibility,
+    # since iterating over a tensor and using scalar elements as split/view sizes
+    # fails during FakeTensor tracing).
+    shapes = value_spatial_shapes_hw if value_spatial_shapes_hw is not None else value_spatial_shapes
+    value_list = value.split([H * W for H, W in shapes], dim=3)
     sampling_grids = 2 * sampling_locations - 1
     sampling_value_list = []
-    for lid_, (H, W) in enumerate(value_spatial_shapes):
+    for lid_, (H, W) in enumerate(shapes):
         # B, n_heads, head_dim, H, W
         value_l_ = value_list[lid_].view(B * n_heads, head_dim, H, W)
         # B, Len_q, n_heads, P, 2 -> B, n_heads, Len_q, P, 2 -> B*n_heads, Len_q, P, 2

--- a/src/rfdetr/models/ops/modules/ms_deform_attn.py
+++ b/src/rfdetr/models/ops/modules/ms_deform_attn.py
@@ -105,26 +105,38 @@ class MSDeformAttn(nn.Module):
         input_spatial_shapes,
         input_level_start_index,
         input_padding_mask=None,
+        input_spatial_shapes_hw: list[tuple[int, int]] | None = None,
     ):
-        r"""
-        :param query                       (N, Length_{query}, C)
-        :param reference_points            (N, Length_{query}, n_levels, 2), range in [0, 1],
-                                           top-left (0,0), bottom-right (1, 1), including padding area
-                                           or (N, Length_{query}, n_levels, 4), add additional (w, h)
-                                           to form reference boxes
-        :param input_flatten               (N, \sum_{l=0}^{L-1} H_l \cdot W_l, C)
-        :param input_spatial_shapes        (n_levels, 2), [(H_0, W_0), (H_1, W_1), ..., (H_{L-1}, W_{L-1})]
-        :param input_level_start_index     (n_levels, ), [0, H_0*W_0, H_0*W_0+H_1*W_1,
-                                           H_0*W_0+H_1*W_1+H_2*W_2, ...,
-                                           H_0*W_0+H_1*W_1+...+H_{L-1}*W_{L-1}]
-        :param input_padding_mask          (N, \sum_{l=0}^{L-1} H_l \cdot W_l), True for padding
-                                           elements, False for non-padding elements
+        """Forward pass of MSDeformAttn.
 
-        :return output                     (N, Length_{query}, C)
+        Args:
+            query: (N, Length_{query}, C)
+            reference_points: (N, Length_{query}, n_levels, 2) with range in [0, 1],
+                top-left (0,0), bottom-right (1, 1), including padding area; or
+                (N, Length_{query}, n_levels, 4) adding additional (w, h) to form reference boxes.
+            input_flatten: (N, sum_{l=0}^{L-1} H_l * W_l, C)
+            input_spatial_shapes: (n_levels, 2), [(H_0, W_0), (H_1, W_1), ..., (H_{L-1}, W_{L-1})]
+            input_level_start_index: (n_levels,), [0, H_0*W_0, H_0*W_0+H_1*W_1, ...,
+                H_0*W_0+H_1*W_1+...+H_{L-1}*W_{L-1}]
+            input_padding_mask: (N, sum_{l=0}^{L-1} H_l * W_l), True for padding elements,
+                False for non-padding elements.
+            input_spatial_shapes_hw: List of (H, W) int pairs, same ordering as
+                input_spatial_shapes. When provided, these Python ints are used for tensor
+                split/view operations inside ms_deform_attn_core_pytorch so that the function
+                is compatible with torch.export.export (FakeTensor tracing cannot extract
+                concrete values from a tensor).
+
+        Returns:
+            Output tensor of shape (N, Length_{query}, C).
         """
         N, Len_q, _ = query.shape
         N, Len_in, _ = input_flatten.shape
-        assert (input_spatial_shapes[:, 0] * input_spatial_shapes[:, 1]).sum() == Len_in
+        expected_len_in = (input_spatial_shapes[:, 0] * input_spatial_shapes[:, 1]).sum()
+        error_msg = "input_spatial_shapes must match the flattened input length"
+        if self._export:
+            torch._assert(expected_len_in == Len_in, error_msg)
+        else:
+            assert expected_len_in == Len_in, error_msg
 
         value = self.value_proj(input_flatten)
         if input_padding_mask is not None:
@@ -152,6 +164,12 @@ class MSDeformAttn(nn.Module):
         attention_weights = F.softmax(attention_weights, -1)
 
         value = value.transpose(1, 2).contiguous().view(N, self.n_heads, self.d_model // self.n_heads, Len_in)
-        output = ms_deform_attn_core_pytorch(value, input_spatial_shapes, sampling_locations, attention_weights)
+        output = ms_deform_attn_core_pytorch(
+            value,
+            input_spatial_shapes,
+            sampling_locations,
+            attention_weights,
+            value_spatial_shapes_hw=input_spatial_shapes_hw,
+        )
         output = self.output_proj(output)
         return output

--- a/src/rfdetr/models/transformer.py
+++ b/src/rfdetr/models/transformer.py
@@ -71,7 +71,7 @@ def gen_sineembed_for_position(pos_tensor, dim=128):
     return pos
 
 
-def gen_encoder_output_proposals(memory, memory_padding_mask, spatial_shapes, unsigmoid=True):
+def gen_encoder_output_proposals(memory, memory_padding_mask=None, spatial_shapes=None, unsigmoid=True):
     r"""
     Input:
         - memory: bs, \sum{hw}, d_model
@@ -332,6 +332,7 @@ class Transformer(nn.Module):
                 level_start_index=level_start_index,
                 spatial_shapes=spatial_shapes,
                 valid_ratios=valid_ratios.to(memory.dtype) if valid_ratios is not None else valid_ratios,
+                spatial_shapes_hw=spatial_shapes_hw,
             )
         else:
             assert self.two_stage, "if not using decoder, two_stage must be True"
@@ -396,8 +397,9 @@ class TransformerDecoder(nn.Module):
         refpoints_unsigmoid: Optional[Tensor] = None,
         # for memory
         level_start_index: Optional[Tensor] = None,  # num_levels
-        spatial_shapes: Optional[Tensor] = None,  # bs, num_levels, 2
+        spatial_shapes: Optional[Tensor] = None,  # num_levels, 2
         valid_ratios: Optional[Tensor] = None,
+        spatial_shapes_hw: list[tuple[int, int]] | None = None,
     ):
         output = tgt
 
@@ -457,6 +459,7 @@ class TransformerDecoder(nn.Module):
                 reference_points=refpoints_input,
                 spatial_shapes=spatial_shapes,
                 level_start_index=level_start_index,
+                spatial_shapes_hw=spatial_shapes_hw,
             )
 
             if not self.lite_refpoint_refine:
@@ -556,6 +559,7 @@ class TransformerDecoderLayer(nn.Module):
         reference_points=None,
         spatial_shapes=None,
         level_start_index=None,
+        spatial_shapes_hw: list[tuple[int, int]] | None = None,
     ):
         bs, num_queries, _ = tgt.shape
 
@@ -586,6 +590,7 @@ class TransformerDecoderLayer(nn.Module):
             spatial_shapes,
             level_start_index,
             memory_key_padding_mask,
+            input_spatial_shapes_hw=spatial_shapes_hw,
         )
         # ========== End of Cross-Attention =============
 
@@ -611,6 +616,7 @@ class TransformerDecoderLayer(nn.Module):
         reference_points=None,
         spatial_shapes=None,
         level_start_index=None,
+        spatial_shapes_hw: list[tuple[int, int]] | None = None,
     ):
         return self.forward_post(
             tgt,
@@ -626,6 +632,7 @@ class TransformerDecoderLayer(nn.Module):
             reference_points,
             spatial_shapes,
             level_start_index,
+            spatial_shapes_hw=spatial_shapes_hw,
         )
 
 

--- a/src/rfdetr/models/weights.py
+++ b/src/rfdetr/models/weights.py
@@ -1,0 +1,95 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""Shared pretrained-weight loading helpers.
+
+This module provides a config-native weight loader for tests and internal
+callers that operate on a ``ModelConfig`` instance directly rather than on the
+legacy namespace used by ``rfdetr.detr``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import List
+
+import torch
+
+from rfdetr.assets.model_weights import download_pretrain_weights, validate_pretrain_weights
+from rfdetr.config import ModelConfig
+from rfdetr.utilities.logger import get_logger
+from rfdetr.utilities.state_dict import _ckpt_args_get, validate_checkpoint_compatibility
+
+logger = get_logger()
+
+__all__ = ["load_pretrain_weights"]
+
+
+def load_pretrain_weights(nn_model: torch.nn.Module, model_config: ModelConfig) -> List[str]:
+    """Load pretrained checkpoint weights into ``nn_model`` in-place.
+
+    Args:
+        nn_model: The model to update.
+        model_config: Model configuration describing the checkpoint and target
+            architecture.
+
+    Returns:
+        Class names extracted from the checkpoint ``args`` block, or an empty
+        list when the checkpoint does not embed them.
+    """
+    pretrain_weights = model_config.pretrain_weights
+    if pretrain_weights is None:
+        return []
+
+    class_names: List[str] = []
+
+    download_pretrain_weights(pretrain_weights)
+    if not os.path.isfile(pretrain_weights):
+        logger.warning("Pretrain weights not found after initial download; retrying without MD5 validation.")
+        download_pretrain_weights(pretrain_weights, redownload=True, validate_md5=False)
+    validate_pretrain_weights(pretrain_weights, strict=False)
+
+    try:
+        checkpoint = torch.load(pretrain_weights, map_location="cpu", weights_only=False)
+    except Exception:
+        logger.info("Failed to load pretrain weights, re-downloading")
+        download_pretrain_weights(pretrain_weights, redownload=True, validate_md5=False)
+        checkpoint = torch.load(pretrain_weights, map_location="cpu", weights_only=False)
+
+    if "args" in checkpoint:
+        class_names = _ckpt_args_get(checkpoint["args"], "class_names") or []
+
+    validate_checkpoint_compatibility(checkpoint, model_config)
+
+    user_set_num_classes = "num_classes" in getattr(model_config, "model_fields_set", set())
+    default_num_classes = type(model_config).model_fields["num_classes"].default
+    num_classes = model_config.num_classes
+    user_overrode_default_num_classes = user_set_num_classes and num_classes != default_num_classes
+
+    checkpoint_num_classes = checkpoint["model"]["class_embed.bias"].shape[0]
+    configured_num_classes_plus_bg = num_classes + 1
+    if checkpoint_num_classes != configured_num_classes_plus_bg:
+        if checkpoint_num_classes < configured_num_classes_plus_bg and not user_overrode_default_num_classes:
+            num_classes = checkpoint_num_classes - 1
+            configured_num_classes_plus_bg = checkpoint_num_classes
+            model_config.num_classes = num_classes
+        nn_model.reinitialize_detection_head(checkpoint_num_classes)
+
+    num_desired_queries = model_config.num_queries * model_config.group_detr
+    query_param_names = ["refpoint_embed.weight", "query_feat.weight"]
+    for name in list(checkpoint["model"].keys()):
+        if any(name.endswith(param_name) for param_name in query_param_names):
+            checkpoint["model"][name] = checkpoint["model"][name][:num_desired_queries]
+
+    nn_model.load_state_dict(checkpoint["model"], strict=False)
+
+    if checkpoint_num_classes < configured_num_classes_plus_bg and user_overrode_default_num_classes:
+        nn_model.reinitialize_detection_head(configured_num_classes_plus_bg)
+
+    if num_classes + 1 < checkpoint_num_classes:
+        nn_model.reinitialize_detection_head(num_classes + 1)
+
+    return class_names

--- a/src/rfdetr/training/module_data.py
+++ b/src/rfdetr/training/module_data.py
@@ -41,16 +41,25 @@ class RFDETRDataModule(LightningDataModule):
         self._dataset_val: Optional[torch.utils.data.Dataset] = None
         self._dataset_test: Optional[torch.utils.data.Dataset] = None
 
-        num_workers = self.train_config.num_workers
+        self._num_workers: int = self.train_config.num_workers
+
+        # Use the fork-safe DEVICE constant instead of torch.cuda.is_available(),
+        # which creates a CUDA driver context that breaks fork-based DDP.
+        from rfdetr.config import DEVICE
+
+        accelerator = str(self.train_config.accelerator).lower()
+        uses_cuda_accelerator = accelerator in {"auto", "gpu", "cuda"}
         self._pin_memory: bool = (
-            torch.cuda.is_available() if self.train_config.pin_memory is None else bool(self.train_config.pin_memory)
+            (DEVICE == "cuda" and uses_cuda_accelerator)
+            if self.train_config.pin_memory is None
+            else bool(self.train_config.pin_memory)
         )
         self._persistent_workers: bool = (
-            num_workers > 0
+            self._num_workers > 0
             if self.train_config.persistent_workers is None
             else bool(self.train_config.persistent_workers)
         )
-        if num_workers > 0:
+        if self._num_workers > 0:
             self._prefetch_factor = (
                 self.train_config.prefetch_factor if self.train_config.prefetch_factor is not None else 2
             )
@@ -104,7 +113,7 @@ class RFDETRDataModule(LightningDataModule):
         dataset = self._dataset_train
         batch_size = self.train_config.batch_size
         effective_batch_size = batch_size * self.train_config.grad_accum_steps
-        num_workers = self.train_config.num_workers
+        num_workers = self._num_workers
 
         if len(dataset) < effective_batch_size * _MIN_TRAIN_BATCHES:
             logger.info(
@@ -152,7 +161,7 @@ class RFDETRDataModule(LightningDataModule):
             sampler=torch.utils.data.SequentialSampler(self._dataset_val),
             drop_last=False,
             collate_fn=collate_fn,
-            num_workers=self.train_config.num_workers,
+            num_workers=self._num_workers,
             pin_memory=self._pin_memory,
             persistent_workers=self._persistent_workers,
             prefetch_factor=self._prefetch_factor,
@@ -170,7 +179,7 @@ class RFDETRDataModule(LightningDataModule):
             sampler=torch.utils.data.SequentialSampler(self._dataset_test),
             drop_last=False,
             collate_fn=collate_fn,
-            num_workers=self.train_config.num_workers,
+            num_workers=self._num_workers,
             pin_memory=self._pin_memory,
             persistent_workers=self._persistent_workers,
             prefetch_factor=self._prefetch_factor,
@@ -188,7 +197,7 @@ class RFDETRDataModule(LightningDataModule):
             sampler=torch.utils.data.SequentialSampler(self._dataset_val),
             drop_last=False,
             collate_fn=collate_fn,
-            num_workers=self.train_config.num_workers,
+            num_workers=self._num_workers,
             pin_memory=self._pin_memory,
             persistent_workers=self._persistent_workers,
             prefetch_factor=self._prefetch_factor,

--- a/src/rfdetr/training/module_data.py
+++ b/src/rfdetr/training/module_data.py
@@ -6,7 +6,7 @@
 
 """LightningDataModule for RF-DETR dataset construction and loaders."""
 
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 import torch
 import torch.utils.data
@@ -22,6 +22,74 @@ from rfdetr.utilities.tensors import collate_fn
 logger = get_logger()
 
 _MIN_TRAIN_BATCHES = 5
+
+
+class GradAccumAlignedDataset(torch.utils.data.Dataset):
+    """Dataset wrapper that pads length to a multiple of ``effective_batch_size * world_size``.
+
+    Workaround for https://github.com/Lightning-AI/pytorch-lightning/issues/19987:
+    PTL fires the optimizer on partial accumulation windows at the tail of the
+    dataset, causing the last optimizer step to be under-scaled.  Padding the
+    dataset to a multiple of ``effective_batch_size * world_size`` ensures that
+    ``drop_last=True`` on the DataLoader becomes a true no-op — every
+    accumulation window is always complete.
+
+    Padding indices are drawn randomly from the original dataset.  Because RF-DETR
+    uses online augmentation, each padded sample receives a fresh random
+    augmentation at ``__getitem__`` time, so it behaves like a new training
+    example rather than a true duplicate.
+
+    This wrapper can be removed once the upstream PTL issue is resolved.
+
+    Args:
+        dataset: The underlying dataset to wrap.
+        effective_batch_size: ``batch_size * grad_accum_steps``.
+        world_size: Number of DDP processes (default 1 for single-GPU/CPU).
+            The alignment unit is ``effective_batch_size * world_size`` so that
+            after PTL's ``DistributedSampler`` splits samples across ranks each
+            rank still receives an exact multiple of ``effective_batch_size``.
+    """
+
+    def __init__(
+        self,
+        dataset: torch.utils.data.Dataset,
+        effective_batch_size: int,
+        world_size: int = 1,
+    ) -> None:
+        if effective_batch_size < 1:
+            raise ValueError(f"effective_batch_size must be >= 1, got {effective_batch_size}")
+        if world_size < 1:
+            raise ValueError(f"world_size must be >= 1, got {world_size}")
+
+        self._dataset = dataset
+        self._dataset_length = len(dataset)  # type: ignore[arg-type]
+        pad_unit = effective_batch_size * world_size
+        remainder = self._dataset_length % pad_unit
+        pad_count = (pad_unit - remainder) % pad_unit
+        pad_index_generator = torch.Generator()
+        pad_index_generator.manual_seed(0)
+        self._pad_indices: list[int] = (
+            torch.randint(
+                0,
+                self._dataset_length,
+                (pad_count,),
+                generator=pad_index_generator,
+            ).tolist()
+            if pad_count > 0
+            else []
+        )
+        self._length = self._dataset_length + pad_count
+
+    def __len__(self) -> int:
+        """Return the padded dataset length (always a multiple of the alignment unit)."""
+        return self._length
+
+    def __getitem__(self, idx: int) -> Any:
+        """Return the item at the (possibly remapped) index."""
+        # pad_indices are fixed at __init__ time; same indices reused every epoch
+        # (different augmentations per epoch due to online augmentation)
+        dataset_idx = idx if idx < self._dataset_length else self._pad_indices[idx - self._dataset_length]
+        return self._dataset[dataset_idx]
 
 
 class RFDETRDataModule(LightningDataModule):
@@ -104,8 +172,12 @@ class RFDETRDataModule(LightningDataModule):
 
         Uses a replacement sampler when the dataset is too small to fill
         ``_MIN_TRAIN_BATCHES`` effective batches (matching legacy behaviour in
-        ``main.py``).  Otherwise uses ``shuffle=True, drop_last=True`` so that
-        PTL can auto-inject ``DistributedSampler`` in DDP mode.
+        ``main.py``).  Otherwise wraps the dataset with
+        :class:`GradAccumAlignedDataset` to ensure its length is an exact
+        multiple of ``effective_batch_size * world_size`` (workaround for
+        https://github.com/Lightning-AI/pytorch-lightning/issues/19987) and
+        then uses ``shuffle=True, drop_last=True`` so that PTL can
+        auto-inject ``DistributedSampler`` in DDP mode.
 
         Returns:
             DataLoader for the training dataset.
@@ -137,11 +209,18 @@ class RFDETRDataModule(LightningDataModule):
                 prefetch_factor=self._prefetch_factor,
             )
 
+        # Pad the dataset to a multiple of effective_batch_size * world_size so
+        # that drop_last=True below becomes a true no-op and PTL never fires the
+        # optimizer on a partial accumulation window.
+        # See https://github.com/Lightning-AI/pytorch-lightning/issues/19987
+        world_size: int = getattr(self.trainer, "world_size", 1) if self.trainer else 1
+        dataset = GradAccumAlignedDataset(dataset, effective_batch_size, world_size)
+
         return DataLoader(
             dataset,
             batch_size=batch_size,
             shuffle=True,
-            drop_last=True,
+            drop_last=True,  # no-op after alignment, but keeps intent explicit
             collate_fn=collate_fn,
             num_workers=num_workers,
             pin_memory=self._pin_memory,

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -327,6 +327,37 @@ class RFDETRModelModule(LightningModule):
         results = self.postprocess(outputs, orig_sizes)
         return {"results": results, "targets": targets}
 
+    @property
+    def _use_fused_optimizer(self) -> bool:
+        """Return whether fused AdamW should be used for the current training configuration.
+
+        Fused AdamW is only safe when the trainer's actual precision is a BF16
+        variant.  Checking GPU capability alone (``is_bf16_supported()``) is
+        insufficient: on Ampere+ hardware that flag is always ``True`` even when
+        the trainer is configured for ``32-true``, which causes a
+        ``params, grads, exp_avgs, and exp_avg_sqs must have same dtype, device,
+        and layout`` crash in DDP because gradient bucket views have non-matching
+        strides in FP32.
+
+        Returns:
+            ``True`` when fused AdamW is both requested and safe to use.
+
+        Examples:
+            >>> # Fused is disabled when trainer precision is 32-true
+            >>> module = RFDETRModelModule.__new__(RFDETRModelModule)
+            >>> module.model_config = type("Cfg", (), {"fused_optimizer": True})()
+            >>> module._trainer = type("Trainer", (), {"precision": "32-true"})()
+            >>> module._trainer.precision = "32-true"
+            >>> module._use_fused_optimizer
+            False
+        """
+        return (
+            self.model_config.fused_optimizer
+            and torch.cuda.is_available()
+            and torch.cuda.is_bf16_supported()
+            and str(self.trainer.precision) in {"bf16-mixed", "bf16", "bf16-true"}
+        )
+
     def configure_optimizers(self) -> Dict[str, Any]:
         """Build AdamW optimizer with layer-wise LR decay and LambdaLR scheduler.
 
@@ -346,12 +377,11 @@ class RFDETRModelModule(LightningModule):
         model_for_params = getattr(self.model, "_orig_mod", self.model)
         param_dicts = get_param_dict(ns, model_for_params)
         param_dicts = [p for p in param_dicts if p["params"].requires_grad]
-        use_fused = self.model_config.fused_optimizer and torch.cuda.is_available() and torch.cuda.is_bf16_supported()
         optimizer = torch.optim.AdamW(
             param_dicts,
             lr=tc.lr,
             weight_decay=tc.weight_decay,
-            fused=use_fused,
+            fused=self._use_fused_optimizer,
         )
 
         total_steps = int(self.trainer.estimated_stepping_batches)
@@ -396,8 +426,7 @@ class RFDETRModelModule(LightningModule):
             gradient_clip_algorithm: Clipping algorithm; forwarded to super()
                 for the non-fused path.
         """
-        use_fused = self.model_config.fused_optimizer and torch.cuda.is_available() and torch.cuda.is_bf16_supported()
-        if use_fused:
+        if self._use_fused_optimizer:
             if gradient_clip_val and gradient_clip_val > 0:
                 torch.nn.utils.clip_grad_norm_(self.parameters(), gradient_clip_val)
         else:

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -74,7 +74,15 @@ class RFDETRModelModule(LightningModule):
 
         # torch.compile is opt-in: set model_config.compile=True to enable.
         # Only enabled on CUDA; MPS and CPU do not benefit from compilation.
-        compile_enabled = model_config.compile and torch.cuda.is_available() and not train_config.multi_scale
+        # Use the fork-safe DEVICE constant instead of torch.cuda.is_available(),
+        # which creates a CUDA driver context that breaks fork-based DDP.
+        from rfdetr.config import DEVICE
+
+        accelerator = str(train_config.accelerator).lower()
+        uses_cuda_accelerator = accelerator in {"auto", "gpu", "cuda"}
+        compile_enabled = (
+            model_config.compile and DEVICE == "cuda" and uses_cuda_accelerator and not train_config.multi_scale
+        )
         if model_config.compile and train_config.multi_scale:
             logger.info("Disabling torch.compile because multi_scale=True introduces dynamic input shapes.")
         if compile_enabled:

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -162,6 +162,17 @@ def build_trainer(
             "%s → spawn-based DDP to avoid OpenMP thread pool corruption after fork.",
             tc.strategy,
         )
+    elif strategy == "ddp" and model_config.segmentation_head:
+        # The segmentation head's sparse_forward() returns dict intermediates and
+        # leaves some parameters unused on certain forward steps, causing DDP to
+        # raise "It looks like your LightningModule has parameters that were not
+        # used in producing the loss" with plain ddp.  Enabling
+        # find_unused_parameters lets DDP traverse the autograd graph after each
+        # backward pass to detect which parameters contributed to the loss.
+        strategy = _DDPStrategy(find_unused_parameters=True)
+        _logger.info(
+            "segmentation_head=True with strategy='ddp' → DDPStrategy(find_unused_parameters=True).",
+        )
     sharded = any(s in str(strategy).lower() for s in ("fsdp", "deepspeed"))
     enable_ema = bool(tc.use_ema) and not sharded
     if tc.use_ema and sharded:

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -14,6 +14,15 @@ from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint, RichProgressBar, TQDMProgressBar
 from pytorch_lightning.callbacks.progress.rich_progress import RichProgressBarTheme
 from pytorch_lightning.loggers import CSVLogger, MLFlowLogger, TensorBoardLogger, WandbLogger
+from pytorch_lightning.strategies import DDPStrategy as _DDPStrategy
+
+# _MultiProcessingLauncher is a private PTL API (leading underscore) that may change
+# in minor PTL releases within the >=2.6,<3 range.  No public equivalent exists in
+# PTL 2.x.  Monitor PTL changelogs when bumping the lower bound.
+try:
+    from pytorch_lightning.strategies.launchers.multiprocessing import _MultiProcessingLauncher
+except ImportError:  # pragma: no cover - exercised in unit tests via monkeypatch
+    _MultiProcessingLauncher = None  # type: ignore[assignment]
 
 from rfdetr.config import ModelConfig, TrainConfig
 from rfdetr.training.callbacks import (
@@ -26,6 +35,57 @@ from rfdetr.training.callbacks.coco_eval import COCOEvalCallback
 from rfdetr.utilities.logger import get_logger
 
 _logger = get_logger()
+
+
+# ---------------------------------------------------------------------------
+# Notebook-safe spawn-based DDP
+# ---------------------------------------------------------------------------
+# ``ddp_notebook`` maps to fork-based DDP which is fundamentally unsafe:
+# PyTorch's OpenMP thread pool (created during model construction) cannot
+# survive fork() — the worker threads become zombie handles, causing
+# "Invalid thread pool!" SIGABRT when the autograd engine initialises in
+# the forked child.
+#
+# PTL considers ``start_method="spawn"`` incompatible with interactive
+# environments and raises ``MisconfigurationException`` if used in Jupyter.
+# However, PTL's own ``_wrapping_function`` is the entry-point for spawned
+# children — no ``if __name__ == "__main__"`` guard is required — so spawn
+# is perfectly safe here.
+#
+# Classes MUST live at module level (not inside a function) so that Python's
+# pickle can serialise them for the spawned child processes.
+
+
+if _MultiProcessingLauncher is not None:
+
+    class _InteractiveSpawnLauncher(_MultiProcessingLauncher):
+        """Spawn launcher that reports itself as interactive-compatible."""
+
+        @property
+        def is_interactive_compatible(self) -> bool:  # type: ignore[override]
+            return True
+
+else:
+    _InteractiveSpawnLauncher = None
+
+
+class _NotebookSpawnDDPStrategy(_DDPStrategy):
+    """Spawn-based DDP strategy that works inside Jupyter / Kaggle notebooks."""
+
+    def _configure_launcher(self) -> None:
+        if self.cluster_environment is None:
+            raise RuntimeError(
+                "_NotebookSpawnDDPStrategy requires a cluster environment; "
+                "ensure the strategy is initialised through PTL's Trainer."
+            )
+        if _InteractiveSpawnLauncher is None:
+            raise RuntimeError(
+                "Notebook spawn strategy requires "
+                "pytorch_lightning.strategies.launchers.multiprocessing._MultiProcessingLauncher. "
+                "Your installed PyTorch Lightning version changed this private API; "
+                "pin/upgrade PTL to a compatible version in the supported >=2.6,<3 range."
+            )
+        self._launcher = _InteractiveSpawnLauncher(self, start_method=self._start_method)
 
 
 def build_trainer(
@@ -69,12 +129,21 @@ def build_trainer(
     def _resolve_precision() -> str:
         if not model_config.amp:
             return "32-true"
+        # Ampere+ GPUs support bf16-mixed which is scaler-free —
+        # no GradScaler.scale/unscale/update overhead per optimizer step.
+        # BF16 is safe for fine-tuning (pretrained weights loaded by default).
+        # Training from random init with very small LR may underflow; callers
+        # can override via trainer_kwargs(precision="16-mixed") if needed.
+        #
+        # Note: torch.cuda.is_available() and torch.cuda.is_bf16_supported() both
+        # create a CUDA driver context in the parent process.  This is intentional
+        # and safe for the multi-process launch modes we rely on here because we
+        # avoid fork-based launching in notebook contexts (see
+        # _NotebookSpawnDDPStrategy above), and spawn/subprocess-based launchers
+        # start child processes with a fresh CUDA state regardless of what the
+        # parent has initialised. If a fork-based path is ever added, this
+        # precision check must be moved into the child process.
         if torch.cuda.is_available():
-            # Ampere+ GPUs support bf16-mixed which is scaler-free —
-            # no GradScaler.scale/unscale/update overhead per optimizer step.
-            # BF16 is safe for fine-tuning (pretrained weights loaded by default).
-            # Training from random init with very small LR may underflow; callers
-            # can override via trainer_kwargs(precision="16-mixed") if needed.
             if torch.cuda.is_bf16_supported():
                 return "bf16-mixed"
             return "16-mixed"
@@ -84,6 +153,15 @@ def build_trainer(
 
     # --- Strategy + EMA sharding guard ---
     strategy = tc.strategy
+
+    # Transparently replace fork-based DDP with spawn-based DDP — see the
+    # module-level comment block above _InteractiveSpawnLauncher for rationale.
+    if strategy in ("ddp_notebook", "ddp_spawn"):
+        strategy = _NotebookSpawnDDPStrategy(start_method="spawn", find_unused_parameters=True)
+        _logger.info(
+            "%s → spawn-based DDP to avoid OpenMP thread pool corruption after fork.",
+            tc.strategy,
+        )
     sharded = any(s in str(strategy).lower() for s in ("fsdp", "deepspeed"))
     enable_ema = bool(tc.use_ema) and not sharded
     if tc.use_ema and sharded:

--- a/tests/assets/test_downloads.py
+++ b/tests/assets/test_downloads.py
@@ -92,15 +92,24 @@ class TestDownloadPretrainWeights:
         # Should not download if file exists with correct hash
         mock_file_operations["download"].assert_not_called()
 
-    def test_file_exists_with_incorrect_md5_redownloads(self, mock_file_operations):
-        """Test that file is re-downloaded if MD5 is incorrect."""
+    def test_file_exists_with_incorrect_md5_warns_and_skips(self, mock_file_operations):
+        """Test that file is NOT re-downloaded when MD5 is incorrect and redownload=False.
+
+        This protects fine-tuned checkpoints that share the same filename as a
+        registry model (e.g. rf-detr-nano.pth) from being silently overwritten.
+        """
         mock_file_operations["exists"].return_value = True
         mock_file_operations["validate"].return_value = False  # Incorrect MD5
 
-        download_pretrain_weights("rf-detr-base.pth")
+        with patch("rfdetr.assets.model_weights.logger.warning") as mock_warning:
+            download_pretrain_weights("rf-detr-base.pth")
 
-        # Should re-download due to incorrect MD5
-        mock_file_operations["download"].assert_called_once()
+        # Should NOT re-download — the user's file must be preserved
+        mock_file_operations["download"].assert_not_called()
+        mock_warning.assert_called_once()
+        warning_msg = mock_warning.call_args[0][0]
+        assert "incorrect MD5 hash" in warning_msg
+        assert "skipping re-download to avoid overwriting it" in warning_msg
 
     def test_redownload_flag_forces_download(self, mock_file_operations):
         """Test that redownload=True forces re-download even if file exists."""
@@ -110,6 +119,20 @@ class TestDownloadPretrainWeights:
         download_pretrain_weights("rf-detr-base.pth", redownload=True)
 
         # Should download despite file existing
+        mock_file_operations["download"].assert_called_once()
+
+    def test_redownload_flag_forces_download_despite_incorrect_md5(self, mock_file_operations):
+        """Test that redownload=True triggers download even when MD5 is incorrect.
+
+        Verifies the force-redownload path where the user explicitly wants to overwrite
+        an existing file (e.g. a fine-tuned checkpoint) with the original registry weights.
+        """
+        mock_file_operations["exists"].return_value = True
+        mock_file_operations["validate"].return_value = False  # Incorrect MD5
+
+        download_pretrain_weights("rf-detr-base.pth", redownload=True)
+
+        # Should download because redownload=True overrides the skip-on-existing-file guard
         mock_file_operations["download"].assert_called_once()
 
     def test_validate_md5_disabled(self, mock_file_operations):
@@ -252,7 +275,7 @@ class TestDownloadErrorHandling:
     @patch("rfdetr.assets.model_weights.os.path.exists")
     @patch("rfdetr.assets.model_weights.logger")
     def test_logs_warning_on_incorrect_md5(self, mock_logger, mock_exists, mock_validate, mock_download):
-        """Test that warning is logged when MD5 is incorrect."""
+        """Test that warning is logged when MD5 is incorrect and no re-download occurs."""
         mock_exists.return_value = True
         mock_validate.return_value = False
 
@@ -262,6 +285,9 @@ class TestDownloadErrorHandling:
         mock_logger.warning.assert_called()
         warning_message = mock_logger.warning.call_args[0][0]
         assert "incorrect MD5 hash" in warning_message
+
+        # Must NOT re-download — fine-tuned checkpoints should be preserved
+        mock_download.assert_not_called()
 
     @patch("rfdetr.assets.model_weights._download_file")
     @patch("rfdetr.assets.model_weights.os.path.exists")

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -4,6 +4,8 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 import torch
 from pydantic import ValidationError
@@ -18,6 +20,7 @@ from rfdetr.config import (
     RFDETRSegXLargeConfig,
     SegmentationTrainConfig,
     TrainConfig,
+    _detect_device,
 )
 
 
@@ -77,7 +80,9 @@ class TestSegmentationTrainConfigNumSelect:
         assert config.num_select is None
 
     def test_explicit_value_is_accepted(self) -> None:
-        config = SegmentationTrainConfig(dataset_dir="/tmp", num_select=42)
+        # Explicitly setting num_select on SegmentationTrainConfig is deprecated (Item #3).
+        with pytest.warns(DeprecationWarning, match="TrainConfig.num_select is deprecated"):
+            config = SegmentationTrainConfig(dataset_dir="/tmp", num_select=42)
         assert config.num_select == 42
 
     @pytest.mark.parametrize(
@@ -297,3 +302,29 @@ class TestBuildTrainerUsesRealFields:
             build_trainer(self._tc(tmp_path, sync_bn=True), self._mc())
 
         assert captured_kwargs.get("sync_batchnorm") is True
+
+
+class TestDetectDevice:
+    """Tests for _detect_device() covering PyTorch accelerator detection paths."""
+
+    @patch("rfdetr.config.torch")
+    def test_falls_back_to_cuda_when_accelerator_module_absent(self, mock_torch: MagicMock) -> None:
+        """Returns 'cuda' via legacy fallback when torch.accelerator lacks current_accelerator (PyTorch < 2.4)."""
+        mock_torch.accelerator = MagicMock(spec=[])  # no current_accelerator → hasattr returns False → fallback
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.backends.mps.is_available.return_value = False
+        assert _detect_device() == "cuda"
+
+    @patch("rfdetr.config.torch")
+    def test_returns_cpu_when_current_accelerator_raises(self, mock_torch: MagicMock) -> None:
+        """Returns 'cpu' directly from the except handler when current_accelerator() raises RuntimeError."""
+        mock_torch.accelerator.current_accelerator.side_effect = RuntimeError("no device")
+        assert _detect_device() == "cpu"
+
+    @patch("rfdetr.config.torch")
+    def test_returns_cpu_when_no_gpu_available(self, mock_torch: MagicMock) -> None:
+        """Returns 'cpu' when accelerator is absent and neither CUDA nor MPS is available."""
+        mock_torch.accelerator = MagicMock(spec=[])  # no current_accelerator → fallback branch
+        mock_torch.cuda.is_available.return_value = False
+        mock_torch.backends.mps.is_available.return_value = False
+        assert _detect_device() == "cpu"

--- a/tests/models/test_optimize_for_inference.py
+++ b/tests/models/test_optimize_for_inference.py
@@ -114,11 +114,20 @@ class TestOptimizeForInferenceDtype:
 class TestOptimizeForInferenceCudaDeviceContext:
     """Verify that optimize_for_inference wraps operations in the correct device context."""
 
-    def test_cuda_device_context_manager_is_used_for_cuda_device(self) -> None:
+    @patch("rfdetr.detr._ensure_model_on_device")
+    @patch("rfdetr.detr.deepcopy")
+    @patch("torch.cuda.device")
+    def test_cuda_device_context_manager_is_used_for_cuda_device(
+        self,
+        mock_cuda_device,
+        mock_deepcopy,
+        _mock_ensure_model_on_device,
+    ) -> None:
         """torch.cuda.device() context should be entered when model is on CUDA."""
         rfdetr = _FakeRFDETR()
         # Simulate a CUDA device without actually requiring CUDA hardware
         rfdetr.model.device = torch.device("cuda", 0)
+        mock_deepcopy.return_value = rfdetr.model.model
 
         entered_devices: list[torch.device] = []
 
@@ -132,11 +141,8 @@ class TestOptimizeForInferenceCudaDeviceContext:
             def __exit__(self, *args):
                 pass
 
-        with (
-            patch("torch.cuda.device", side_effect=_CapturingDeviceCtx),
-            patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model),
-        ):
-            rfdetr.optimize_for_inference(compile=False, dtype=torch.float32)
+        mock_cuda_device.side_effect = _CapturingDeviceCtx
+        rfdetr.optimize_for_inference(compile=False, dtype=torch.float32)
 
         assert len(entered_devices) == 1
         assert entered_devices[0] == torch.device("cuda", 0)
@@ -155,11 +161,20 @@ class TestOptimizeForInferenceCudaDeviceContext:
 
         mock_cuda_device.assert_not_called()
 
-    def test_cuda_device_context_uses_model_device(self) -> None:
+    @patch("rfdetr.detr._ensure_model_on_device")
+    @patch("rfdetr.detr.deepcopy")
+    @patch("torch.cuda.device")
+    def test_cuda_device_context_uses_model_device(
+        self,
+        mock_cuda_device,
+        mock_deepcopy,
+        _mock_ensure_model_on_device,
+    ) -> None:
         """The device passed to torch.cuda.device() should match self.model.device."""
         rfdetr = _FakeRFDETR()
         expected_device = torch.device("cuda", 2)
         rfdetr.model.device = expected_device
+        mock_deepcopy.return_value = rfdetr.model.model
 
         captured: dict[str, torch.device] = {}
 
@@ -173,11 +188,8 @@ class TestOptimizeForInferenceCudaDeviceContext:
             def __exit__(self, *args):
                 pass
 
-        with (
-            patch("torch.cuda.device", side_effect=_CapturingCtx),
-            patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model),
-        ):
-            rfdetr.optimize_for_inference(compile=False)
+        mock_cuda_device.side_effect = _CapturingCtx
+        rfdetr.optimize_for_inference(compile=False)
 
         assert captured.get("device") == expected_device
 

--- a/tests/models/test_predict.py
+++ b/tests/models/test_predict.py
@@ -30,10 +30,12 @@ def _is_online(host: str, port: int, timeout_s: float = 3.0) -> bool:
 
 
 class _DummyModel:
-    def __init__(self) -> None:
+    def __init__(self, class_names: list[str] | None = None, labels: list[int] | None = None) -> None:
         self.device = torch.device("cpu")
         self.resolution = 28
         self.model = torch.nn.Identity()
+        self.class_names = class_names
+        self._labels = labels if labels is not None else [1]
 
     def postprocess(self, predictions: Any, target_sizes: torch.Tensor) -> list[dict[str, torch.Tensor]]:
         batch = target_sizes.shape[0]
@@ -41,9 +43,9 @@ class _DummyModel:
         for _ in range(batch):
             results.append(
                 {
-                    "scores": torch.tensor([0.9]),
-                    "labels": torch.tensor([1]),
-                    "boxes": torch.tensor([[0.0, 0.0, 1.0, 1.0]]),
+                    "scores": torch.tensor([0.9] * len(self._labels)),
+                    "labels": torch.tensor(self._labels),
+                    "boxes": torch.tensor([[0.0, 0.0, 1.0, 1.0]] * len(self._labels)),
                 }
             )
         return results
@@ -331,3 +333,105 @@ class TestPredictPatchSize:
         img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
         with pytest.raises(ValueError, match="default resolution"):
             model.predict(img)
+
+
+class TestPredictClassNameData:
+    """Verify that ``predict()`` populates ``data["class_name"]`` in the returned Detections.
+
+    class IDs are always 0-indexed (COCO category IDs are remapped during training);
+    including the class name string in ``data`` lets callers read the class directly
+    without a separate lookup into ``model.class_names``.
+    """
+
+    def _make_model_with_class_names(self, class_names: list[str], labels: list[int]) -> _DummyRFDETR:
+        """Return a _DummyRFDETR whose inner model carries custom class_names and returns given labels."""
+        model = _DummyRFDETR()
+        model.model = _DummyModel(class_names=class_names, labels=labels)
+        return model
+
+    def test_class_name_key_present_in_detections_data(self) -> None:
+        """predict() must include 'class_name' in detections.data when class_names is set."""
+        model = self._make_model_with_class_names(["cat", "dog"], labels=[0])
+        img = PIL.Image.new("RGB", (28, 28))
+        detections = model.predict(img)
+        assert "class_name" in detections.data, "data['class_name'] must be present"
+
+    def test_class_name_values_match_class_id(self) -> None:
+        """class_name at each position must equal class_names[class_id]."""
+        model = self._make_model_with_class_names(["cat", "dog", "bird"], labels=[0, 1, 2])
+        img = PIL.Image.new("RGB", (28, 28))
+        detections = model.predict(img)
+        np.testing.assert_array_equal(
+            detections.data["class_name"],
+            np.array(["cat", "dog", "bird"]),
+            err_msg="class_name must match class_names[class_id] for each detection",
+        )
+
+    def test_class_name_with_remapped_coco_dataset(self) -> None:
+        """Simulates a single-class COCO dataset where category_id=1 is remapped to label=0.
+
+        After training with remap_category_ids=True, the model outputs class_id=0 for the
+        first class.  class_name must correctly map 0 → the first class name.
+        """
+        # Single-class model: category_id=1 was remapped to label=0 during training.
+        model = self._make_model_with_class_names(["myclass"], labels=[0])
+        img = PIL.Image.new("RGB", (28, 28))
+        detections = model.predict(img)
+        assert detections.class_id[0] == 0, "class_id must be 0 (0-indexed)"
+        assert detections.data["class_name"][0] == "myclass", (
+            "class_name must be 'myclass' even though the original COCO category_id was 1"
+        )
+
+    def test_class_name_falls_back_to_coco_when_no_custom_names(self) -> None:
+        """Without custom class_names, class_name maps class_id via COCO_CLASS_NAMES."""
+        from rfdetr.assets.coco_classes import COCO_CLASS_NAMES
+
+        # _DummyModel with no custom class_names; labels=[1] → COCO_CLASS_NAMES[1]
+        model = _DummyRFDETR()
+        img = PIL.Image.new("RGB", (28, 28))
+        detections = model.predict(img)
+        assert "class_name" in detections.data
+        assert detections.data["class_name"][0] == COCO_CLASS_NAMES[1], (
+            "class_name must fall back to COCO_CLASS_NAMES[class_id]"
+        )
+
+    def test_class_name_empty_array_when_no_detections(self) -> None:
+        """When threshold filters all detections, data['class_name'] must be an empty array."""
+        model = self._make_model_with_class_names(["cat"], labels=[0])
+        img = PIL.Image.new("RGB", (28, 28))
+        # threshold=1.1 filters out all detections (confidence=0.9 < 1.1)
+        detections = model.predict(img, threshold=1.1)
+        assert "class_name" in detections.data
+        assert len(detections.data["class_name"]) == 0, "class_name must be empty when no detections pass threshold"
+        assert detections.data["class_name"].dtype == object, (
+            "class_name dtype must be object even when the array is empty (not float64)"
+        )
+
+    def test_class_name_out_of_bounds_class_id_returns_empty_string(self) -> None:
+        """A class_id >= len(class_names) must map to an empty string (no IndexError)."""
+        # class_names has 2 entries but labels includes out-of-bounds id=5
+        model = self._make_model_with_class_names(["cat", "dog"], labels=[5])
+        img = PIL.Image.new("RGB", (28, 28))
+        detections = model.predict(img)
+        assert detections.data["class_name"][0] == "", "Out-of-bounds class_id must produce empty string"
+
+    def test_class_name_negative_class_id_returns_empty_string(self) -> None:
+        """A negative class_id must map to an empty string (bounds check: 0 <= cid)."""
+        model = self._make_model_with_class_names(["cat", "dog"], labels=[-1])
+        img = PIL.Image.new("RGB", (28, 28))
+        detections = model.predict(img)
+        assert detections.data["class_name"][0] == "", "Negative class_id must produce empty string"
+
+    def test_class_name_populated_for_each_image_in_batch(self) -> None:
+        """class_name must be correctly populated for every Detections in a batch prediction."""
+        model = self._make_model_with_class_names(["cat", "dog"], labels=[0, 1])
+        img1 = PIL.Image.new("RGB", (28, 28))
+        img2 = PIL.Image.new("RGB", (28, 28))
+        results = model.predict([img1, img2])
+        assert isinstance(results, list), "batch predict must return a list"
+        assert len(results) == 2, "one Detections per input image"
+        for idx, det in enumerate(results):
+            assert "class_name" in det.data, f"image {idx}: class_name must be present"
+            assert list(det.data["class_name"]) == ["cat", "dog"], (
+                f"image {idx}: class_name must match class_names[class_id]"
+            )

--- a/tests/models/test_transformer.py
+++ b/tests/models/test_transformer.py
@@ -3,10 +3,61 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
+"""Tests for transformer utilities, MS deformable attention core, and MSDeformAttn module."""
 
+import pytest
 import torch
 
+from rfdetr.models.ops.functions import ms_deform_attn_core_pytorch
+from rfdetr.models.ops.modules.ms_deform_attn import MSDeformAttn
 from rfdetr.models.transformer import gen_encoder_output_proposals
+
+
+@pytest.fixture(autouse=True)
+def _reset_random_seeds() -> None:
+    """Ensure reproducible random state for every test."""
+    torch.manual_seed(42)
+    torch.cuda.manual_seed_all(42)
+
+
+_MSDeformInputs = tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, list[tuple[int, int]]]
+
+
+def _build_ms_deform_inputs(
+    bsz: int = 1,
+    n_heads: int = 2,
+    head_dim: int = 4,
+    len_q: int = 3,
+    npts: int = 1,
+    levels: list[tuple[int, int]] | None = None,
+) -> _MSDeformInputs:
+    """Build minimal valid inputs for ms_deform_attn_core_pytorch.
+
+    Args:
+        bsz: Batch size.
+        n_heads: Number of attention heads.
+        head_dim: Dimension per head.
+        len_q: Number of query elements.
+        npts: Number of sampling points per level.
+        levels: List of (H, W) int pairs; defaults to [(4, 4), (2, 2)].
+
+    Returns:
+        Tuple of (value, spatial_shapes_tensor, sampling_locations,
+                  attention_weights, spatial_shapes_hw).
+    """
+    if levels is None:
+        levels = [(4, 4), (2, 2)]
+    nlvl = len(levels)
+
+    total_hw = sum(ht * wd for ht, wd in levels)
+    spatial_shapes_tensor = torch.tensor(levels, dtype=torch.long)
+    value = torch.randn(bsz, n_heads, head_dim, total_hw)
+    # sampling_locations: (bsz, len_q, n_heads, nlvl, npts, 2) in [0, 1]
+    sampling_locations = torch.rand(bsz, len_q, n_heads, nlvl, npts, 2)
+    # attention_weights: (bsz, len_q, n_heads, nlvl * npts)
+    attention_weights = torch.softmax(torch.randn(bsz, len_q, n_heads, nlvl * npts), dim=-1)
+
+    return value, spatial_shapes_tensor, sampling_locations, attention_weights, levels
 
 
 def test_gen_encoder_output_proposals_passes_ij_indexing_to_meshgrid(monkeypatch) -> None:
@@ -27,34 +78,290 @@ def test_gen_encoder_output_proposals_passes_ij_indexing_to_meshgrid(monkeypatch
     spatial_shapes = torch.tensor([[2, 2]], dtype=torch.long)
 
     output_memory, output_proposals = gen_encoder_output_proposals(
-        memory=memory,
-        memory_padding_mask=None,
+        memory,
         spatial_shapes=spatial_shapes,
-        unsigmoid=True,
     )
 
     assert call_count == 1
-    assert output_memory.shape == memory.shape
-    assert output_proposals.shape == (1, 4, 4)
+
+
+def test_gen_encoder_output_proposals_rejects_non_square_ij_indexing(monkeypatch) -> None:
+    """Wrong meshgrid indexing (xy vs ij) produces different proposals for non-square spatial shapes."""
+    original_meshgrid = torch.meshgrid
+
+    def _meshgrid_wrong_indexing(*args, **kwargs):
+        kwargs["indexing"] = "xy"
+        return original_meshgrid(*args, **kwargs)
+
+    # Use non-square spatial shapes so that ij vs xy indexing produces observably different outputs.
+    memory = torch.randn(1, 8, 8)
+    spatial_shapes = torch.tensor([[2, 4]], dtype=torch.long)
+
+    correct_memory, correct_proposals = gen_encoder_output_proposals(memory, spatial_shapes=spatial_shapes)
+
+    monkeypatch.setattr(torch, "meshgrid", _meshgrid_wrong_indexing)
+
+    wrong_memory, wrong_proposals = gen_encoder_output_proposals(memory, spatial_shapes=spatial_shapes)
+
+    assert not torch.allclose(correct_proposals, wrong_proposals), (
+        "xy indexing must produce different proposals than ij indexing for non-square spatial shapes"
+    )
 
 
 def test_gen_encoder_output_proposals_accepts_int_tuple_spatial_shapes() -> None:
-    """Regression: spatial_shapes as list[tuple[int, int]] with masks=None must not crash.
+    """`gen_encoder_output_proposals` must accept `spatial_shapes` as a tensor of int pairs."""
+    batch = 2
+    ht, wd = 4, 4
+    memory = torch.randn(batch, ht * wd, 8)
+    spatial_shapes = torch.tensor([[ht, wd]], dtype=torch.long)
 
-    Transformer.forward() passes Python int pairs (from bs, c, h, w = src.shape) to
-    gen_encoder_output_proposals. The export path (masks=None) triggers the else branch
-    which previously called H_.expand(N_) — failing with AttributeError on a Python int.
+    output_memory, output_proposals = gen_encoder_output_proposals(memory, spatial_shapes=spatial_shapes)
+
+    assert output_memory.shape == memory.shape
+    assert output_proposals.shape == (batch, ht * wd, 4)
+
+
+def test_gen_encoder_output_proposals_accepts_python_int_pair_spatial_shapes() -> None:
+    """`gen_encoder_output_proposals` must accept `spatial_shapes` as `list[tuple[int, int]]` with no padding mask.
+
+    Regression: `Transformer.forward` passes Python int pairs derived from `src.shape`, so the
+    export-driven call path uses `list[tuple[int, int]]` rather than a tensor.
     """
-    batch, h, w, d = 2, 3, 4, 8
-    memory = torch.randn(batch, h * w, d)
-    spatial_shapes = [(h, w)]  # Python int pairs, as produced by Transformer.forward()
+    batch, ht, wd, dim = 2, 4, 4, 8
+    memory = torch.randn(batch, ht * wd, dim)
+    spatial_shapes = [(ht, wd)]  # Python int pairs, as produced by Transformer.forward()
 
     output_memory, output_proposals = gen_encoder_output_proposals(
-        memory=memory,
+        memory,
         memory_padding_mask=None,
         spatial_shapes=spatial_shapes,
-        unsigmoid=True,
     )
 
     assert output_memory.shape == memory.shape
-    assert output_proposals.shape == (batch, h * w, 4)
+    assert output_proposals.shape == (batch, ht * wd, 4)
+
+
+class TestMSDeformAttnCorePytorch:
+    """Tests for ms_deform_attn_core_pytorch with Python int pair spatial shapes.
+
+    Regression suite for torch.export.export compatibility: iterating over a
+    spatial_shapes tensor yields FakeTensor scalars during FakeTensor tracing,
+    which cannot be used as Python int split/view sizes.  The function now
+    accepts an optional ``value_spatial_shapes_hw`` list of Python int pairs
+    that bypasses tensor iteration.
+    """
+
+    @pytest.fixture
+    def make_inputs(self) -> _MSDeformInputs:
+        """Default two-level inputs: levels=[(4, 4), (2, 2)]."""
+        return _build_ms_deform_inputs()
+
+    @pytest.fixture
+    def single_level_inputs(self) -> _MSDeformInputs:
+        """Single-level inputs: levels=[(8, 8)]."""
+        return _build_ms_deform_inputs(levels=[(8, 8)])
+
+    def test_with_tensor_spatial_shapes(self, make_inputs: _MSDeformInputs) -> None:
+        """Baseline: passing only the tensor spatial_shapes still works."""
+        value, spatial_shapes_tensor, sampling_locations, attention_weights, _ = make_inputs
+
+        output = ms_deform_attn_core_pytorch(value, spatial_shapes_tensor, sampling_locations, attention_weights)
+
+        bsz, n_heads, head_dim, _ = value.shape
+        len_q = sampling_locations.shape[1]
+        assert output.shape == (bsz, len_q, n_heads * head_dim)
+
+    def test_with_python_int_pair_spatial_shapes(self, make_inputs: _MSDeformInputs) -> None:
+        """Regression: value_spatial_shapes_hw list of Python int pairs must be accepted.
+
+        This is the torch.export.export-compatible code path: tensor scalar values
+        (from iterating over a FakeTensor) cannot be used as split/view sizes, so the
+        caller passes explicit Python int pairs via value_spatial_shapes_hw instead.
+        """
+        value, spatial_shapes_tensor, sampling_locations, attention_weights, levels = make_inputs
+
+        output = ms_deform_attn_core_pytorch(
+            value,
+            spatial_shapes_tensor,
+            sampling_locations,
+            attention_weights,
+            value_spatial_shapes_hw=levels,
+        )
+
+        bsz, n_heads, head_dim, _ = value.shape
+        len_q = sampling_locations.shape[1]
+        assert output.shape == (bsz, len_q, n_heads * head_dim)
+
+    def test_tensor_and_hw_paths_produce_identical_outputs(self, make_inputs: _MSDeformInputs) -> None:
+        """Python int pair path and tensor iteration path must produce the same result."""
+        value, spatial_shapes_tensor, sampling_locations, attention_weights, levels = make_inputs
+
+        out_tensor_path = ms_deform_attn_core_pytorch(
+            value, spatial_shapes_tensor, sampling_locations, attention_weights
+        )
+        out_hw_path = ms_deform_attn_core_pytorch(
+            value,
+            spatial_shapes_tensor,
+            sampling_locations,
+            attention_weights,
+            value_spatial_shapes_hw=levels,
+        )
+
+        torch.testing.assert_close(out_tensor_path, out_hw_path)
+
+    def test_single_level(self, single_level_inputs: _MSDeformInputs) -> None:
+        """Single-level case with Python int pair path must not crash."""
+        value, spatial_shapes_tensor, sampling_locations, attention_weights, levels = single_level_inputs
+
+        output = ms_deform_attn_core_pytorch(
+            value,
+            spatial_shapes_tensor,
+            sampling_locations,
+            attention_weights,
+            value_spatial_shapes_hw=levels,
+        )
+
+        assert output.shape[0] == 1
+
+
+class TestMSDeformAttnModule:
+    """Tests for MSDeformAttn.forward covering the export-compatibility changes.
+
+    Validates the module-level parameter threading and export-mode assert guard
+    introduced in the torch.export.export compatibility fix.
+    """
+
+    _d_model = 32
+    _n_heads = 4
+    _n_levels = 2
+    _n_points = 1
+    _hw_pairs: list[tuple[int, int]] = [(4, 4), (2, 2)]
+
+    def _make_module_inputs(
+        self,
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        list[tuple[int, int]],
+    ]:
+        """Build minimal valid inputs for MSDeformAttn.forward.
+
+        Returns:
+            Tuple of (query, reference_points, input_flatten,
+                      input_spatial_shapes, input_level_start_index, hw_pairs).
+        """
+        hw_pairs = self._hw_pairs
+        total_len = sum(ht * wd for ht, wd in hw_pairs)
+        bsz, len_q = 1, 3
+
+        query = torch.randn(bsz, len_q, self._d_model)
+        reference_points = torch.rand(bsz, len_q, self._n_levels, 2)
+        input_flatten = torch.randn(bsz, total_len, self._d_model)
+        input_spatial_shapes = torch.tensor(hw_pairs, dtype=torch.long)
+        # Cumulative start index per level: [0, H0*W0]
+        starts = [sum(ht * wd for ht, wd in hw_pairs[:idx]) for idx in range(self._n_levels)]
+        input_level_start_index = torch.tensor(starts, dtype=torch.long)
+
+        return query, reference_points, input_flatten, input_spatial_shapes, input_level_start_index, hw_pairs
+
+    def test_forward_without_hw_param_backward_compat(self) -> None:
+        """MSDeformAttn.forward without hw param produces correct output shape."""
+        module = MSDeformAttn(
+            d_model=self._d_model, n_levels=self._n_levels, n_heads=self._n_heads, n_points=self._n_points
+        )
+        query, ref_pts, input_flatten, spatial_shapes, level_start_index, _ = self._make_module_inputs()
+
+        output = module(query, ref_pts, input_flatten, spatial_shapes, level_start_index)
+
+        bsz, len_q, _ = query.shape
+        assert output.shape == (bsz, len_q, self._d_model)
+
+    def test_forward_with_hw_param_produces_correct_shape(self) -> None:
+        """MSDeformAttn.forward with input_spatial_shapes_hw produces correct output shape."""
+        module = MSDeformAttn(
+            d_model=self._d_model, n_levels=self._n_levels, n_heads=self._n_heads, n_points=self._n_points
+        )
+        query, ref_pts, input_flatten, spatial_shapes, level_start_index, hw_pairs = self._make_module_inputs()
+
+        output = module(
+            query, ref_pts, input_flatten, spatial_shapes, level_start_index, input_spatial_shapes_hw=hw_pairs
+        )
+
+        bsz, len_q, _ = query.shape
+        assert output.shape == (bsz, len_q, self._d_model)
+
+    def test_export_mode_forward_with_hw_param(self) -> None:
+        """MSDeformAttn.forward in export mode with hw param must not raise."""
+        module = MSDeformAttn(
+            d_model=self._d_model, n_levels=self._n_levels, n_heads=self._n_heads, n_points=self._n_points
+        )
+        module.export()
+        query, ref_pts, input_flatten, spatial_shapes, level_start_index, hw_pairs = self._make_module_inputs()
+
+        output = module(
+            query, ref_pts, input_flatten, spatial_shapes, level_start_index, input_spatial_shapes_hw=hw_pairs
+        )
+
+        bsz, len_q, _ = query.shape
+        assert output.shape == (bsz, len_q, self._d_model)
+
+    def test_export_flag_set_after_export_call(self) -> None:
+        """Calling .export() must set _export=True, enabling the torch._assert guard path."""
+        module = MSDeformAttn(
+            d_model=self._d_model, n_levels=self._n_levels, n_heads=self._n_heads, n_points=self._n_points
+        )
+        assert not module._export
+
+        module.export()
+
+        assert module._export
+
+
+def test_ms_deform_attn_core_pytorch_export_compatible() -> None:
+    """torch.export.export must succeed on a module using ms_deform_attn_core_pytorch with hw param.
+
+    Regression test for the FakeTensor tracing failure: iterating over spatial_shapes
+    and using the scalar elements as split/view sizes fails during torch.export.export
+    because FakeTensor data is not allocated. Passing value_spatial_shapes_hw (concrete
+    Python ints from a module attribute) bypasses the tensor iteration entirely.
+    """
+    levels: list[tuple[int, int]] = [(4, 4), (2, 2)]
+    bsz, n_heads, head_dim = 1, 2, 4
+    total_hw = sum(ht * wd for ht, wd in levels)
+    len_q, nlvl, npts = 3, len(levels), 1
+
+    class _MinimalDeformAttn(torch.nn.Module):
+        """Minimal wrapper to test torch.export.export on the hw-param code path."""
+
+        def __init__(self, hw: list[tuple[int, int]]) -> None:
+            super().__init__()
+            self.hw = hw
+
+        def forward(
+            self,
+            value: torch.Tensor,
+            spatial_shapes: torch.Tensor,
+            sampling_locations: torch.Tensor,
+            attention_weights: torch.Tensor,
+        ) -> torch.Tensor:
+            """Forward using concrete Python int pairs for export compatibility."""
+            return ms_deform_attn_core_pytorch(
+                value,
+                spatial_shapes,
+                sampling_locations,
+                attention_weights,
+                value_spatial_shapes_hw=self.hw,
+            )
+
+    value = torch.randn(bsz, n_heads, head_dim, total_hw)
+    spatial_shapes = torch.tensor(levels, dtype=torch.long)
+    sampling_locations = torch.rand(bsz, len_q, n_heads, nlvl, npts, 2)
+    attention_weights = torch.softmax(torch.randn(bsz, len_q, n_heads, nlvl * npts), dim=-1)
+
+    module = _MinimalDeformAttn(hw=levels)
+
+    exported = torch.export.export(module, args=(value, spatial_shapes, sampling_locations, attention_weights))
+    assert exported is not None

--- a/tests/models/test_transformer.py
+++ b/tests/models/test_transformer.py
@@ -17,7 +17,8 @@ from rfdetr.models.transformer import gen_encoder_output_proposals
 def _reset_random_seeds() -> None:
     """Ensure reproducible random state for every test."""
     torch.manual_seed(42)
-    torch.cuda.manual_seed_all(42)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(42)
 
 
 _MSDeformInputs = tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, list[tuple[int, int]]]

--- a/tests/training/test_auto_batch.py
+++ b/tests/training/test_auto_batch.py
@@ -105,7 +105,6 @@ def test_resolve_auto_batch_config_returns_expected_values():
     assert result.device_name == "Fake GPU"
 
 
-@patch("rfdetr.detr.is_main_process", return_value=False)
 @patch("rfdetr.training.auto_batch.resolve_auto_batch_config")
 @patch("rfdetr.training.build_trainer")
 @patch("rfdetr.training.RFDETRDataModule")
@@ -117,7 +116,6 @@ def test_train_auto_batch_ensures_model_on_device_before_resolve(
     _mock_data_module: MagicMock,
     _mock_build_trainer: MagicMock,
     mock_resolve: MagicMock,
-    _mock_is_main: MagicMock,
 ) -> None:
     """_ensure_model_on_device must be called before resolve_auto_batch_config when batch_size='auto'."""
     auto_result = SimpleNamespace(safe_micro_batch=4, recommended_grad_accum_steps=1, effective_batch_size=4)

--- a/tests/training/test_auto_batch.py
+++ b/tests/training/test_auto_batch.py
@@ -139,6 +139,7 @@ def test_train_auto_batch_ensures_model_on_device_before_resolve(
         dataset_dir=None,
         resume=None,
         class_names=None,
+        save_dataset_grids=False,
     )
     mock_self = MagicMock()
     mock_self.model_config = SimpleNamespace(model_name=None)

--- a/tests/training/test_auto_batch.py
+++ b/tests/training/test_auto_batch.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 
+from rfdetr.detr import RFDETR
 from rfdetr.training import auto_batch
 from rfdetr.training.auto_batch import AutoBatchResult
 
@@ -102,6 +103,58 @@ def test_resolve_auto_batch_config_returns_expected_values():
     assert result.recommended_grad_accum_steps == 4
     assert result.effective_batch_size == 20
     assert result.device_name == "Fake GPU"
+
+
+@patch("rfdetr.detr.is_main_process", return_value=False)
+@patch("rfdetr.training.auto_batch.resolve_auto_batch_config")
+@patch("rfdetr.training.build_trainer")
+@patch("rfdetr.training.RFDETRDataModule")
+@patch("rfdetr.training.RFDETRModelModule")
+@patch("rfdetr.detr._ensure_model_on_device")
+def test_train_auto_batch_ensures_model_on_device_before_resolve(
+    mock_ensure: MagicMock,
+    _mock_module: MagicMock,
+    _mock_data_module: MagicMock,
+    _mock_build_trainer: MagicMock,
+    mock_resolve: MagicMock,
+    _mock_is_main: MagicMock,
+) -> None:
+    """_ensure_model_on_device must be called before resolve_auto_batch_config when batch_size='auto'."""
+    auto_result = SimpleNamespace(safe_micro_batch=4, recommended_grad_accum_steps=1, effective_batch_size=4)
+    call_order: list[str] = []
+
+    def _ensure_side_effect(model: object) -> None:
+        call_order.append("ensure")
+
+    def _resolve_side_effect(**_kwargs: object) -> object:
+        call_order.append("resolve")
+        return auto_result
+
+    mock_ensure.side_effect = _ensure_side_effect
+    mock_resolve.side_effect = _resolve_side_effect
+
+    train_config = SimpleNamespace(
+        batch_size="auto",
+        grad_accum_steps=99,
+        dataset_dir=None,
+        resume=None,
+        class_names=None,
+    )
+    mock_self = MagicMock()
+    mock_self.model_config = SimpleNamespace(model_name=None)
+    mock_self.get_train_config.return_value = train_config
+
+    RFDETR.train(mock_self)
+
+    assert train_config.batch_size == 4
+    assert train_config.grad_accum_steps == 1
+    mock_ensure.assert_called_once_with(mock_self.model)
+    mock_resolve.assert_called_once_with(
+        model_context=mock_self.model,
+        model_config=mock_self.model_config,
+        train_config=train_config,
+    )
+    assert call_order == ["ensure", "resolve"]
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for segmentation probe")

--- a/tests/training/test_build_trainer.py
+++ b/tests/training/test_build_trainer.py
@@ -7,6 +7,7 @@
 """Tests for build_trainer() — PTL Ch3/T5 (callbacks) and Ch4/T1 (precision, loggers, trainer kwargs)."""
 
 import warnings
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pytorch_lightning.callbacks import ModelCheckpoint
@@ -235,13 +236,7 @@ class TestBuildTrainerPrecision:
         assert trainer.precision == "32-true"
 
     def test_amp_true_cuda_no_bf16_gives_16_mixed(self, tmp_path):
-        """amp=True with CUDA but no bf16 support must produce '16-mixed'.
-
-        We mock the Trainer constructor to capture the precision kwarg rather
-        than inspecting trainer.precision after construction: PTL may re-detect
-        hardware bf16 support during __init__ and normalise the precision string
-        on machines that happen to have a bf16-capable GPU.
-        """
+        """amp=True with CUDA but no bf16 support must produce '16-mixed'."""
         import unittest.mock as mock
 
         captured: dict = {}
@@ -259,12 +254,7 @@ class TestBuildTrainerPrecision:
         assert captured["precision"] == "16-mixed"
 
     def test_amp_true_cuda_bf16_supported_gives_bf16_mixed(self, tmp_path):
-        """amp=True with CUDA + bf16 hardware produces 'bf16-mixed' (scaler-free).
-
-        On Ampere+ GPUs (bf16 supported) we select bf16-mixed to eliminate
-        GradScaler overhead.  Fine-tuning from pretrained weights is safe with
-        BF16; callers training from scratch can override via trainer_kwargs.
-        """
+        """amp=True with CUDA + bf16 hardware produces 'bf16-mixed'."""
         import unittest.mock as mock
 
         captured: dict = {}
@@ -280,6 +270,80 @@ class TestBuildTrainerPrecision:
         ):
             build_trainer(_tc(tmp_path, use_ema=False), _mc(amp=True))
         assert captured["precision"] == "bf16-mixed"
+
+    @patch("torch.cuda.is_available", return_value=True)
+    @patch("torch.cuda.is_bf16_supported", return_value=False)
+    @patch("rfdetr.training.trainer.Trainer")
+    def test_amp_true_ddp_notebook_probes_bf16_normally(
+        self, mock_trainer: MagicMock, _mock_bf16: MagicMock, _mock_cuda: MagicMock, tmp_path
+    ):
+        """ddp_notebook uses standard precision probing (spawn makes CUDA init safe).
+
+        With spawn-based DDP, child processes start fresh — CUDA init in the
+        parent does not propagate.  So ``is_bf16_supported()`` is safe to call
+        and pre-Ampere GPUs correctly get ``16-mixed`` instead of the slower
+        bf16 emulation path.  Simulates pre-Ampere GPU: CUDA available, bf16 NOT supported.
+        """
+        captured: dict = {}
+
+        def _fake_trainer(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        mock_trainer.side_effect = _fake_trainer
+        build_trainer(
+            _tc(tmp_path, use_ema=False, strategy="ddp_notebook"),
+            _mc(amp=True),
+        )
+        assert captured["precision"] == "16-mixed"
+
+    @pytest.mark.parametrize("strategy_name", ["ddp_notebook", "ddp_spawn"])
+    def test_ddp_notebook_and_spawn_use_interactive_spawn(self, tmp_path, strategy_name):
+        """ddp_notebook and ddp_spawn must be replaced with interactive spawn DDPStrategy.
+
+        Fork-based DDP inherits the parent's OpenMP thread pool which is
+        invalid after fork, causing SIGABRT in the autograd engine.
+        ddp_spawn is blocked by PTL in notebooks without the override.
+        """
+        import unittest.mock as mock
+
+        from pytorch_lightning.strategies import DDPStrategy
+
+        captured: dict = {}
+
+        def _fake_trainer(**kwargs):
+            captured.update(kwargs)
+            return mock.MagicMock()
+
+        with mock.patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer):
+            build_trainer(
+                _tc(tmp_path, use_ema=False, strategy=strategy_name),
+                _mc(amp=True),
+            )
+        strategy_obj = captured["strategy"]
+        assert isinstance(strategy_obj, DDPStrategy)
+        assert strategy_obj._start_method == "spawn"
+        assert strategy_obj._ddp_kwargs.get("find_unused_parameters") is True
+
+    @patch("rfdetr.training.trainer._InteractiveSpawnLauncher", None)
+    def test_ddp_notebook_raises_clear_error_when_private_launcher_is_missing(self, tmp_path):
+        """Missing private PTL launcher should raise a targeted compatibility error."""
+        captured: dict = {}
+
+        def _fake_trainer(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        with patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer):
+            build_trainer(
+                _tc(tmp_path, use_ema=False, strategy="ddp_notebook"),
+                _mc(amp=True),
+            )
+
+        strategy = captured["strategy"]
+        strategy.cluster_environment = object()
+        with pytest.raises(RuntimeError, match="private API"):
+            strategy._configure_launcher()
 
 
 class TestBuildTrainerEMAShardingGuard:

--- a/tests/training/test_build_trainer.py
+++ b/tests/training/test_build_trainer.py
@@ -647,3 +647,99 @@ class TestBuildTrainerDDPFields:
         tc = _tc(tmp_path, use_ema=False, devices="auto")
         # Should not raise during config construction.
         assert tc.devices == "auto"
+
+
+class TestBuildTrainerSegmentationDDP:
+    """build_trainer() must enable find_unused_parameters when segmentation_head=True + strategy='ddp'."""
+
+    def test_ddp_segmentation_enables_find_unused_parameters(self, tmp_path):
+        """strategy='ddp' + segmentation_head=True must produce DDPStrategy(find_unused_parameters=True).
+
+        The segmentation head's sparse_forward() leaves parameters unused on some
+        forward steps.  Plain DDP raises RuntimeError unless find_unused_parameters
+        is enabled.
+        """
+        import unittest.mock as mock
+
+        from pytorch_lightning.strategies import DDPStrategy
+
+        captured: dict = {}
+
+        def _fake_trainer(**kwargs):
+            captured.update(kwargs)
+            return mock.MagicMock()
+
+        tc = _tc(tmp_path, use_ema=False, strategy="ddp")
+        mc = _mc(segmentation_head=True)
+        with mock.patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer):
+            build_trainer(tc, mc)
+
+        strategy_obj = captured["strategy"]
+        assert isinstance(strategy_obj, DDPStrategy)
+        assert strategy_obj._ddp_kwargs.get("find_unused_parameters") is True
+
+    def test_ddp_no_segmentation_strategy_unchanged(self, tmp_path):
+        """strategy='ddp' without segmentation_head must pass the string through unchanged.
+
+        Only the segmentation path needs find_unused_parameters; standard detection
+        DDP must not be wrapped unnecessarily to avoid the autograd-graph traversal
+        overhead on every backward pass.
+        """
+        import unittest.mock as mock
+
+        captured: dict = {}
+
+        def _fake_trainer(**kwargs):
+            captured.update(kwargs)
+            return mock.MagicMock()
+
+        tc = _tc(tmp_path, use_ema=False, strategy="ddp")
+        mc = _mc(segmentation_head=False)
+        with mock.patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer):
+            build_trainer(tc, mc)
+
+        assert captured["strategy"] == "ddp"
+
+    def test_ddp_spawn_segmentation_preserves_find_unused_parameters(self, tmp_path):
+        """strategy='ddp_spawn' + segmentation_head=True must keep find_unused_parameters=True.
+
+        ddp_spawn is already replaced with an interactive-spawn DDPStrategy that has
+        find_unused_parameters=True for notebook compatibility.  Segmentation must not
+        accidentally drop that flag when the ddp_spawn path is taken instead of the
+        plain 'ddp' path.
+        """
+        import unittest.mock as mock
+
+        from pytorch_lightning.strategies import DDPStrategy
+
+        captured: dict = {}
+
+        def _fake_trainer(**kwargs):
+            captured.update(kwargs)
+            return mock.MagicMock()
+
+        tc = _tc(tmp_path, use_ema=False, strategy="ddp_spawn")
+        mc = _mc(segmentation_head=True)
+        with mock.patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer):
+            build_trainer(tc, mc)
+
+        strategy_obj = captured["strategy"]
+        assert isinstance(strategy_obj, DDPStrategy)
+        assert strategy_obj._ddp_kwargs.get("find_unused_parameters") is True
+
+    def test_non_ddp_strategy_with_segmentation_is_unchanged(self, tmp_path):
+        """Strategies other than 'ddp' must not be wrapped even when segmentation is on."""
+        import unittest.mock as mock
+
+        captured: dict = {}
+
+        def _fake_trainer(**kwargs):
+            captured.update(kwargs)
+            return mock.MagicMock()
+
+        tc = _tc(tmp_path, use_ema=False, strategy="auto")
+        mc = _mc(segmentation_head=True)
+        with mock.patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer):
+            build_trainer(tc, mc)
+
+        assert captured["strategy"] == "auto"

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -24,7 +24,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 
-from rfdetr.config import RFDETRBaseConfig, TrainConfig
+from rfdetr.config import RFDETRBaseConfig, RFDETRSmallConfig, TrainConfig
 from rfdetr.detr import RFDETR, RFDETRLarge
 from rfdetr.training.auto_batch import AutoBatchResult
 from rfdetr.training.checkpoint import convert_legacy_checkpoint
@@ -525,6 +525,88 @@ class TestRFDETRTrainPTLAbsorption:
             RFDETR.train(mock_self, do_benchmark=True)
         depr = [x for x in w if issubclass(x.category, DeprecationWarning)]
         assert any("do_benchmark" in str(d.message) or "rfdetr benchmark" in str(d.message) for d in depr)
+
+    def test_resolution_kwarg_updates_model_config_resolution(self, tmp_path, patch_lit):
+        """resolution kwarg is applied to model_config.resolution before training."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
+        valid_resolution = block_size * 11  # guaranteed divisible and different from default
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self, resolution=valid_resolution)
+        assert mock_self.model_config.resolution == valid_resolution
+
+    def test_resolution_kwarg_does_not_implicitly_update_positional_encoding_size(self, tmp_path, patch_lit):
+        """Pretrained-specific PE (RFDETRBase DINOv2=37) is preserved when resolution is overridden."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        # RFDETRBaseConfig: PE=37 (DINOv2 native 518//14), resolution=560, patch_size=14.
+        # PE != resolution // patch_size, so the smart PE guard leaves PE unchanged.
+        original_pe = mock_self.model_config.positional_encoding_size
+        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
+        valid_override_resolution = block_size * 11  # different from default 560
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self, resolution=valid_override_resolution)
+        assert mock_self.model_config.positional_encoding_size == original_pe
+
+    def test_resolution_kwarg_updates_positional_encoding_size_for_formula_derived_config(self, tmp_path, patch_lit):
+        """For configs where PE == resolution // patch_size, resolution override updates PE."""
+        # RFDETRSmallConfig: patch_size=16, num_windows=2, resolution=512, PE=32=512//16.
+        mock_self = _make_rfdetr_self(tmp_path)
+        mock_self.model_config = RFDETRSmallConfig(pretrain_weights=None, num_classes=3, device="cpu")
+        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
+        new_resolution = block_size * 21  # 672 for Small — valid and different from default 512
+        expected_pe = new_resolution // mock_self.model_config.patch_size
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self, resolution=new_resolution)
+        assert mock_self.model_config.positional_encoding_size == expected_pe
+
+    def test_resolution_kwarg_does_not_reach_get_train_config(self, tmp_path, patch_lit):
+        """resolution kwarg is popped before get_train_config is called."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self, resolution=block_size * 10)
+        assert "resolution" not in mock_self.get_train_config.call_args.kwargs
+
+    def test_resolution_indivisible_raises_value_error(self, tmp_path, patch_lit):
+        """resolution not divisible by patch_size * num_windows raises ValueError."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
+        indivisible = block_size * 10 + 1  # guaranteed not divisible by block_size
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt, pytest.raises(ValueError, match=f"resolution={indivisible}"):
+            RFDETR.train(mock_self, resolution=indivisible)
+
+    def test_resolution_none_leaves_model_config_unchanged(self, tmp_path, patch_lit):
+        """Omitting resolution leaves model_config.resolution unchanged."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        original_resolution = mock_self.model_config.resolution
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self)
+        assert mock_self.model_config.resolution == original_resolution
+
+    @pytest.mark.parametrize(
+        "bad_resolution",
+        [
+            pytest.param(0, id="zero"),
+            pytest.param(-56, id="negative"),
+            pytest.param(True, id="bool_true"),
+            pytest.param(False, id="bool_false"),
+            pytest.param(1.5, id="non_integer_float"),
+            pytest.param(560.0, id="whole_number_float"),
+            pytest.param("560", id="string"),
+        ],
+    )
+    def test_resolution_invalid_type_or_value_raises_value_error(self, tmp_path, patch_lit, bad_resolution):
+        """Non-positive, bool, or non-integer resolution raises ValueError before divisibility check."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt, pytest.raises(ValueError, match="resolution must be a positive integer"):
+            RFDETR.train(mock_self, resolution=bad_resolution)
 
     def test_returns_none(self, tmp_path, patch_lit):
         """RFDETR.train() returns None."""

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -616,6 +616,80 @@ class TestRFDETRTrainPTLAbsorption:
             result = RFDETR.train(mock_self)
         assert result is None
 
+    def test_save_dataset_grids_true_calls_grid_saver(self, tmp_path, patch_lit):
+        """save_dataset_grids=True triggers DatasetGridSaver.save_grid() for train and val."""
+        mock_self = _make_rfdetr_self(tmp_path, save_dataset_grids=True)
+        p_mod, p_dm, p_bt, _mcls, _dmcls, _mock_bt = patch_lit
+        mock_saver_cls = MagicMock(name="DatasetGridSaver")
+        with (
+            p_mod,
+            p_dm,
+            p_bt,
+            patch("rfdetr.datasets.save_grids.DatasetGridSaver", mock_saver_cls),
+        ):
+            RFDETR.train(mock_self)
+
+        # DatasetGridSaver must be constructed twice (train + val) and save_grid called on each
+        assert mock_saver_cls.call_count == 2
+        assert mock_saver_cls.return_value.save_grid.call_count == 2
+
+        # setup("fit") must be called on the datamodule before training
+        dm_instance = _dmcls.return_value
+        dm_instance.setup.assert_called_with("fit")
+
+    def test_save_dataset_grids_false_skips_grid_saver(self, tmp_path, patch_lit):
+        """save_dataset_grids=False (default) must not call DatasetGridSaver at all."""
+        mock_self = _make_rfdetr_self(tmp_path)  # default save_dataset_grids=False
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        mock_saver_cls = MagicMock(name="DatasetGridSaver")
+        with (
+            p_mod,
+            p_dm,
+            p_bt,
+            patch("rfdetr.datasets.save_grids.DatasetGridSaver", mock_saver_cls),
+        ):
+            RFDETR.train(mock_self)
+
+        mock_saver_cls.assert_not_called()
+
+    def test_save_dataset_grids_uses_output_dir_subdir(self, tmp_path, patch_lit):
+        """Grid images are saved to <output_dir>/dataset_grids."""
+        from pathlib import Path
+
+        mock_self = _make_rfdetr_self(tmp_path, save_dataset_grids=True)
+        config = mock_self.get_train_config.return_value
+        p_mod, p_dm, p_bt, _mcls, _dmcls, _mock_bt = patch_lit
+        mock_saver_cls = MagicMock(name="DatasetGridSaver")
+        with (
+            p_mod,
+            p_dm,
+            p_bt,
+            patch("rfdetr.datasets.save_grids.DatasetGridSaver", mock_saver_cls),
+        ):
+            RFDETR.train(mock_self)
+
+        expected_output_dir = Path(config.output_dir) / "dataset_grids"
+        called_dirs = [call.args[1] for call in mock_saver_cls.call_args_list]
+        assert all(d == expected_output_dir for d in called_dirs)
+
+    def test_save_dataset_grids_failure_does_not_abort_training(self, tmp_path, patch_lit):
+        """A save_grid() failure must not abort training — trainer.fit() must still be called."""
+        mock_self = _make_rfdetr_self(tmp_path, save_dataset_grids=True)
+        p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = patch_lit
+        mock_saver_cls = MagicMock(name="DatasetGridSaver")
+        mock_saver_cls.return_value.save_grid.side_effect = OSError("disk full")
+        with (
+            p_mod,
+            p_dm,
+            p_bt,
+            patch("rfdetr.datasets.save_grids.DatasetGridSaver", mock_saver_cls),
+        ):
+            # Must not raise even though save_grid() fails
+            RFDETR.train(mock_self)
+
+        # Training must proceed regardless of the grid-save failure
+        mock_bt.return_value.fit.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # 3. convert_legacy_checkpoint

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -139,6 +139,7 @@ class TestRFDETRTrainPTL:
         mock_config = MagicMock(spec=TrainConfig)
         mock_config.resume = ""
         mock_config.batch_size = 4  # int so auto-batch branch is not taken
+        mock_config.save_dataset_grids = False
         mock_self.get_train_config.return_value = mock_config
 
         p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = patch_lit

--- a/tests/training/test_load_pretrain_weights.py
+++ b/tests/training/test_load_pretrain_weights.py
@@ -53,7 +53,13 @@ from rfdetr.models.weights import load_pretrain_weights
 # ---------------------------------------------------------------------------
 
 
-def _make_checkpoint(num_classes=91, num_queries=300, group_detr=13):
+def _make_checkpoint(
+    num_classes=91,
+    num_queries=300,
+    group_detr=13,
+    segmentation_head=False,
+    patch_size=14,
+):
     """Build a minimal checkpoint dict with the given class count.
 
     Args:
@@ -69,11 +75,7 @@ def _make_checkpoint(num_classes=91, num_queries=300, group_detr=13):
         "query_feat.weight": torch.randn(total_queries, 256),
         "other_layer.weight": torch.randn(10, 10),
     }
-    ckpt_args = SimpleNamespace(
-        segmentation_head=False,
-        patch_size=14,
-        class_names=[],
-    )
+    ckpt_args = SimpleNamespace(segmentation_head=segmentation_head, patch_size=patch_size, class_names=[])
     return {"model": state, "args": ckpt_args}
 
 
@@ -136,8 +138,8 @@ class TestLoadPretrainWeightsIntoSecondReinit:
             f"Expected exactly 1 reinit call (to checkpoint size), but got {len(calls)}: "
             f"{calls}. The second reinit to {args.num_classes + 1} destroys loaded weights."
         )
-        assert mc.num_classes == 2, (
-            f"mc.num_classes must be auto-aligned to 2 (checkpoint_logits - 1), got {mc.num_classes}"
+        assert args.num_classes == 2, (
+            f"args.num_classes must be auto-aligned to 2 (checkpoint_logits - 1), got {args.num_classes}"
         )
 
     def test_no_mismatch_no_reinit(self, monkeypatch):
@@ -365,8 +367,12 @@ class TestModuleLoadPretrainWeightsSecondReinit:
         and fires exactly one reinit call — to 9 (the checkpoint size).
         """
         # 8 dataset categories → training builds a model with 8+1=9 logits.
-        checkpoint = _make_checkpoint(num_classes=9)
         mc = config_cls(pretrain_weights="/fake/weights.pth", device="cpu")
+        checkpoint = _make_checkpoint(
+            num_classes=9,
+            segmentation_head=mc.segmentation_head,
+            patch_size=mc.patch_size,
+        )
         monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
 
         fake_model = MagicMock()

--- a/tests/training/test_load_pretrain_weights.py
+++ b/tests/training/test_load_pretrain_weights.py
@@ -32,7 +32,21 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 import torch
 
-from rfdetr.config import RFDETRBaseConfig, TrainConfig
+from rfdetr.config import (
+    RFDETRBaseConfig,
+    RFDETRLargeConfig,
+    RFDETRMediumConfig,
+    RFDETRNanoConfig,
+    RFDETRSeg2XLargeConfig,
+    RFDETRSegLargeConfig,
+    RFDETRSegMediumConfig,
+    RFDETRSegNanoConfig,
+    RFDETRSegSmallConfig,
+    RFDETRSegXLargeConfig,
+    RFDETRSmallConfig,
+    TrainConfig,
+)
+from rfdetr.models.weights import load_pretrain_weights
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -121,6 +135,9 @@ class TestLoadPretrainWeightsIntoSecondReinit:
         assert len(calls) == 1, (
             f"Expected exactly 1 reinit call (to checkpoint size), but got {len(calls)}: "
             f"{calls}. The second reinit to {args.num_classes + 1} destroys loaded weights."
+        )
+        assert mc.num_classes == 2, (
+            f"mc.num_classes must be auto-aligned to 2 (checkpoint_logits - 1), got {mc.num_classes}"
         )
 
     def test_no_mismatch_no_reinit(self, monkeypatch):
@@ -316,3 +333,51 @@ class TestModuleLoadPretrainWeightsSecondReinit:
 
         calls = fake_model.reinitialize_detection_head.call_args_list
         assert calls == [call(91), call(3)], f"Expected reinit to [91, 3] (expand then trim), got {calls}"
+
+    # All non-deprecated model configs (RFDETRLargeDeprecatedConfig and
+    # RFDETRBaseConfig are excluded; the former is deprecated, the latter
+    # serves as the base class for the concrete variants below).
+    @pytest.mark.parametrize(
+        "config_cls",
+        [
+            pytest.param(RFDETRNanoConfig, id="nano"),
+            pytest.param(RFDETRSmallConfig, id="small"),
+            pytest.param(RFDETRMediumConfig, id="medium"),
+            pytest.param(RFDETRLargeConfig, id="large"),
+            pytest.param(RFDETRSegNanoConfig, id="seg_nano"),
+            pytest.param(RFDETRSegSmallConfig, id="seg_small"),
+            pytest.param(RFDETRSegMediumConfig, id="seg_medium"),
+            pytest.param(RFDETRSegLargeConfig, id="seg_large"),
+            pytest.param(RFDETRSegXLargeConfig, id="seg_xlarge"),
+            pytest.param(RFDETRSeg2XLargeConfig, id="seg_2xlarge"),
+        ],
+    )
+    def test_eight_class_finetune_checkpoint_auto_aligns_num_classes_and_reinits_once(self, monkeypatch, config_cls):
+        """Auto-align ``mc.num_classes`` and avoid a second reinit for 8-class checkpoints.
+
+        Scenario (from user bug report): user trains on 8 categories (IDs 0–7).
+        The checkpoint stores ``class_embed.bias`` with shape [9] (8 user classes
+        + 1 background). Loading without specifying ``num_classes`` must NOT
+        trigger a second reinit to 91 after temporarily matching the checkpoint
+        size for ``load_state_dict``.
+
+        This test asserts the loader auto-aligns ``mc.num_classes`` to 8 (9 - 1)
+        and fires exactly one reinit call — to 9 (the checkpoint size).
+        """
+        # 8 dataset categories → training builds a model with 8+1=9 logits.
+        checkpoint = _make_checkpoint(num_classes=9)
+        mc = config_cls(pretrain_weights="/fake/weights.pth", device="cpu")
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
+
+        fake_model = MagicMock()
+        load_pretrain_weights(fake_model, mc)
+
+        calls = fake_model.reinitialize_detection_head.call_args_list
+        assert len(calls) == 1, (
+            f"Expected exactly 1 reinit call (to checkpoint size 9), but got {len(calls)}: "
+            f"{calls}. A second reinit to 91 would produce OOB class IDs like 73."
+        )
+        assert calls[0] == call(9), f"Reinit must resize to checkpoint's 9 logits, got {calls[0]}"
+        assert mc.num_classes == 8, (
+            f"mc.num_classes must be auto-aligned to 8 (checkpoint_logits - 1), got {mc.num_classes}"
+        )

--- a/tests/training/test_module_data.py
+++ b/tests/training/test_module_data.py
@@ -178,11 +178,34 @@ class TestInit:
         dm = build_datamodule(train_config=tc)
         assert dm._pin_memory is False
 
+    @patch("rfdetr.config.DEVICE", "cuda")
+    def test_pin_memory_defaults_to_false_when_accelerator_is_cpu(self, build_datamodule, base_train_config):
+        """Default pin_memory stays off when training is explicitly CPU-only."""
+        tc = base_train_config(pin_memory=None, accelerator="cpu")
+        dm = build_datamodule(train_config=tc)
+        assert dm._pin_memory is False
+
     def test_persistent_workers_override_is_respected(self, build_datamodule, base_train_config):
         """persistent_workers can be explicitly overridden from TrainConfig."""
         tc = base_train_config(num_workers=2, persistent_workers=False)
         dm = build_datamodule(train_config=tc)
         assert dm._persistent_workers is False
+
+    def test_ddp_notebook_preserves_num_workers(self, build_datamodule, base_train_config):
+        """ddp_notebook keeps num_workers as configured (spawn-based DDP
+        children initialise CUDA fresh; DataLoader fork workers are CPU-only
+        and never touch CUDA, so nested forks are safe)."""
+        tc = base_train_config(num_workers=4, strategy="ddp_notebook")
+        dm = build_datamodule(train_config=tc)
+        assert dm._num_workers == 4
+        assert dm._prefetch_factor == 2
+
+    def test_other_strategy_preserves_num_workers(self, build_datamodule, base_train_config):
+        """Non-ddp_notebook strategies also keep num_workers as configured."""
+        tc = base_train_config(num_workers=4, strategy="ddp")
+        dm = build_datamodule(train_config=tc)
+        assert dm._num_workers == 4
+        assert dm._prefetch_factor == 2  # default prefetch_factor for num_workers>0
 
 
 class TestSetup:

--- a/tests/training/test_module_data.py
+++ b/tests/training/test_module_data.py
@@ -391,6 +391,144 @@ class TestTrainDataloader:
         loader = dm.train_dataloader()
         assert isinstance(loader.batch_sampler, torch.utils.data.BatchSampler)
 
+    @pytest.mark.parametrize(
+        "dataset_length, batch_size, grad_accum_steps",
+        [
+            pytest.param(100, 2, 1, id="already_aligned_ga1"),
+            pytest.param(96, 2, 4, id="already_aligned_ga4"),
+            pytest.param(101, 2, 4, id="unaligned_one_extra"),
+            pytest.param(50, 2, 8, id="unaligned_ga8"),
+            pytest.param(59143, 2, 8, id="large_unaligned_coco_like"),
+            pytest.param(100, 3, 3, id="non_power_of_two_ga"),
+        ],
+    )
+    def test_train_dataloader_length_is_multiple_of_grad_accum(
+        self, tmp_path, dataset_length, batch_size, grad_accum_steps
+    ):
+        """len(train_dataloader()) is always a multiple of grad_accum_steps.
+
+        Verifies the workaround for
+        https://github.com/Lightning-AI/pytorch-lightning/issues/19987:
+        the training DataLoader must never present a partial accumulation
+        window to PTL.
+        """
+        dm = self._setup_dm_with_train(
+            tmp_path,
+            dataset_length=dataset_length,
+            batch_size=batch_size,
+            grad_accum_steps=grad_accum_steps,
+        )
+        loader = dm.train_dataloader()
+        assert len(loader) % grad_accum_steps == 0, (
+            f"len(loader)={len(loader)} is not a multiple of grad_accum_steps={grad_accum_steps}"
+        )
+
+    def test_train_dataloader_respects_trainer_world_size(self, tmp_path):
+        """Large-dataset path aligns wrapped dataset length to effective_batch_size * world_size."""
+        dm = self._setup_dm_with_train(
+            tmp_path,
+            dataset_length=101,
+            batch_size=2,
+            grad_accum_steps=4,
+        )
+        dm.trainer = MagicMock(world_size=3)
+
+        loader = dm.train_dataloader()
+
+        assert len(loader.dataset) % (2 * 4 * 3) == 0
+        assert len(loader.dataset) == 120
+
+
+class TestGradAccumAlignedDataset:
+    """Unit tests for the GradAccumAlignedDataset wrapper."""
+
+    def _make_dataset(self, length: int) -> torch.utils.data.TensorDataset:
+        """Return a simple TensorDataset of given length."""
+        return torch.utils.data.TensorDataset(torch.arange(length))
+
+    def test_aligned_length_is_multiple_of_pad_unit(self):
+        """Padded length is always a multiple of effective_batch_size * world_size."""
+        from rfdetr.training.module_data import GradAccumAlignedDataset
+
+        ds = self._make_dataset(50)
+        wrapped = GradAccumAlignedDataset(ds, effective_batch_size=16, world_size=1)
+        assert len(wrapped) % 16 == 0
+
+    def test_no_padding_needed_when_already_aligned(self):
+        """If len(dataset) % pad_unit == 0, length is unchanged."""
+        from rfdetr.training.module_data import GradAccumAlignedDataset
+
+        ds = self._make_dataset(64)
+        wrapped = GradAccumAlignedDataset(ds, effective_batch_size=16, world_size=1)
+        assert len(wrapped) == 64
+
+    def test_padding_adds_correct_count(self):
+        """Exactly (pad_unit - remainder) % pad_unit samples are added."""
+        from rfdetr.training.module_data import GradAccumAlignedDataset
+
+        ds = self._make_dataset(50)  # 50 % 16 = 2 → pad 14
+        wrapped = GradAccumAlignedDataset(ds, effective_batch_size=16, world_size=1)
+        assert len(wrapped) == 64
+
+    def test_getitem_forwards_to_original_dataset(self):
+        """Items in the original range map directly to the underlying dataset."""
+        from rfdetr.training.module_data import GradAccumAlignedDataset
+
+        ds = self._make_dataset(10)
+        wrapped = GradAccumAlignedDataset(ds, effective_batch_size=4, world_size=1)
+        for i in range(10):
+            (val,) = wrapped[i]
+            assert val.item() == i
+
+    def test_padded_indices_are_valid(self):
+        """All padded indices point to valid positions in the original dataset."""
+        from rfdetr.training.module_data import GradAccumAlignedDataset
+
+        n = 10
+        ds = self._make_dataset(n)
+        wrapped = GradAccumAlignedDataset(ds, effective_batch_size=4, world_size=1)
+        for i in range(len(wrapped)):
+            (val,) = wrapped[i]
+            assert 0 <= val.item() < n
+
+    @pytest.mark.parametrize(
+        "n, eff_bs, world_size",
+        [
+            pytest.param(100, 4, 1, id="aligned_single_gpu"),
+            pytest.param(101, 4, 1, id="unaligned_single_gpu"),
+            pytest.param(100, 4, 2, id="aligned_ddp2"),
+            pytest.param(97, 4, 2, id="unaligned_ddp2"),
+        ],
+    )
+    def test_length_always_multiple_of_pad_unit(self, n, eff_bs, world_size):
+        """len(wrapped) % (eff_bs * world_size) == 0 for all inputs."""
+        from rfdetr.training.module_data import GradAccumAlignedDataset
+
+        ds = self._make_dataset(n)
+        wrapped = GradAccumAlignedDataset(ds, effective_batch_size=eff_bs, world_size=world_size)
+        assert len(wrapped) % (eff_bs * world_size) == 0
+
+    @pytest.mark.parametrize(
+        "effective_batch_size, world_size",
+        [
+            pytest.param(0, 1, id="zero_effective_batch_size"),
+            pytest.param(-1, 1, id="negative_effective_batch_size"),
+            pytest.param(2, 0, id="zero_world_size"),
+            pytest.param(2, -1, id="negative_world_size"),
+        ],
+    )
+    def test_raises_for_non_positive_alignment_inputs(self, effective_batch_size, world_size):
+        """Non-positive alignment inputs fail with a clear ValueError."""
+        from rfdetr.training.module_data import GradAccumAlignedDataset
+
+        ds = self._make_dataset(10)
+        with pytest.raises(ValueError, match="must be >= 1"):
+            GradAccumAlignedDataset(
+                ds,
+                effective_batch_size=effective_batch_size,
+                world_size=world_size,
+            )
+
 
 class TestValDataloader:
     """val_dataloader() returns a SequentialSampler with drop_last=False."""

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -184,11 +184,20 @@ class TestInit:
         mc = _base_model_config(compile=True)
         tc = _base_train_config(tmp_path, multi_scale=False)
         with (
-            patch("torch.cuda.is_available", return_value=True),
+            patch("rfdetr.config.DEVICE", "cuda"),
             patch("rfdetr.training.module_model.torch.compile", side_effect=lambda m, **_: m) as mock_compile,
         ):
             _build_module(model_config=mc, train_config=tc, tmp_path=tmp_path)
         mock_compile.assert_called_once()
+
+    @patch("rfdetr.training.module_model.torch.compile")
+    @patch("rfdetr.config.DEVICE", "cuda")
+    def test_compile_disabled_when_train_accelerator_is_cpu(self, _mock_compile: MagicMock, tmp_path):
+        """compile stays disabled when training is explicitly forced to CPU."""
+        mc = _base_model_config(compile=True)
+        tc = _base_train_config(tmp_path, multi_scale=False, accelerator="cpu")
+        _build_module(model_config=mc, train_config=tc, tmp_path=tmp_path)
+        _mock_compile.assert_not_called()
 
 
 class TestLoadPretrainWeights:

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -959,6 +959,126 @@ class TestConfigureOptimizers:
         # At the final step, cosine schedule must end at lr_min_factor.
         assert lr_lambda(1000) == pytest.approx(0.2)
 
+    @patch("rfdetr.training.module_model.get_param_dict")
+    @patch("rfdetr.training.module_model.torch.cuda.is_bf16_supported", return_value=True)
+    @patch("rfdetr.training.module_model.torch.cuda.is_available", return_value=True)
+    def test_fused_optimizer_disabled_when_precision_not_bf16(
+        self,
+        mock_cuda_available,
+        mock_bf16_supported,
+        mock_get_param_dict,
+        tmp_path,
+    ):
+        """Fused AdamW must be disabled when trainer precision is not bf16-mixed.
+
+        On Ampere+ GPUs torch.cuda.is_bf16_supported() is True even when the
+        trainer is configured for 32-true precision.  The old code always enabled
+        fused AdamW based on GPU capability alone, crashing with
+        ``params, grads, exp_avgs, and exp_avg_sqs must have same dtype, device,
+        and layout`` when DDP gradient bucket views had non-matching strides.
+        The fix checks ``trainer.precision`` before enabling fused.
+        """
+        module, param_dicts = self._setup_module(tmp_path)
+        mock_get_param_dict.return_value = param_dicts
+        # Simulate trainer configured for full FP32 precision.
+        module._trainer.precision = "32-true"
+
+        optimizer = module.configure_optimizers()["optimizer"]
+
+        assert not optimizer.defaults.get("fused")
+
+    @patch("rfdetr.training.module_model.get_param_dict")
+    @patch("rfdetr.training.module_model.torch.cuda.is_bf16_supported", return_value=True)
+    @patch("rfdetr.training.module_model.torch.cuda.is_available", return_value=True)
+    def test_fused_optimizer_enabled_when_precision_is_bf16_mixed(
+        self,
+        mock_cuda_available,
+        mock_bf16_supported,
+        mock_get_param_dict,
+        tmp_path,
+    ):
+        """Fused AdamW must be enabled when both GPU supports BF16 and trainer uses bf16-mixed.
+
+        The fused path is beneficial (and safe) only when training precision is
+        actually BF16: parameters, gradients, and optimizer state all stay in
+        the same dtype/layout, satisfying the fused kernel requirements.
+        """
+        module, param_dicts = self._setup_module(tmp_path)
+        mock_get_param_dict.return_value = param_dicts
+        # Simulate trainer configured for BF16 mixed precision.
+        module._trainer.precision = "bf16-mixed"
+
+        optimizer = module.configure_optimizers()["optimizer"]
+
+        assert optimizer.defaults.get("fused") is True
+
+
+class TestClipGradients:
+    """Tests for clip_gradients() — verifies precision gating mirrors configure_optimizers()."""
+
+    def _setup_module(self, tmp_path, precision: str):
+        tc = _base_train_config(tmp_path)
+        module, _, _, _ = _build_module(train_config=tc)
+        trainer = MagicMock()
+        trainer.precision = precision
+        module._trainer = trainer
+        type(module).trainer = property(lambda self: self._trainer)
+        return module
+
+    @pytest.mark.parametrize(
+        "precision",
+        [
+            pytest.param("32-true", id="fp32"),
+            pytest.param("16-mixed", id="fp16-mixed"),
+        ],
+    )
+    @patch("rfdetr.training.module_model.torch.cuda.is_bf16_supported", return_value=True)
+    @patch("rfdetr.training.module_model.torch.cuda.is_available", return_value=True)
+    def test_clip_gradients_delegates_to_super_when_not_bf16(
+        self,
+        mock_cuda_available,
+        mock_bf16_supported,
+        precision,
+        tmp_path,
+    ):
+        """clip_gradients must delegate to super() when trainer precision is not a BF16 variant.
+
+        On Ampere+ GPUs is_bf16_supported() is True regardless of actual precision.
+        The method must check trainer.precision before choosing the fused path, mirroring
+        the same gate in configure_optimizers() to prevent silent divergence.
+        """
+        module = self._setup_module(tmp_path, precision=precision)
+
+        with patch.object(type(module).__bases__[0], "clip_gradients") as mock_super_clip:
+            module.clip_gradients(MagicMock(), gradient_clip_val=0.1)
+
+        mock_super_clip.assert_called_once()
+
+    @patch("rfdetr.training.module_model.torch.cuda.is_bf16_supported", return_value=True)
+    @patch("rfdetr.training.module_model.torch.cuda.is_available", return_value=True)
+    @patch("rfdetr.training.module_model.torch.nn.utils.clip_grad_norm_")
+    def test_clip_gradients_uses_clip_grad_norm_when_bf16_mixed(
+        self,
+        mock_clip_grad_norm,
+        mock_cuda_available,
+        mock_bf16_supported,
+        tmp_path,
+    ):
+        """clip_gradients must call clip_grad_norm_ directly when precision is bf16-mixed.
+
+        When fused AdamW is active (BF16, no GradScaler), the standard PTL AMP plugin
+        refuses to clip gradients.  clip_grad_norm_ is called directly instead, bypassing
+        the scaler-aware path that would otherwise raise.
+        """
+        module = self._setup_module(tmp_path, precision="bf16-mixed")
+
+        module.clip_gradients(MagicMock(), gradient_clip_val=0.5)
+
+        mock_clip_grad_norm.assert_called_once()
+        _, call_kwargs = mock_clip_grad_norm.call_args
+        # Positional arg[1] is max_norm
+        assert mock_clip_grad_norm.call_args[0][1] == pytest.approx(0.5)
+
 
 class TestPredictStep:
     """Tests for predict_step() — verifies that only samples (not targets) are passed


### PR DESCRIPTION
## 🌱 Changed

- **Class names on predictions.** `predict()` now includes `class_name` in the returned `detections.data` dict, mapping each detection's 0-indexed class ID to its human-readable name. No more manual lookups.

    ```python
    model = RFDETRSmall(pretrain_weights="path/to/fine_tuned.pth")
    detections = model.predict("image.jpg", threshold=0.5)
    print(detections.data["class_name"])  # ["cat", "dog", "cat"]
    ```

## 🔧 Fixed

- Fixed segmentation training crashing on multi-GPU DDP setups. The segmentation head leaves some parameters unused on certain forward steps, which triggered `RuntimeError: parameters that were not used in producing the loss`. `build_trainer()` now automatically enables `find_unused_parameters=True` when `segmentation_head=True`.

- Fixed fused AdamW optimizer crash during FP32 multi-GPU training. On Ampere+ GPUs, fused AdamW was enabled whenever the hardware supported BF16 — even when the trainer was explicitly configured for `precision="32-true"`. This caused a dtype mismatch in DDP gradient buckets. The optimizer now checks the trainer's actual precision setting, not just GPU capability.

- Fixed multi-GPU DDP training failing in Jupyter notebooks and Kaggle. Fork-based DDP corrupted PyTorch's OpenMP thread pool, causing `SIGABRT` on the second process. RF-DETR now uses a spawn-based DDP strategy in interactive environments, avoiding the thread pool issue entirely.

- Fixed `RFDETR.train(resolution=...)` being silently ignored. The `resolution` kwarg is a model-level setting, not a training config field, so it was quietly dropped. It is now applied to the model config before training begins, with validation that the value is divisible by `patch_size * num_windows`.

    ```python
    model = RFDETRSmall()
    model.train(dataset_dir="./dataset", resolution=768)  # now works
    ```

- Fixed `save_dataset_grids` being silently a no-op. The grid saver was never wired into the training loop. Dataset sample grids are now saved to `{output_dir}/dataset_grids/` when enabled. Grid save failures are caught and logged without interrupting training.

- Fixed partial gradient-accumulation windows at the end of training epochs. When the dataset length was not evenly divisible by `effective_batch_size * world_size`, PyTorch Lightning would fire the optimizer on an incomplete accumulation window. The training dataset is now padded to an exact multiple, ensuring every optimizer step uses a full gradient window.

- Fixed `torch.export.export` failing on the transformer decoder. The `spatial_shapes_hw` parameter was not threaded through the decoder layers, breaking export for models using multi-scale deformable attention.

- Fixed `download_pretrain_weights()` silently overwriting fine-tuned checkpoints. When a fine-tuned checkpoint shared a filename with a registry model (e.g. `rf-detr-nano.pth`), an MD5 mismatch would trigger a re-download that replaced the user's weights. The function now returns early when the file exists and `redownload=False`, emitting a warning instead.

---

## 🏆 Contributors

Welcome to our new contributors, and thank you to everyone who helped with this release:

- **M. Fazri Nizar** (@mfazrinizar) ([LinkedIn](https://linkedin.com/in/mfazrinizar)) — *multi-GPU DDP training in notebooks*
- **Jiahao Sun** (@sjhddh) ([LinkedIn](https://www.linkedin.com/in/jiahao7sun/)) — *config type hint fix*
- **Jirka Borovec** (@Borda) ([LinkedIn](https://www.linkedin.com/in/jirka-borovec)) — *release coordination, reviews*

*Automated contributions: @copilot-swe-agent[bot], @pre-commit-ci[bot]*

---

**Full changelog**: https://github.com/roboflow/rf-detr/compare/1.6.3...1.6.4
