### PR TITLE
feat(docs): add GEO infrastructure

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -72,7 +72,7 @@ jobs:
           cp /tmp/llms.txt llms.txt
           git add robots.txt llms.txt
           git diff --staged --quiet || git commit -m "chore: update root static files (robots.txt, llms.txt)"
-          git push origin gh-pages
+          git push origin gh-pages || (git pull --rebase origin gh-pages && git push origin gh-pages)
 
       # IndexNow: replace bing-indexnow-key-placeholder with actual key from https://www.bing.com/indexnow
       - name: Notify IndexNow (Bing)

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -66,17 +66,20 @@ jobs:
         run: |
           cp root-static/robots.txt /tmp/robots.txt
           cp root-static/llms.txt /tmp/llms.txt
+          cp root-static/cace9ef287cb8d641db90d4295fcb1e1.txt /tmp/indexnow.txt
           git fetch origin gh-pages:refs/remotes/origin/gh-pages
           git checkout -B gh-pages origin/gh-pages
           cp /tmp/robots.txt robots.txt
           cp /tmp/llms.txt llms.txt
-          git add robots.txt llms.txt
+          cp /tmp/indexnow.txt cace9ef287cb8d641db90d4295fcb1e1.txt
+          git add robots.txt llms.txt cace9ef287cb8d641db90d4295fcb1e1.txt
           git diff --staged --quiet || git commit -m "chore: update root static files (robots.txt, llms.txt)"
           git push origin gh-pages || (git pull --rebase origin gh-pages && git push origin gh-pages)
 
-      # IndexNow: replace INDEXNOW_KEY_PLACEHOLDER with the actual key from https://www.bing.com/indexnow
-      # The key file must also be deployed to the site root (root-static/<key>.txt) and
-      # injected into gh-pages via the "Deploy root static files" step above.
+      # IndexNow key: cace9ef287cb8d641db90d4295fcb1e1
+      # Key file served at https://rfdetr.roboflow.com/cace9ef287cb8d641db90d4295fcb1e1.txt
+      # (deployed via "Deploy root static files" step above).
+      # To rotate: generate new key, update root-static/<key>.txt, replace key string here.
       - name: 📡 Notify IndexNow (Bing)
         if: (github.event_name == 'push' && github.ref == 'refs/heads/develop') || github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && github.event.action == 'published')
         run: |
@@ -84,8 +87,8 @@ jobs:
             -H "Content-Type: application/json; charset=utf-8" \
             -d '{
               "host": "rfdetr.roboflow.com",
-              "key": "INDEXNOW_KEY_PLACEHOLDER",
-              "keyLocation": "https://rfdetr.roboflow.com/INDEXNOW_KEY_PLACEHOLDER.txt",
+              "key": "cace9ef287cb8d641db90d4295fcb1e1",
+              "keyLocation": "https://rfdetr.roboflow.com/cace9ef287cb8d641db90d4295fcb1e1.txt",
               "urlList": [
                 "https://rfdetr.roboflow.com/",
                 "https://rfdetr.roboflow.com/latest/",

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -74,13 +74,31 @@ jobs:
           git diff --staged --quiet || git commit -m "chore: update root static files (robots.txt, llms.txt)"
           git push origin gh-pages || (git pull --rebase origin gh-pages && git push origin gh-pages)
 
-      # IndexNow: replace bing-indexnow-key-placeholder with actual key from https://www.bing.com/indexnow
-      - name: Notify IndexNow (Bing)
+      # IndexNow: replace INDEXNOW_KEY_PLACEHOLDER with the actual key from https://www.bing.com/indexnow
+      # The key file must also be deployed to the site root (root-static/<key>.txt) and
+      # injected into gh-pages via the "Deploy root static files" step above.
+      - name: 📡 Notify IndexNow (Bing)
         if: (github.event_name == 'push' && github.ref == 'refs/heads/develop') || github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && github.event.action == 'published')
         run: |
-          curl -s -o /dev/null -w "%{http_code}" \
-            "https://api.indexnow.org/indexnow?url=https://rfdetr.roboflow.com/latest/sitemap.xml&key=bing-indexnow-key-placeholder" \
-            -H "Content-Type: application/json" || true
+          curl -s -o /dev/null -w "%{http_code}" -X POST "https://api.indexnow.org/IndexNow" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            -d '{
+              "host": "rfdetr.roboflow.com",
+              "key": "INDEXNOW_KEY_PLACEHOLDER",
+              "keyLocation": "https://rfdetr.roboflow.com/INDEXNOW_KEY_PLACEHOLDER.txt",
+              "urlList": [
+                "https://rfdetr.roboflow.com/",
+                "https://rfdetr.roboflow.com/latest/",
+                "https://rfdetr.roboflow.com/latest/learn/install/",
+                "https://rfdetr.roboflow.com/latest/learn/pretrained/",
+                "https://rfdetr.roboflow.com/latest/learn/run/detection/",
+                "https://rfdetr.roboflow.com/latest/learn/run/segmentation/",
+                "https://rfdetr.roboflow.com/latest/learn/train/",
+                "https://rfdetr.roboflow.com/latest/learn/export/",
+                "https://rfdetr.roboflow.com/latest/learn/deploy/",
+                "https://rfdetr.roboflow.com/latest/learn/benchmarks/"
+              ]
+            }' || true
 
       - name: Minimize uv cache
         run: uv cache prune --ci

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -61,5 +61,18 @@ jobs:
           latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
           uv run mike deploy --push --update-aliases $latest_tag latest
 
+      - name: Deploy root static files to gh-pages
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/develop') || github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && github.event.action == 'published')
+        run: |
+          cp root-static/robots.txt /tmp/robots.txt
+          cp root-static/llms.txt /tmp/llms.txt
+          git fetch origin gh-pages
+          git checkout gh-pages
+          cp /tmp/robots.txt robots.txt
+          cp /tmp/llms.txt llms.txt
+          git add robots.txt llms.txt
+          git diff --staged --quiet || git commit -m "chore: update root static files (robots.txt, llms.txt)"
+          git push origin gh-pages
+
       - name: Minimize uv cache
         run: uv cache prune --ci

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -66,8 +66,8 @@ jobs:
         run: |
           cp root-static/robots.txt /tmp/robots.txt
           cp root-static/llms.txt /tmp/llms.txt
-          git fetch origin gh-pages
-          git checkout gh-pages
+          git fetch origin gh-pages:refs/remotes/origin/gh-pages
+          git checkout -B gh-pages origin/gh-pages
           cp /tmp/robots.txt robots.txt
           cp /tmp/llms.txt llms.txt
           git add robots.txt llms.txt

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -74,5 +74,13 @@ jobs:
           git diff --staged --quiet || git commit -m "chore: update root static files (robots.txt, llms.txt)"
           git push origin gh-pages
 
+      # IndexNow: replace bing-indexnow-key-placeholder with actual key from https://www.bing.com/indexnow
+      - name: Notify IndexNow (Bing)
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/develop') || github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && github.event.action == 'published')
+        run: |
+          curl -s -o /dev/null -w "%{http_code}" \
+            "https://api.indexnow.org/indexnow?url=https://rfdetr.roboflow.com/latest/sitemap.xml&key=bing-indexnow-key-placeholder" \
+            -H "Content-Type: application/json" || true
+
       - name: Minimize uv cache
         run: uv cache prune --ci

--- a/.gitignore
+++ b/.gitignore
@@ -203,6 +203,7 @@ notebooks/*.py
 
 # tracking work in progress
 .codex/logs
+.plans/
 .reports/
 .temp/
 cache-gh/

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,5 @@
 ---
+description: RF-DETR is a real-time transformer for object detection and instance segmentation by Roboflow. DINOv2 backbone, SOTA on COCO (60.1 AP50:95). Apache 2.0.
 hide:
   - navigation
 ---
@@ -76,7 +77,7 @@ You can install and use `rfdetr` in a [**Python>=3.10**](https://www.python.org/
 
     ---
 
-    ![](https://i.ytimg.com/vi/-OvpdLAElFA/maxresdefault.jpg)
+    ![Train RF-DETR on a Custom Dataset](https://i.ytimg.com/vi/-OvpdLAElFA/maxresdefault.jpg){ width="1280" height="720" loading="lazy" }
 
     End to end walkthrough of training RF-DETR on a custom dataset.
 
@@ -86,7 +87,7 @@ You can install and use `rfdetr` in a [**Python>=3.10**](https://www.python.org/
 
     ---
 
-    ![](https://blog.roboflow.com/content/images/size/w1000/format/webp/2025/06/inst-3-.png)
+    ![Deploy RF-DETR to NVIDIA Jetson](https://blog.roboflow.com/content/images/size/w1000/format/webp/2025/06/inst-3-.png){ width="1000" height="563" loading="lazy" }
 
     Instructions for deploying RF-DETR on NVIDIA Jetson with Roboflow Inference.
 
@@ -96,7 +97,7 @@ You can install and use `rfdetr` in a [**Python>=3.10**](https://www.python.org/
 
     ---
 
-    ![](https://blog.roboflow.com/content/images/size/w1000/format/webp/2025/03/img-blog-nycerebro-2.png)
+    ![Train and Deploy RF-DETR with Roboflow](https://blog.roboflow.com/content/images/size/w1000/format/webp/2025/03/img-blog-nycerebro-2.png){ width="1000" height="563" loading="lazy" }
 
     Cloud training and hardware deployment workflow using Roboflow.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -134,3 +134,26 @@ RF-DETR achieves the best accuracy–latency trade-off among real-time object de
 | RF-DETR-Seg-L   | 70.5                 | 47.1                    | 8.8          | 36.2       | 504×504    |
 | RF-DETR-Seg-XL  | 72.2                 | 48.8                    | 13.5         | 38.1       | 624×624    |
 | RF-DETR-Seg-2XL | 73.1                 | 49.9                    | 21.8         | 38.6       | 768×768    |
+
+## Frequently Asked Questions
+
+**What is RF-DETR?**
+RF-DETR (Roboflow Detection Transformer) is a real-time object detection and instance segmentation model from Roboflow. It uses a DINOv2 vision transformer backbone and achieves state-of-the-art accuracy–latency trade-offs on COCO and RF100-VL.
+
+**How does RF-DETR compare to YOLOv11?**
+RF-DETR-L achieves 56.5 AP50:95 on COCO at 6.8 ms latency on an NVIDIA T4, outperforming YOLOv11x (54.7 AP) at lower latency. The DINOv2 backbone gives RF-DETR stronger performance on domain-shift benchmarks such as RF100-VL.
+
+**What GPU is required to train RF-DETR?**
+A CUDA-capable GPU with at least 8 GB VRAM (e.g., NVIDIA RTX 3060, T4, A10) is recommended for fine-tuning. Smaller models (RF-DETR-N and RF-DETR-S) can fit in 6 GB VRAM with reduced batch size. CPU inference is supported for evaluation.
+
+**Which dataset formats does RF-DETR support?**
+RF-DETR supports COCO JSON and YOLO-format datasets (with `dataset_type: "yolo"`). Roboflow datasets export directly to both formats. Detection and segmentation datasets use the same format — the model variant determines the task.
+
+**Can RF-DETR run in real time?**
+Yes. RF-DETR-N runs at 2.3 ms per frame on a T4 GPU (TensorRT FP16, batch 1), and RF-DETR-L at 6.8 ms — both well within real-time thresholds. ONNX and TFLite exports are available for edge deployment.
+
+**What is the difference between RF-DETR detection and segmentation models?**
+Detection models (e.g., `RFDETRLarge`) output bounding boxes. Segmentation models (e.g., `RFDETRSegLarge`) additionally output instance masks. Both share the same backbone and training API; segmentation adds a mask head and requires COCO-format segmentation annotations.
+
+**Is RF-DETR open source?**
+Yes. Core models (Nano through Large) and all training/inference code are released under the Apache 2.0 license. XLarge and 2XLarge models require the `rfdetr[plus]` package (PML 1.0 license).

--- a/docs/learn/benchmarks.md
+++ b/docs/learn/benchmarks.md
@@ -10,6 +10,13 @@ Latency is measured as single-image inference latency rather than sustained thro
 
 Accuracy and latency are always measured using the same model artifact and the same numerical precision. This avoids reporting FP32 accuracy together with FP16 latency, which can lead to misleading comparisons because naive FP16 conversion can significantly degrade accuracy for some models.
 
+!!! info "Metric definitions"
+
+    **AP50**: Detection accuracy at IoU threshold >= 0.50.
+    **AP50:95**: Mean accuracy averaged over IoU thresholds 0.50 to 0.95 (step 0.05) — the primary COCO metric.
+    Latency measured on NVIDIA T4, TensorRT 10.4, CUDA 12.4, FP16, batch size 1,
+    with 200 ms thermal buffer between passes to reduce GPU thermal variance.
+
 ## Detection
 
 <img alt="rf_detr_1-4_latency_accuracy_object_detection" src="https://storage.googleapis.com/com-roboflow-marketing/rf-detr/rf_detr_1-4_latency_accuracy_object_detection.png" />

--- a/docs/learn/benchmarks.md
+++ b/docs/learn/benchmarks.md
@@ -1,4 +1,16 @@
+---
+description: RF-DETR benchmark results on COCO and RF100-VL for detection and segmentation. Compare accuracy and latency against YOLO, D-FINE, and LW-DETR.
+---
+
 # Benchmarks
+
+!!! tip "Key Takeaways"
+
+    - RF-DETR-2XL achieves 60.1 AP50:95 on COCO detection at 17.2 ms latency (T4, TensorRT FP16)
+    - RF-DETR-L outperforms YOLOv11x (56.5 vs 54.7 AP50:95) at lower latency (6.8 vs 10.5 ms)
+    - Segmentation models range from 40.3 AP (Nano, 3.4 ms) to 49.9 AP (2XL, 21.8 ms) on COCO
+    - All latency measured on NVIDIA T4 with TensorRT 10.4, CUDA 12.4, FP16, batch size 1
+    - RF100-VL results demonstrate strong domain-shift generalization across 100 diverse datasets
 
 This page reports RF-DETR benchmark results for object detection and instance segmentation on Microsoft COCO and RF100-VL. All benchmark numbers and plots match the latest released checkpoints and tables shown below. Latency values are measured on an NVIDIA T4 with TensorRT in FP16 at batch size 1. For full methodology details and architectural context, see the RF-DETR paper.
 

--- a/docs/learn/deploy.md
+++ b/docs/learn/deploy.md
@@ -1,4 +1,15 @@
+---
+description: Deploy fine-tuned RF-DETR detection and segmentation models to Roboflow for cloud inference, edge hardware, and multi-step vision workflows.
+---
+
 # Deploy a Trained RF-DETR Model
+
+!!! tip "Key Takeaways"
+
+    - Deploy fine-tuned RF-DETR models to Roboflow with a single `deploy_to_roboflow()` call
+    - Supports both detection and segmentation model deployment
+    - Run deployed models via Roboflow Inference on cloud, edge hardware, or NVIDIA Jetson
+    - Model weights are cached locally after the first inference run for fast subsequent predictions
 
 You can deploy a fine-tuned RF-DETR model to Roboflow.
 

--- a/docs/learn/export.md
+++ b/docs/learn/export.md
@@ -1,4 +1,16 @@
+---
+description: Export RF-DETR models to ONNX, TensorRT, and TFLite (FP32/FP16/INT8) for high-performance inference on GPUs, mobile, and edge devices.
+---
+
 # Export RF-DETR Model
+
+!!! tip "Key Takeaways"
+
+    - Export to ONNX for cross-platform inference with ONNX Runtime, OpenVINO, or TensorRT
+    - Export to TFLite (FP32, FP16, INT8) for mobile and edge deployment
+    - TensorRT conversion delivers lowest latency on NVIDIA GPUs (2.3 ms for Nano)
+    - INT8 quantization requires calibration data from your dataset for accurate results
+    - Custom input resolutions supported (must be divisible by 14)
 
 RF-DETR supports exporting models to ONNX and TFLite formats, enabling deployment across a wide range of inference frameworks, edge devices, and hardware accelerators.
 

--- a/docs/learn/install.md
+++ b/docs/learn/install.md
@@ -1,3 +1,7 @@
+---
+description: Install RF-DETR via pip, uv, or from source. Set up a development environment for contributing to Roboflow's real-time detection transformer.
+---
+
 # Installation
 
 Welcome to RF-DETR! This guide will help you install and set up RF-DETR for your projects. Whether you're a developer looking to contribute or an end-user ready to start using RF-DETR, we've got you covered.

--- a/docs/learn/migration.md
+++ b/docs/learn/migration.md
@@ -1,3 +1,7 @@
+---
+description: RF-DETR migration guide for deprecated module paths. Update imports from rfdetr.util and rfdetr.deploy to their canonical replacements.
+---
+
 # Deprecated APIs
 
 RF-DETR has reorganised its internal package layout. A set of backward-compatibility

--- a/docs/learn/pretrained.md
+++ b/docs/learn/pretrained.md
@@ -1,3 +1,7 @@
+---
+description: Run pre-trained RF-DETR models (Nano to 2XLarge) on images, video, webcam, and RTSP streams. COCO-trained with real-time DINOv2 backbone.
+---
+
 You can run any of the four supported RF-DETR base models -- Nano, Small, Medium, Large -- with [Inference](https://github.com/roboflow/inference), an open source computer vision inference server. The base models are trained on the [Microsoft COCO dataset](https://universe.roboflow.com/microsoft/coco). XLarge and 2XLarge detection models are also available via `pip install rfdetr[plus]` and are provided under the PML 1.0 license.
 
 === "Run on an Image"

--- a/docs/learn/run/detection.md
+++ b/docs/learn/run/detection.md
@@ -1,3 +1,7 @@
+---
+description: Run RF-DETR object detection on images, video, and streams. Nano to 2XLarge models with 2.3-17.2 ms latency and up to 60.1 AP on COCO.
+---
+
 # Run an RF-DETR Object Detection Model
 
 RF-DETR is a real-time transformer architecture for object detection, built on a DINOv2 vision transformer backbone. The base models are trained on the Microsoft COCO dataset and achieve state-of-the-art accuracy and latency trade-offs.

--- a/docs/learn/run/segmentation.md
+++ b/docs/learn/run/segmentation.md
@@ -1,3 +1,7 @@
+---
+description: Run RF-DETR instance segmentation on images, video, and streams. Mask predictions with 3.4-21.8 ms latency using DINOv2 backbone.
+---
+
 # Run an RF-DETR Instance Segmentation Model
 
 RF-DETR is a real-time transformer architecture for instance segmentation, built on a DINOv2 vision transformer backbone. The base models are trained on the Microsoft COCO dataset and achieve strong accuracy and latency trade-offs.

--- a/docs/learn/train/advanced.md
+++ b/docs/learn/train/advanced.md
@@ -1,3 +1,7 @@
+---
+description: Advanced RF-DETR training with resume, early stopping, multi-GPU DDP, gradient checkpointing, and memory optimization for large models.
+---
+
 # Advanced Training
 
 This page covers advanced training topics including resuming training, early stopping, multi-GPU training, and memory optimization techniques.

--- a/docs/learn/train/augmentations.md
+++ b/docs/learn/train/augmentations.md
@@ -1,3 +1,7 @@
+---
+description: Configure RF-DETR data augmentations with Albumentations. Built-in presets for aerial, industrial, and small datasets plus custom transforms.
+---
+
 # Augmentations
 
 RF-DETR supports custom data augmentations via [Albumentations](https://albumentations.ai/), with automatic bounding box and mask handling for geometric transforms. Albumentations 1.4.24+ and 2.x are supported.

--- a/docs/learn/train/customization.md
+++ b/docs/learn/train/customization.md
@@ -1,3 +1,7 @@
+---
+description: Customize RF-DETR training with PyTorch Lightning primitives. Direct access to RFDETRModelModule, RFDETRDataModule, and build_trainer.
+---
+
 # Custom Training API
 
 The high-level `RFDETR.train()` method is the quickest path to fine-tuning, but the underlying training primitives are fully public and are the **recommended path for any customisation**: custom callbacks, alternative loggers, mixed-precision overrides, multi-GPU strategies, or integration with external training frameworks.

--- a/docs/learn/train/dataset-formats.md
+++ b/docs/learn/train/dataset-formats.md
@@ -1,3 +1,7 @@
+---
+description: RF-DETR dataset format guide for COCO JSON and YOLO. Auto-detection, directory structure, annotation schemas, and format conversion.
+---
+
 # Dataset Formats
 
 RF-DETR supports training on datasets in two popular formats: **COCO** and **YOLO**. The format is automatically detected based on your dataset's directory structure—simply pass your dataset directory to the `train()` method.

--- a/docs/learn/train/index.md
+++ b/docs/learn/train/index.md
@@ -1,4 +1,16 @@
+---
+description: Train RF-DETR detection and segmentation models on custom datasets. Supports COCO and YOLO formats with one-line Python API and PyTorch Lightning.
+---
+
 # Train an RF-DETR Model
+
+!!! tip "Key Takeaways"
+
+    - Train detection or segmentation models with a single `model.train(dataset_dir=...)` call
+    - Supports both COCO JSON and YOLO dataset formats with automatic detection
+    - Fine-tune from COCO-pretrained checkpoints (Nano to 2XLarge) for fastest convergence
+    - Built on PyTorch Lightning — use the high-level API or access PTL primitives directly for full control
+    - EMA weights, early stopping, and best-model checkpointing are included by default
 
 You can train RF-DETR object detection and segmentation models on a custom dataset using the `rfdetr` Python package, or in the cloud using Roboflow.
 

--- a/docs/learn/train/loggers.md
+++ b/docs/learn/train/loggers.md
@@ -1,3 +1,7 @@
+---
+description: Track RF-DETR training with TensorBoard, Weights and Biases, ClearML, and MLflow. Configure multiple experiment loggers simultaneously.
+---
+
 # Training Loggers
 
 RF-DETR supports integration with popular experiment tracking and visualization platforms. You can enable one or more loggers to monitor your training runs, compare experiments, and track metrics over time.

--- a/docs/learn/train/training-parameters.md
+++ b/docs/learn/train/training-parameters.md
@@ -1,3 +1,7 @@
+---
+description: Complete RF-DETR training parameter reference. Learning rate, batch size, EMA, early stopping, resolution, and hardware configuration.
+---
+
 # Training Parameters
 
 This page provides a complete reference of all parameters available when training RF-DETR models.

--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -60,6 +60,70 @@
     ]
   }
   </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "What is RF-DETR?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "RF-DETR (Roboflow Detection Transformer) is a real-time object detection and instance segmentation model from Roboflow. It uses a DINOv2 vision transformer backbone and achieves state-of-the-art accuracy\u2013latency trade-offs on COCO and RF100-VL."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How does RF-DETR compare to YOLOv11?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "RF-DETR-L achieves 56.5 AP50:95 on COCO at 6.8 ms latency on an NVIDIA T4, outperforming YOLOv11x (54.7 AP) at lower latency. The DINOv2 backbone gives RF-DETR stronger performance on domain-shift benchmarks such as RF100-VL."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What GPU is required to train RF-DETR?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "A CUDA-capable GPU with at least 8 GB VRAM is recommended for fine-tuning. Smaller models (RF-DETR-N and RF-DETR-S) can fit in 6 GB VRAM with reduced batch size. CPU inference is supported for evaluation."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Which dataset formats does RF-DETR support?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "RF-DETR supports COCO JSON and YOLO-format datasets. Roboflow datasets export directly to both formats. Detection and segmentation datasets use the same format \u2014 the model variant determines the task."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Can RF-DETR run in real time?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes. RF-DETR-N runs at 2.3 ms per frame on a T4 GPU (TensorRT FP16, batch 1), and RF-DETR-L at 6.8 ms \u2014 both well within real-time thresholds. ONNX and TFLite exports are available for edge deployment."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is the difference between RF-DETR detection and segmentation models?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Detection models output bounding boxes. Segmentation models additionally output instance masks. Both share the same backbone and training API; segmentation adds a mask head and requires COCO-format segmentation annotations."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Is RF-DETR open source?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes. Core models (Nano through Large) and all training/inference code are released under the Apache 2.0 license. XLarge and 2XLarge models require the rfdetr[plus] package (PML 1.0 license)."
+        }
+      }
+    ]
+  }
+  </script>
   {% else %}
   {# JSON-LD: TechArticle — content pages #}
   <script type="application/ld+json">

--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -1,0 +1,77 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  {{ super() }}
+
+  {% if page %}
+  {# Open Graph — all pages #}
+  <meta property="og:title" content="{{ page.title }} - {{ config.site_name }}">
+  <meta property="og:description" content="{{ page.meta.description | default(config.site_description) }}">
+  <meta property="og:type" content="{% if page.is_homepage %}website{% else %}article{% endif %}">
+  <meta property="og:url" content="{{ page.canonical_url }}">
+  <meta property="og:image" content="{{ config.site_url }}assets/og-image.png">
+
+  {# Twitter Card — all pages #}
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@roboflow">
+  <meta name="twitter:title" content="{{ page.title }} - {{ config.site_name }}">
+  <meta name="twitter:description" content="{{ page.meta.description | default(config.site_description) }}">
+  <meta name="twitter:image" content="{{ config.site_url }}assets/og-image.png">
+
+  {# JSON-LD: Organization + SoftwareApplication — homepage only #}
+  {% if page.is_homepage %}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Organization",
+        "name": "Roboflow",
+        "url": "https://roboflow.com",
+        "sameAs": [
+          "https://github.com/roboflow",
+          "https://www.linkedin.com/company/roboflow-ai/",
+          "https://twitter.com/roboflow",
+          "https://www.youtube.com/@Roboflow",
+          "https://pypi.org/project/rfdetr/"
+        ]
+      },
+      {
+        "@type": "SoftwareApplication",
+        "name": "RF-DETR",
+        "alternateName": "rfdetr",
+        "applicationCategory": "DeveloperApplication",
+        "operatingSystem": "Linux, macOS, Windows",
+        "url": "{{ config.site_url }}",
+        "downloadUrl": "https://pypi.org/project/rfdetr/",
+        "description": "RF-DETR is a real-time transformer architecture for object detection and instance segmentation by Roboflow. DINOv2 backbone, SOTA on COCO. ICLR 2026.",
+        "author": {"@type": "Organization", "name": "Roboflow", "url": "https://roboflow.com"},
+        "license": "https://www.apache.org/licenses/LICENSE-2.0",
+        "codeRepository": "https://github.com/roboflow/rf-detr",
+        "programmingLanguage": "Python",
+        "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"},
+        "sameAs": [
+          "https://github.com/roboflow/rf-detr",
+          "https://pypi.org/project/rfdetr/",
+          "https://arxiv.org/abs/2511.09554"
+        ]
+      }
+    ]
+  }
+  </script>
+  {% else %}
+  {# JSON-LD: TechArticle — content pages #}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    "headline": "{{ page.title }}",
+    "description": "{{ page.meta.description | default(config.site_description) }}",
+    "url": "{{ page.canonical_url }}",
+    "author": {"@type": "Organization", "name": "Roboflow", "url": "https://roboflow.com"},
+    "publisher": {"@type": "Organization", "name": "Roboflow", "url": "https://roboflow.com"}
+  }
+  </script>
+  {% endif %}
+  {% endif %}
+{% endblock %}

--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -4,19 +4,20 @@
   {{ super() }}
 
   {% if page %}
+  {% set og_image_url = 'assets/og-image.png' | url %}
   {# Open Graph — all pages #}
   <meta property="og:title" content="{{ page.title }} - {{ config.site_name }}">
   <meta property="og:description" content="{{ page.meta.description | default(config.site_description) }}">
   <meta property="og:type" content="{% if page.is_homepage %}website{% else %}article{% endif %}">
   <meta property="og:url" content="{{ page.canonical_url }}">
-  <meta property="og:image" content="{{ config.site_url }}assets/og-image.png">
+  <meta property="og:image" content="{{ og_image_url }}">
 
   {# Twitter Card — all pages #}
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@roboflow">
   <meta name="twitter:title" content="{{ page.title }} - {{ config.site_name }}">
   <meta name="twitter:description" content="{{ page.meta.description | default(config.site_description) }}">
-  <meta name="twitter:image" content="{{ config.site_url }}assets/og-image.png">
+  <meta name="twitter:image" content="{{ og_image_url }}">
 
   {# JSON-LD: Organization + SoftwareApplication — homepage only #}
   {% if page.is_homepage %}

--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -130,8 +130,8 @@
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",
-    "headline": "{{ page.title }}",
-    "description": "{{ page.meta.description | default(config.site_description) }}",
+    "headline": {{ page.title | tojson }},
+    "description": {{ page.meta.description | default(config.site_description) | tojson }},
     "url": "{{ page.canonical_url }}",
     "author": {"@type": "Organization", "name": "Roboflow", "url": "https://roboflow.com"},
     "publisher": {"@type": "Organization", "name": "Roboflow", "url": "https://roboflow.com"}

--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -29,6 +29,7 @@
         "@type": "Organization",
         "name": "Roboflow",
         "url": "https://roboflow.com",
+        "logo": "https://storage.googleapis.com/com-roboflow-marketing/rf-detr/rf_detr_1-4_latency_accuracy_object_detection.png",
         "sameAs": [
           "https://github.com/roboflow",
           "https://www.linkedin.com/company/roboflow-ai/",
@@ -135,6 +136,39 @@
     "url": "{{ page.canonical_url }}",
     "author": {"@type": "Organization", "name": "Roboflow", "url": "https://roboflow.com"},
     "publisher": {"@type": "Organization", "name": "Roboflow", "url": "https://roboflow.com"}
+  }
+  </script>
+  {# JSON-LD: BreadcrumbList — content pages #}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "RF-DETR",
+        "item": "{{ config.site_url }}"
+      }{% if page.parent %},
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": {{ page.parent.title | tojson }},
+        "item": "{{ config.site_url }}{{ page.parent.url }}"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": {{ page.title | tojson }},
+        "item": "{{ page.canonical_url }}"
+      }{% else %},
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": {{ page.title | tojson }},
+        "item": "{{ page.canonical_url }}"
+      }{% endif %}
+    ]
   }
   </script>
   {% endif %}

--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -4,20 +4,20 @@
   {{ super() }}
 
   {% if page %}
-  {% set og_image_url = 'assets/og-image.png' | url %}
+  {% set og_image_url = page.meta.image | default(config.extra.og_image | default('')) %}
   {# Open Graph — all pages #}
   <meta property="og:title" content="{{ page.title }} - {{ config.site_name }}">
   <meta property="og:description" content="{{ page.meta.description | default(config.site_description) }}">
   <meta property="og:type" content="{% if page.is_homepage %}website{% else %}article{% endif %}">
   <meta property="og:url" content="{{ page.canonical_url }}">
-  <meta property="og:image" content="{{ og_image_url }}">
+  {% if og_image_url %}<meta property="og:image" content="{{ og_image_url }}">{% endif %}
 
   {# Twitter Card — all pages #}
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@roboflow">
   <meta name="twitter:title" content="{{ page.title }} - {{ config.site_name }}">
   <meta name="twitter:description" content="{{ page.meta.description | default(config.site_description) }}">
-  <meta name="twitter:image" content="{{ og_image_url }}">
+  {% if og_image_url %}<meta name="twitter:image" content="{{ og_image_url }}">{% endif %}
 
   {# JSON-LD: Organization + SoftwareApplication — homepage only #}
   {% if page.is_homepage %}

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -103,6 +103,10 @@ theme:
 
 plugins:
   - search
+  - meta
+  - git-revision-date-localized:
+      enable_creation_date: false
+      type: date
   - mkdocstrings:
       default_handler: python
       handlers:

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -8,6 +8,7 @@ edit_uri: https://github.com/roboflow/rf-detr/tree/main/docs
 copyright: Roboflow 2025. All rights reserved.
 
 extra:
+  og_image: https://storage.googleapis.com/com-roboflow-marketing/rf-detr/rf_detr_1-4_latency_accuracy_object_detection.png
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/roboflow

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -103,7 +103,6 @@ theme:
 
 plugins:
   - search
-  - meta
   - git-revision-date-localized:
       enable_creation_date: false
       type: date

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,7 +1,7 @@
 site_name: RF-DETR
 site_url: https://rfdetr.roboflow.com/
 site_author: Roboflow
-site_description: "SOTA Real-Time Object Detection Model"
+site_description: "Real-time transformer for object detection and instance segmentation. DINOv2 backbone, SOTA on COCO (60.1 AP50:95). Apache 2.0. Works with Python ≥3.10."
 repo_name: roboflow/rf-detr
 repo_url: https://github.com/roboflow/rf-detr
 edit_uri: https://github.com/roboflow/rf-detr/tree/main/docs

--- a/root-static/cace9ef287cb8d641db90d4295fcb1e1.txt
+++ b/root-static/cace9ef287cb8d641db90d4295fcb1e1.txt
@@ -1,0 +1,1 @@
+cace9ef287cb8d641db90d4295fcb1e1

--- a/root-static/llms.txt
+++ b/root-static/llms.txt
@@ -1,0 +1,24 @@
+# RF-DETR
+> Real-time object detection and instance segmentation transformer by Roboflow. ICLR 2026.
+> Apache 2.0 for base models (Nano-Large). DINOv2 backbone. SOTA on COCO (60.1 AP50:95, 2XL).
+> Install: pip install rfdetr (Python >=3.10, PyTorch >=2.2.0)
+
+## Getting Started
+- [Install](https://rfdetr.roboflow.com/latest/learn/install/): pip install rfdetr
+- [Run Pretrained](https://rfdetr.roboflow.com/latest/learn/pretrained/): Nano/Small/Medium/Large/XLarge/2XLarge
+- [Train](https://rfdetr.roboflow.com/latest/learn/train/): RFDETR.train() API, COCO and YOLO formats
+- [Export](https://rfdetr.roboflow.com/latest/learn/export/): ONNX, TFLite, TensorRT
+- [Deploy](https://rfdetr.roboflow.com/latest/learn/deploy/): deploy_to_roboflow() API
+
+## Benchmarks
+- [COCO and RF100-VL Results](https://rfdetr.roboflow.com/latest/learn/benchmarks/): T4 TensorRT FP16, batch 1
+
+## API Reference
+- [RFDETR base class](https://rfdetr.roboflow.com/latest/reference/rfdetr/): train(), predict(), export(), deploy_to_roboflow()
+- [Detection models](https://rfdetr.roboflow.com/latest/reference/base/): RFDETRNano through RFDETR2XLarge
+- [Segmentation models](https://rfdetr.roboflow.com/latest/reference/medium/): RFDETRSegNano through RFDETRSeg2XLarge
+
+## Optional
+- [GitHub](https://github.com/roboflow/rf-detr): 6.4k stars, Apache 2.0
+- [arXiv Paper](https://arxiv.org/abs/2511.09554): ICLR 2026
+- [PyPI](https://pypi.org/project/rfdetr/): rfdetr package

--- a/root-static/llms.txt
+++ b/root-static/llms.txt
@@ -15,8 +15,8 @@
 
 ## API Reference
 - [RFDETR base class](https://rfdetr.roboflow.com/latest/reference/rfdetr/): train(), predict(), export(), deploy_to_roboflow()
-- [Detection models](https://rfdetr.roboflow.com/latest/reference/base/): RFDETRNano through RFDETR2XLarge
-- [Segmentation models](https://rfdetr.roboflow.com/latest/reference/medium/): RFDETRSegNano through RFDETRSeg2XLarge
+- [Detection models](https://rfdetr.roboflow.com/latest/reference/nano/): RFDETRNano through RFDETR2XLarge
+- [Segmentation models](https://rfdetr.roboflow.com/latest/reference/seg_nano/): RFDETRSegNano through RFDETRSeg2XLarge
 
 ## Optional
 - [GitHub](https://github.com/roboflow/rf-detr): 6.4k stars, Apache 2.0

--- a/root-static/robots.txt
+++ b/root-static/robots.txt
@@ -1,0 +1,19 @@
+User-agent: *
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+Sitemap: https://rfdetr.roboflow.com/latest/sitemap.xml

--- a/root-static/robots.txt
+++ b/root-static/robots.txt
@@ -1,5 +1,17 @@
 User-agent: *
 Allow: /
+# Block numeric-versioned paths (/0.x/, /1.x/, etc.) — canonical URL is /latest/
+# robots.txt has no character classes, so one Disallow per leading digit is required.
+Disallow: /0.*/
+Disallow: /1.*/
+Disallow: /2.*/
+Disallow: /3.*/
+Disallow: /4.*/
+Disallow: /5.*/
+Disallow: /6.*/
+Disallow: /7.*/
+Disallow: /8.*/
+Disallow: /9.*/
 
 User-agent: GPTBot
 Allow: /
@@ -14,6 +26,12 @@ User-agent: CCBot
 Allow: /
 
 User-agent: Google-Extended
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: GoogleOther
 Allow: /
 
 Sitemap: https://rfdetr.roboflow.com/latest/sitemap.xml


### PR DESCRIPTION
This pull request introduces several improvements to the documentation, site metadata, and deployment workflow for the project. The main changes include enhanced SEO and social sharing metadata, the addition of static files for deployment, improved documentation clarity, and workflow automation for publishing updates.

**Documentation and SEO improvements:**

- Added a custom Jinja2 template `docs/theme/main.html` to inject Open Graph, Twitter Card, and JSON-LD metadata for better SEO and social sharing. The template dynamically adjusts metadata for the homepage and content pages.
- Added a concise description meta tag to `docs/index.md` for improved search engine visibility.
- Improved image accessibility and performance in `docs/index.md` by adding alt text and lazy loading to images. [[1]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L79-R80) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L89-R90) [[3]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L99-R100)
- Added a clearly formatted info block defining benchmark metrics in `docs/learn/benchmarks.md` for better documentation clarity.

**Deployment and workflow automation:**

- Updated `.github/workflows/publish-docs.yml` to deploy `robots.txt` and `llms.txt` from `root-static/` to the `gh-pages` branch automatically on relevant events, ensuring static files are always up to date.

**Static files and configuration:**

- Added `root-static/robots.txt` to allow all user-agents and AI bots, and to specify the sitemap location, improving both crawlability and AI indexing.
- Added `root-static/llms.txt` with project information, installation instructions, and links for LLMs and search engines.
- Enabled the `meta` MkDocs plugin and configured `git-revision-date-localized` for improved metadata and revision tracking in `mkdocs.yaml`.