### PR TITLE
fix: use EMA metrics for segm mAP logging instead of base metrics

### DIFF
--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -385,10 +385,6 @@ class COCOEvalCallback(Callback):
         self.map_metric.reset()
         self._f1_local = init_matching_accumulator()
 
-    def _has_ema_callback(self, trainer: Any) -> bool:
-        """Return whether an EMA callback is present in the Trainer."""
-        return self._get_ema_callback(trainer) is not None
-
     def _get_ema_callback(self, trainer: Any) -> Any:
         """Return the EMA callback instance, or ``None`` if not present."""
         for callback in getattr(trainer, "callbacks", []):

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -299,13 +299,17 @@ class COCOEvalCallback(Callback):
         # in on_validation_batch_end, so base and EMA values are independent.
         if self.map_metric_ema is not None:
             ema_metrics = self.map_metric_ema.compute()
-            ema_mar_key = f"{pfx}mar_{self._max_dets}"
             pl_module.log(f"{split}/ema_mAP_50_95", ema_metrics[f"{pfx}map"], prog_bar=True)
             pl_module.log(f"{split}/ema_mAP_50", ema_metrics[f"{pfx}map_50"])
-            pl_module.log(f"{split}/ema_mAR", ema_metrics[ema_mar_key])
+            pl_module.log(f"{split}/ema_mAR", ema_metrics[mar_key])
             trainer.callback_metrics[f"{split}/ema_mAP_50_95"] = ema_metrics[f"{pfx}map"].detach().cpu()
             trainer.callback_metrics[f"{split}/ema_mAP_50"] = ema_metrics[f"{pfx}map_50"].detach().cpu()
-            trainer.callback_metrics[f"{split}/ema_mAR"] = ema_metrics[ema_mar_key].detach().cpu()
+            trainer.callback_metrics[f"{split}/ema_mAR"] = ema_metrics[mar_key].detach().cpu()
+            if self._segmentation:
+                pl_module.log(f"{split}/ema_segm_mAP_50_95", ema_metrics["segm_map"])
+                pl_module.log(f"{split}/ema_segm_mAP_50", ema_metrics["segm_map_50"])
+                trainer.callback_metrics[f"{split}/ema_segm_mAP_50_95"] = ema_metrics["segm_map"].detach().cpu()
+                trainer.callback_metrics[f"{split}/ema_segm_mAP_50"] = ema_metrics["segm_map_50"].detach().cpu()
             self.map_metric_ema.reset()
 
         if self._segmentation:
@@ -315,11 +319,6 @@ class COCOEvalCallback(Callback):
             pl_module.log(f"{split}/segm_mAP_50", metrics["segm_map_50"])
             trainer.callback_metrics[f"{split}/segm_mAP_50_95"] = metrics["segm_map"].detach().cpu()
             trainer.callback_metrics[f"{split}/segm_mAP_50"] = metrics["segm_map_50"].detach().cpu()
-            if self.map_metric_ema is not None:
-                pl_module.log(f"{split}/ema_segm_mAP_50_95", ema_metrics["segm_map"])
-                pl_module.log(f"{split}/ema_segm_mAP_50", ema_metrics["segm_map_50"])
-                trainer.callback_metrics[f"{split}/ema_segm_mAP_50_95"] = ema_metrics["segm_map"].detach().cpu()
-                trainer.callback_metrics[f"{split}/ema_segm_mAP_50"] = ema_metrics["segm_map_50"].detach().cpu()
 
         # F1 sweep — run first so per-class F1/prec/rec are available when
         # building the unified per-class table rows below.

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -315,11 +315,11 @@ class COCOEvalCallback(Callback):
             pl_module.log(f"{split}/segm_mAP_50", metrics["segm_map_50"])
             trainer.callback_metrics[f"{split}/segm_mAP_50_95"] = metrics["segm_map"].detach().cpu()
             trainer.callback_metrics[f"{split}/segm_mAP_50"] = metrics["segm_map_50"].detach().cpu()
-            if self._has_ema_callback(trainer):
-                pl_module.log(f"{split}/ema_segm_mAP_50_95", metrics["segm_map"])
-                pl_module.log(f"{split}/ema_segm_mAP_50", metrics["segm_map_50"])
-                trainer.callback_metrics[f"{split}/ema_segm_mAP_50_95"] = metrics["segm_map"].detach().cpu()
-                trainer.callback_metrics[f"{split}/ema_segm_mAP_50"] = metrics["segm_map_50"].detach().cpu()
+            if self.map_metric_ema is not None:
+                pl_module.log(f"{split}/ema_segm_mAP_50_95", ema_metrics["segm_map"])
+                pl_module.log(f"{split}/ema_segm_mAP_50", ema_metrics["segm_map_50"])
+                trainer.callback_metrics[f"{split}/ema_segm_mAP_50_95"] = ema_metrics["segm_map"].detach().cpu()
+                trainer.callback_metrics[f"{split}/ema_segm_mAP_50"] = ema_metrics["segm_map_50"].detach().cpu()
 
         # F1 sweep — run first so per-class F1/prec/rec are available when
         # building the unified per-class table rows below.

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -261,7 +261,10 @@ class COCOEvalCallback(Callback):
 
         Computes mAP (via ``self.map_metric``), runs the F1 confidence-threshold
         sweep, logs all scalar metrics via ``pl_module.log``, prints two summary
-        tables to the terminal, and resets internal accumulators.
+        tables to the terminal, and resets internal accumulators.  When
+        ``self.map_metric_ema`` is set, EMA variants of all metrics (including
+        ``ema_segm_mAP_50_95`` and ``ema_segm_mAP_50`` for segmentation models)
+        are logged under the same ``split/`` namespace.
 
         Args:
             trainer: The PTL Trainer.

--- a/tests/training/test_coco_eval_callback.py
+++ b/tests/training/test_coco_eval_callback.py
@@ -513,6 +513,38 @@ class TestOnValidationEpochEnd:
         assert "val/ema_mAP_50" in trainer.callback_metrics
         assert "val/ema_mAR" in trainer.callback_metrics
 
+    def test_ema_segm_metrics_use_ema_values_not_base(self) -> None:
+        """EMA segmentation metrics must come from map_metric_ema, not the
+        base map_metric.  Regression test for #978."""
+        cb = COCOEvalCallback(max_dets=500, segmentation=True)
+        trainer = _make_trainer()
+        trainer.callback_metrics = {}
+        cb.setup(trainer, _make_pl_module(), stage="fit")
+
+        # Base metrics: segm_map=0.35
+        base_metrics = _minimal_metrics(pfx="bbox_")
+        base_metrics["segm_map"] = torch.tensor(0.35)
+        base_metrics["segm_map_50"] = torch.tensor(0.55)
+        cb.map_metric = MagicMock(name="map_metric")
+        cb.map_metric.compute.return_value = base_metrics
+
+        # EMA metrics: segm_map=0.45 (deliberately different)
+        ema_metrics = _minimal_metrics(pfx="bbox_")
+        ema_metrics["segm_map"] = torch.tensor(0.45)
+        ema_metrics["segm_map_50"] = torch.tensor(0.65)
+        cb.map_metric_ema = MagicMock(name="map_metric_ema")
+        cb.map_metric_ema.compute.return_value = ema_metrics
+        module = _make_pl_module()
+
+        cb.on_validation_epoch_end(trainer, module)
+
+        # EMA segm values must differ from base
+        assert trainer.callback_metrics["val/ema_segm_mAP_50_95"].item() == pytest.approx(0.45)
+        assert trainer.callback_metrics["val/ema_segm_mAP_50"].item() == pytest.approx(0.65)
+        # Base segm values unchanged
+        assert trainer.callback_metrics["val/segm_mAP_50_95"].item() == pytest.approx(0.35)
+        assert trainer.callback_metrics["val/segm_mAP_50"].item() == pytest.approx(0.55)
+
     def test_ghost_class_with_negative_ar_sentinel_is_filtered(self) -> None:
         """A class where both ap=-1 and ar=-1 (negative sentinels, not NaN) must
         be excluded from the per-class table.  The old filter checked for NaN

--- a/tests/training/test_coco_eval_callback.py
+++ b/tests/training/test_coco_eval_callback.py
@@ -544,6 +544,10 @@ class TestOnValidationEpochEnd:
         # Base segm values unchanged
         assert trainer.callback_metrics["val/segm_mAP_50_95"].item() == pytest.approx(0.35)
         assert trainer.callback_metrics["val/segm_mAP_50"].item() == pytest.approx(0.55)
+        # pl_module.log() must also receive EMA values (covers both changed code paths)
+        logged = {c.args[0]: c.args[1] for c in module.log.call_args_list if len(c.args) >= 2}
+        assert logged["val/ema_segm_mAP_50_95"].item() == pytest.approx(0.45)
+        assert logged["val/ema_segm_mAP_50"].item() == pytest.approx(0.65)
 
     def test_ghost_class_with_negative_ar_sentinel_is_filtered(self) -> None:
         """A class where both ap=-1 and ar=-1 (negative sentinels, not NaN) must

--- a/tests/training/test_coco_eval_callback.py
+++ b/tests/training/test_coco_eval_callback.py
@@ -4,7 +4,7 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
-"""Unit tests for COCOEvalCallback (PTL Ch3/T3)."""
+"""Unit tests for COCOEvalCallback."""
 
 from unittest.mock import MagicMock, patch
 


### PR DESCRIPTION
## What does this PR do?

Fixes a copy-paste bug in `COCOEvalCallback._compute_and_log` where EMA segmentation metrics (`ema_segm_mAP_50_95`, `ema_segm_mAP_50`) were reading from the **base** `metrics` dict instead of the `ema_metrics` dict. This caused the logged EMA segmentation mAP values to always be identical to the base model values, silently defeating the purpose of EMA tracking for segmentation.

The condition guarding the EMA segmentation block also used `self._has_ema_callback(trainer)`, which walks the trainer's callback list. This PR replaces it with `self.map_metric_ema is not None`, which is the same guard already used by the detection metric path a few lines above and is both cheaper and more direct.

**Related Issue(s):** Fixes #978

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

Added `test_ema_segm_metrics_use_ema_values_not_base` in `tests/training/test_coco_eval_callback.py`. The test sets up base metrics with `segm_map=0.35` and EMA metrics with `segm_map=0.45`, then asserts that:

- `val/segm_mAP_50_95` equals the base value (0.35)
- `val/ema_segm_mAP_50_95` equals the EMA value (0.45), not the base value

Before this fix, both values were 0.35 because the EMA path was reading from the wrong dict.

Also ran a full segmentation training session with `RFDETRSegNano` (3 epochs, `use_ema=True`, `eval_interval=1`) to confirm no runtime errors occur during actual training with EMA enabled.

All 50 tests in `test_coco_eval_callback.py` pass locally.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

The bug was introduced when segmentation metric logging was added to `_compute_and_log`. The detection EMA block correctly reads from `ema_metrics`, but the segmentation EMA block below it was copy-pasted from the base segmentation block and the variable name was never updated from `metrics` to `ema_metrics`. Similarly, the condition check was left as `_has_ema_callback(trainer)` instead of matching the `self.map_metric_ema is not None` pattern used everywhere else in the same method.
