### PR TITLE
fix: infer `patch_size` from projection weight in `validate_checkpoint_compatibility`

### DIFF
--- a/src/rfdetr/utilities/state_dict.py
+++ b/src/rfdetr/utilities/state_dict.py
@@ -255,6 +255,26 @@ def validate_checkpoint_compatibility(checkpoint: dict[str, Any], model_args: An
                     ckpt_num_classes - 1,
                 )
 
+    # Infer patch_size from the patch-embedding projection weight when the checkpoint
+    # has no "args" key (e.g., COCO pretrained release weights that only store "model").
+    # Conv2d projection shape is [out_channels, in_channels, kernel_h, kernel_w];
+    # kernel_h == patch_size for square kernels.  Raises before load_state_dict fires,
+    # replacing the otherwise-cryptic "size mismatch" RuntimeError. Regression: #965.
+    # NOTE: key path is DINOv2-specific; non-DINOv2 backbones simply won't have this key
+    # and the check is silently skipped, preserving backward compatibility.
+    _patch_proj_key = "backbone.0.encoder.encoder.embeddings.patch_embeddings.projection.weight"
+    _ckpt_proj_w = checkpoint.get("model", {}).get(_patch_proj_key)
+    if _ckpt_proj_w is not None and _ckpt_proj_w.shape[2] == _ckpt_proj_w.shape[3]:
+        _inferred_ps = int(_ckpt_proj_w.shape[-1])
+        _model_ps: int | None = getattr(model_args, "patch_size", None)
+        if _model_ps is not None and _inferred_ps != _model_ps:
+            raise ValueError(
+                f"The checkpoint was trained with patch_size={_inferred_ps}, but the current model uses "
+                f"patch_size={_model_ps}. The checkpoint is incompatible with this model architecture. "
+                "To resolve this, either instantiate/configure the model with the checkpoint's patch_size or "
+                "use a checkpoint that was trained with the same patch_size as the current model."
+            )
+
     if "args" not in checkpoint:
         return
 

--- a/src/rfdetr/utilities/state_dict.py
+++ b/src/rfdetr/utilities/state_dict.py
@@ -27,6 +27,24 @@ _PTL_COMPAT_KEYS = (
 )
 
 
+def _raise_patch_size_mismatch(ckpt_patch_size: int, model_patch_size: int) -> None:
+    """Raise a descriptive ValueError for a patch_size incompatibility.
+
+    Args:
+        ckpt_patch_size: patch_size recorded in (or inferred from) the checkpoint.
+        model_patch_size: patch_size the current model is configured with.
+
+    Raises:
+        ValueError: Always — describes the mismatch and how to resolve it.
+    """
+    raise ValueError(
+        f"The checkpoint was trained with patch_size={ckpt_patch_size}, but the current model uses "
+        f"patch_size={model_patch_size}. The checkpoint is incompatible with this model architecture. "
+        "To resolve this, either instantiate/configure the model with the checkpoint's patch_size or "
+        "use a checkpoint that was trained with the same patch_size as the current model."
+    )
+
+
 def _ckpt_args_get(args: Any, field: str, default: Any = None) -> Any:
     """Get a field from checkpoint ``"args"``, handling both dict and attribute access.
 
@@ -287,12 +305,7 @@ def validate_checkpoint_compatibility(checkpoint: dict[str, Any], model_args: An
             _inferred_ps = int(_ckpt_proj_shape[-1])
             _model_ps: int | None = getattr(model_args, "patch_size", None)
             if _model_ps is not None and _inferred_ps != _model_ps:
-                raise ValueError(
-                    f"The checkpoint was trained with patch_size={_inferred_ps}, but the current model uses "
-                    f"patch_size={_model_ps}. The checkpoint is incompatible with this model architecture. "
-                    "To resolve this, either instantiate/configure the model with the checkpoint's patch_size or "
-                    "use a checkpoint that was trained with the same patch_size as the current model."
-                )
+                _raise_patch_size_mismatch(_inferred_ps, _model_ps)
     if "args" not in checkpoint:
         return
 
@@ -319,9 +332,4 @@ def validate_checkpoint_compatibility(checkpoint: dict[str, Any], model_args: An
     ckpt_patch_size: int | None = _ckpt_args_get(ckpt_args, "patch_size")
     model_patch_size: int | None = getattr(model_args, "patch_size", None)
     if ckpt_patch_size is not None and model_patch_size is not None and ckpt_patch_size != model_patch_size:
-        raise ValueError(
-            f"The checkpoint was trained with patch_size={ckpt_patch_size}, but the current model uses "
-            f"patch_size={model_patch_size}. The checkpoint is incompatible with this model architecture. "
-            "To resolve this, either instantiate/configure the model with the checkpoint's patch_size or "
-            "use a checkpoint that was trained with the same patch_size as the current model."
-        )
+        _raise_patch_size_mismatch(ckpt_patch_size, model_patch_size)

--- a/src/rfdetr/utilities/state_dict.py
+++ b/src/rfdetr/utilities/state_dict.py
@@ -283,7 +283,7 @@ def validate_checkpoint_compatibility(checkpoint: dict[str, Any], model_args: An
         _patch_proj_key = "backbone.0.encoder.encoder.embeddings.patch_embeddings.projection.weight"
         _ckpt_proj_w = checkpoint.get("model", {}).get(_patch_proj_key)
         _ckpt_proj_shape = getattr(_ckpt_proj_w, "shape", None)
-        if _ckpt_proj_shape is not None and len(_ckpt_proj_shape) >= 4 and _ckpt_proj_shape[2] == _ckpt_proj_shape[3]:
+        if _ckpt_proj_shape is not None and len(_ckpt_proj_shape) == 4 and _ckpt_proj_shape[2] == _ckpt_proj_shape[3]:
             _inferred_ps = int(_ckpt_proj_shape[-1])
             _model_ps: int | None = getattr(model_args, "patch_size", None)
             if _model_ps is not None and _inferred_ps != _model_ps:

--- a/src/rfdetr/utilities/state_dict.py
+++ b/src/rfdetr/utilities/state_dict.py
@@ -208,14 +208,25 @@ def validate_checkpoint_compatibility(checkpoint: dict[str, Any], model_args: An
 
     Raises:
         ValueError: If ``segmentation_head`` or ``patch_size`` in the checkpoint
-            args do not match those of the model.
+            args do not match those of the model, or if the ``patch_size`` inferred
+            from the DINOv2 projection weight shape differs from
+            ``model_args.patch_size`` when no explicit ``args.patch_size`` is present.
 
     Note:
         This helper does not mutate ``model_args``. It emits ``logger.warning``
         (not an exception) for class-count mismatches so that callers can still
         proceed with reinitialization or weight loading.
 
-        Two scenarios are distinguished:
+        When ``"args"`` is absent or ``args.patch_size`` is not set, a fallback
+        infers ``patch_size`` from the DINOv2 patch-embedding projection weight
+        shape (key ``backbone.0.encoder.encoder.embeddings.patch_embeddings.projection.weight``).
+        This fallback **can raise** :class:`ValueError` on a mismatch, providing a
+        clear error before the cryptic :class:`RuntimeError` from
+        :meth:`~torch.nn.Module.load_state_dict` would otherwise fire.
+        For all other attributes (e.g. ``segmentation_head``), if either side is
+        missing, that check is skipped silently — preserving backward compatibility.
+
+        Two class-count scenarios are distinguished:
 
         * Backbone pretrain: the checkpoint head was trained with more classes
           than the current ``model_args.num_classes``. In this case the detection

--- a/src/rfdetr/utilities/state_dict.py
+++ b/src/rfdetr/utilities/state_dict.py
@@ -255,26 +255,33 @@ def validate_checkpoint_compatibility(checkpoint: dict[str, Any], model_args: An
                     ckpt_num_classes - 1,
                 )
 
-    # Infer patch_size from the patch-embedding projection weight when the checkpoint
-    # has no "args" key (e.g., COCO pretrained release weights that only store "model").
+    # Infer patch_size from the patch-embedding projection weight only as a fallback
+    # when the checkpoint has no explicit args.patch_size (e.g., COCO pretrained
+    # release weights that only store "model").
     # Conv2d projection shape is [out_channels, in_channels, kernel_h, kernel_w];
-    # kernel_h == patch_size for square kernels.  Raises before load_state_dict fires,
+    # kernel_h == patch_size for square kernels. Raises before load_state_dict fires,
     # replacing the otherwise-cryptic "size mismatch" RuntimeError. Regression: #965.
     # NOTE: key path is DINOv2-specific; non-DINOv2 backbones simply won't have this key
     # and the check is silently skipped, preserving backward compatibility.
-    _patch_proj_key = "backbone.0.encoder.encoder.embeddings.patch_embeddings.projection.weight"
-    _ckpt_proj_w = checkpoint.get("model", {}).get(_patch_proj_key)
-    if _ckpt_proj_w is not None and _ckpt_proj_w.shape[2] == _ckpt_proj_w.shape[3]:
-        _inferred_ps = int(_ckpt_proj_w.shape[-1])
-        _model_ps: int | None = getattr(model_args, "patch_size", None)
-        if _model_ps is not None and _inferred_ps != _model_ps:
-            raise ValueError(
-                f"The checkpoint was trained with patch_size={_inferred_ps}, but the current model uses "
-                f"patch_size={_model_ps}. The checkpoint is incompatible with this model architecture. "
-                "To resolve this, either instantiate/configure the model with the checkpoint's patch_size or "
-                "use a checkpoint that was trained with the same patch_size as the current model."
-            )
+    _ckpt_args = checkpoint.get("args")
+    _ckpt_patch_size_from_args: int | None = None
+    if _ckpt_args is not None:
+        _ckpt_patch_size_from_args = _ckpt_args_get(_ckpt_args, "patch_size")
 
+    if _ckpt_patch_size_from_args is None:
+        _patch_proj_key = "backbone.0.encoder.encoder.embeddings.patch_embeddings.projection.weight"
+        _ckpt_proj_w = checkpoint.get("model", {}).get(_patch_proj_key)
+        _ckpt_proj_shape = getattr(_ckpt_proj_w, "shape", None)
+        if _ckpt_proj_shape is not None and len(_ckpt_proj_shape) >= 4 and _ckpt_proj_shape[2] == _ckpt_proj_shape[3]:
+            _inferred_ps = int(_ckpt_proj_shape[-1])
+            _model_ps: int | None = getattr(model_args, "patch_size", None)
+            if _model_ps is not None and _inferred_ps != _model_ps:
+                raise ValueError(
+                    f"The checkpoint was trained with patch_size={_inferred_ps}, but the current model uses "
+                    f"patch_size={_model_ps}. The checkpoint is incompatible with this model architecture. "
+                    "To resolve this, either instantiate/configure the model with the checkpoint's patch_size or "
+                    "use a checkpoint that was trained with the same patch_size as the current model."
+                )
     if "args" not in checkpoint:
         return
 

--- a/tests/utilities/test_state_dict.py
+++ b/tests/utilities/test_state_dict.py
@@ -258,6 +258,17 @@ class TestValidateCheckpointCompatibility:
             ),
             pytest.param(
                 {
+                    "model": {
+                        "backbone.0.encoder.encoder.embeddings.patch_embeddings.projection.weight": torch.zeros(
+                            384, 3, 16, 16, 16
+                        )  # 5D — Conv3d-like; rank guard (== 4) must skip cleanly
+                    }
+                },
+                {"patch_size": 8},
+                id="proj_weight_5d_skips",
+            ),
+            pytest.param(
+                {
                     "args": SimpleNamespace(patch_size=14),
                     "model": {
                         "backbone.0.encoder.encoder.embeddings.patch_embeddings.projection.weight": torch.zeros(

--- a/tests/utilities/test_state_dict.py
+++ b/tests/utilities/test_state_dict.py
@@ -176,6 +176,90 @@ class TestValidateCheckpointCompatibility:
             validate_checkpoint_compatibility(checkpoint, model_args)
 
     # ------------------------------------------------------------------
+    # patch_size inferred from projection weight (no "args" key)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "ckpt_patch_size,model_patch_size,should_raise",
+        [
+            pytest.param(16, 12, True, id="ckpt_16_model_12_raises"),
+            pytest.param(14, 16, True, id="ckpt_14_model_16_raises"),
+            pytest.param(16, 16, False, id="matching_16_no_raise"),
+        ],
+    )
+    def test_patch_size_inferred_from_projection_weight(
+        self, ckpt_patch_size: int, model_patch_size: int, should_raise: bool
+    ) -> None:
+        """Projection weight shape used to infer ckpt patch_size when 'args' key absent.
+
+        Regression test for #965 — pretrained COCO weights lack 'args', so the
+        shape-based fallback must fire before load_state_dict raises a cryptic RuntimeError.
+        """
+        proj_key = "backbone.0.encoder.encoder.embeddings.patch_embeddings.projection.weight"
+        proj_weight = torch.zeros(384, 3, ckpt_patch_size, ckpt_patch_size)
+        checkpoint = {"model": {proj_key: proj_weight}}  # no "args" key
+        model_args = SimpleNamespace(patch_size=model_patch_size)
+
+        if should_raise:
+            with pytest.raises(
+                ValueError,
+                match=rf"patch_size={ckpt_patch_size}.*patch_size={model_patch_size}"
+                rf"|patch_size={model_patch_size}.*patch_size={ckpt_patch_size}",
+            ):
+                validate_checkpoint_compatibility(checkpoint, model_args)
+        else:
+            validate_checkpoint_compatibility(checkpoint, model_args)  # must not raise
+
+    @pytest.mark.parametrize(
+        "checkpoint,model_args_kwargs",
+        [
+            pytest.param(
+                {},
+                {"patch_size": 16},
+                id="no_model_key_skips",
+            ),
+            pytest.param(
+                {"model": {}},
+                {"patch_size": 16},
+                id="no_projection_key_skips",
+            ),
+            pytest.param(
+                {
+                    "model": {
+                        "backbone.0.encoder.encoder.embeddings.patch_embeddings.projection.weight": torch.zeros(
+                            384, 3, 16, 16
+                        )
+                    }
+                },
+                {},
+                id="model_no_patch_size_attr_skips",
+            ),
+        ],
+    )
+    def test_projection_inference_silently_skips_when_incomplete(
+        self, checkpoint: dict, model_args_kwargs: dict
+    ) -> None:
+        """Shape-based patch_size check is skipped when key or attribute is absent.
+
+        Verifies backward compatibility: missing projection key, missing model key,
+        or model_args without patch_size attribute must all be handled without error.
+        """
+        model_args = SimpleNamespace(**model_args_kwargs)
+        validate_checkpoint_compatibility(checkpoint, model_args)  # must not raise
+
+    def test_non_square_projection_kernel_skips_check(self) -> None:
+        """Non-square patch projection kernel is skipped — patch_size cannot be inferred reliably.
+
+        Guards against hypothetical future backbones with non-square Conv2d kernels
+        where shape[-1] would not equal patch_size.
+        """
+        proj_key = "backbone.0.encoder.encoder.embeddings.patch_embeddings.projection.weight"
+        proj_weight = torch.zeros(384, 3, 16, 14)  # non-square: h=16, w=14
+        checkpoint = {"model": {proj_key: proj_weight}}
+        model_args = SimpleNamespace(patch_size=16)
+        validate_checkpoint_compatibility(checkpoint, model_args)  # must not raise
+
+    # ------------------------------------------------------------------
     # class-count mismatch warnings
     # ------------------------------------------------------------------
 

--- a/tests/utilities/test_state_dict.py
+++ b/tests/utilities/test_state_dict.py
@@ -234,6 +234,52 @@ class TestValidateCheckpointCompatibility:
                 {},
                 id="model_no_patch_size_attr_skips",
             ),
+            pytest.param(
+                {
+                    "model": {
+                        "backbone.0.encoder.encoder.embeddings.patch_embeddings.projection.weight": torch.zeros(
+                            384, 3
+                        )  # 2D — not a Conv2d weight; rank guard must skip cleanly
+                    }
+                },
+                {"patch_size": 16},
+                id="proj_weight_2d_skips",
+            ),
+            pytest.param(
+                {
+                    "model": {
+                        "backbone.0.encoder.encoder.embeddings.patch_embeddings.projection.weight": torch.zeros(
+                            384, 3, 16
+                        )  # 3D — not a Conv2d weight; rank guard must skip cleanly
+                    }
+                },
+                {"patch_size": 16},
+                id="proj_weight_3d_skips",
+            ),
+            pytest.param(
+                {
+                    "args": SimpleNamespace(patch_size=14),
+                    "model": {
+                        "backbone.0.encoder.encoder.embeddings.patch_embeddings.projection.weight": torch.zeros(
+                            384, 3, 16, 16
+                        )  # projection suggests 16, but args.patch_size=14 takes precedence
+                    },
+                },
+                {"patch_size": 14},
+                id="args_patch_size_suppresses_projection_inference",
+            ),
+            pytest.param(
+                {
+                    "args": {"patch_size": 14},  # PTL-style dict args (not SimpleNamespace)
+                    "model": {
+                        "backbone.0.encoder.encoder.embeddings.patch_embeddings.projection.weight": torch.zeros(
+                            384, 3, 16, 16
+                        )  # projection suggests 16, but dict args["patch_size"]=14 takes precedence
+                    },
+                },
+                {"patch_size": 14},
+                id="dict_args_patch_size_suppresses_projection_inference",
+            ),
         ],
     )
     def test_projection_inference_silently_skips_when_incomplete(
@@ -242,7 +288,8 @@ class TestValidateCheckpointCompatibility:
         """Shape-based patch_size check is skipped when key or attribute is absent.
 
         Verifies backward compatibility: missing projection key, missing model key,
-        or model_args without patch_size attribute must all be handled without error.
+        model_args without patch_size attribute, non-4D projection weights, or an
+        explicit args.patch_size (SimpleNamespace or dict) must all be handled without error.
         """
         model_args = SimpleNamespace(**model_args_kwargs)
         validate_checkpoint_compatibility(checkpoint, model_args)  # must not raise


### PR DESCRIPTION
This pull request improves the robustness and clarit#965  patch size compatibility checks between model checkpoints and model configurations, particularly addressing cases where pretrained weights lack explicit configuration metadata. It also adds comprehensive tests to ensure correct and backward-compatible behavior.

**Patch size inference and validation improvements:**

* Added logic in `validate_checkpoint_compatibility` to infer `patch_size` from the shape of the patch embedding projection weight when the checkpoint lacks an `"args"` key, ensuring early and clear errors for mismatched patch sizes and improving user experience when loading COCO-pretrained weights.

**Testing and backward compatibility:**

* Added parameterized tests to verify that patch size mismatches detected via projection weight inference raise clear errors, and that matching sizes do not raise.
* Added tests to confirm that the patch size inference logic is silently skipped when required keys or attributes are missing, preserving backward compatibility.
* Added a test to ensure that non-square projection kernels (where patch size cannot be reliably inferred) are skipped, preventing false errors for future or non-standard backbones.

---

resolves #965