### PR TITLE
fix: interpolate PE in `load_pretrain_weights` for custom resolution

### DIFF
--- a/src/rfdetr/models/weights.py
+++ b/src/rfdetr/models/weights.py
@@ -42,9 +42,9 @@ _PE_KEY_SUFFIX = "embeddings.position_embeddings"
 
 def _interpolate_position_embeddings(
     checkpoint_state: dict,
-    model_config: ModelConfig,
+    pe_size: int,
 ) -> None:
-    """Interpolate DINOv2 positional embeddings in *checkpoint_state* to match *model_config*.
+    """Interpolate DINOv2 positional embeddings in *checkpoint_state* to match *pe_size*.
 
     When the model is configured with a custom ``resolution`` that differs from the
     checkpoint's training resolution, the DINOv2 backbone's ``position_embeddings``
@@ -52,16 +52,15 @@ def _interpolate_position_embeddings(
     skip shape mismatches on matching keys — it raises ``RuntimeError``.
 
     This function bicubic-interpolates every PE tensor in the checkpoint whose shape
-    differs from the target grid derived from ``model_config.positional_encoding_size``,
-    modifying *checkpoint_state* in-place before ``load_state_dict`` is called.
+    differs from the target grid, modifying *checkpoint_state* in-place before
+    ``load_state_dict`` is called.
 
     Args:
         checkpoint_state: The ``"model"`` sub-dict from a loaded checkpoint.
-        model_config: The model configuration used to derive the target PE size.
-            ``model_config.positional_encoding_size`` gives the target grid side length
-            (number of patches per spatial dimension, assuming a square grid).
+        pe_size: Target grid side length in patches (number of patches per spatial
+            dimension, assuming a square grid).  Typically
+            ``model_config.positional_encoding_size``.
     """
-    pe_size = model_config.positional_encoding_size
     n_target = pe_size * pe_size  # target number of patch tokens
 
     pe_keys = [k for k in checkpoint_state if k.endswith(_PE_KEY_SUFFIX)]
@@ -75,10 +74,8 @@ def _interpolate_position_embeddings(
         h_tgt = int(math.isqrt(n_target))
         if h_src * h_src != n_source or h_tgt * h_tgt != n_target:
             logger.warning(
-                "Skipping PE interpolation for %s: grid size is not a perfect square (source %d, target %d).",
-                key,
-                n_source,
-                n_target,
+                f"Skipping PE interpolation for {key}:"
+                f" grid size is not a perfect square (source {n_source}, target {n_target}).",
             )
             continue
 
@@ -262,7 +259,7 @@ def load_pretrain_weights(
         if any(name.endswith(x) for x in query_param_names):
             checkpoint["model"][name] = checkpoint["model"][name][:num_desired_queries]
 
-    _interpolate_position_embeddings(checkpoint["model"], mc)
+    _interpolate_position_embeddings(checkpoint["model"], mc.positional_encoding_size)
     nn_model.load_state_dict(checkpoint["model"], strict=False)
 
     # If the user explicitly set a class count larger than the checkpoint,

--- a/src/rfdetr/models/weights.py
+++ b/src/rfdetr/models/weights.py
@@ -19,11 +19,13 @@ extraction from ``detr.py:_load_pretrain_weights_into``.
 from __future__ import annotations
 
 import functools
+import math
 import os
 import warnings
 from typing import List
 
 import torch
+import torch.nn.functional as F  # noqa: N812
 
 from rfdetr.assets.model_weights import download_pretrain_weights, validate_pretrain_weights
 from rfdetr.config import ModelConfig, TrainConfig
@@ -34,6 +36,73 @@ from rfdetr.utilities.state_dict import _ckpt_args_get, validate_checkpoint_comp
 logger = get_logger()
 
 __all__ = ["load_pretrain_weights", "apply_lora"]
+
+_PE_KEY_SUFFIX = "embeddings.position_embeddings"
+
+
+def _interpolate_position_embeddings(
+    checkpoint_state: dict,
+    model_config: ModelConfig,
+) -> None:
+    """Interpolate DINOv2 positional embeddings in *checkpoint_state* to match *model_config*.
+
+    When the model is configured with a custom ``resolution`` that differs from the
+    checkpoint's training resolution, the DINOv2 backbone's ``position_embeddings``
+    parameter has an incompatible shape.  ``load_state_dict(strict=False)`` does **not**
+    skip shape mismatches on matching keys — it raises ``RuntimeError``.
+
+    This function bicubic-interpolates every PE tensor in the checkpoint whose shape
+    differs from the target grid derived from ``model_config.positional_encoding_size``,
+    modifying *checkpoint_state* in-place before ``load_state_dict`` is called.
+
+    Args:
+        checkpoint_state: The ``"model"`` sub-dict from a loaded checkpoint.
+        model_config: The model configuration used to derive the target PE size.
+            ``model_config.positional_encoding_size`` gives the target grid side length
+            (number of patches per spatial dimension, assuming a square grid).
+    """
+    pe_size = model_config.positional_encoding_size
+    n_target = pe_size * pe_size  # target number of patch tokens
+
+    pe_keys = [k for k in checkpoint_state if k.endswith(_PE_KEY_SUFFIX)]
+    for key in pe_keys:
+        ckpt_pe = checkpoint_state[key]  # [1, N_src+1, dim]
+        n_source = ckpt_pe.shape[1] - 1  # exclude class token
+        if n_source == n_target:
+            continue  # no mismatch — skip
+
+        h_src = int(math.isqrt(n_source))
+        h_tgt = int(math.isqrt(n_target))
+        if h_src * h_src != n_source or h_tgt * h_tgt != n_target:
+            logger.warning(
+                "Skipping PE interpolation for %s: grid size is not a perfect square (source %d, target %d).",
+                key,
+                n_source,
+                n_target,
+            )
+            continue
+
+        dim = ckpt_pe.shape[-1]
+        class_token = ckpt_pe[:, 0]  # [1, dim]
+        patch_pe = ckpt_pe[:, 1:]  # [1, N_src, dim]
+
+        patch_pe = patch_pe.reshape(1, h_src, h_src, dim).permute(0, 3, 1, 2)  # [1, dim, H, W]
+        patch_pe = F.interpolate(
+            patch_pe.float(),
+            size=(h_tgt, h_tgt),
+            mode="bicubic",
+            align_corners=False,
+            antialias=patch_pe.device.type != "mps",
+        ).to(ckpt_pe.dtype)
+        patch_pe = patch_pe.permute(0, 2, 3, 1).reshape(1, n_target, dim)  # [1, N_tgt, dim]
+
+        checkpoint_state[key] = torch.cat([class_token.unsqueeze(0), patch_pe], dim=1)
+        logger.debug(
+            "Interpolated positional embeddings %s: %s → %s.",
+            key,
+            tuple(ckpt_pe.shape),
+            tuple(checkpoint_state[key].shape),
+        )
 
 
 @deprecated(
@@ -193,6 +262,7 @@ def load_pretrain_weights(
         if any(name.endswith(x) for x in query_param_names):
             checkpoint["model"][name] = checkpoint["model"][name][:num_desired_queries]
 
+    _interpolate_position_embeddings(checkpoint["model"], mc)
     nn_model.load_state_dict(checkpoint["model"], strict=False)
 
     # If the user explicitly set a class count larger than the checkpoint,

--- a/src/rfdetr/models/weights.py
+++ b/src/rfdetr/models/weights.py
@@ -83,7 +83,7 @@ def _interpolate_position_embeddings(
             continue
 
         dim = ckpt_pe.shape[-1]
-        class_token = ckpt_pe[:, 0]  # [1, dim]
+        class_token = ckpt_pe[:, :1]  # [1, 1, dim] — keeps the sequence dimension
         patch_pe = ckpt_pe[:, 1:]  # [1, N_src, dim]
 
         patch_pe = patch_pe.reshape(1, h_src, h_src, dim).permute(0, 3, 1, 2)  # [1, dim, H, W]
@@ -96,7 +96,7 @@ def _interpolate_position_embeddings(
         ).to(ckpt_pe.dtype)
         patch_pe = patch_pe.permute(0, 2, 3, 1).reshape(1, n_target, dim)  # [1, N_tgt, dim]
 
-        checkpoint_state[key] = torch.cat([class_token.unsqueeze(0), patch_pe], dim=1)
+        checkpoint_state[key] = torch.cat([class_token, patch_pe], dim=1)
         logger.debug(
             "Interpolated positional embeddings %s: %s → %s.",
             key,

--- a/src/rfdetr/variants.py
+++ b/src/rfdetr/variants.py
@@ -144,7 +144,11 @@ class RFDETRLarge(RFDETR):
         # When the user explicitly sets a custom resolution, a PE size mismatch
         # is caused by the resolution change — not by deprecated weights.  Guard
         # against the fallback heuristic misclassifying it as deprecated weights.
-        _custom_resolution = "resolution" in kwargs
+        # Only suppress the fallback when the provided resolution genuinely differs
+        # from the class default; passing resolution=<default> explicitly (e.g. from
+        # a serialised config round-trip) must still allow the deprecated-weights retry.
+        _default_resolution = RFDETRLargeConfig.model_fields["resolution"].default
+        _custom_resolution = "resolution" in kwargs and kwargs.get("resolution") != _default_resolution
         try:
             super().__init__(**kwargs)
         except (ValueError, RuntimeError) as exc:

--- a/src/rfdetr/variants.py
+++ b/src/rfdetr/variants.py
@@ -141,10 +141,14 @@ class RFDETRLarge(RFDETR):
     def __init__(self, **kwargs):
         self.init_error = None
         self.is_deprecated = False
+        # When the user explicitly sets a custom resolution, a PE size mismatch
+        # is caused by the resolution change — not by deprecated weights.  Guard
+        # against the fallback heuristic misclassifying it as deprecated weights.
+        _custom_resolution = "resolution" in kwargs
         try:
             super().__init__(**kwargs)
         except (ValueError, RuntimeError) as exc:
-            if not self._should_fallback_to_deprecated_config(exc):
+            if _custom_resolution or not self._should_fallback_to_deprecated_config(exc):
                 raise
             self.init_error = exc
             self.is_deprecated = True

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -1259,6 +1259,36 @@ class TestRFDETRLargeFallback:
         assert call_count == 2
         warn_spy.assert_called_once()
 
+    def test_pe_size_mismatch_with_custom_resolution_does_not_retry(self, monkeypatch, patch_lit):
+        """Custom resolution= must not trigger deprecated-config fallback on PE size mismatch.
+
+        Regression for #960: when ``resolution=`` is explicitly passed, a positional
+        embedding size mismatch is caused by the resolution change — not by deprecated
+        weights.  The fallback must be suppressed so the error surfaces to the caller
+        rather than silently loading the wrong model architecture.
+        """
+        call_count = 0
+
+        def _raise_pe_mismatch(self, **kwargs):
+            del self
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError(
+                "Error(s) in loading state_dict for LWDETR:\n\t"
+                "size mismatch for backbone.0.encoder.encoder.embeddings.position_embeddings: "
+                "copying a param with shape torch.Size([1, 577, 384]) from checkpoint, "
+                "the shape in current model is torch.Size([1, 1601, 384])."
+            )
+
+        monkeypatch.setattr(RFDETR, "__init__", _raise_pe_mismatch)
+
+        with pytest.raises(RuntimeError, match="size mismatch"):
+            RFDETRLarge(resolution=640)
+
+        assert call_count == 1, (
+            f"Expected no deprecated-config retry when resolution= is set, but __init__ was called {call_count} times."
+        )
+
 
 # ---------------------------------------------------------------------------
 # 7. _load_pretrain_weights_into — detr.py path (the non-PTL scenario from #806)

--- a/tests/training/test_load_pretrain_weights.py
+++ b/tests/training/test_load_pretrain_weights.py
@@ -368,6 +368,36 @@ class TestLoadPretrainWeightsPEInterpolation:
             "BaseConfig's non-formula-derived PE must be the interpolation target."
         )
 
+    def test_non_square_source_pe_logs_warning_and_is_not_modified(self, monkeypatch):
+        """Non-square source PE grids are skipped with a warning and left unchanged.
+
+        When ``n_source`` is not a perfect square the interpolation is skipped to
+        avoid producing malformed embeddings.  The tensor must remain untouched and
+        a warning must be emitted via the weights module logger.
+        """
+        mc = RFDETRNanoConfig(pretrain_weights="/fake/weights.pth", device="cpu")
+        # positional_encoding_size=24 → n_target=576 (perfect square, so the
+        # target-side guard does not trigger; only the source-side guard fires)
+
+        dim = 384
+        # 17 is not a perfect square: isqrt(17)=4, 4*4=16 ≠ 17
+        non_square_n_source = 17
+        original_pe = torch.randn(1, non_square_n_source + 1, dim)
+        checkpoint = _make_checkpoint(num_classes=91)
+        checkpoint["model"][PE_KEY] = original_pe.clone()
+
+        warning_calls: list[tuple] = []
+        monkeypatch.setattr("rfdetr.models.weights.logger.warning", lambda *a, **kw: warning_calls.append(a))
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
+        fake_model = MagicMock()
+        load_pretrain_weights(fake_model, mc)
+
+        pe = checkpoint["model"][PE_KEY]
+        assert torch.equal(pe, original_pe), "Non-square source PE must not be modified."
+        assert any("not a perfect square" in str(args) for args in warning_calls), (
+            f"Expected a 'not a perfect square' warning; got calls: {warning_calls}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Deprecation: train_config argument

--- a/tests/training/test_load_pretrain_weights.py
+++ b/tests/training/test_load_pretrain_weights.py
@@ -339,6 +339,34 @@ class TestLoadPretrainWeightsPEInterpolation:
         assert pe.shape == torch.Size([1, 577, dim]), "Matching PE shape must not be modified."
         assert torch.equal(pe, original_pe), "Matching PE tensor values must not be modified."
 
+    def test_base_config_non_formula_pe_is_interpolated_from_smaller_checkpoint(self, monkeypatch):
+        """RFDETRBaseConfig PE=37 (not formula-derived) is interpolated when checkpoint differs.
+
+        RFDETRBaseConfig.positional_encoding_size=37 is not updated by
+        ``_sync_pe_with_resolution`` because 37 ≠ 560//16=35 (not formula-derived).
+        Loading a checkpoint with a smaller PE grid (e.g., 24×24) must still
+        trigger interpolation to the model's fixed PE=37×37 target.
+        """
+        mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu")
+        assert mc.positional_encoding_size == 37, "RFDETRBaseConfig PE must remain 37 (not formula-derived)"
+
+        dim = 384
+        src_pe_size = 24
+        src_n = src_pe_size * src_pe_size + 1
+        checkpoint = _make_checkpoint(num_classes=91)
+        checkpoint["model"][PE_KEY] = torch.randn(1, src_n, dim)
+
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
+        fake_model = MagicMock()
+        load_pretrain_weights(fake_model, mc)
+
+        pe = checkpoint["model"][PE_KEY]
+        expected_n = 37 * 37 + 1
+        assert pe.shape == torch.Size([1, expected_n, dim]), (
+            f"Expected PE shape [1, {expected_n}, {dim}] (37×37 grid), got {tuple(pe.shape)}. "
+            "BaseConfig's non-formula-derived PE must be the interpolation target."
+        )
+
 
 # ---------------------------------------------------------------------------
 # Deprecation: train_config argument

--- a/tests/training/test_load_pretrain_weights.py
+++ b/tests/training/test_load_pretrain_weights.py
@@ -337,6 +337,7 @@ class TestLoadPretrainWeightsPEInterpolation:
 
         pe = checkpoint["model"][PE_KEY]
         assert pe.shape == torch.Size([1, 577, dim]), "Matching PE shape must not be modified."
+        assert torch.equal(pe, original_pe), "Matching PE tensor values must not be modified."
 
 
 # ---------------------------------------------------------------------------

--- a/tests/training/test_load_pretrain_weights.py
+++ b/tests/training/test_load_pretrain_weights.py
@@ -252,6 +252,94 @@ class TestLoadPretrainWeightsSecondReinit:
 
 
 # ---------------------------------------------------------------------------
+# Regression #960: PE interpolation for custom resolution
+# ---------------------------------------------------------------------------
+
+PE_KEY = "backbone.0.encoder.encoder.embeddings.position_embeddings"
+
+
+class TestLoadPretrainWeightsPEInterpolation:
+    """Regression tests for #960 — PE must be interpolated when resolution changes.
+
+    ``load_pretrain_weights`` must bicubic-interpolate the checkpoint's DINOv2
+    positional embeddings to match the model's ``positional_encoding_size`` before
+    calling ``load_state_dict``.  Without this, any custom ``resolution`` that
+    changes the PE grid size causes a ``RuntimeError: size mismatch``.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _patch_download(self, monkeypatch):
+        """Suppress all download and file-existence side effects."""
+        monkeypatch.setattr("rfdetr.models.weights.download_pretrain_weights", lambda *a, **kw: None)
+        monkeypatch.setattr("rfdetr.models.weights.validate_pretrain_weights", lambda *a, **kw: None)
+        monkeypatch.setattr("rfdetr.models.weights.validate_checkpoint_compatibility", lambda *a, **kw: None)
+        monkeypatch.setattr("rfdetr.models.weights.os.path.isfile", lambda _: True)
+
+    @pytest.mark.parametrize(
+        "src_pe_size, tgt_resolution, patch_size, expected_tgt_pe_size",
+        [
+            pytest.param(24, 640, 16, 40, id="nano_24x24_upscale_to_40x40"),
+            pytest.param(40, 384, 16, 24, id="nano_40x40_downscale_to_24x24"),
+            pytest.param(32, 640, 16, 40, id="small_32x32_upscale_to_40x40"),
+        ],
+    )
+    def test_pe_in_checkpoint_is_interpolated_to_model_resolution(
+        self, monkeypatch, src_pe_size, tgt_resolution, patch_size, expected_tgt_pe_size
+    ):
+        """Checkpoint PE is bicubic-interpolated to match model_config.positional_encoding_size.
+
+        Regression for #960: ``load_pretrain_weights`` must not raise ``RuntimeError``
+        when model resolution differs from checkpoint resolution.  The PE tensor in the
+        checkpoint must be resized in-place before ``load_state_dict`` is called.
+        """
+        mc = RFDETRNanoConfig(
+            pretrain_weights="/fake/weights.pth",
+            device="cpu",
+            resolution=tgt_resolution,
+            patch_size=patch_size,
+        )
+        assert mc.positional_encoding_size == tgt_resolution // patch_size
+
+        dim = 384
+        src_n = src_pe_size * src_pe_size + 1  # patches + class token
+        checkpoint = _make_checkpoint(num_classes=91)
+        checkpoint["model"][PE_KEY] = torch.randn(1, src_n, dim)
+
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
+        fake_model = MagicMock()
+        load_pretrain_weights(fake_model, mc)
+
+        pe = checkpoint["model"][PE_KEY]
+        expected_n = expected_tgt_pe_size * expected_tgt_pe_size + 1
+        assert pe.shape == torch.Size([1, expected_n, dim]), (
+            f"Expected PE shape [1, {expected_n}, {dim}], got {tuple(pe.shape)}. "
+            f"PE was not interpolated from {src_pe_size}x{src_pe_size} "
+            f"to {expected_tgt_pe_size}x{expected_tgt_pe_size}."
+        )
+
+    def test_matching_pe_shape_is_not_modified(self, monkeypatch):
+        """When checkpoint PE matches model expectations, the tensor is not changed.
+
+        Ensures PE interpolation is a no-op for same-resolution checkpoints so that
+        normal weight loading is unaffected.
+        """
+        mc = RFDETRNanoConfig(pretrain_weights="/fake/weights.pth", device="cpu")
+        # Default: positional_encoding_size=24 → PE = [1, 24*24+1, 384] = [1, 577, 384]
+
+        dim = 384
+        original_pe = torch.randn(1, 577, dim)
+        checkpoint = _make_checkpoint(num_classes=91)
+        checkpoint["model"][PE_KEY] = original_pe.clone()
+
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
+        fake_model = MagicMock()
+        load_pretrain_weights(fake_model, mc)
+
+        pe = checkpoint["model"][PE_KEY]
+        assert pe.shape == torch.Size([1, 577, dim]), "Matching PE shape must not be modified."
+
+
+# ---------------------------------------------------------------------------
 # Deprecation: train_config argument
 # ---------------------------------------------------------------------------
 

--- a/tests/training/test_load_pretrain_weights.py
+++ b/tests/training/test_load_pretrain_weights.py
@@ -303,7 +303,7 @@ class TestLoadPretrainWeightsPEInterpolation:
         dim = 384
         src_n = src_pe_size * src_pe_size + 1  # patches + class token
         checkpoint = _make_checkpoint(num_classes=91)
-        checkpoint["model"][PE_KEY] = torch.randn(1, src_n, dim)
+        checkpoint["model"][PE_KEY] = torch.randn(1, src_n, dim).half()  # float16 to verify dtype round-trip
 
         monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
         fake_model = MagicMock()
@@ -316,6 +316,7 @@ class TestLoadPretrainWeightsPEInterpolation:
             f"PE was not interpolated from {src_pe_size}x{src_pe_size} "
             f"to {expected_tgt_pe_size}x{expected_tgt_pe_size}."
         )
+        assert pe.dtype == torch.float16, f"Dtype must be preserved after interpolation, got {pe.dtype}"
 
     def test_matching_pe_shape_is_not_modified(self, monkeypatch):
         """When checkpoint PE matches model expectations, the tensor is not changed.


### PR DESCRIPTION
This pull request introduces robust support for custom input resolutions in the DINOv2 backbone by automatically resizing (interpolating) positional embeddings from pre-trained checkpoints to match the model's configured resolution. It also ensures that errors caused by explicit custom resolutions are not mistakenly attributed to deprecated weights, and adds comprehensive regression tests for these behaviors.

**Automatic positional embedding interpolation for custom resolutions:**

* Added `_interpolate_position_embeddings` to `weights.py`, which bicubic-interpolates positional embeddings from the checkpoint to match the model's configured grid size, preventing shape mismatch errors when loading weights with custom `resolution` settings.
* Integrated the new interpolation logic into `load_pretrain_weights`, ensuring all checkpoint loads correctly adapt positional embeddings before calling `load_state_dict`.

**Deprecation fallback improvements:**

* Updated the fallback logic in the model variant loader to avoid retrying with deprecated weights when a custom `resolution` is explicitly set, ensuring that genuine shape mismatches are surfaced as errors rather than being silently handled.

**Regression and unit tests:**

* Added targeted regression tests in `test_load_pretrain_weights.py` to verify that positional embeddings are interpolated correctly for various source and target resolutions, and that no modification occurs when the shapes already match.
* Added a regression test in `test_detr_shim.py` to ensure that specifying a custom resolution does not trigger the deprecated-config fallback on positional embedding size mismatches.

**Imports and dependencies:**

* Added necessary imports (`math`, `torch.nn.functional as F`) to support the new interpolation logic in `weights.py`.

---

Fixes #960