### PR TITLE
fix: persist `_best_ema` in `BestModelCallback.state_dict` to survive reume

### DIFF
--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -10,6 +10,10 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
 
 import torch
 from pytorch_lightning import LightningModule, Trainer
@@ -180,6 +184,36 @@ class BestModelCallback(ModelCheckpoint):
         if config_type_name.startswith("RFDETR") and config_type_name.endswith("Config"):
             return config_type_name.removesuffix("Config")
         return None
+
+    def state_dict(self) -> dict[str, Any]:
+        """Return callback state including ``_best_ema`` for Lightning checkpointing.
+
+        Extends the parent :class:`~pytorch_lightning.callbacks.ModelCheckpoint`
+        state dict with ``_best_ema`` so that ``trainer.fit(ckpt_path=...)``
+        resumes EMA tracking from the correct high-water mark rather than
+        resetting to ``0.0``.
+
+        Returns:
+            State dict with all parent fields plus ``"_best_ema"``.
+        """
+        state = super().state_dict()
+        state["_best_ema"] = self._best_ema
+        return state
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        """Restore callback state from a Lightning checkpoint.
+
+        Pops ``"_best_ema"`` from *state_dict* before delegating to the parent
+        so the parent does not receive an unexpected key.  Defaults to ``0.0``
+        when the key is absent (e.g. checkpoints saved before this fix).
+
+        Args:
+            state_dict: Callback state dict as produced by :meth:`state_dict`.
+        """
+        # Copy to avoid mutating the caller's dict — PTL may reuse it.
+        state = dict(state_dict)
+        self._best_ema = float(state.pop("_best_ema", 0.0))
+        super().load_state_dict(state)
 
     def _save_checkpoint(self, trainer: Trainer, filepath: str) -> None:
         """Save stripped ``.pth`` format instead of a full ``.ckpt``.

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -203,7 +203,7 @@ class BestModelCallback(ModelCheckpoint):
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
         """Restore callback state from a Lightning checkpoint.
 
-        Pops ``"_best_ema"`` from *state_dict* before delegating to the parent
+        Pops ``"_best_ema"`` from a shallow copy of *state_dict* before delegating to the parent
         so the parent does not receive an unexpected key.  Defaults to ``0.0``
         when the key is absent (e.g. checkpoints saved before this fix).
 

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -43,7 +43,10 @@ class BestModelCallback(ModelCheckpoint):
     is actually logged.  On non-eval epochs (when ``eval_interval > 1`` causes
     COCO evaluation to be skipped) the callback is a no-op.
 
-    ``state_dict()`` and ``load_state_dict()`` are overridden to persist ``_best_ema`` in the Lightning callback state, ensuring that ``trainer.fit(ckpt_path=...)`` resumes EMA high-water-mark tracking from the correct value.
+    ``state_dict()`` and ``load_state_dict()`` are overridden to persist
+    ``_best_ema`` in the Lightning callback state, ensuring that
+    ``trainer.fit(ckpt_path=...)`` resumes EMA high-water-mark tracking
+    from the correct value.
 
     Args:
         output_dir: Directory where checkpoint files are written.

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import math
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -213,6 +214,8 @@ class BestModelCallback(ModelCheckpoint):
         # Copy to avoid mutating the caller's dict — PTL may reuse it.
         state = dict(state_dict)
         self._best_ema = float(state.pop("_best_ema", 0.0))
+        if not math.isfinite(self._best_ema):
+            self._best_ema = 0.0
         super().load_state_dict(state)
 
     def _save_checkpoint(self, trainer: Trainer, filepath: str) -> None:

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -43,6 +43,8 @@ class BestModelCallback(ModelCheckpoint):
     is actually logged.  On non-eval epochs (when ``eval_interval > 1`` causes
     COCO evaluation to be skipped) the callback is a no-op.
 
+    ``state_dict()`` and ``load_state_dict()`` are overridden to persist ``_best_ema`` in the Lightning callback state, ensuring that ``trainer.fit(ckpt_path=...)`` resumes EMA high-water-mark tracking from the correct value.
+
     Args:
         output_dir: Directory where checkpoint files are written.
         monitor_regular: Metric key for the regular model mAP.

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -1261,3 +1261,34 @@ class TestBestEmaStatePersistence:
             "on_fit_end must select EMA (epoch 3, best=0.8) over regular (epoch 1, best=0.6); "
             f"got epoch_completed={completed} — _best_ema not restored from state_dict"
         )
+
+    @pytest.mark.parametrize(
+        ("mutate_state", "expected_best_ema"),
+        [
+            pytest.param(
+                lambda state: state.pop("_best_ema"),
+                0.0,
+                id="missing_key",
+            ),
+            pytest.param(
+                lambda state: state.__setitem__("_best_ema", int(1)),
+                1.0,
+                id="int_coercion",
+            ),
+            pytest.param(
+                lambda state: state.__setitem__("_best_ema", str("0.75")),
+                0.75,
+                id="string_coercion",
+            ),
+        ],
+    )
+    def test_load_state_dict_backward_compat(self, tmp_path: Path, mutate_state, expected_best_ema: float) -> None:
+        """load_state_dict() keeps backward-compatible _best_ema restoration behavior."""
+        cb = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
+        state = cb.state_dict()
+        mutate_state(state)
+
+        cb.load_state_dict(state)
+
+        assert isinstance(cb._best_ema, float)
+        assert cb._best_ema == expected_best_ema

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -1192,12 +1192,15 @@ class TestBestEmaStatePersistence:
         # --- Pre-resume phase: establish EMA best of 0.75 ---
         cb_pre = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
         pl_module = _make_pl_module()
-        trainer_pre = _make_trainer({"val/mAP_50_95": 0.4, "val/ema_mAP_50_95": 0.75})
+        trainer_pre = _make_trainer(
+            {"val/mAP_50_95": 0.4, "val/ema_mAP_50_95": 0.75},
+            current_epoch=5,
+        )
         cb_pre.on_validation_end(trainer_pre, pl_module)
 
         ema_path = tmp_path / "checkpoint_best_ema.pth"
         assert ema_path.exists()
-        mtime_before = ema_path.stat().st_mtime_ns
+        baseline_epoch = torch.load(ema_path, map_location="cpu", weights_only=False)["epoch"]
         saved_state = cb_pre.state_dict()
 
         # --- Resume phase: fresh callback loaded from saved state ---
@@ -1205,10 +1208,13 @@ class TestBestEmaStatePersistence:
         cb_resumed.load_state_dict(saved_state)
 
         # Post-resume validation reports EMA=0.5 — worse than pre-resume best (0.75).
-        trainer_post = _make_trainer({"val/mAP_50_95": 0.45, "val/ema_mAP_50_95": 0.5})
+        trainer_post = _make_trainer(
+            {"val/mAP_50_95": 0.45, "val/ema_mAP_50_95": 0.5},
+            current_epoch=7,
+        )
         cb_resumed.on_validation_end(trainer_post, pl_module)
 
-        assert ema_path.stat().st_mtime_ns == mtime_before, (
+        assert torch.load(ema_path, map_location="cpu", weights_only=False)["epoch"] == baseline_epoch, (
             "checkpoint_best_ema.pth must not be overwritten by an inferior post-resume EMA value"
         )
 

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -1292,3 +1292,22 @@ class TestBestEmaStatePersistence:
 
         assert isinstance(cb._best_ema, float)
         assert cb._best_ema == expected_best_ema
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            pytest.param(float("nan"), id="nan"),
+            pytest.param(float("inf"), id="inf"),
+            pytest.param(float("-inf"), id="neg_inf"),
+        ],
+    )
+    def test_load_state_dict_non_finite_values(self, bad_value) -> None:
+        """load_state_dict() resets non-finite persisted _best_ema values to 0.0."""
+        cb = BestModelCallback(output_dir=".")
+        cb._best_ema = 999.0
+        state = cb.state_dict()
+        state["_best_ema"] = bad_value
+
+        cb.load_state_dict(state)
+
+        assert cb._best_ema == 0.0

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -1311,3 +1311,29 @@ class TestBestEmaStatePersistence:
         cb.load_state_dict(state)
 
         assert cb._best_ema == 0.0
+
+    def test_load_state_dict_does_not_mutate_caller_dict(self, tmp_path: Path) -> None:
+        """load_state_dict must not pop or mutate the caller-supplied dict."""
+        cb1 = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
+        cb1._best_ema = 0.75
+        original_sd = cb1.state_dict()
+        saved = dict(original_sd)
+
+        cb2 = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
+        cb2.load_state_dict(original_sd)
+
+        assert original_sd["_best_ema"] == 0.75
+        assert original_sd == saved
+
+    def test_state_dict_roundtrip_initial_zero(self, tmp_path: Path) -> None:
+        """state_dict/load_state_dict round-trips the default _best_ema=0.0 correctly."""
+        cb1 = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
+        sd = cb1.state_dict()
+
+        assert "_best_ema" in sd
+        assert sd["_best_ema"] == 0.0
+
+        cb2 = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
+        cb2.load_state_dict(sd)
+
+        assert cb2._best_ema == 0.0

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -1132,3 +1132,126 @@ class TestCheckpointRfdetrVersion:
 
         ckpt = torch.load(tmp_path / "checkpoint_best_regular.pth", weights_only=False)
         assert "rfdetr_version" not in ckpt
+
+
+# ---------------------------------------------------------------------------
+# _best_ema state persistence across resume (#969)
+# ---------------------------------------------------------------------------
+
+
+class TestBestEmaStatePersistence:
+    """Regression tests for _best_ema not surviving Lightning checkpoint resume.
+
+    Before the fix, BestModelCallback did not override state_dict() /
+    load_state_dict(), so _best_ema was never included in the Lightning callback
+    state bundle.  On resume via trainer.fit(ckpt_path=...) the callback was
+    reconstructed fresh with _best_ema=0.0, causing any positive post-resume EMA
+    value to trivially overwrite checkpoint_best_ema.pth with inferior weights.
+
+    Regression tests for GitHub issue #969.
+    """
+
+    def test_state_dict_includes_best_ema(self, tmp_path: Path) -> None:
+        """state_dict() must include _best_ema so it survives Lightning checkpointing."""
+        cb = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
+        pl_module = _make_pl_module()
+
+        # Drive _best_ema to 0.75 via a validation pass.
+        trainer = _make_trainer({"val/mAP_50_95": 0.4, "val/ema_mAP_50_95": 0.75})
+        cb.on_validation_end(trainer, pl_module)
+
+        state = cb.state_dict()
+
+        assert "_best_ema" in state, "_best_ema must be present in state_dict() output"
+        assert state["_best_ema"] == pytest.approx(0.75)
+
+    def test_load_state_dict_restores_best_ema(self, tmp_path: Path) -> None:
+        """load_state_dict() must restore _best_ema from the persisted state."""
+        # First callback: train to _best_ema=0.75.
+        cb_first = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
+        pl_module = _make_pl_module()
+        trainer = _make_trainer({"val/mAP_50_95": 0.4, "val/ema_mAP_50_95": 0.75})
+        cb_first.on_validation_end(trainer, pl_module)
+        saved_state = cb_first.state_dict()
+
+        # Second callback: simulate a fresh resume by loading the saved state.
+        cb_resumed = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
+        cb_resumed.load_state_dict(saved_state)
+
+        assert cb_resumed._best_ema == pytest.approx(0.75), (
+            "load_state_dict() must restore _best_ema; without fix it stays 0.0"
+        )
+
+    def test_resume_does_not_clobber_ema_checkpoint_with_inferior_weights(self, tmp_path: Path) -> None:
+        """After resume, inferior post-resume EMA must not overwrite checkpoint_best_ema.pth.
+
+        Without the fix: _best_ema resets to 0.0 on resume, so any positive EMA
+        metric (0.5) trivially satisfies ema_val > _best_ema and overwrites the
+        checkpoint saved pre-resume (0.75).
+        """
+        # --- Pre-resume phase: establish EMA best of 0.75 ---
+        cb_pre = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
+        pl_module = _make_pl_module()
+        trainer_pre = _make_trainer({"val/mAP_50_95": 0.4, "val/ema_mAP_50_95": 0.75})
+        cb_pre.on_validation_end(trainer_pre, pl_module)
+
+        ema_path = tmp_path / "checkpoint_best_ema.pth"
+        assert ema_path.exists()
+        mtime_before = ema_path.stat().st_mtime_ns
+        saved_state = cb_pre.state_dict()
+
+        # --- Resume phase: fresh callback loaded from saved state ---
+        cb_resumed = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
+        cb_resumed.load_state_dict(saved_state)
+
+        # Post-resume validation reports EMA=0.5 — worse than pre-resume best (0.75).
+        trainer_post = _make_trainer({"val/mAP_50_95": 0.45, "val/ema_mAP_50_95": 0.5})
+        cb_resumed.on_validation_end(trainer_post, pl_module)
+
+        assert ema_path.stat().st_mtime_ns == mtime_before, (
+            "checkpoint_best_ema.pth must not be overwritten by an inferior post-resume EMA value"
+        )
+
+    def test_on_fit_end_selects_ema_winner_after_resume(self, tmp_path: Path) -> None:
+        """on_fit_end picks EMA winner correctly when _best_ema is properly restored.
+
+        Without the fix: _best_ema=0.0 after resume, so regular (0.6) wins over
+        the true EMA best (0.8) — checkpoint_best_total.pth is built from the
+        wrong source.  Use epoch number as a distinguisher: pre-resume EMA was
+        saved at epoch 3; regular was saved at epoch 1; total epoch must be 3
+        (EMA epoch) when EMA correctly wins.
+        """
+        # Pre-resume epoch 1: regular best=0.6.
+        cb_pre = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95", run_test=False)
+        pl_module = _make_pl_module()
+        trainer_ep1 = _make_trainer({"val/mAP_50_95": 0.6, "val/ema_mAP_50_95": 0.5}, current_epoch=1)
+        cb_pre.on_validation_end(trainer_ep1, pl_module)
+
+        # Pre-resume epoch 3: EMA best=0.8 (better than epoch-1 EMA=0.5).
+        trainer_ep3 = _make_trainer({"val/mAP_50_95": 0.55, "val/ema_mAP_50_95": 0.8}, current_epoch=3)
+        cb_pre.on_validation_end(trainer_ep3, pl_module)
+
+        saved_state = cb_pre.state_dict()
+
+        # Resume: fresh callback, load state, run fit_end.
+        cb_resumed = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95", run_test=False)
+        cb_resumed.load_state_dict(saved_state)
+
+        # fit_end uses _best_ema to decide EMA vs regular winner.
+        # trainer_ep3 carries best_model_score=0.6 (regular) and _best_ema=0.8 (EMA wins).
+        cb_resumed.on_fit_end(trainer_ep3, pl_module)
+
+        total = tmp_path / "checkpoint_best_total.pth"
+        assert total.exists()
+        total_data = torch.load(total, map_location="cpu", weights_only=False)
+        # strip_checkpoint preserves the `loops` key.
+        # epoch_progress.current.completed == trainer.current_epoch + 1 at save time.
+        # EMA checkpoint was saved at epoch 3 → completed=4.
+        # Regular checkpoint was saved at epoch 1 → completed=2.
+        # If _best_ema was NOT restored (bug), regular wins → completed=2.
+        # If _best_ema IS restored (fix), EMA wins → completed=4.
+        completed = total_data["loops"]["fit_loop"]["epoch_progress"]["current"]["completed"]
+        assert completed == 4, (
+            "on_fit_end must select EMA (epoch 3, best=0.8) over regular (epoch 1, best=0.6); "
+            f"got epoch_completed={completed} — _best_ema not restored from state_dict"
+        )


### PR DESCRIPTION
This pull request fixes a bug where the `_best_ema` value in the `BestModelCallback` was not being correctly saved and restored when resuming training from a PyTorch Lightning checkpoint. Without this fix, resuming training would reset the tracked best EMA metric, potentially causing inferior model weights to overwrite the best ones. The update ensures correct persistence of `_best_ema` by overriding the `state_dict` and `load_state_dict` methods, and adds comprehensive regression tests to prevent future regressions.

**Callback state persistence improvements:**

* Added `state_dict` and `load_state_dict` methods to `BestModelCallback` in `best_model.py` to save and restore the `_best_ema` value as part of the Lightning checkpoint, preventing loss of the best EMA metric after resuming training.
* Updated imports in `best_model.py` to support new type annotations.

**Testing and regression coverage:**

* Added a new `TestBestEmaStatePersistence` class to `test_best_model_callback.py`, providing regression tests to ensure `_best_ema` is correctly persisted and restored, and that inferior EMA values do not overwrite the best checkpoint after resuming training.

---

resolves #969