### PR TITLE
test: add regression tests for multi-scale hook propagation and `resolution` kwarg handling

### DIFF
--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -8,6 +8,7 @@
 
 1. ``TestRFDETRTrainPTL``           — RFDETR.train() delegates to PTL build_trainer().fit()
 2. ``TestRFDETRTrainPTLAbsorption`` — Legacy kwargs absorbed by RFDETR.train()
+2b.``TestResolutionKwarg``          — resolution= kwarg validation, sync, and PE update
 3. ``TestConvertLegacyCheckpoint``  — convert_legacy_checkpoint() round-trip
 4. ``TestOnLoadCheckpoint``         — RFDETRModule.on_load_checkpoint() auto-detect
 5. ``TestPublicAPIExports``         — rfdetr.__init__ exports RFDETRModule/DataModule/build_trainer
@@ -527,88 +528,6 @@ class TestRFDETRTrainPTLAbsorption:
         depr = [x for x in w if issubclass(x.category, DeprecationWarning)]
         assert any("do_benchmark" in str(d.message) or "rfdetr benchmark" in str(d.message) for d in depr)
 
-    def test_resolution_kwarg_updates_model_config_resolution(self, tmp_path, patch_lit):
-        """resolution kwarg is applied to model_config.resolution before training."""
-        mock_self = _make_rfdetr_self(tmp_path)
-        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
-        valid_resolution = block_size * 11  # guaranteed divisible and different from default
-        p_mod, p_dm, p_bt, *_ = patch_lit
-        with p_mod, p_dm, p_bt:
-            RFDETR.train(mock_self, resolution=valid_resolution)
-        assert mock_self.model_config.resolution == valid_resolution
-
-    def test_resolution_kwarg_does_not_implicitly_update_positional_encoding_size(self, tmp_path, patch_lit):
-        """Pretrained-specific PE (RFDETRBase DINOv2=37) is preserved when resolution is overridden."""
-        mock_self = _make_rfdetr_self(tmp_path)
-        # RFDETRBaseConfig: PE=37 (DINOv2 native 518//14), resolution=560, patch_size=14.
-        # PE != resolution // patch_size, so the smart PE guard leaves PE unchanged.
-        original_pe = mock_self.model_config.positional_encoding_size
-        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
-        valid_override_resolution = block_size * 11  # different from default 560
-        p_mod, p_dm, p_bt, *_ = patch_lit
-        with p_mod, p_dm, p_bt:
-            RFDETR.train(mock_self, resolution=valid_override_resolution)
-        assert mock_self.model_config.positional_encoding_size == original_pe
-
-    def test_resolution_kwarg_updates_positional_encoding_size_for_formula_derived_config(self, tmp_path, patch_lit):
-        """For configs where PE == resolution // patch_size, resolution override updates PE."""
-        # RFDETRSmallConfig: patch_size=16, num_windows=2, resolution=512, PE=32=512//16.
-        mock_self = _make_rfdetr_self(tmp_path)
-        mock_self.model_config = RFDETRSmallConfig(pretrain_weights=None, num_classes=3, device="cpu")
-        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
-        new_resolution = block_size * 21  # 672 for Small — valid and different from default 512
-        expected_pe = new_resolution // mock_self.model_config.patch_size
-        p_mod, p_dm, p_bt, *_ = patch_lit
-        with p_mod, p_dm, p_bt:
-            RFDETR.train(mock_self, resolution=new_resolution)
-        assert mock_self.model_config.positional_encoding_size == expected_pe
-
-    def test_resolution_kwarg_does_not_reach_get_train_config(self, tmp_path, patch_lit):
-        """resolution kwarg is popped before get_train_config is called."""
-        mock_self = _make_rfdetr_self(tmp_path)
-        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
-        p_mod, p_dm, p_bt, *_ = patch_lit
-        with p_mod, p_dm, p_bt:
-            RFDETR.train(mock_self, resolution=block_size * 10)
-        assert "resolution" not in mock_self.get_train_config.call_args.kwargs
-
-    def test_resolution_indivisible_raises_value_error(self, tmp_path, patch_lit):
-        """resolution not divisible by patch_size * num_windows raises ValueError."""
-        mock_self = _make_rfdetr_self(tmp_path)
-        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
-        indivisible = block_size * 10 + 1  # guaranteed not divisible by block_size
-        p_mod, p_dm, p_bt, *_ = patch_lit
-        with p_mod, p_dm, p_bt, pytest.raises(ValueError, match=f"resolution={indivisible}"):
-            RFDETR.train(mock_self, resolution=indivisible)
-
-    def test_resolution_none_leaves_model_config_unchanged(self, tmp_path, patch_lit):
-        """Omitting resolution leaves model_config.resolution unchanged."""
-        mock_self = _make_rfdetr_self(tmp_path)
-        original_resolution = mock_self.model_config.resolution
-        p_mod, p_dm, p_bt, *_ = patch_lit
-        with p_mod, p_dm, p_bt:
-            RFDETR.train(mock_self)
-        assert mock_self.model_config.resolution == original_resolution
-
-    @pytest.mark.parametrize(
-        "bad_resolution",
-        [
-            pytest.param(0, id="zero"),
-            pytest.param(-56, id="negative"),
-            pytest.param(True, id="bool_true"),
-            pytest.param(False, id="bool_false"),
-            pytest.param(1.5, id="non_integer_float"),
-            pytest.param(560.0, id="whole_number_float"),
-            pytest.param("560", id="string"),
-        ],
-    )
-    def test_resolution_invalid_type_or_value_raises_value_error(self, tmp_path, patch_lit, bad_resolution):
-        """Non-positive, bool, or non-integer resolution raises ValueError before divisibility check."""
-        mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, *_ = patch_lit
-        with p_mod, p_dm, p_bt, pytest.raises(ValueError, match="resolution must be a positive integer"):
-            RFDETR.train(mock_self, resolution=bad_resolution)
-
     def test_returns_none(self, tmp_path, patch_lit):
         """RFDETR.train() returns None."""
         mock_self = _make_rfdetr_self(tmp_path)
@@ -690,6 +609,130 @@ class TestRFDETRTrainPTLAbsorption:
 
         # Training must proceed regardless of the grid-save failure
         mock_bt.return_value.fit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 2b. resolution= kwarg handling
+# ---------------------------------------------------------------------------
+
+
+class TestResolutionKwarg:
+    """RFDETR.train(resolution=...) applies, validates, and syncs the resolution override."""
+
+    def test_updates_model_config_resolution(self, tmp_path, patch_lit):
+        """resolution kwarg is applied to model_config.resolution before training."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
+        valid_resolution = block_size * 11  # guaranteed divisible and different from default
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self, resolution=valid_resolution)
+        assert mock_self.model_config.resolution == valid_resolution
+
+    def test_does_not_implicitly_update_positional_encoding_size(self, tmp_path, patch_lit):
+        """Pretrained-specific PE (RFDETRBase DINOv2=37) is preserved when resolution is overridden."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        # RFDETRBaseConfig: PE=37 (DINOv2 native 518//14), resolution=560, patch_size=14.
+        # PE != resolution // patch_size, so the smart PE guard leaves PE unchanged.
+        original_pe = mock_self.model_config.positional_encoding_size
+        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
+        valid_override_resolution = block_size * 11  # different from default 560
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self, resolution=valid_override_resolution)
+        assert mock_self.model_config.positional_encoding_size == original_pe
+
+    def test_updates_positional_encoding_size_for_formula_derived_config(self, tmp_path, patch_lit):
+        """For configs where PE == resolution // patch_size, resolution override updates PE."""
+        # RFDETRSmallConfig: patch_size=16, num_windows=2, resolution=512, PE=32=512//16.
+        mock_self = _make_rfdetr_self(tmp_path)
+        mock_self.model_config = RFDETRSmallConfig(pretrain_weights=None, num_classes=3, device="cpu")
+        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
+        new_resolution = block_size * 21  # 672 for Small — valid and different from default 512
+        expected_pe = new_resolution // mock_self.model_config.patch_size
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self, resolution=new_resolution)
+        assert mock_self.model_config.positional_encoding_size == expected_pe
+
+    def test_does_not_reach_get_train_config(self, tmp_path, patch_lit):
+        """resolution kwarg is popped before get_train_config is called."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self, resolution=block_size * 10)
+        assert "resolution" not in mock_self.get_train_config.call_args.kwargs
+
+    def test_indivisible_raises_value_error(self, tmp_path, patch_lit):
+        """resolution not divisible by patch_size * num_windows raises ValueError."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
+        indivisible = block_size * 10 + 1  # guaranteed not divisible by block_size
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt, pytest.raises(ValueError, match=f"resolution={indivisible}"):
+            RFDETR.train(mock_self, resolution=indivisible)
+
+    def test_none_leaves_model_config_unchanged(self, tmp_path, patch_lit):
+        """Omitting resolution leaves model_config.resolution unchanged."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        original_resolution = mock_self.model_config.resolution
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self)
+        assert mock_self.model_config.resolution == original_resolution
+
+    @pytest.mark.parametrize(
+        "bad_resolution",
+        [
+            pytest.param(0, id="zero"),
+            pytest.param(-56, id="negative"),
+            pytest.param(True, id="bool_true"),
+            pytest.param(False, id="bool_false"),
+            pytest.param(1.5, id="non_integer_float"),
+            pytest.param(560.0, id="whole_number_float"),
+            pytest.param("560", id="string"),
+        ],
+    )
+    def test_invalid_type_or_value_raises_value_error(self, tmp_path, patch_lit, bad_resolution):
+        """Non-positive, bool, or non-integer resolution raises ValueError before divisibility check."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt, pytest.raises(ValueError, match="resolution must be a positive integer"):
+            RFDETR.train(mock_self, resolution=bad_resolution)
+
+    def test_syncs_model_resolution_attribute(self, tmp_path, patch_lit):
+        """resolution kwarg sets model.resolution so predict()/export() see the new resolution.
+
+        Regression test for #952 — keeps the cached inference/export context in sync after
+        a resolution override in train().
+        """
+        mock_self = _make_rfdetr_self(tmp_path)
+        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
+        new_resolution = block_size * 11
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self, resolution=new_resolution)
+        assert mock_self.model.resolution == new_resolution
+
+    def test_syncs_model_args_resolution_and_pe(self, tmp_path, patch_lit):
+        """resolution kwarg updates model.args.resolution and model.args.positional_encoding_size.
+
+        For formula-derived configs (PE == resolution // patch_size), both fields in model.args
+        must be kept consistent with model_config so export/deployment pipelines use the
+        correct values.  Regression test for #952.
+        """
+        mock_self = _make_rfdetr_self(tmp_path)
+        # RFDETRSmallConfig: formula-derived PE (512 // 16 == 32), so PE updates with resolution.
+        mock_self.model_config = RFDETRSmallConfig(pretrain_weights=None, num_classes=3, device="cpu")
+        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
+        new_resolution = block_size * 21  # 672 for Small — valid, different from default 512
+        expected_pe = new_resolution // mock_self.model_config.patch_size
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self, resolution=new_resolution)
+        assert mock_self.model.args.resolution == new_resolution
+        assert mock_self.model.args.positional_encoding_size == expected_pe
 
 
 # ---------------------------------------------------------------------------

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -8,7 +8,7 @@
 
 1. ``TestRFDETRTrainPTL``           — RFDETR.train() delegates to PTL build_trainer().fit()
 2. ``TestRFDETRTrainPTLAbsorption`` — Legacy kwargs absorbed by RFDETR.train()
-2b.``TestResolutionKwarg``          — resolution= kwarg validation, sync, and PE update
+2b. ``TestResolutionKwarg``         — resolution= kwarg validation, sync, and PE update
 3. ``TestConvertLegacyCheckpoint``  — convert_legacy_checkpoint() round-trip
 4. ``TestOnLoadCheckpoint``         — RFDETRModule.on_load_checkpoint() auto-detect
 5. ``TestPublicAPIExports``         — rfdetr.__init__ exports RFDETRModule/DataModule/build_trainer

--- a/tests/training/test_trainer_smoke.py
+++ b/tests/training/test_trainer_smoke.py
@@ -302,6 +302,74 @@ class _DDPModule(RFDETRModelModule):
         return torch.optim.AdamW(self.parameters(), lr=1e-4)
 
 
+class _MultiScaleCheckDDPModule(RFDETRModelModule):
+    """DDP-safe module that asserts on_train_batch_start mutation reaches training_step.
+
+    With multi_scale=True and _FakeDataset's 32×32 images, on_train_batch_start
+    interpolates samples.tensors to a multi-scale resolution (≥392 for
+    RFDETRBaseConfig resolution=560).  This module raises AssertionError in
+    training_step if the tensor height is still 32, meaning the in-place
+    NestedTensor mutation did not propagate through the PTL batch-hook chain.
+
+    Must be defined at module level so pickle can look up the class by qualified
+    name when ddp_spawn deserialises it in the child process.
+
+    Regression guard for issue #952.
+    """
+
+    def configure_optimizers(self):
+        """Minimal single-group AdamW — bypasses get_param_dict."""
+        return torch.optim.AdamW(self.parameters(), lr=1e-4)
+
+    def training_step(self, batch, batch_idx):
+        """Assert resize from on_train_batch_start propagated before calling super."""
+        samples, _ = batch
+        h = samples.tensors.shape[2]
+        if h == 32:
+            raise AssertionError(
+                f"training_step received images at original 32-px height (h={h}). "
+                "on_train_batch_start's in-place NestedTensor mutation did not "
+                "propagate through the PTL hook chain. "
+                "Regression of issue #952: resize bypass in DDP batch-hook chain."
+            )
+        return super().training_step(batch, batch_idx)
+
+
+# ---------------------------------------------------------------------------
+# Multi-scale hook propagation tests (issue #952 regression)
+# ---------------------------------------------------------------------------
+
+
+class TestMultiScaleHookPropagation:
+    """on_train_batch_start resize must propagate to training_step via NestedTensor mutation.
+
+    _FakeDataset emits 32×32 images.  With multi_scale=True and
+    RFDETRBaseConfig(resolution=560, patch_size=14, num_windows=4) the computed
+    scales start at 392, so none equal 32.  _MultiScaleCheckDDPModule raises
+    AssertionError in training_step if h==32, making trainer.fit() fail when
+    the in-place mutation does not propagate.
+    """
+
+    def test_mutation_persists_to_training_step(self, base_model_config, base_train_config):
+        """Single-process: training_step must see resized tensors, not original 32×32."""
+        mc = base_model_config()
+        tc = base_train_config(multi_scale=True, use_ema=False, run_test=False)
+        fake_dataset = _FakeDataset(length=20)
+
+        with (
+            patch("rfdetr.training.module_model.build_model_from_config", return_value=_TinyModel()),
+            patch(
+                "rfdetr.training.module_model.build_criterion_from_config",
+                return_value=(_FakeCriterion(), _FakePostProcess()),
+            ),
+            patch("rfdetr.training.module_data.build_dataset", return_value=fake_dataset),
+        ):
+            module = _MultiScaleCheckDDPModule(mc, tc)
+            datamodule = RFDETRDataModule(mc, tc)
+            trainer = build_trainer(tc, mc, accelerator="cpu", fast_dev_run=2)
+            trainer.fit(module, datamodule=datamodule)
+
+
 # Windows CI currently cannot run this smoke test because gloo DDP spawn fails
 # with makeDeviceForHostname unsupported-device errors.
 @pytest.mark.skipif(sys.platform == "win32", reason="gloo DDP spawn unsupported on Windows CI")
@@ -326,6 +394,42 @@ def test_ddp_spawn_fit_runs_without_error(base_model_config, base_train_config):
         ),
     ):
         module = _DDPModule(mc, tc)
+
+    datamodule = RFDETRDataModule(mc, tc)
+    # Pre-set datasets: build_dataset mock doesn't survive the spawn boundary.
+    datamodule._dataset_train = fake_dataset
+    datamodule._dataset_val = fake_dataset
+
+    trainer = build_trainer(tc, mc, accelerator="cpu", fast_dev_run=2)
+    trainer.fit(module, datamodule=datamodule)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="gloo DDP spawn unsupported on Windows CI")
+def test_ddp_spawn_multi_scale_mutation_propagates(base_model_config, base_train_config):
+    """ddp_spawn with multi_scale=True must propagate on_train_batch_start resize to training_step.
+
+    _MultiScaleCheckDDPModule raises AssertionError in training_step when the
+    NestedTensor height is still 32 (original _FakeDataset size).  If trainer.fit()
+    completes without error the PTL batch-hook reference chain is intact in DDP,
+    i.e. the in-place mutation in on_train_batch_start is visible in training_step
+    on both workers.
+
+    Regression test for issue #952 on CPU DDP (non-Windows): confirms the
+    transforms/resize propagation is not a Windows-only concern.
+    """
+    mc = base_model_config()
+    tc = base_train_config(multi_scale=True, use_ema=False, run_test=False, devices=2, strategy="ddp_spawn")
+
+    fake_dataset = _FakeDataset(length=20)
+
+    with (
+        patch("rfdetr.training.module_model.build_model_from_config", return_value=_TinyModel()),
+        patch(
+            "rfdetr.training.module_model.build_criterion_from_config",
+            return_value=(_FakeCriterion(), _FakePostProcess()),
+        ),
+    ):
+        module = _MultiScaleCheckDDPModule(mc, tc)
 
     datamodule = RFDETRDataModule(mc, tc)
     # Pre-set datasets: build_dataset mock doesn't survive the spawn boundary.


### PR DESCRIPTION
This pull request adds comprehensive regression tests for the `resolution` keyword argument handling in `RFDETR.train()` and introduces tests to ensure that multi-scale image resizing propagates correctly through PyTorch Lightning's DDP (Distributed Data Parallel) training hooks. These tests address and guard against regressions for issue #952, which involved synchronization and mutation propagation bugs in model training and export workflows.

The most important changes are:

**Resolution kwarg handling and validation [[1]](diffhunk://#diff-6b1d80c3cb1bad19362f3974e085ec0eec262356a56dfbac555707b8b0cc0cb8R11) [[2]](diffhunk://#diff-6b1d80c3cb1bad19362f3974e085ec0eec262356a56dfbac555707b8b0cc0cb8L530-L611) [[3]](diffhunk://#diff-6b1d80c3cb1bad19362f3974e085ec0eec262356a56dfbac555707b8b0cc0cb8R614-R737):**
* Refactors and expands tests for `resolution` handling into a dedicated `TestResolutionKwarg` class, covering validation, divisibility, type checking, and synchronization of the resolution and positional encoding fields across model, model_config, and model.args.
* Ensures that invalid values (non-integer, non-positive, bool, or indivisible resolutions) raise appropriate `ValueError`s, and that the `resolution` kwarg does not leak into downstream config methods.
* Adds regression tests to verify that overriding `resolution` keeps all relevant fields in sync, preventing inference/export mismatches after training.

**Multi-scale DDP hook propagation regression tests [[1]](diffhunk://#diff-07131f05a0bc9988dc66d7fac6acbf77bf4fbd2ed56946d7510f63ea89f55898R305-R372) [[2]](diffhunk://#diff-07131f05a0bc9988dc66d7fac6acbf77bf4fbd2ed56946d7510f63ea89f55898R405-R440):**
* Introduces `_MultiScaleCheckDDPModule`, a test module that asserts the `on_train_batch_start` resize propagates to `training_step`, raising if the mutation is lost.
* Adds single-process and DDP (including `ddp_spawn`) tests to ensure that the in-place batch mutation for multi-scale training is visible in `training_step`, guarding against regressions in the PTL batch-hook chain (issue #952). [[1]](diffhunk://#diff-07131f05a0bc9988dc66d7fac6acbf77bf4fbd2ed56946d7510f63ea89f55898R305-R372) [[2]](diffhunk://#diff-07131f05a0bc9988dc66d7fac6acbf77bf4fbd2ed56946d7510f63ea89f55898R405-R440)

These changes significantly strengthen regression coverage for model configuration overrides and distributed training edge cases.

---

adding more tests for #930