### PR TITLE
releasing `1.6.5` [rebase & merge]

### DIFF
--- a/.github/workflows/ci-typing.yml
+++ b/.github/workflows/ci-typing.yml
@@ -45,22 +45,3 @@ jobs:
       - name: Minimize uv cache
         continue-on-error: true
         run: uv cache prune --ci
-
-  type-check-guardian:
-    runs-on: ubuntu-latest
-    needs: type-check
-    if: always()
-    steps:
-      - name: 📋 Display type-check result
-        run: echo "${{ needs.type-check.result }}"
-      - name: ❌ Fail guardian on type-check failure
-        if: needs.type-check.result == 'failure'
-        run: exit 1
-      - name: ⚠️ cancelled or skipped...
-        if: contains(fromJSON('["cancelled", "skipped"]'), needs.type-check.result)
-        run: |
-          echo "type-check job result is '${{ needs.type-check.result }}'; failing explicitly."
-          exit 1
-      - name: ✅ type check succeeded
-        if: needs.type-check.result == 'success'
-        run: echo "All type checks passed in job 'type-check'."

--- a/.gitignore
+++ b/.gitignore
@@ -194,6 +194,11 @@ debugging/
 
 # AI assistant
 .claude/
+.codex/
+.plans/
+.reports/
+.temp/
+cache-gh/
 
 # Local docs development (versions.json is managed by mike on gh-pages in production)
 docs/versions.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `predict()` storing `detections.data["source_shape"]` as a Python `tuple`, which caused `TypeError: Unsupported data type for key 'source_shape': <class 'tuple'>` whenever `sv.Detections` was iterated (e.g. `list(detections)`, `for d in detections`, `MeanAveragePrecision.compute()`). The value is now an `np.ndarray` of shape `(N, 2)` and dtype `int64`, with one `[height, width]` row per detection. ([#963](https://github.com/roboflow/rf-detr/issues/963))
+
 ---
 
 ## [1.6.4] — 2026-04-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed `predict()` storing `detections.data["source_shape"]` as a Python `tuple`, which caused `TypeError: Unsupported data type for key 'source_shape': <class 'tuple'>` whenever `sv.Detections` was iterated (e.g. `list(detections)`, `for d in detections`, `MeanAveragePrecision.compute()`). The value is now an `np.ndarray` of shape `(N, 2)` and dtype `int64`, with one `[height, width]` row per detection. ([#963](https://github.com/roboflow/rf-detr/issues/963))
-- Fixed `predict()` emitting a misleading "class_id out of range" warning when the model predicts the background/no-object class (class index `num_classes`). RF-DETR uses `num_classes + 1` outputs internally; the last class is the background class and is expected behaviour, not an error. Background-class detections now map `data["class_name"]` to `"__background__"` without any warning.
-- Fixed `predict()` raising `IndexError` when boolean- or integer-indexing `sv.Detections` with `include_source_image=True` (the default). `source_image` is now stored in `detections.metadata["source_image"]` instead of `detections.data["source_image"]`. **Migration**: update any code that reads `detections.data["source_image"]` to `detections.metadata["source_image"]`. ([#972](https://github.com/roboflow/rf-detr/pull/972), closes [#968](https://github.com/roboflow/rf-detr/issues/968))
-
 ---
+
+## [1.6.5] — 2026-04-22
+
+### Breaking Changes
+
+- `predict()` now stores the source image in `detections.metadata["source_image"]` instead of `detections.data["source_image"]`. supervision indexes every value in `data` by the detection mask; `source_image` is per-image, not per-detection, so boolean/integer indexing raised `IndexError`. Moving it to `metadata` (passed through unchanged) fixes the issue. Update any code that reads `detections.data["source_image"]`. ([#972](https://github.com/roboflow/rf-detr/pull/972), [#968](https://github.com/roboflow/rf-detr/issues/968))
+
+### Fixed
+
+- Fixed segmentation training crash on T4 and P100 GPUs: cuDNN engine selection fails for depthwise convolution backward on some CUDA stacks (Kaggle, Colab). A custom `autograd.Function` now disables cuDNN in both forward and backward passes. ([#967](https://github.com/roboflow/rf-detr/pull/967))
+- Fixed `ema_segm_mAP_50_95` and `ema_segm_mAP_50` being computed from the base (non-EMA) metric accumulator instead of the EMA accumulator, producing misleading validation scores for segmentation models. ([#980](https://github.com/roboflow/rf-detr/pull/980))
+- Fixed `BestModelCallback` losing the best EMA score on training resume because `_best_ema` was not persisted in `state_dict()`. ([#973](https://github.com/roboflow/rf-detr/pull/973))
+- Fixed `positional_encoding_size` not updating when `resolution` is set at construction time (e.g. `RFDETRLarge(resolution=640)`), causing shape mismatches during forward. A model validator now auto-syncs PE size. ([#956](https://github.com/roboflow/rf-detr/pull/956))
+- Fixed pretrained weight loading crash with custom resolution: DINOv2 positional embeddings are now bicubic-interpolated to match the target grid before `load_state_dict`. ([#964](https://github.com/roboflow/rf-detr/pull/964))
+- Fixed `validate_checkpoint_compatibility` producing a cryptic `RuntimeError` on `patch_size` mismatch when checkpoint lacks explicit `args.patch_size`. The function now infers `patch_size` from the DINOv2 projection weight shape and raises a descriptive `ValueError`. ([#971](https://github.com/roboflow/rf-detr/pull/971))
+- Fixed `predict()` storing `detections.data["source_shape"]` as a Python `tuple`, which caused `TypeError` whenever `sv.Detections` was iterated. The value is now an `np.ndarray` of shape `(N, 2)` and dtype `int64`. ([#966](https://github.com/roboflow/rf-detr/pull/966), [#963](https://github.com/roboflow/rf-detr/issues/963))
+- Fixed `predict()` emitting a misleading "class_id out of range" warning for the background/no-object class (class index `num_classes`). Background-class detections now map `data["class_name"]` to `"__background__"` without any warning. ([#970](https://github.com/roboflow/rf-detr/issues/970))
 
 ## [1.6.4] — 2026-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `predict()` storing `detections.data["source_shape"]` as a Python `tuple`, which caused `TypeError: Unsupported data type for key 'source_shape': <class 'tuple'>` whenever `sv.Detections` was iterated (e.g. `list(detections)`, `for d in detections`, `MeanAveragePrecision.compute()`). The value is now an `np.ndarray` of shape `(N, 2)` and dtype `int64`, with one `[height, width]` row per detection. ([#963](https://github.com/roboflow/rf-detr/issues/963))
+- Fixed `predict()` emitting a misleading "class_id out of range" warning when the model predicts the background/no-object class (class index `num_classes`). RF-DETR uses `num_classes + 1` outputs internally; the last class is the background class and is expected behaviour, not an error. Background-class detections now map `data["class_name"]` to `"__background__"` without any warning.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed `predict()` storing `detections.data["source_shape"]` as a Python `tuple`, which caused `TypeError: Unsupported data type for key 'source_shape': <class 'tuple'>` whenever `sv.Detections` was iterated (e.g. `list(detections)`, `for d in detections`, `MeanAveragePrecision.compute()`). The value is now an `np.ndarray` of shape `(N, 2)` and dtype `int64`, with one `[height, width]` row per detection. ([#963](https://github.com/roboflow/rf-detr/issues/963))
 - Fixed `predict()` emitting a misleading "class_id out of range" warning when the model predicts the background/no-object class (class index `num_classes`). RF-DETR uses `num_classes + 1` outputs internally; the last class is the background class and is expected behaviour, not an error. Background-class detections now map `data["class_name"]` to `"__background__"` without any warning.
+- Fixed `predict()` raising `IndexError` when boolean- or integer-indexing `sv.Detections` with `include_source_image=True` (the default). `source_image` is now stored in `detections.metadata["source_image"]` instead of `detections.data["source_image"]`. **Migration**: update any code that reads `detections.data["source_image"]` to `detections.metadata["source_image"]`. ([#972](https://github.com/roboflow/rf-detr/pull/972), closes [#968](https://github.com/roboflow/rf-detr/issues/968))
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ detections = model.predict("https://media.roboflow.com/dog.jpg", threshold=0.5)
 
 labels = [f"{COCO_CLASSES[class_id]}" for class_id in detections.class_id]
 
-annotated_image = sv.BoxAnnotator().annotate(detections.data["source_image"], detections)
+annotated_image = sv.BoxAnnotator().annotate(detections.metadata["source_image"], detections)
 annotated_image = sv.LabelAnnotator().annotate(annotated_image, detections, labels)
 ```
 
@@ -190,7 +190,7 @@ detections = model.predict("https://media.roboflow.com/dog.jpg", threshold=0.5)
 
 labels = [f"{COCO_CLASSES[class_id]}" for class_id in detections.class_id]
 
-annotated_image = sv.MaskAnnotator().annotate(detections.data["source_image"], detections)
+annotated_image = sv.MaskAnnotator().annotate(detections.metadata["source_image"], detections)
 annotated_image = sv.LabelAnnotator().annotate(annotated_image, detections, labels)
 ```
 

--- a/docs/learn/run/detection.md
+++ b/docs/learn/run/detection.md
@@ -34,7 +34,7 @@ Perform inference on an image using either the `rfdetr` package or the `inferenc
 
     labels = [f"{COCO_CLASSES[class_id]}" for class_id in detections.class_id]
 
-    annotated_image = sv.BoxAnnotator().annotate(detections.data["source_image"], detections)
+    annotated_image = sv.BoxAnnotator().annotate(detections.metadata["source_image"], detections)
     annotated_image = sv.LabelAnnotator().annotate(annotated_image, detections, labels)
     ```
 

--- a/docs/learn/run/segmentation.md
+++ b/docs/learn/run/segmentation.md
@@ -32,7 +32,7 @@ Perform inference on an image using either the `rfdetr` package or the `inferenc
 
     labels = [f"{COCO_CLASSES[class_id]}" for class_id in detections.class_id]
 
-    annotated_image = sv.MaskAnnotator().annotate(detections.data["source_image"], detections)
+    annotated_image = sv.MaskAnnotator().annotate(detections.metadata["source_image"], detections)
     annotated_image = sv.LabelAnnotator().annotate(annotated_image, detections, labels)
     ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rfdetr"
-version = "1.6.4"
+version = "1.6.5"
 description = "RF-DETR"
 readme = "README.md"
 authors = [

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -114,6 +114,44 @@ class ModelConfig(BaseConfig):
     freeze_encoder: bool = False
     license: str = "Apache-2.0"
 
+    @model_validator(mode="after")
+    def _sync_pe_with_resolution(self) -> "ModelConfig":
+        """Auto-update positional_encoding_size when resolution is explicitly provided.
+
+        When a user provides a custom ``resolution`` at construction time (e.g.,
+        ``RFDETRLarge(resolution=640)``), ``positional_encoding_size`` is updated
+        proportionally, provided the class-default PE is formula-derived
+        (``default_pe == default_resolution // patch_size``).
+
+        Configs with a pretrained-specific PE (e.g., ``RFDETRBaseConfig`` with
+        ``positional_encoding_size=37`` for DINOv2's native 518 px grid, while
+        ``resolution=560``) are left unchanged.
+        """
+        if "resolution" not in self.model_fields_set or "positional_encoding_size" in self.model_fields_set:
+            return self
+
+        cls = type(self)
+        default_resolution = cls.model_fields["resolution"].default
+        default_pe = cls.model_fields["positional_encoding_size"].default
+        default_patch_size = cls.model_fields["patch_size"].default
+
+        # Skip when any relevant default is not a concrete integer (abstract base
+        # class fields have no defaults; required fields use PydanticUndefined,
+        # not int).
+        if (
+            not isinstance(default_resolution, int)
+            or not isinstance(default_pe, int)
+            or not isinstance(default_patch_size, int)
+        ):
+            return self
+
+        # Only update PE when the class default is formula-derived from the class
+        # default resolution and patch size.
+        if default_pe == default_resolution // default_patch_size:
+            self.positional_encoding_size = self.resolution // self.patch_size
+
+        return self
+
     @field_validator("pretrain_weights", mode="after")
     @classmethod
     def expand_path(cls, v: Optional[str]) -> Optional[str]:

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -1092,6 +1092,17 @@ class RFDETR:
               ``include_source_image=True``, which is the default).
             * ``"source_shape"`` – ``(height, width)`` tuple of the source image dimensions.
 
+            The ``metadata`` dict of each :class:`~supervision.Detections` object
+            contains:
+
+            * ``"source_image"`` – the original input image as a ``uint8`` numpy
+              array of shape ``(H, W, 3)`` (only present when
+              ``include_source_image=True``, which is the default).  Stored in
+              ``metadata`` rather than ``data`` so that boolean and integer indexing
+              of :class:`~supervision.Detections` works correctly — supervision
+              indexes every value in ``data`` by the detection mask, but passes
+              ``metadata`` through unchanged.
+
         Raises:
             ValueError: If ``shape`` cannot be unpacked as a two-element sequence,
                 if either dimension does not support the ``__index__`` protocol
@@ -1247,7 +1258,7 @@ class RFDETR:
                     class_id=labels.cpu().numpy(),
                 )
 
-            detections.data["source_image"] = source_images[i]
+            detections.metadata["source_image"] = source_images[i]
             detections.data["source_shape"] = np.tile(np.array(orig_sizes[i], dtype=np.int64), (len(detections), 1))
 
             # Attach class names so callers can map class_id → name without a

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -1473,11 +1473,11 @@ class RFDETRLarge(RFDETR):
                 logger.warning(
                     "\n"
                     "=" * 100 + "\n"
-                                "WARNING: Automatically switched to deprecated model configuration,"
-                                " due to using deprecated weights."
-                                " This will be removed in a future version.\n"
-                                " Please retrain your model with the new weights and configuration.\n"
-                                "=" * 100 + "\n"
+                    "WARNING: Automatically switched to deprecated model configuration,"
+                    " due to using deprecated weights."
+                    " This will be removed in a future version.\n"
+                    " Please retrain your model with the new weights and configuration.\n"
+                    "=" * 100 + "\n"
                 )
             except Exception:
                 raise self.init_error

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -1088,8 +1088,6 @@ class RFDETR:
               0-indexed; ``class_names[0]`` is the first class regardless of the
               original dataset format (COCO category IDs are remapped to 0-based
               indices during training).
-            * ``"source_image"`` – the original input image (only present when
-              ``include_source_image=True``, which is the default).
             * ``"source_shape"`` – ``(height, width)`` tuple of the source image dimensions.
 
             The ``metadata`` dict of each :class:`~supervision.Detections` object

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -1255,16 +1255,25 @@ class RFDETR:
             # original dataset format (COCO category IDs are remapped during
             # training), so class_names[class_id] is the correct mapping.
             # Always set data["class_name"] for a consistent interface.
+            #
+            # RF-DETR uses num_classes + 1 logits internally; class index n is the
+            # background/no-object class and is expected — map it to "__background__"
+            # without warning.  Indices outside [0, n] are genuinely unexpected and
+            # still produce an empty string with a one-time warning.
             class_ids = detections.class_id if detections.class_id is not None else np.array([], dtype=int)
-            oob_ids = [cid for cid in class_ids if not (0 <= cid < n)]
-            if oob_ids:
+            truly_oob = [cid for cid in class_ids if not (0 <= cid <= n)]
+            if truly_oob:
                 logger.warning_once(
-                    "predict() encountered class_id values out of range [0, %d): %s — mapping to empty string",
+                    "predict() encountered class_id values out of range [0, %d]: %s — mapping to empty string",
                     n,
-                    oob_ids[:5],
+                    truly_oob[:5],
                 )
             detections.data["class_name"] = np.array(
-                [model_class_names[cid] if 0 <= cid < n else "" for cid in class_ids], dtype=object
+                [
+                    model_class_names[cid] if 0 <= cid < n else ("__background__" if cid == n else "")
+                    for cid in class_ids
+                ],
+                dtype=object,
             )
 
             detections_list.append(detections)

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -1433,10 +1433,18 @@ class RFDETRLarge(RFDETR):
     def __init__(self, **kwargs):
         self.init_error = None
         self.is_deprecated = False
+        # When the user explicitly sets a custom resolution, a PE size mismatch
+        # is caused by the resolution change — not by deprecated weights.  Guard
+        # against the fallback heuristic misclassifying it as deprecated weights.
+        # Only suppress the fallback when the provided resolution genuinely differs
+        # from the class default; passing resolution=<default> explicitly (e.g. from
+        # a serialised config round-trip) must still allow the deprecated-weights retry.
+        _default_resolution = RFDETRLargeConfig.model_fields["resolution"].default
+        _custom_resolution = "resolution" in kwargs and kwargs.get("resolution") != _default_resolution
         try:
             super().__init__(**kwargs)
         except (ValueError, RuntimeError) as exc:
-            if not self._should_fallback_to_deprecated_config(exc):
+            if _custom_resolution or not self._should_fallback_to_deprecated_config(exc):
                 raise
             self.init_error = exc
             self.is_deprecated = True
@@ -1445,11 +1453,11 @@ class RFDETRLarge(RFDETR):
                 logger.warning(
                     "\n"
                     "=" * 100 + "\n"
-                    "WARNING: Automatically switched to deprecated model configuration,"
-                    " due to using deprecated weights."
-                    " This will be removed in a future version.\n"
-                    " Please retrain your model with the new weights and configuration.\n"
-                    "=" * 100 + "\n"
+                                "WARNING: Automatically switched to deprecated model configuration,"
+                                " due to using deprecated weights."
+                                " This will be removed in a future version.\n"
+                                " Please retrain your model with the new weights and configuration.\n"
+                                "=" * 100 + "\n"
                 )
             except Exception:
                 raise self.init_error

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -1248,7 +1248,7 @@ class RFDETR:
                 )
 
             detections.data["source_image"] = source_images[i]
-            detections.data["source_shape"] = orig_sizes[i]
+            detections.data["source_shape"] = np.tile(np.array(orig_sizes[i], dtype=np.int64), (len(detections), 1))
 
             # Attach class names so callers can map class_id → name without a
             # separate lookup.  class_id is always 0-indexed regardless of the

--- a/src/rfdetr/models/heads/segmentation.py
+++ b/src/rfdetr/models/heads/segmentation.py
@@ -13,6 +13,130 @@ import torch.nn.functional as F
 from rfdetr.utilities.tensors import _bilinear_grid_sample
 
 
+class _DepthwiseConvWithoutCuDNN(torch.autograd.Function):
+    """Depthwise conv2d with cuDNN disabled in both forward and backward.
+
+    ``torch.backends.cudnn.flags(enabled=False)`` as a context manager only
+    covers operations executed within its scope.  ``nn.Conv2d`` records the
+    forward op in the autograd graph; the corresponding backward kernels run
+    later, **outside** that scope, with cuDNN re-enabled.  On some CUDA stacks
+    (T4 / P100 on Kaggle / Colab) cuDNN fails engine selection for depthwise
+    conv backward, raising::
+
+        RuntimeError: GET was unable to find an engine to execute this computation
+
+    This ``Function`` disables cuDNN in ``backward`` as well, fixing the crash.
+
+    See: https://github.com/roboflow/rf-detr/issues/731
+    """
+
+    @staticmethod
+    def forward(
+        ctx: torch.autograd.function.FunctionCtx,
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor | None,
+        stride: tuple[int, ...],
+        padding: tuple[int, ...],
+        dilation: tuple[int, ...],
+        groups: int,
+    ) -> torch.Tensor:
+        """Run depthwise conv2d forward with cuDNN disabled.
+
+        Args:
+            ctx: Autograd context.
+            x: Input feature map ``(N, C, H, W)``.
+            weight: Convolution weight tensor.
+            bias: Optional convolution bias tensor.
+            stride: Convolution stride.
+            padding: Convolution padding.
+            dilation: Convolution dilation.
+            groups: Number of groups (equals ``C`` for depthwise).
+
+        Returns:
+            Output feature map ``(N, C, H, W)``.
+        """
+        ctx.save_for_backward(x, weight)
+        ctx.has_bias = bias is not None
+        ctx.stride = stride
+        ctx.padding = padding
+        ctx.dilation = dilation
+        ctx.groups = groups
+        # Note: torch.backends.cudnn.flags() is process-global state, not op-local.
+        # Safe under DDP (separate processes per rank), but concurrent backward passes
+        # in the same process (DataParallel, user threads) could briefly observe the
+        # wrong cuDNN setting.  For DDP-only training this is not a concern.
+        with torch.backends.cudnn.flags(enabled=False):
+            return F.conv2d(x, weight, bias, stride=stride, padding=padding, dilation=dilation, groups=groups)
+
+    @staticmethod
+    def backward(
+        ctx: torch.autograd.function.FunctionCtx,
+        grad_output: torch.Tensor,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, None, None, None, None]:
+        """Compute gradients with cuDNN disabled.
+
+        Args:
+            ctx: Autograd context with saved tensors and conv parameters.
+            grad_output: Upstream gradient ``(N, C, H, W)``.
+
+        Returns:
+            Gradients for each ``forward`` input.  Inputs that do not require
+            gradients (``ctx.needs_input_grad[i]`` is ``False``) get ``None``.
+            Non-tensor inputs always get ``None``.
+
+        Note:
+            Under AMP (``"16-mixed"``), ``grad_output`` arrives as ``fp16`` while
+            the saved ``weight`` stays ``fp32``.  Both tensors are upcast to
+            ``weight.dtype`` before calling ``conv2d_input`` / ``conv2d_weight``.
+            ``grad_input`` is then cast back to the original input dtype so
+            downstream gradient accumulation uses the expected dtype.
+        """
+        x, weight = ctx.saved_tensors
+        input_dtype = x.dtype
+
+        needs_x_grad = ctx.needs_input_grad[0]
+        needs_w_grad = ctx.needs_input_grad[1]
+        needs_b_grad = ctx.has_bias and ctx.needs_input_grad[2]
+
+        grad_input = None
+        grad_weight = None
+        grad_bias = None
+
+        if needs_x_grad or needs_w_grad:
+            # Under AMP ("16-mixed" on T4/P100), grad_output arrives as fp16 while
+            # weight stays fp32.  conv2d_input/conv2d_weight require matching dtypes,
+            # so upcast to weight.dtype (fp32); cast grad_input back afterward.
+            grad_output_cast = grad_output.to(dtype=weight.dtype)
+            # Same process-global caveat as forward: safe under DDP, not under DataParallel.
+            with torch.backends.cudnn.flags(enabled=False):
+                if needs_x_grad:
+                    grad_input = torch.nn.grad.conv2d_input(
+                        x.shape,
+                        weight,
+                        grad_output_cast,
+                        stride=ctx.stride,
+                        padding=ctx.padding,
+                        dilation=ctx.dilation,
+                        groups=ctx.groups,
+                    ).to(dtype=input_dtype)
+                if needs_w_grad:
+                    grad_weight = torch.nn.grad.conv2d_weight(
+                        x.to(dtype=weight.dtype),
+                        weight.shape,
+                        grad_output_cast,
+                        stride=ctx.stride,
+                        padding=ctx.padding,
+                        dilation=ctx.dilation,
+                        groups=ctx.groups,
+                    )
+
+        if needs_b_grad:
+            grad_bias = grad_output.to(dtype=weight.dtype).sum(dim=(0, 2, 3))
+
+        return grad_input, grad_weight, grad_bias, None, None, None, None
+
+
 class DepthwiseConvBlock(nn.Module):
     r"""Simplified ConvNeXt block without the MLP subnet"""
 
@@ -29,10 +153,19 @@ class DepthwiseConvBlock(nn.Module):
         )
 
     def _depthwise_conv(self, x: torch.Tensor) -> torch.Tensor:
-        # Always run this depthwise conv with cuDNN disabled to avoid
-        # backend engine selection failures on some CUDA stacks (e.g. T4/Colab).
-        with torch.backends.cudnn.flags(enabled=False):
-            return self.dwconv(x)
+        # Custom autograd Function so cuDNN is disabled in both forward AND
+        # backward.  A plain context-manager only covers forward; the backward
+        # for nn.Conv2d runs outside that scope and re-enables cuDNN,
+        # triggering RuntimeError on T4/P100 GPUs (issue #731).
+        return _DepthwiseConvWithoutCuDNN.apply(
+            x,
+            self.dwconv.weight,
+            self.dwconv.bias,
+            self.dwconv.stride,
+            self.dwconv.padding,
+            self.dwconv.dilation,
+            self.dwconv.groups,
+        )
 
     def forward(self, x):
         input = x

--- a/src/rfdetr/models/weights.py
+++ b/src/rfdetr/models/weights.py
@@ -13,10 +13,13 @@ legacy namespace used by ``rfdetr.detr``.
 
 from __future__ import annotations
 
+import functools
+import math
 import os
 from typing import List
 
 import torch
+import torch.nn.functional as F  # noqa: N812
 
 from rfdetr.assets.model_weights import download_pretrain_weights, validate_pretrain_weights
 from rfdetr.config import ModelConfig
@@ -26,6 +29,70 @@ from rfdetr.utilities.state_dict import _ckpt_args_get, validate_checkpoint_comp
 logger = get_logger()
 
 __all__ = ["load_pretrain_weights"]
+
+_PE_KEY_SUFFIX = "embeddings.position_embeddings"
+
+
+def _interpolate_position_embeddings(
+        checkpoint_state: dict,
+        pe_size: int,
+) -> None:
+    """Interpolate DINOv2 positional embeddings in *checkpoint_state* to match *pe_size*.
+
+    When the model is configured with a custom ``resolution`` that differs from the
+    checkpoint's training resolution, the DINOv2 backbone's ``position_embeddings``
+    parameter has an incompatible shape.  ``load_state_dict(strict=False)`` does **not**
+    skip shape mismatches on matching keys — it raises ``RuntimeError``.
+
+    This function bicubic-interpolates every PE tensor in the checkpoint whose shape
+    differs from the target grid, modifying *checkpoint_state* in-place before
+    ``load_state_dict`` is called.
+
+    Args:
+        checkpoint_state: The ``"model"`` sub-dict from a loaded checkpoint.
+        pe_size: Target grid side length in patches (number of patches per spatial
+            dimension, assuming a square grid).  Typically
+            ``model_config.positional_encoding_size``.
+    """
+    n_target = pe_size * pe_size  # target number of patch tokens
+
+    pe_keys = [k for k in checkpoint_state if k.endswith(_PE_KEY_SUFFIX)]
+    for key in pe_keys:
+        ckpt_pe = checkpoint_state[key]  # [1, N_src+1, dim]
+        n_source = ckpt_pe.shape[1] - 1  # exclude class token
+        if n_source == n_target:
+            continue  # no mismatch — skip
+
+        h_src = int(math.isqrt(n_source))
+        h_tgt = int(math.isqrt(n_target))
+        if h_src * h_src != n_source or h_tgt * h_tgt != n_target:
+            logger.warning(
+                f"Skipping PE interpolation for {key}:"
+                f" grid size is not a perfect square (source {n_source}, target {n_target}).",
+            )
+            continue
+
+        dim = ckpt_pe.shape[-1]
+        class_token = ckpt_pe[:, :1]  # [1, 1, dim] — keeps the sequence dimension
+        patch_pe = ckpt_pe[:, 1:]  # [1, N_src, dim]
+
+        patch_pe = patch_pe.reshape(1, h_src, h_src, dim).permute(0, 3, 1, 2)  # [1, dim, H, W]
+        patch_pe = F.interpolate(
+            patch_pe.float(),
+            size=(h_tgt, h_tgt),
+            mode="bicubic",
+            align_corners=False,
+            antialias=patch_pe.device.type != "mps",
+        ).to(ckpt_pe.dtype)
+        patch_pe = patch_pe.permute(0, 2, 3, 1).reshape(1, n_target, dim)  # [1, N_tgt, dim]
+
+        checkpoint_state[key] = torch.cat([class_token, patch_pe], dim=1)
+        logger.debug(
+            "Interpolated positional embeddings %s: %s → %s.",
+            key,
+            tuple(ckpt_pe.shape),
+            tuple(checkpoint_state[key].shape),
+        )
 
 
 def load_pretrain_weights(nn_model: torch.nn.Module, model_config: ModelConfig) -> List[str]:

--- a/src/rfdetr/models/weights.py
+++ b/src/rfdetr/models/weights.py
@@ -13,13 +13,12 @@ legacy namespace used by ``rfdetr.detr``.
 
 from __future__ import annotations
 
-import functools
 import math
 import os
 from typing import List
 
 import torch
-import torch.nn.functional as F  # noqa: N812
+import torch.nn.functional as F
 
 from rfdetr.assets.model_weights import download_pretrain_weights, validate_pretrain_weights
 from rfdetr.config import ModelConfig
@@ -34,8 +33,8 @@ _PE_KEY_SUFFIX = "embeddings.position_embeddings"
 
 
 def _interpolate_position_embeddings(
-        checkpoint_state: dict,
-        pe_size: int,
+    checkpoint_state: dict,
+    pe_size: int,
 ) -> None:
     """Interpolate DINOv2 positional embeddings in *checkpoint_state* to match *pe_size*.
 
@@ -151,6 +150,7 @@ def load_pretrain_weights(nn_model: torch.nn.Module, model_config: ModelConfig) 
         if any(name.endswith(param_name) for param_name in query_param_names):
             checkpoint["model"][name] = checkpoint["model"][name][:num_desired_queries]
 
+    _interpolate_position_embeddings(checkpoint["model"], model_config.positional_encoding_size)
     nn_model.load_state_dict(checkpoint["model"], strict=False)
 
     if checkpoint_num_classes < configured_num_classes_plus_bg and user_overrode_default_num_classes:

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import math
 import shutil
 from pathlib import Path
-from typing import Optional, Any
+from typing import Any, Optional
 
 import torch
 from pytorch_lightning import LightningModule, Trainer

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -8,9 +8,10 @@
 
 from __future__ import annotations
 
+import math
 import shutil
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Any
 
 import torch
 from pytorch_lightning import LightningModule, Trainer
@@ -37,6 +38,11 @@ class BestModelCallback(ModelCheckpoint):
     Checkpoints are only updated on validation epochs where the monitor metric
     is actually logged.  On non-eval epochs (when ``eval_interval > 1`` causes
     COCO evaluation to be skipped) the callback is a no-op.
+
+    ``state_dict()`` and ``load_state_dict()`` are overridden to persist
+    ``_best_ema`` in the Lightning callback state, ensuring that
+    ``trainer.fit(ckpt_path=...)`` resumes EMA high-water-mark tracking
+    from the correct value.
 
     Args:
         output_dir: Directory where checkpoint files are written.
@@ -133,6 +139,38 @@ class BestModelCallback(ModelCheckpoint):
         _orig = getattr(pl_module.model, "_orig_mod", None)
         raw = _orig if isinstance(_orig, torch.nn.Module) else pl_module.model
         return raw.state_dict()
+
+    def state_dict(self) -> dict[str, Any]:
+        """Return callback state including ``_best_ema`` for Lightning checkpointing.
+
+        Extends the parent :class:`~pytorch_lightning.callbacks.ModelCheckpoint`
+        state dict with ``_best_ema`` so that ``trainer.fit(ckpt_path=...)``
+        resumes EMA tracking from the correct high-water mark rather than
+        resetting to ``0.0``.
+
+        Returns:
+            State dict with all parent fields plus ``"_best_ema"``.
+        """
+        state = super().state_dict()
+        state["_best_ema"] = self._best_ema
+        return state
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        """Restore callback state from a Lightning checkpoint.
+
+        Pops ``"_best_ema"`` from a shallow copy of *state_dict* before delegating to the parent
+        so the parent does not receive an unexpected key.  Defaults to ``0.0``
+        when the key is absent (e.g. checkpoints saved before this fix).
+
+        Args:
+            state_dict: Callback state dict as produced by :meth:`state_dict`.
+        """
+        # Copy to avoid mutating the caller's dict — PTL may reuse it.
+        state = dict(state_dict)
+        self._best_ema = float(state.pop("_best_ema", 0.0))
+        if not math.isfinite(self._best_ema):
+            self._best_ema = 0.0
+        super().load_state_dict(state)
 
     def _save_checkpoint(self, trainer: Trainer, filepath: str) -> None:
         """Save stripped ``.pth`` format instead of a full ``.ckpt``.

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -261,7 +261,10 @@ class COCOEvalCallback(Callback):
 
         Computes mAP (via ``self.map_metric``), runs the F1 confidence-threshold
         sweep, logs all scalar metrics via ``pl_module.log``, prints two summary
-        tables to the terminal, and resets internal accumulators.
+        tables to the terminal, and resets internal accumulators.  When
+        ``self.map_metric_ema`` is set, EMA variants of all metrics (including
+        ``ema_segm_mAP_50_95`` and ``ema_segm_mAP_50`` for segmentation models)
+        are logged under the same ``split/`` namespace.
 
         Args:
             trainer: The PTL Trainer.
@@ -299,13 +302,17 @@ class COCOEvalCallback(Callback):
         # in on_validation_batch_end, so base and EMA values are independent.
         if self.map_metric_ema is not None:
             ema_metrics = self.map_metric_ema.compute()
-            ema_mar_key = f"{pfx}mar_{self._max_dets}"
             pl_module.log(f"{split}/ema_mAP_50_95", ema_metrics[f"{pfx}map"], prog_bar=True)
             pl_module.log(f"{split}/ema_mAP_50", ema_metrics[f"{pfx}map_50"])
-            pl_module.log(f"{split}/ema_mAR", ema_metrics[ema_mar_key])
+            pl_module.log(f"{split}/ema_mAR", ema_metrics[mar_key])
             trainer.callback_metrics[f"{split}/ema_mAP_50_95"] = ema_metrics[f"{pfx}map"].detach().cpu()
             trainer.callback_metrics[f"{split}/ema_mAP_50"] = ema_metrics[f"{pfx}map_50"].detach().cpu()
-            trainer.callback_metrics[f"{split}/ema_mAR"] = ema_metrics[ema_mar_key].detach().cpu()
+            trainer.callback_metrics[f"{split}/ema_mAR"] = ema_metrics[mar_key].detach().cpu()
+            if self._segmentation:
+                pl_module.log(f"{split}/ema_segm_mAP_50_95", ema_metrics["segm_map"])
+                pl_module.log(f"{split}/ema_segm_mAP_50", ema_metrics["segm_map_50"])
+                trainer.callback_metrics[f"{split}/ema_segm_mAP_50_95"] = ema_metrics["segm_map"].detach().cpu()
+                trainer.callback_metrics[f"{split}/ema_segm_mAP_50"] = ema_metrics["segm_map_50"].detach().cpu()
             self.map_metric_ema.reset()
 
         if self._segmentation:
@@ -315,11 +322,6 @@ class COCOEvalCallback(Callback):
             pl_module.log(f"{split}/segm_mAP_50", metrics["segm_map_50"])
             trainer.callback_metrics[f"{split}/segm_mAP_50_95"] = metrics["segm_map"].detach().cpu()
             trainer.callback_metrics[f"{split}/segm_mAP_50"] = metrics["segm_map_50"].detach().cpu()
-            if self._has_ema_callback(trainer):
-                pl_module.log(f"{split}/ema_segm_mAP_50_95", metrics["segm_map"])
-                pl_module.log(f"{split}/ema_segm_mAP_50", metrics["segm_map_50"])
-                trainer.callback_metrics[f"{split}/ema_segm_mAP_50_95"] = metrics["segm_map"].detach().cpu()
-                trainer.callback_metrics[f"{split}/ema_segm_mAP_50"] = metrics["segm_map_50"].detach().cpu()
 
         # F1 sweep — run first so per-class F1/prec/rec are available when
         # building the unified per-class table rows below.
@@ -385,10 +387,6 @@ class COCOEvalCallback(Callback):
         self._print_metrics_tables(trainer, split, overall, per_class)
         self.map_metric.reset()
         self._f1_local = init_matching_accumulator()
-
-    def _has_ema_callback(self, trainer: Any) -> bool:
-        """Return whether an EMA callback is present in the Trainer."""
-        return self._get_ema_callback(trainer) is not None
 
     def _get_ema_callback(self, trainer: Any) -> Any:
         """Return the EMA callback instance, or ``None`` if not present."""

--- a/src/rfdetr/utilities/state_dict.py
+++ b/src/rfdetr/utilities/state_dict.py
@@ -27,6 +27,24 @@ _PTL_COMPAT_KEYS = (
 )
 
 
+def _raise_patch_size_mismatch(ckpt_patch_size: int, model_patch_size: int) -> None:
+    """Raise a descriptive ValueError for a patch_size incompatibility.
+
+    Args:
+        ckpt_patch_size: patch_size recorded in (or inferred from) the checkpoint.
+        model_patch_size: patch_size the current model is configured with.
+
+    Raises:
+        ValueError: Always — describes the mismatch and how to resolve it.
+    """
+    raise ValueError(
+        f"The checkpoint was trained with patch_size={ckpt_patch_size}, but the current model uses "
+        f"patch_size={model_patch_size}. The checkpoint is incompatible with this model architecture. "
+        "To resolve this, either instantiate/configure the model with the checkpoint's patch_size or "
+        "use a checkpoint that was trained with the same patch_size as the current model."
+    )
+
+
 def _ckpt_args_get(args: Any, field: str, default: Any = None) -> Any:
     """Get a field from checkpoint ``"args"``, handling both dict and attribute access.
 
@@ -198,14 +216,25 @@ def validate_checkpoint_compatibility(checkpoint: Dict[str, Any], model_args: An
 
     Raises:
         ValueError: If ``segmentation_head`` or ``patch_size`` in the checkpoint
-            args do not match those of the model.
+            args do not match those of the model, or if the ``patch_size`` inferred
+            from the DINOv2 projection weight shape differs from
+            ``model_args.patch_size`` when no explicit ``args.patch_size`` is present.
 
     Note:
         This helper does not mutate ``model_args``. It emits ``logger.warning``
         (not an exception) for class-count mismatches so that callers can still
         proceed with reinitialization or weight loading.
 
-        Two scenarios are distinguished:
+        When ``"args"`` is absent or ``args.patch_size`` is not set, a fallback
+        infers ``patch_size`` from the DINOv2 patch-embedding projection weight
+        shape (key ``backbone.0.encoder.encoder.embeddings.patch_embeddings.projection.weight``).
+        This fallback **can raise** :class:`ValueError` on a mismatch, providing a
+        clear error before the cryptic :class:`RuntimeError` from
+        :meth:`~torch.nn.Module.load_state_dict` would otherwise fire.
+        For all other attributes (e.g. ``segmentation_head``), if either side is
+        missing, that check is skipped silently — preserving backward compatibility.
+
+        Two class-count scenarios are distinguished:
 
         * Backbone pretrain: the checkpoint head was trained with more classes
           than the current ``model_args.num_classes``. In this case the detection
@@ -245,6 +274,28 @@ def validate_checkpoint_compatibility(checkpoint: Dict[str, Any], model_args: An
                     ckpt_num_classes - 1,
                 )
 
+    # Infer patch_size from the patch-embedding projection weight only as a fallback
+    # when the checkpoint has no explicit args.patch_size (e.g., COCO pretrained
+    # release weights that only store "model").
+    # Conv2d projection shape is [out_channels, in_channels, kernel_h, kernel_w];
+    # kernel_h == patch_size for square kernels. Raises before load_state_dict fires,
+    # replacing the otherwise-cryptic "size mismatch" RuntimeError. Regression: #965.
+    # NOTE: key path is DINOv2-specific; non-DINOv2 backbones simply won't have this key
+    # and the check is silently skipped, preserving backward compatibility.
+    _ckpt_args = checkpoint.get("args")
+    _ckpt_patch_size_from_args: int | None = None
+    if _ckpt_args is not None:
+        _ckpt_patch_size_from_args = _ckpt_args_get(_ckpt_args, "patch_size")
+
+    if _ckpt_patch_size_from_args is None:
+        _patch_proj_key = "backbone.0.encoder.encoder.embeddings.patch_embeddings.projection.weight"
+        _ckpt_proj_w = checkpoint.get("model", {}).get(_patch_proj_key)
+        _ckpt_proj_shape = getattr(_ckpt_proj_w, "shape", None)
+        if _ckpt_proj_shape is not None and len(_ckpt_proj_shape) == 4 and _ckpt_proj_shape[2] == _ckpt_proj_shape[3]:
+            _inferred_ps = int(_ckpt_proj_shape[-1])
+            _model_ps: int | None = getattr(model_args, "patch_size", None)
+            if _model_ps is not None and _inferred_ps != _model_ps:
+                _raise_patch_size_mismatch(_inferred_ps, _model_ps)
     if "args" not in checkpoint:
         return
 
@@ -268,9 +319,4 @@ def validate_checkpoint_compatibility(checkpoint: Dict[str, Any], model_args: An
     ckpt_patch_size: Optional[int] = _ckpt_args_get(ckpt_args, "patch_size")
     model_patch_size: Optional[int] = getattr(model_args, "patch_size", None)
     if ckpt_patch_size is not None and model_patch_size is not None and ckpt_patch_size != model_patch_size:
-        raise ValueError(
-            f"The checkpoint was trained with patch_size={ckpt_patch_size}, but the current model uses "
-            f"patch_size={model_patch_size}. The checkpoint is incompatible with this model architecture. "
-            "To resolve this, either instantiate/configure the model with the checkpoint's patch_size or "
-            "use a checkpoint that was trained with the same patch_size as the current model."
-        )
+        _raise_patch_size_mismatch(ckpt_patch_size, model_patch_size)

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -12,12 +12,16 @@ from pydantic import ValidationError
 
 from rfdetr.config import (
     ModelConfig,
+    RFDETRLargeConfig,
+    RFDETRMediumConfig,
+    RFDETRNanoConfig,
     RFDETRSeg2XLargeConfig,
     RFDETRSegLargeConfig,
     RFDETRSegMediumConfig,
     RFDETRSegNanoConfig,
     RFDETRSegSmallConfig,
     RFDETRSegXLargeConfig,
+    RFDETRSmallConfig,
     SegmentationTrainConfig,
     TrainConfig,
     _detect_device,
@@ -302,6 +306,53 @@ class TestBuildTrainerUsesRealFields:
             build_trainer(self._tc(tmp_path, sync_bn=True), self._mc())
 
         assert captured_kwargs.get("sync_batchnorm") is True
+
+
+class TestSyncPEWithResolutionAtConstruction:
+    """Tests for the _sync_pe_with_resolution model_validator.
+
+    When a user provides a custom resolution at construction time (e.g.,
+    ``RFDETRLarge(resolution=640)``), positional_encoding_size must be updated
+    proportionally for configs where the default PE is formula-derived
+    (``default_pe == default_resolution // patch_size``).
+    """
+
+    @pytest.mark.parametrize(
+        "config_cls, new_resolution, expected_pe",
+        [
+            pytest.param(RFDETRLargeConfig, 640, 640 // 16, id="large_640"),
+            pytest.param(RFDETRLargeConfig, 576, 576 // 16, id="large_576"),
+            pytest.param(RFDETRSmallConfig, 640, 640 // 16, id="small_640"),
+            pytest.param(RFDETRMediumConfig, 640, 640 // 16, id="medium_640"),
+            pytest.param(RFDETRNanoConfig, 416, 416 // 16, id="nano_416"),
+            pytest.param(RFDETRSegNanoConfig, 360, 360 // 12, id="seg_nano_360"),
+            pytest.param(RFDETRSegSmallConfig, 480, 480 // 12, id="seg_small_480"),
+            pytest.param(RFDETRSegMediumConfig, 480, 480 // 12, id="seg_medium_480"),
+            pytest.param(RFDETRSegLargeConfig, 576, 576 // 12, id="seg_large_576"),
+            pytest.param(RFDETRSegXLargeConfig, 576, 576 // 12, id="seg_xlarge_576"),
+            pytest.param(RFDETRSeg2XLargeConfig, 720, 720 // 12, id="seg_2xlarge_720"),
+        ],
+    )
+    def test_positional_encoding_size_updated_for_formula_derived_configs(
+        self,
+        config_cls: type,
+        new_resolution: int,
+        expected_pe: int,
+    ) -> None:
+        """PE is auto-derived from the custom resolution for formula-derived model configs."""
+        cfg = config_cls(resolution=new_resolution, pretrain_weights=None)
+        assert cfg.positional_encoding_size == expected_pe
+
+    def test_explicit_positional_encoding_size_is_not_overridden(self) -> None:
+        """When positional_encoding_size is explicitly provided, the validator must not override it."""
+        cfg = RFDETRLargeConfig(resolution=640, positional_encoding_size=50, pretrain_weights=None)
+        assert cfg.positional_encoding_size == 50
+
+    def test_default_resolution_preserves_default_pe(self) -> None:
+        """Constructing with default resolution (no explicit resolution) must not change PE."""
+        cfg = RFDETRLargeConfig(pretrain_weights=None)
+        assert cfg.resolution == 704
+        assert cfg.positional_encoding_size == 44  # 704 // 16
 
 
 class TestDetectDevice:

--- a/tests/models/test_predict.py
+++ b/tests/models/test_predict.py
@@ -144,8 +144,8 @@ class TestPredictSourceData:
         model = _DummyRFDETR()
         detections_list = model.predict([img1, img2])
         assert isinstance(detections_list, list)
-        assert detections_list[0].data["source_image"].shape == (48, 64, 3)
-        assert detections_list[1].data["source_image"].shape == (24, 32, 3)
+        assert detections_list[0].metadata["source_image"].shape == (48, 64, 3)
+        assert detections_list[1].metadata["source_image"].shape == (24, 32, 3)
         assert np.array_equal(detections_list[0].data["source_shape"], np.array([[48, 64]]))
         assert np.array_equal(detections_list[1].data["source_shape"], np.array([[24, 32]]))
 
@@ -169,6 +169,57 @@ class TestPredictSourceData:
             data = det_tuple[-1]
             assert np.array_equal(data["source_shape"], [48, 64])
 
+    def test_source_image_survives_boolean_index(self) -> None:
+        """Boolean-mask indexing must not raise IndexError when source_image is present.
+
+        Regression test for https://github.com/roboflow/rf-detr/issues/968.
+        source_image was stored as (H, W, C) in detections.data; supervision's
+        __getitem__ tried to index it with a per-detection boolean mask, raising
+        IndexError because H != N.
+        """
+        img = PIL.Image.new("RGB", (64, 48), color=(128, 128, 128))
+        model = _DummyRFDETR()
+        model.model = _DummyModel(labels=[0, 1])  # 2 detections
+        detections = model.predict(img)  # include_source_image=True by default
+
+        # Boolean-mask filtering — the pattern from issue #968
+        mask = detections.confidence > 0.5
+        filtered = detections[mask]
+        assert len(filtered) == int(mask.sum())
+        # source_image must survive the index operation unchanged (not dropped, not sliced)
+        assert "source_image" in filtered.metadata
+        assert filtered.metadata["source_image"].shape == (48, 64, 3)
+
+    def test_source_image_survives_class_id_boolean_index(self) -> None:
+        """Boolean index on class_id must not raise IndexError — exact issue #968 pattern.
+
+        The reporter used ``detections.class_id == 1`` to filter by class, producing a
+        partial boolean mask (1 of 2 detections).  This is the primary reproduction path
+        from the original bug report.
+        """
+        img = PIL.Image.new("RGB", (64, 48), color=(128, 128, 128))
+        model = _DummyRFDETR()
+        model.model = _DummyModel(labels=[0, 1])  # class_id 0 and 1
+        detections = model.predict(img)
+
+        # Exact pattern from issue #968: filter by class_id
+        mask = detections.class_id == 1  # partial mask — 1 of 2 detections
+        filtered = detections[mask]
+        assert len(filtered) == 1
+        assert "source_image" in filtered.metadata
+        assert filtered.metadata["source_image"].shape == (48, 64, 3)
+
+    def test_source_image_survives_integer_index(self) -> None:
+        """Integer indexing must pass metadata["source_image"] through unchanged."""
+        img = PIL.Image.new("RGB", (64, 48), color=(128, 128, 128))
+        model = _DummyRFDETR()
+        model.model = _DummyModel(labels=[0, 1])  # 2 detections
+        detections = model.predict(img)
+
+        single = detections[0]
+        assert "source_image" in single.metadata
+        assert single.metadata["source_image"].shape == (48, 64, 3)
+
     def test_source_shape_survives_detections_indexing(self) -> None:
         """Integer and boolean-mask indexing of sv.Detections must work correctly.
 
@@ -176,14 +227,11 @@ class TestPredictSourceData:
         MeanAveragePrecision.compute() uses __getitem__ (not just __iter__) on
         Detections objects — both paths go through get_data_item() and would have
         crashed on the old tuple format.
-
-        include_source_image=False avoids the pre-existing source_image indexing bug
-        (source_image is a per-image array, not per-detection; tracked separately).
         """
         img = PIL.Image.new("RGB", (64, 48), color=(128, 128, 128))
         model = _DummyRFDETR()
         model.model = _DummyModel(labels=[0, 1])  # 2 detections
-        detections = model.predict(img, include_source_image=False)
+        detections = model.predict(img)
 
         # Integer indexing: detections[i] returns a Detections with 1 element
         single = detections[0]

--- a/tests/models/test_predict.py
+++ b/tests/models/test_predict.py
@@ -105,9 +105,9 @@ class TestPredictSourceData:
         img = PIL.Image.new("RGB", (64, 48), color=(128, 128, 128))
         model = _DummyRFDETR()
         detections = model.predict(img)
-        assert "source_image" in detections.data
-        assert isinstance(detections.data["source_image"], np.ndarray)
-        assert detections.data["source_image"].shape == (48, 64, 3)
+        assert "source_image" in detections.metadata
+        assert isinstance(detections.metadata["source_image"], np.ndarray)
+        assert detections.metadata["source_image"].shape == (48, 64, 3)
 
     def test_source_shape_from_pil(self) -> None:
         """PIL input stores source_shape as a per-detection numpy array."""
@@ -125,10 +125,10 @@ class TestPredictSourceData:
         tensor = torch.rand(3, 48, 64)
         model = _DummyRFDETR()
         detections = model.predict(tensor)
-        assert "source_image" in detections.data
-        assert isinstance(detections.data["source_image"], np.ndarray)
-        assert detections.data["source_image"].dtype == np.uint8
-        assert detections.data["source_image"].shape == (48, 64, 3)
+        assert "source_image" in detections.metadata
+        assert isinstance(detections.metadata["source_image"], np.ndarray)
+        assert detections.metadata["source_image"].dtype == np.uint8
+        assert detections.metadata["source_image"].shape == (48, 64, 3)
 
     def test_tensor_with_negative_values_raises(self) -> None:
         """Tensor with negative pixel values raises ValueError."""

--- a/tests/models/test_predict.py
+++ b/tests/models/test_predict.py
@@ -513,3 +513,70 @@ class TestPredictClassNameData:
             assert list(det.data["class_name"]) == ["cat", "dog"], (
                 f"image {idx}: class_name must match class_names[class_id]"
             )
+
+    def test_background_class_id_maps_to_background_label(self) -> None:
+        """DETR's background/no-object class (class_id == n) must map to '__background__'.
+
+        RF-DETR internally allocates num_classes + 1 outputs; the extra class at
+        index n is the background/no-object class. Returning it as '__background__'
+        is unambiguous, whereas the previous empty string was indistinguishable from
+        a genuine OOB error.
+
+        Regression / contract test for https://github.com/roboflow/rf-detr/pull/966
+        post-merge issue reported by @Alarmod.
+        """
+        # class_names has 2 entries (n=2); background class is label index 2
+        model = self._make_model_with_class_names(["cat", "dog"], labels=[2])
+        img = PIL.Image.new("RGB", (28, 28))
+        detections = model.predict(img)
+        assert detections.data["class_name"][0] == "__background__", (
+            "Background class (class_id == num_classes) must map to '__background__', not empty string"
+        )
+
+    def test_background_class_id_does_not_emit_oob_warning(self) -> None:
+        """Predicting the background class must not emit an out-of-range warning.
+
+        The background class (class_id == num_classes) is expected DETR behaviour,
+        not a model error. Warning on it misleads users into thinking something is wrong.
+
+        Uses _warned_once state (not caplog) because the RF-DETR logger has propagate=False,
+        which prevents caplog from capturing records via the root-logger handler.
+
+        Regression / contract test for https://github.com/roboflow/rf-detr/pull/966
+        post-merge issue reported by @Alarmod.
+        """
+        from rfdetr.utilities.logger import get_logger
+
+        # Reset warning_once state so this test is not affected by earlier tests that may
+        # have already triggered the same message template, masking a reintroduced warning.
+        logger = get_logger()
+        logger._warned_once.clear()
+
+        model = self._make_model_with_class_names(["cat", "dog"], labels=[2])
+        img = PIL.Image.new("RGB", (28, 28))
+        model.predict(img)
+        oob_warnings = [msg for msg in logger._warned_once if "out of range" in msg]
+        assert not oob_warnings, "Background class (class_id == num_classes) must not trigger an out-of-range warning"
+
+    def test_truly_oob_class_id_still_maps_to_empty_string_and_warns(self) -> None:
+        """A class_id strictly above num_classes still maps to empty string AND emits a warning.
+
+        class_id == n is background (no warning); class_id > n is truly unexpected — must
+        produce '' AND trigger the out-of-range warning so the caller knows something is wrong.
+
+        Uses _warned_once state (not caplog) because the RF-DETR logger has propagate=False,
+        which prevents caplog from capturing records via the root-logger handler.
+        """
+        from rfdetr.utilities.logger import get_logger
+
+        # Reset warning_once state so this test is not affected by deduplication from earlier tests.
+        logger = get_logger()
+        logger._warned_once.clear()
+
+        # n=2, background is class_id=2; class_id=5 is truly OOB (> n)
+        model = self._make_model_with_class_names(["cat", "dog"], labels=[5])
+        img = PIL.Image.new("RGB", (28, 28))
+        detections = model.predict(img)
+        assert detections.data["class_name"][0] == "", "Truly OOB class_id (> num_classes) must produce empty string"
+        oob_warnings = [msg for msg in logger._warned_once if "out of range" in msg]
+        assert oob_warnings, "Truly OOB class_id (> num_classes) must trigger an out-of-range warning"

--- a/tests/models/test_predict.py
+++ b/tests/models/test_predict.py
@@ -110,12 +110,15 @@ class TestPredictSourceData:
         assert detections.data["source_image"].shape == (48, 64, 3)
 
     def test_source_shape_from_pil(self) -> None:
-        """PIL input stores the original (height, width) tuple."""
+        """PIL input stores source_shape as a per-detection numpy array."""
         img = PIL.Image.new("RGB", (64, 48), color=(128, 128, 128))
         model = _DummyRFDETR()
         detections = model.predict(img)
         assert "source_shape" in detections.data
-        assert detections.data["source_shape"] == (48, 64)
+        assert isinstance(detections.data["source_shape"], np.ndarray)
+        assert detections.data["source_shape"].dtype == np.int64
+        assert detections.data["source_shape"].shape == (len(detections), 2)
+        assert np.array_equal(detections.data["source_shape"][0], [48, 64])
 
     def test_source_image_from_tensor(self) -> None:
         """Tensor input stores the original image as a uint8 numpy array."""
@@ -143,8 +146,83 @@ class TestPredictSourceData:
         assert isinstance(detections_list, list)
         assert detections_list[0].data["source_image"].shape == (48, 64, 3)
         assert detections_list[1].data["source_image"].shape == (24, 32, 3)
-        assert detections_list[0].data["source_shape"] == (48, 64)
-        assert detections_list[1].data["source_shape"] == (24, 32)
+        assert np.array_equal(detections_list[0].data["source_shape"], np.array([[48, 64]]))
+        assert np.array_equal(detections_list[1].data["source_shape"], np.array([[24, 32]]))
+
+    def test_source_shape_survives_detections_iteration(self) -> None:
+        """Iterating sv.Detections must not raise TypeError and must yield correct values.
+
+        Regression test for https://github.com/roboflow/rf-detr/issues/963.
+        supervision's Detections.__iter__ calls get_data_item() on every data value,
+        which requires array-like types — storing source_shape as a Python tuple
+        raised TypeError: Unsupported data type for key 'source_shape': <class 'tuple'>.
+        """
+        img = PIL.Image.new("RGB", (64, 48), color=(128, 128, 128))
+        model = _DummyRFDETR()
+        detections = model.predict(img)
+
+        # sv.Detections.__iter__ yields (xyxy, mask, confidence, class_id, tracker_id, data)
+        iterated = list(detections)
+        assert len(iterated) == len(detections)
+        # Each iterated element's data dict must contain a 1-D [h, w] array
+        for det_tuple in iterated:
+            data = det_tuple[-1]
+            assert np.array_equal(data["source_shape"], [48, 64])
+
+    def test_source_shape_survives_detections_indexing(self) -> None:
+        """Integer and boolean-mask indexing of sv.Detections must work correctly.
+
+        Regression test for https://github.com/roboflow/rf-detr/issues/963.
+        MeanAveragePrecision.compute() uses __getitem__ (not just __iter__) on
+        Detections objects — both paths go through get_data_item() and would have
+        crashed on the old tuple format.
+
+        include_source_image=False avoids the pre-existing source_image indexing bug
+        (source_image is a per-image array, not per-detection; tracked separately).
+        """
+        img = PIL.Image.new("RGB", (64, 48), color=(128, 128, 128))
+        model = _DummyRFDETR()
+        model.model = _DummyModel(labels=[0, 1])  # 2 detections
+        detections = model.predict(img, include_source_image=False)
+
+        # Integer indexing: detections[i] returns a Detections with 1 element
+        single = detections[0]
+        assert np.array_equal(single.data["source_shape"], np.array([[48, 64]]))
+
+        # Boolean-mask indexing: used by supervision metrics to filter detections
+        mask = detections.confidence > 0.5
+        filtered = detections[mask]
+        assert filtered.data["source_shape"].shape == (int(mask.sum()), 2)
+        assert np.all(filtered.data["source_shape"] == np.array([48, 64]))
+
+    def test_source_shape_correct_for_zero_detections(self) -> None:
+        """source_shape must have shape (0, 2) when threshold filters all detections.
+
+        Regression test for https://github.com/roboflow/rf-detr/issues/963.
+        The zero-detection path must not raise and must produce an empty array, not a
+        scalar or a (1, 2) array.
+        """
+        img = PIL.Image.new("RGB", (64, 48), color=(128, 128, 128))
+        model = _DummyRFDETR()
+        # confidence=0.9 < 1.1 → all detections filtered
+        detections = model.predict(img, threshold=1.1)
+        assert "source_shape" in detections.data
+        assert isinstance(detections.data["source_shape"], np.ndarray)
+        assert detections.data["source_shape"].shape == (0, 2)
+
+    def test_source_shape_correct_for_multiple_detections(self) -> None:
+        """source_shape must have shape (N, 2) for N detections, each row [height, width].
+
+        Regression test for https://github.com/roboflow/rf-detr/issues/963.
+        """
+        img = PIL.Image.new("RGB", (64, 48), color=(128, 128, 128))
+        model = _DummyRFDETR()
+        model.model = _DummyModel(labels=[0, 1])  # 2 detections
+        detections = model.predict(img)
+        assert "source_shape" in detections.data
+        assert isinstance(detections.data["source_shape"], np.ndarray)
+        assert detections.data["source_shape"].shape == (2, 2)
+        assert np.all(detections.data["source_shape"] == np.array([48, 64]))
 
 
 class TestPredictShape:

--- a/tests/models/test_segmentation_head.py
+++ b/tests/models/test_segmentation_head.py
@@ -4,12 +4,20 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
+"""Tests for DepthwiseConvBlock and _DepthwiseConvWithoutCuDNN (segmentation head)."""
+
 from contextlib import contextmanager
 
 import pytest
 import torch
 
 from rfdetr.models.heads.segmentation import DepthwiseConvBlock
+
+
+@pytest.fixture(autouse=True)
+def _reset_random_seeds() -> None:
+    """Reset random seeds before each test for reproducibility."""
+    torch.manual_seed(42)
 
 
 @pytest.mark.parametrize(
@@ -37,47 +45,177 @@ def test_depthwise_conv_block_forward(device: str) -> None:
     assert y.shape == x.shape
 
 
-def test_depthwise_conv_block_always_disables_cudnn(monkeypatch) -> None:
-    """Depthwise conv should execute with cuDNN disabled for compatibility."""
+def test_depthwise_conv_forward_disables_cudnn(monkeypatch) -> None:
+    """Depthwise conv should execute with cuDNN disabled during forward."""
     block = DepthwiseConvBlock(dim=8)
-    cudnn_enabled = True
-
-    class _MockDepthwiseConv(torch.nn.Module):
-        def __init__(self) -> None:
-            super().__init__()
-            self.calls = 0
-
-        def forward(self, x: torch.Tensor) -> torch.Tensor:
-            self.calls += 1
-            assert not cudnn_enabled
-            return x
-
-    fallback_dwconv = _MockDepthwiseConv()
-    block.dwconv = fallback_dwconv
-
-    fallback_context_calls = 0
     enabled_calls: list[bool] = []
+    original_flags = torch.backends.cudnn.flags
 
     @contextmanager
-    def _fake_cudnn_flags(*, enabled: bool):
-        nonlocal cudnn_enabled, fallback_context_calls
-        previous = cudnn_enabled
-        cudnn_enabled = enabled
+    def _tracking_flags(*, enabled: bool):
         enabled_calls.append(enabled)
-        fallback_context_calls += 1
-        try:
+        with original_flags(enabled=enabled):
             yield
-        finally:
-            cudnn_enabled = previous
 
-    monkeypatch.setattr(torch.backends.cudnn, "flags", _fake_cudnn_flags)
+    monkeypatch.setattr(torch.backends.cudnn, "flags", _tracking_flags)
 
-    assert cudnn_enabled
     x = torch.randn(1, 8, 4, 4)
     y = block(x)
-    assert cudnn_enabled
-
     assert y.shape == x.shape
-    assert fallback_dwconv.calls == 1
-    assert fallback_context_calls == 1
-    assert enabled_calls == [False]
+    assert enabled_calls, "torch.backends.cudnn.flags was never called"
+    assert all(not e for e in enabled_calls)
+
+
+def test_depthwise_conv_backward_disables_cudnn(monkeypatch) -> None:
+    """Backward pass must also run with cuDNN disabled (issue #731).
+
+    The previous fix (PR #728) only wrapped the forward pass in a context
+    manager.  The backward kernels ran with cuDNN re-enabled, causing
+    RuntimeError on T4/P100 GPUs.
+    """
+    block = DepthwiseConvBlock(dim=8)
+    enabled_calls: list[bool] = []
+    original_flags = torch.backends.cudnn.flags
+
+    @contextmanager
+    def _tracking_flags(*, enabled: bool):
+        enabled_calls.append(enabled)
+        with original_flags(enabled=enabled):
+            yield
+
+    monkeypatch.setattr(torch.backends.cudnn, "flags", _tracking_flags)
+
+    x = torch.randn(1, 8, 4, 4, requires_grad=True)
+    y = block(x)
+    y.sum().backward()
+
+    assert x.grad is not None
+    assert x.grad.shape == x.shape
+    # cuDNN must be disabled for both forward and backward
+    assert len(enabled_calls) >= 2
+    assert all(not e for e in enabled_calls)
+
+
+@pytest.mark.parametrize(
+    "device",
+    [
+        pytest.param("cpu", id="cpu"),
+        pytest.param(
+            "cuda",
+            id="gpu",
+            marks=[
+                pytest.mark.gpu,
+                pytest.mark.skipif(
+                    not torch.cuda.is_available(),
+                    reason="CUDA is not available",
+                ),
+            ],
+        ),
+    ],
+)
+def test_depthwise_conv_backward_produces_correct_gradients(device: str) -> None:
+    """Backward pass through DepthwiseConvBlock produces valid gradients."""
+    block = DepthwiseConvBlock(dim=8).to(device)
+    x = torch.randn(1, 8, 4, 4, device=device, requires_grad=True)
+    y = block(x)
+    y.sum().backward()
+    assert x.grad is not None
+    assert x.grad.shape == x.shape
+    assert torch.isfinite(x.grad).all()
+
+
+def test_depthwise_conv_gradients_match_reference() -> None:
+    """Custom autograd Function gradients match nn.Conv2d gradients.
+
+    Verifies that _DepthwiseConvWithoutCuDNN produces the same gradients as
+    a standard nn.Conv2d forward+backward (run with cuDNN disabled globally).
+    """
+    torch.manual_seed(42)
+    dim = 8
+    block = DepthwiseConvBlock(dim=dim)
+
+    # Reference: run standard nn.Conv2d with cuDNN globally disabled
+    x_ref = torch.randn(1, dim, 4, 4, requires_grad=True)
+    with torch.backends.cudnn.flags(enabled=False):
+        y_ref = block.dwconv(x_ref)
+    y_ref.sum().backward()
+
+    x_ref_grad = x_ref.grad.clone()
+    weight_ref_grad = block.dwconv.weight.grad.clone()
+    bias_ref_grad = block.dwconv.bias.grad.clone()
+
+    # Our implementation via _depthwise_conv.  zero_grad() so that the second
+    # backward does not accumulate into weight.grad from the first run.
+    block.zero_grad()
+    x_test = x_ref.detach().clone().requires_grad_(True)
+    y_test = block._depthwise_conv(x_test)
+    y_test.sum().backward()
+
+    assert torch.allclose(y_ref, y_test, atol=1e-6)
+    assert torch.allclose(x_ref_grad, x_test.grad, atol=1e-6)
+    assert torch.allclose(weight_ref_grad, block.dwconv.weight.grad, atol=1e-6)
+    assert torch.allclose(bias_ref_grad, block.dwconv.bias.grad, atol=1e-6)
+
+
+def test_depthwise_conv_backward_fp16_grad_output() -> None:
+    """Backward must not crash when grad_output is fp16 (AMP 16-mixed on T4/P100).
+
+    On T4/P100, trainer resolves amp=True to '16-mixed'.  In that mode the
+    backward receives fp16 grad_output while the saved weight stays fp32.
+    Without explicit dtype casting, conv2d_input raises:
+        RuntimeError: expected scalar type Half but found Float
+    """
+    dim = 8
+    block = DepthwiseConvBlock(dim=dim)
+    x = torch.randn(1, dim, 4, 4, requires_grad=True)
+
+    # Simulate 16-mixed backward: forward in fp32, grad_output arrives as fp16
+    y = block._depthwise_conv(x)
+    grad_output = torch.ones_like(y, dtype=torch.float16)
+    y.backward(grad_output)
+
+    assert x.grad is not None
+    assert x.grad.dtype == torch.float32
+    assert torch.isfinite(x.grad).all()
+
+
+def test_depthwise_conv_no_cudnn_bias_none() -> None:
+    """_DepthwiseConvWithoutCuDNN forward and backward work correctly with bias=None.
+
+    Exercises the ctx.has_bias=False branch in forward and the grad_bias=None
+    return in backward — never reached via DepthwiseConvBlock (always has bias).
+    """
+    from rfdetr.models.heads.segmentation import _DepthwiseConvWithoutCuDNN
+
+    dim = 8
+    weight = torch.randn(dim, 1, 3, 3, requires_grad=True)
+    x = torch.randn(1, dim, 4, 4, requires_grad=True)
+    y = _DepthwiseConvWithoutCuDNN.apply(x, weight, None, (1, 1), (1, 1), (1, 1), dim)
+    y_ref = torch.nn.functional.conv2d(x.detach(), weight.detach(), None, stride=1, padding=1, dilation=1, groups=dim)
+    assert torch.allclose(y.detach(), y_ref, atol=1e-6)
+    y.sum().backward()
+    assert x.grad is not None
+    assert x.grad.shape == x.shape
+    assert torch.isfinite(x.grad).all()
+    assert weight.grad is not None
+    assert weight.grad.shape == weight.shape
+    assert torch.isfinite(weight.grad).all()
+
+
+@pytest.mark.parametrize("layer_scale_init_value", [0, 1e-6], ids=["no_gamma", "with_gamma"])
+def test_depthwise_conv_block_layer_scale(layer_scale_init_value: float) -> None:
+    """DepthwiseConvBlock with and without layer scaling produces valid output and gradients.
+
+    Exercises the gamma=None (layer_scale_init_value=0) and gamma!=None
+    (layer_scale_init_value>0) branches in DepthwiseConvBlock.forward().
+    """
+    block = DepthwiseConvBlock(dim=8, layer_scale_init_value=layer_scale_init_value)
+    x = torch.randn(1, 8, 4, 4, requires_grad=True)
+    y = block(x)
+    assert y.shape == x.shape
+    y.sum().backward()
+    assert x.grad is not None
+    assert torch.isfinite(x.grad).all()
+    if layer_scale_init_value > 0:
+        assert block.gamma is not None
+        assert block.gamma.grad is not None

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -983,3 +983,208 @@ class TestRFDETREarlyStopping:
                 break
 
         assert new_stop_epoch == expected_stop_epoch
+
+
+# ---------------------------------------------------------------------------
+# _best_ema state persistence across resume (#969)
+# ---------------------------------------------------------------------------
+
+
+class TestBestEmaStatePersistence:
+    """Regression tests for _best_ema not surviving Lightning checkpoint resume.
+
+    Before the fix, BestModelCallback did not override state_dict() /
+    load_state_dict(), so _best_ema was never included in the Lightning callback
+    state bundle.  On resume via trainer.fit(ckpt_path=...) the callback was
+    reconstructed fresh with _best_ema=0.0, causing any positive post-resume EMA
+    value to trivially overwrite checkpoint_best_ema.pth with inferior weights.
+
+    Regression tests for GitHub issue #969.
+    """
+
+    def test_state_dict_includes_best_ema(self, tmp_path: Path) -> None:
+        """state_dict() must include _best_ema so it survives Lightning checkpointing."""
+        cb = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
+        pl_module = _make_pl_module()
+
+        # Drive _best_ema to 0.75 via a validation pass.
+        trainer = _make_trainer({"val/mAP_50_95": 0.4, "val/ema_mAP_50_95": 0.75})
+        cb.on_validation_end(trainer, pl_module)
+
+        state = cb.state_dict()
+
+        assert "_best_ema" in state, "_best_ema must be present in state_dict() output"
+        assert state["_best_ema"] == pytest.approx(0.75)
+
+    def test_load_state_dict_restores_best_ema(self, tmp_path: Path) -> None:
+        """load_state_dict() must restore _best_ema from the persisted state."""
+        # First callback: train to _best_ema=0.75.
+        cb_first = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
+        pl_module = _make_pl_module()
+        trainer = _make_trainer({"val/mAP_50_95": 0.4, "val/ema_mAP_50_95": 0.75})
+        cb_first.on_validation_end(trainer, pl_module)
+        saved_state = cb_first.state_dict()
+
+        # Second callback: simulate a fresh resume by loading the saved state.
+        cb_resumed = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
+        cb_resumed.load_state_dict(saved_state)
+
+        assert cb_resumed._best_ema == pytest.approx(0.75), (
+            "load_state_dict() must restore _best_ema; without fix it stays 0.0"
+        )
+
+    def test_resume_does_not_clobber_ema_checkpoint_with_inferior_weights(self, tmp_path: Path) -> None:
+        """After resume, inferior post-resume EMA must not overwrite checkpoint_best_ema.pth.
+
+        Without the fix: _best_ema resets to 0.0 on resume, so any positive EMA
+        metric (0.5) trivially satisfies ema_val > _best_ema and overwrites the
+        checkpoint saved pre-resume (0.75).
+        """
+        # --- Pre-resume phase: establish EMA best of 0.75 ---
+        cb_pre = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
+        pl_module = _make_pl_module()
+        trainer_pre = _make_trainer(
+            {"val/mAP_50_95": 0.4, "val/ema_mAP_50_95": 0.75},
+            current_epoch=5,
+        )
+        cb_pre.on_validation_end(trainer_pre, pl_module)
+
+        ema_path = tmp_path / "checkpoint_best_ema.pth"
+        assert ema_path.exists()
+        baseline_epoch = torch.load(ema_path, map_location="cpu", weights_only=False)["epoch"]
+        saved_state = cb_pre.state_dict()
+
+        # --- Resume phase: fresh callback loaded from saved state ---
+        cb_resumed = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
+        cb_resumed.load_state_dict(saved_state)
+
+        # Post-resume validation reports EMA=0.5 — worse than pre-resume best (0.75).
+        trainer_post = _make_trainer(
+            {"val/mAP_50_95": 0.45, "val/ema_mAP_50_95": 0.5},
+            current_epoch=7,
+        )
+        cb_resumed.on_validation_end(trainer_post, pl_module)
+
+        assert torch.load(ema_path, map_location="cpu", weights_only=False)["epoch"] == baseline_epoch, (
+            "checkpoint_best_ema.pth must not be overwritten by an inferior post-resume EMA value"
+        )
+
+    def test_on_fit_end_selects_ema_winner_after_resume(self, tmp_path: Path) -> None:
+        """on_fit_end picks EMA winner correctly when _best_ema is properly restored.
+
+        Without the fix: _best_ema=0.0 after resume, so regular (0.6) wins over
+        the true EMA best (0.8) — checkpoint_best_total.pth is built from the
+        wrong source.  Use epoch number as a distinguisher: pre-resume EMA was
+        saved at epoch 3; regular was saved at epoch 1; total epoch must be 3
+        (EMA epoch) when EMA correctly wins.
+        """
+        # Pre-resume epoch 1: regular best=0.6.
+        cb_pre = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95", run_test=False)
+        pl_module = _make_pl_module()
+        trainer_ep1 = _make_trainer({"val/mAP_50_95": 0.6, "val/ema_mAP_50_95": 0.5}, current_epoch=1)
+        cb_pre.on_validation_end(trainer_ep1, pl_module)
+
+        # Pre-resume epoch 3: EMA best=0.8 (better than epoch-1 EMA=0.5).
+        trainer_ep3 = _make_trainer({"val/mAP_50_95": 0.55, "val/ema_mAP_50_95": 0.8}, current_epoch=3)
+        cb_pre.on_validation_end(trainer_ep3, pl_module)
+
+        saved_state = cb_pre.state_dict()
+
+        # Resume: fresh callback, load state, run fit_end.
+        cb_resumed = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95", run_test=False)
+        cb_resumed.load_state_dict(saved_state)
+
+        # fit_end uses _best_ema to decide EMA vs regular winner.
+        # trainer_ep3 carries best_model_score=0.6 (regular) and _best_ema=0.8 (EMA wins).
+        cb_resumed.on_fit_end(trainer_ep3, pl_module)
+
+        total = tmp_path / "checkpoint_best_total.pth"
+        assert total.exists()
+        total_data = torch.load(total, map_location="cpu", weights_only=False)
+        # strip_checkpoint preserves the `loops` key.
+        # epoch_progress.current.completed == trainer.current_epoch + 1 at save time.
+        # EMA checkpoint was saved at epoch 3 → completed=4.
+        # Regular checkpoint was saved at epoch 1 → completed=2.
+        # If _best_ema was NOT restored (bug), regular wins → completed=2.
+        # If _best_ema IS restored (fix), EMA wins → completed=4.
+        completed = total_data["loops"]["fit_loop"]["epoch_progress"]["current"]["completed"]
+        assert completed == 4, (
+            "on_fit_end must select EMA (epoch 3, best=0.8) over regular (epoch 1, best=0.6); "
+            f"got epoch_completed={completed} — _best_ema not restored from state_dict"
+        )
+
+    @pytest.mark.parametrize(
+        ("mutate_state", "expected_best_ema"),
+        [
+            pytest.param(
+                lambda state: state.pop("_best_ema"),
+                0.0,
+                id="missing_key",
+            ),
+            pytest.param(
+                lambda state: state.__setitem__("_best_ema", int(1)),
+                1.0,
+                id="int_coercion",
+            ),
+            pytest.param(
+                lambda state: state.__setitem__("_best_ema", str("0.75")),
+                0.75,
+                id="string_coercion",
+            ),
+        ],
+    )
+    def test_load_state_dict_backward_compat(self, tmp_path: Path, mutate_state, expected_best_ema: float) -> None:
+        """load_state_dict() keeps backward-compatible _best_ema restoration behavior."""
+        cb = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
+        state = cb.state_dict()
+        mutate_state(state)
+
+        cb.load_state_dict(state)
+
+        assert isinstance(cb._best_ema, float)
+        assert cb._best_ema == expected_best_ema
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            pytest.param(float("nan"), id="nan"),
+            pytest.param(float("inf"), id="inf"),
+            pytest.param(float("-inf"), id="neg_inf"),
+        ],
+    )
+    def test_load_state_dict_non_finite_values(self, bad_value) -> None:
+        """load_state_dict() resets non-finite persisted _best_ema values to 0.0."""
+        cb = BestModelCallback(output_dir=".")
+        cb._best_ema = 999.0
+        state = cb.state_dict()
+        state["_best_ema"] = bad_value
+
+        cb.load_state_dict(state)
+
+        assert cb._best_ema == 0.0
+
+    def test_load_state_dict_does_not_mutate_caller_dict(self, tmp_path: Path) -> None:
+        """load_state_dict must not pop or mutate the caller-supplied dict."""
+        cb1 = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
+        cb1._best_ema = 0.75
+        original_sd = cb1.state_dict()
+        saved = dict(original_sd)
+
+        cb2 = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
+        cb2.load_state_dict(original_sd)
+
+        assert original_sd["_best_ema"] == 0.75
+        assert original_sd == saved
+
+    def test_state_dict_roundtrip_initial_zero(self, tmp_path: Path) -> None:
+        """state_dict/load_state_dict round-trips the default _best_ema=0.0 correctly."""
+        cb1 = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
+        sd = cb1.state_dict()
+
+        assert "_best_ema" in sd
+        assert sd["_best_ema"] == 0.0
+
+        cb2 = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
+        cb2.load_state_dict(sd)
+
+        assert cb2._best_ema == 0.0

--- a/tests/training/test_coco_eval_callback.py
+++ b/tests/training/test_coco_eval_callback.py
@@ -4,7 +4,7 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
-"""Unit tests for COCOEvalCallback (PTL Ch3/T3)."""
+"""Unit tests for COCOEvalCallback."""
 
 from unittest.mock import MagicMock, patch
 
@@ -512,6 +512,42 @@ class TestOnValidationEpochEnd:
         assert "val/ema_mAP_50_95" in trainer.callback_metrics
         assert "val/ema_mAP_50" in trainer.callback_metrics
         assert "val/ema_mAR" in trainer.callback_metrics
+
+    def test_ema_segm_metrics_use_ema_values_not_base(self) -> None:
+        """EMA segmentation metrics must come from map_metric_ema, not the
+        base map_metric.  Regression test for #978."""
+        cb = COCOEvalCallback(max_dets=500, segmentation=True)
+        trainer = _make_trainer()
+        trainer.callback_metrics = {}
+        cb.setup(trainer, _make_pl_module(), stage="fit")
+
+        # Base metrics: segm_map=0.35
+        base_metrics = _minimal_metrics(pfx="bbox_")
+        base_metrics["segm_map"] = torch.tensor(0.35)
+        base_metrics["segm_map_50"] = torch.tensor(0.55)
+        cb.map_metric = MagicMock(name="map_metric")
+        cb.map_metric.compute.return_value = base_metrics
+
+        # EMA metrics: segm_map=0.45 (deliberately different)
+        ema_metrics = _minimal_metrics(pfx="bbox_")
+        ema_metrics["segm_map"] = torch.tensor(0.45)
+        ema_metrics["segm_map_50"] = torch.tensor(0.65)
+        cb.map_metric_ema = MagicMock(name="map_metric_ema")
+        cb.map_metric_ema.compute.return_value = ema_metrics
+        module = _make_pl_module()
+
+        cb.on_validation_epoch_end(trainer, module)
+
+        # EMA segm values must differ from base
+        assert trainer.callback_metrics["val/ema_segm_mAP_50_95"].item() == pytest.approx(0.45)
+        assert trainer.callback_metrics["val/ema_segm_mAP_50"].item() == pytest.approx(0.65)
+        # Base segm values unchanged
+        assert trainer.callback_metrics["val/segm_mAP_50_95"].item() == pytest.approx(0.35)
+        assert trainer.callback_metrics["val/segm_mAP_50"].item() == pytest.approx(0.55)
+        # pl_module.log() must also receive EMA values (covers both changed code paths)
+        logged = {c.args[0]: c.args[1] for c in module.log.call_args_list if len(c.args) >= 2}
+        assert logged["val/ema_segm_mAP_50_95"].item() == pytest.approx(0.45)
+        assert logged["val/ema_segm_mAP_50"].item() == pytest.approx(0.65)
 
     def test_ghost_class_with_negative_ar_sentinel_is_filtered(self) -> None:
         """A class where both ap=-1 and ar=-1 (negative sentinels, not NaN) must

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -8,6 +8,7 @@
 
 1. ``TestRFDETRTrainPTL``           — RFDETR.train() delegates to PTL build_trainer().fit()
 2. ``TestRFDETRTrainPTLAbsorption`` — Legacy kwargs absorbed by RFDETR.train()
+2b. ``TestResolutionKwarg``         — resolution= kwarg validation, sync, and PE update
 3. ``TestConvertLegacyCheckpoint``  — convert_legacy_checkpoint() round-trip
 4. ``TestOnLoadCheckpoint``         — RFDETRModule.on_load_checkpoint() auto-detect
 5. ``TestPublicAPIExports``         — rfdetr.__init__ exports RFDETRModule/DataModule/build_trainer
@@ -527,88 +528,6 @@ class TestRFDETRTrainPTLAbsorption:
         depr = [x for x in w if issubclass(x.category, DeprecationWarning)]
         assert any("do_benchmark" in str(d.message) or "rfdetr benchmark" in str(d.message) for d in depr)
 
-    def test_resolution_kwarg_updates_model_config_resolution(self, tmp_path, patch_lit):
-        """resolution kwarg is applied to model_config.resolution before training."""
-        mock_self = _make_rfdetr_self(tmp_path)
-        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
-        valid_resolution = block_size * 11  # guaranteed divisible and different from default
-        p_mod, p_dm, p_bt, *_ = patch_lit
-        with p_mod, p_dm, p_bt:
-            RFDETR.train(mock_self, resolution=valid_resolution)
-        assert mock_self.model_config.resolution == valid_resolution
-
-    def test_resolution_kwarg_does_not_implicitly_update_positional_encoding_size(self, tmp_path, patch_lit):
-        """Pretrained-specific PE (RFDETRBase DINOv2=37) is preserved when resolution is overridden."""
-        mock_self = _make_rfdetr_self(tmp_path)
-        # RFDETRBaseConfig: PE=37 (DINOv2 native 518//14), resolution=560, patch_size=14.
-        # PE != resolution // patch_size, so the smart PE guard leaves PE unchanged.
-        original_pe = mock_self.model_config.positional_encoding_size
-        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
-        valid_override_resolution = block_size * 11  # different from default 560
-        p_mod, p_dm, p_bt, *_ = patch_lit
-        with p_mod, p_dm, p_bt:
-            RFDETR.train(mock_self, resolution=valid_override_resolution)
-        assert mock_self.model_config.positional_encoding_size == original_pe
-
-    def test_resolution_kwarg_updates_positional_encoding_size_for_formula_derived_config(self, tmp_path, patch_lit):
-        """For configs where PE == resolution // patch_size, resolution override updates PE."""
-        # RFDETRSmallConfig: patch_size=16, num_windows=2, resolution=512, PE=32=512//16.
-        mock_self = _make_rfdetr_self(tmp_path)
-        mock_self.model_config = RFDETRSmallConfig(pretrain_weights=None, num_classes=3, device="cpu")
-        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
-        new_resolution = block_size * 21  # 672 for Small — valid and different from default 512
-        expected_pe = new_resolution // mock_self.model_config.patch_size
-        p_mod, p_dm, p_bt, *_ = patch_lit
-        with p_mod, p_dm, p_bt:
-            RFDETR.train(mock_self, resolution=new_resolution)
-        assert mock_self.model_config.positional_encoding_size == expected_pe
-
-    def test_resolution_kwarg_does_not_reach_get_train_config(self, tmp_path, patch_lit):
-        """resolution kwarg is popped before get_train_config is called."""
-        mock_self = _make_rfdetr_self(tmp_path)
-        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
-        p_mod, p_dm, p_bt, *_ = patch_lit
-        with p_mod, p_dm, p_bt:
-            RFDETR.train(mock_self, resolution=block_size * 10)
-        assert "resolution" not in mock_self.get_train_config.call_args.kwargs
-
-    def test_resolution_indivisible_raises_value_error(self, tmp_path, patch_lit):
-        """resolution not divisible by patch_size * num_windows raises ValueError."""
-        mock_self = _make_rfdetr_self(tmp_path)
-        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
-        indivisible = block_size * 10 + 1  # guaranteed not divisible by block_size
-        p_mod, p_dm, p_bt, *_ = patch_lit
-        with p_mod, p_dm, p_bt, pytest.raises(ValueError, match=f"resolution={indivisible}"):
-            RFDETR.train(mock_self, resolution=indivisible)
-
-    def test_resolution_none_leaves_model_config_unchanged(self, tmp_path, patch_lit):
-        """Omitting resolution leaves model_config.resolution unchanged."""
-        mock_self = _make_rfdetr_self(tmp_path)
-        original_resolution = mock_self.model_config.resolution
-        p_mod, p_dm, p_bt, *_ = patch_lit
-        with p_mod, p_dm, p_bt:
-            RFDETR.train(mock_self)
-        assert mock_self.model_config.resolution == original_resolution
-
-    @pytest.mark.parametrize(
-        "bad_resolution",
-        [
-            pytest.param(0, id="zero"),
-            pytest.param(-56, id="negative"),
-            pytest.param(True, id="bool_true"),
-            pytest.param(False, id="bool_false"),
-            pytest.param(1.5, id="non_integer_float"),
-            pytest.param(560.0, id="whole_number_float"),
-            pytest.param("560", id="string"),
-        ],
-    )
-    def test_resolution_invalid_type_or_value_raises_value_error(self, tmp_path, patch_lit, bad_resolution):
-        """Non-positive, bool, or non-integer resolution raises ValueError before divisibility check."""
-        mock_self = _make_rfdetr_self(tmp_path)
-        p_mod, p_dm, p_bt, *_ = patch_lit
-        with p_mod, p_dm, p_bt, pytest.raises(ValueError, match="resolution must be a positive integer"):
-            RFDETR.train(mock_self, resolution=bad_resolution)
-
     def test_returns_none(self, tmp_path, patch_lit):
         """RFDETR.train() returns None."""
         mock_self = _make_rfdetr_self(tmp_path)
@@ -690,6 +609,130 @@ class TestRFDETRTrainPTLAbsorption:
 
         # Training must proceed regardless of the grid-save failure
         mock_bt.return_value.fit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 2b. resolution= kwarg handling
+# ---------------------------------------------------------------------------
+
+
+class TestResolutionKwarg:
+    """RFDETR.train(resolution=...) applies, validates, and syncs the resolution override."""
+
+    def test_updates_model_config_resolution(self, tmp_path, patch_lit):
+        """resolution kwarg is applied to model_config.resolution before training."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
+        valid_resolution = block_size * 11  # guaranteed divisible and different from default
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self, resolution=valid_resolution)
+        assert mock_self.model_config.resolution == valid_resolution
+
+    def test_does_not_implicitly_update_positional_encoding_size(self, tmp_path, patch_lit):
+        """Pretrained-specific PE (RFDETRBase DINOv2=37) is preserved when resolution is overridden."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        # RFDETRBaseConfig: PE=37 (DINOv2 native 518//14), resolution=560, patch_size=14.
+        # PE != resolution // patch_size, so the smart PE guard leaves PE unchanged.
+        original_pe = mock_self.model_config.positional_encoding_size
+        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
+        valid_override_resolution = block_size * 11  # different from default 560
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self, resolution=valid_override_resolution)
+        assert mock_self.model_config.positional_encoding_size == original_pe
+
+    def test_updates_positional_encoding_size_for_formula_derived_config(self, tmp_path, patch_lit):
+        """For configs where PE == resolution // patch_size, resolution override updates PE."""
+        # RFDETRSmallConfig: patch_size=16, num_windows=2, resolution=512, PE=32=512//16.
+        mock_self = _make_rfdetr_self(tmp_path)
+        mock_self.model_config = RFDETRSmallConfig(pretrain_weights=None, num_classes=3, device="cpu")
+        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
+        new_resolution = block_size * 21  # 672 for Small — valid and different from default 512
+        expected_pe = new_resolution // mock_self.model_config.patch_size
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self, resolution=new_resolution)
+        assert mock_self.model_config.positional_encoding_size == expected_pe
+
+    def test_does_not_reach_get_train_config(self, tmp_path, patch_lit):
+        """resolution kwarg is popped before get_train_config is called."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self, resolution=block_size * 10)
+        assert "resolution" not in mock_self.get_train_config.call_args.kwargs
+
+    def test_indivisible_raises_value_error(self, tmp_path, patch_lit):
+        """resolution not divisible by patch_size * num_windows raises ValueError."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
+        indivisible = block_size * 10 + 1  # guaranteed not divisible by block_size
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt, pytest.raises(ValueError, match=f"resolution={indivisible}"):
+            RFDETR.train(mock_self, resolution=indivisible)
+
+    def test_none_leaves_model_config_unchanged(self, tmp_path, patch_lit):
+        """Omitting resolution leaves model_config.resolution unchanged."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        original_resolution = mock_self.model_config.resolution
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self)
+        assert mock_self.model_config.resolution == original_resolution
+
+    @pytest.mark.parametrize(
+        "bad_resolution",
+        [
+            pytest.param(0, id="zero"),
+            pytest.param(-56, id="negative"),
+            pytest.param(True, id="bool_true"),
+            pytest.param(False, id="bool_false"),
+            pytest.param(1.5, id="non_integer_float"),
+            pytest.param(560.0, id="whole_number_float"),
+            pytest.param("560", id="string"),
+        ],
+    )
+    def test_invalid_type_or_value_raises_value_error(self, tmp_path, patch_lit, bad_resolution):
+        """Non-positive, bool, or non-integer resolution raises ValueError before divisibility check."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt, pytest.raises(ValueError, match="resolution must be a positive integer"):
+            RFDETR.train(mock_self, resolution=bad_resolution)
+
+    def test_syncs_model_resolution_attribute(self, tmp_path, patch_lit):
+        """resolution kwarg sets model.resolution so predict()/export() see the new resolution.
+
+        Regression test for #952 — keeps the cached inference/export context in sync after
+        a resolution override in train().
+        """
+        mock_self = _make_rfdetr_self(tmp_path)
+        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
+        new_resolution = block_size * 11
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self, resolution=new_resolution)
+        assert mock_self.model.resolution == new_resolution
+
+    def test_syncs_model_args_resolution_and_pe(self, tmp_path, patch_lit):
+        """resolution kwarg updates model.args.resolution and model.args.positional_encoding_size.
+
+        For formula-derived configs (PE == resolution // patch_size), both fields in model.args
+        must be kept consistent with model_config so export/deployment pipelines use the
+        correct values.  Regression test for #952.
+        """
+        mock_self = _make_rfdetr_self(tmp_path)
+        # RFDETRSmallConfig: formula-derived PE (512 // 16 == 32), so PE updates with resolution.
+        mock_self.model_config = RFDETRSmallConfig(pretrain_weights=None, num_classes=3, device="cpu")
+        block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
+        new_resolution = block_size * 21  # 672 for Small — valid, different from default 512
+        expected_pe = new_resolution // mock_self.model_config.patch_size
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self, resolution=new_resolution)
+        assert mock_self.model.args.resolution == new_resolution
+        assert mock_self.model.args.positional_encoding_size == expected_pe
 
 
 # ---------------------------------------------------------------------------

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -1155,6 +1155,36 @@ class TestRFDETRLargeFallback:
         assert call_count == 2
         warn_spy.assert_called_once()
 
+    def test_pe_size_mismatch_with_custom_resolution_does_not_retry(self, monkeypatch, patch_lit):
+        """Custom resolution= must not trigger deprecated-config fallback on PE size mismatch.
+
+        Regression for #960: when ``resolution=`` is explicitly passed, a positional
+        embedding size mismatch is caused by the resolution change — not by deprecated
+        weights.  The fallback must be suppressed so the error surfaces to the caller
+        rather than silently loading the wrong model architecture.
+        """
+        call_count = 0
+
+        def _raise_pe_mismatch(self, **kwargs):
+            del self
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError(
+                "Error(s) in loading state_dict for LWDETR:\n\t"
+                "size mismatch for backbone.0.encoder.encoder.embeddings.position_embeddings: "
+                "copying a param with shape torch.Size([1, 577, 384]) from checkpoint, "
+                "the shape in current model is torch.Size([1, 1601, 384])."
+            )
+
+        monkeypatch.setattr(RFDETR, "__init__", _raise_pe_mismatch)
+
+        with pytest.raises(RuntimeError, match="size mismatch"):
+            RFDETRLarge(resolution=640)
+
+        assert call_count == 1, (
+            f"Expected no deprecated-config retry when resolution= is set, but __init__ was called {call_count} times."
+        )
+
 
 # ---------------------------------------------------------------------------
 # 7. _load_pretrain_weights_into — detr.py path (the non-PTL scenario from #806)

--- a/tests/training/test_load_pretrain_weights.py
+++ b/tests/training/test_load_pretrain_weights.py
@@ -387,3 +387,151 @@ class TestModuleLoadPretrainWeightsSecondReinit:
         assert mc.num_classes == 8, (
             f"mc.num_classes must be auto-aligned to 8 (checkpoint_logits - 1), got {mc.num_classes}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Regression #960: PE interpolation for custom resolution
+# ---------------------------------------------------------------------------
+
+PE_KEY = "backbone.0.encoder.encoder.embeddings.position_embeddings"
+
+
+class TestLoadPretrainWeightsPEInterpolation:
+    """Regression tests for #960 — PE must be interpolated when resolution changes.
+
+    ``load_pretrain_weights`` must bicubic-interpolate the checkpoint's DINOv2
+    positional embeddings to match the model's ``positional_encoding_size`` before
+    calling ``load_state_dict``.  Without this, any custom ``resolution`` that
+    changes the PE grid size causes a ``RuntimeError: size mismatch``.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _patch_download(self, monkeypatch):
+        """Suppress all download and file-existence side effects."""
+        monkeypatch.setattr("rfdetr.models.weights.download_pretrain_weights", lambda *a, **kw: None)
+        monkeypatch.setattr("rfdetr.models.weights.validate_pretrain_weights", lambda *a, **kw: None)
+        monkeypatch.setattr("rfdetr.models.weights.validate_checkpoint_compatibility", lambda *a, **kw: None)
+        monkeypatch.setattr("rfdetr.models.weights.os.path.isfile", lambda _: True)
+
+    @pytest.mark.parametrize(
+        "src_pe_size, tgt_resolution, patch_size, expected_tgt_pe_size",
+        [
+            pytest.param(24, 640, 16, 40, id="nano_24x24_upscale_to_40x40"),
+            pytest.param(40, 384, 16, 24, id="nano_40x40_downscale_to_24x24"),
+            pytest.param(32, 640, 16, 40, id="small_32x32_upscale_to_40x40"),
+        ],
+    )
+    def test_pe_in_checkpoint_is_interpolated_to_model_resolution(
+        self, monkeypatch, src_pe_size, tgt_resolution, patch_size, expected_tgt_pe_size
+    ):
+        """Checkpoint PE is bicubic-interpolated to match model_config.positional_encoding_size.
+
+        Regression for #960: ``load_pretrain_weights`` must not raise ``RuntimeError``
+        when model resolution differs from checkpoint resolution.  The PE tensor in the
+        checkpoint must be resized in-place before ``load_state_dict`` is called.
+        """
+        mc = RFDETRNanoConfig(
+            pretrain_weights="/fake/weights.pth",
+            device="cpu",
+            resolution=tgt_resolution,
+            patch_size=patch_size,
+        )
+        assert mc.positional_encoding_size == tgt_resolution // patch_size
+
+        dim = 384
+        src_n = src_pe_size * src_pe_size + 1  # patches + class token
+        checkpoint = _make_checkpoint(num_classes=91)
+        checkpoint["model"][PE_KEY] = torch.randn(1, src_n, dim).half()  # float16 to verify dtype round-trip
+
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
+        fake_model = MagicMock()
+        load_pretrain_weights(fake_model, mc)
+
+        pe = checkpoint["model"][PE_KEY]
+        expected_n = expected_tgt_pe_size * expected_tgt_pe_size + 1
+        assert pe.shape == torch.Size([1, expected_n, dim]), (
+            f"Expected PE shape [1, {expected_n}, {dim}], got {tuple(pe.shape)}. "
+            f"PE was not interpolated from {src_pe_size}x{src_pe_size} "
+            f"to {expected_tgt_pe_size}x{expected_tgt_pe_size}."
+        )
+        assert pe.dtype == torch.float16, f"Dtype must be preserved after interpolation, got {pe.dtype}"
+
+    def test_matching_pe_shape_is_not_modified(self, monkeypatch):
+        """When checkpoint PE matches model expectations, the tensor is not changed.
+
+        Ensures PE interpolation is a no-op for same-resolution checkpoints so that
+        normal weight loading is unaffected.
+        """
+        mc = RFDETRNanoConfig(pretrain_weights="/fake/weights.pth", device="cpu")
+        # Default: positional_encoding_size=24 → PE = [1, 24*24+1, 384] = [1, 577, 384]
+
+        dim = 384
+        original_pe = torch.randn(1, 577, dim)
+        checkpoint = _make_checkpoint(num_classes=91)
+        checkpoint["model"][PE_KEY] = original_pe.clone()
+
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
+        fake_model = MagicMock()
+        load_pretrain_weights(fake_model, mc)
+
+        pe = checkpoint["model"][PE_KEY]
+        assert pe.shape == torch.Size([1, 577, dim]), "Matching PE shape must not be modified."
+        assert torch.equal(pe, original_pe), "Matching PE tensor values must not be modified."
+
+    def test_base_config_non_formula_pe_is_interpolated_from_smaller_checkpoint(self, monkeypatch):
+        """RFDETRBaseConfig PE=37 (not formula-derived) is interpolated when checkpoint differs.
+
+        RFDETRBaseConfig.positional_encoding_size=37 is not updated by
+        ``_sync_pe_with_resolution`` because 37 ≠ 560//16=35 (not formula-derived).
+        Loading a checkpoint with a smaller PE grid (e.g., 24×24) must still
+        trigger interpolation to the model's fixed PE=37×37 target.
+        """
+        mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu")
+        assert mc.positional_encoding_size == 37, "RFDETRBaseConfig PE must remain 37 (not formula-derived)"
+
+        dim = 384
+        src_pe_size = 24
+        src_n = src_pe_size * src_pe_size + 1
+        checkpoint = _make_checkpoint(num_classes=91)
+        checkpoint["model"][PE_KEY] = torch.randn(1, src_n, dim)
+
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
+        fake_model = MagicMock()
+        load_pretrain_weights(fake_model, mc)
+
+        pe = checkpoint["model"][PE_KEY]
+        expected_n = 37 * 37 + 1
+        assert pe.shape == torch.Size([1, expected_n, dim]), (
+            f"Expected PE shape [1, {expected_n}, {dim}] (37×37 grid), got {tuple(pe.shape)}. "
+            "BaseConfig's non-formula-derived PE must be the interpolation target."
+        )
+
+    def test_non_square_source_pe_logs_warning_and_is_not_modified(self, monkeypatch):
+        """Non-square source PE grids are skipped with a warning and left unchanged.
+
+        When ``n_source`` is not a perfect square the interpolation is skipped to
+        avoid producing malformed embeddings.  The tensor must remain untouched and
+        a warning must be emitted via the weights module logger.
+        """
+        mc = RFDETRNanoConfig(pretrain_weights="/fake/weights.pth", device="cpu")
+        # positional_encoding_size=24 → n_target=576 (perfect square, so the
+        # target-side guard does not trigger; only the source-side guard fires)
+
+        dim = 384
+        # 17 is not a perfect square: isqrt(17)=4, 4*4=16 ≠ 17
+        non_square_n_source = 17
+        original_pe = torch.randn(1, non_square_n_source + 1, dim)
+        checkpoint = _make_checkpoint(num_classes=91)
+        checkpoint["model"][PE_KEY] = original_pe.clone()
+
+        warning_calls: list[tuple] = []
+        monkeypatch.setattr("rfdetr.models.weights.logger.warning", lambda *a, **kw: warning_calls.append(a))
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
+        fake_model = MagicMock()
+        load_pretrain_weights(fake_model, mc)
+
+        pe = checkpoint["model"][PE_KEY]
+        assert torch.equal(pe, original_pe), "Non-square source PE must not be modified."
+        assert any("not a perfect square" in str(args) for args in warning_calls), (
+            f"Expected a 'not a perfect square' warning; got calls: {warning_calls}"
+        )

--- a/tests/training/test_trainer_smoke.py
+++ b/tests/training/test_trainer_smoke.py
@@ -302,6 +302,74 @@ class _DDPModule(RFDETRModelModule):
         return torch.optim.AdamW(self.parameters(), lr=1e-4)
 
 
+class _MultiScaleCheckDDPModule(RFDETRModelModule):
+    """DDP-safe module that asserts on_train_batch_start mutation reaches training_step.
+
+    With multi_scale=True and _FakeDataset's 32×32 images, on_train_batch_start
+    interpolates samples.tensors to a multi-scale resolution (≥392 for
+    RFDETRBaseConfig resolution=560).  This module raises AssertionError in
+    training_step if the tensor height is still 32, meaning the in-place
+    NestedTensor mutation did not propagate through the PTL batch-hook chain.
+
+    Must be defined at module level so pickle can look up the class by qualified
+    name when ddp_spawn deserialises it in the child process.
+
+    Regression guard for issue #952.
+    """
+
+    def configure_optimizers(self):
+        """Minimal single-group AdamW — bypasses get_param_dict."""
+        return torch.optim.AdamW(self.parameters(), lr=1e-4)
+
+    def training_step(self, batch, batch_idx):
+        """Assert resize from on_train_batch_start propagated before calling super."""
+        samples, _ = batch
+        h = samples.tensors.shape[2]
+        if h == 32:
+            raise AssertionError(
+                f"training_step received images at original 32-px height (h={h}). "
+                "on_train_batch_start's in-place NestedTensor mutation did not "
+                "propagate through the PTL hook chain. "
+                "Regression of issue #952: resize bypass in DDP batch-hook chain."
+            )
+        return super().training_step(batch, batch_idx)
+
+
+# ---------------------------------------------------------------------------
+# Multi-scale hook propagation tests (issue #952 regression)
+# ---------------------------------------------------------------------------
+
+
+class TestMultiScaleHookPropagation:
+    """on_train_batch_start resize must propagate to training_step via NestedTensor mutation.
+
+    _FakeDataset emits 32×32 images.  With multi_scale=True and
+    RFDETRBaseConfig(resolution=560, patch_size=14, num_windows=4) the computed
+    scales start at 392, so none equal 32.  _MultiScaleCheckDDPModule raises
+    AssertionError in training_step if h==32, making trainer.fit() fail when
+    the in-place mutation does not propagate.
+    """
+
+    def test_mutation_persists_to_training_step(self, base_model_config, base_train_config):
+        """Single-process: training_step must see resized tensors, not original 32×32."""
+        mc = base_model_config()
+        tc = base_train_config(multi_scale=True, use_ema=False, run_test=False)
+        fake_dataset = _FakeDataset(length=20)
+
+        with (
+            patch("rfdetr.training.module_model.build_model_from_config", return_value=_TinyModel()),
+            patch(
+                "rfdetr.training.module_model.build_criterion_from_config",
+                return_value=(_FakeCriterion(), _FakePostProcess()),
+            ),
+            patch("rfdetr.training.module_data.build_dataset", return_value=fake_dataset),
+        ):
+            module = _MultiScaleCheckDDPModule(mc, tc)
+            datamodule = RFDETRDataModule(mc, tc)
+            trainer = build_trainer(tc, mc, accelerator="cpu", fast_dev_run=2)
+            trainer.fit(module, datamodule=datamodule)
+
+
 # Windows CI currently cannot run this smoke test because gloo DDP spawn fails
 # with makeDeviceForHostname unsupported-device errors.
 @pytest.mark.skipif(sys.platform == "win32", reason="gloo DDP spawn unsupported on Windows CI")
@@ -326,6 +394,42 @@ def test_ddp_spawn_fit_runs_without_error(base_model_config, base_train_config):
         ),
     ):
         module = _DDPModule(mc, tc)
+
+    datamodule = RFDETRDataModule(mc, tc)
+    # Pre-set datasets: build_dataset mock doesn't survive the spawn boundary.
+    datamodule._dataset_train = fake_dataset
+    datamodule._dataset_val = fake_dataset
+
+    trainer = build_trainer(tc, mc, accelerator="cpu", fast_dev_run=2)
+    trainer.fit(module, datamodule=datamodule)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="gloo DDP spawn unsupported on Windows CI")
+def test_ddp_spawn_multi_scale_mutation_propagates(base_model_config, base_train_config):
+    """ddp_spawn with multi_scale=True must propagate on_train_batch_start resize to training_step.
+
+    _MultiScaleCheckDDPModule raises AssertionError in training_step when the
+    NestedTensor height is still 32 (original _FakeDataset size).  If trainer.fit()
+    completes without error the PTL batch-hook reference chain is intact in DDP,
+    i.e. the in-place mutation in on_train_batch_start is visible in training_step
+    on both workers.
+
+    Regression test for issue #952 on CPU DDP (non-Windows): confirms the
+    transforms/resize propagation is not a Windows-only concern.
+    """
+    mc = base_model_config()
+    tc = base_train_config(multi_scale=True, use_ema=False, run_test=False, devices=2, strategy="ddp_spawn")
+
+    fake_dataset = _FakeDataset(length=20)
+
+    with (
+        patch("rfdetr.training.module_model.build_model_from_config", return_value=_TinyModel()),
+        patch(
+            "rfdetr.training.module_model.build_criterion_from_config",
+            return_value=(_FakeCriterion(), _FakePostProcess()),
+        ),
+    ):
+        module = _MultiScaleCheckDDPModule(mc, tc)
 
     datamodule = RFDETRDataModule(mc, tc)
     # Pre-set datasets: build_dataset mock doesn't survive the spawn boundary.

--- a/tests/training/test_trainer_smoke.py
+++ b/tests/training/test_trainer_smoke.py
@@ -357,9 +357,9 @@ class TestMultiScaleHookPropagation:
         fake_dataset = _FakeDataset(length=20)
 
         with (
-            patch("rfdetr.training.module_model.build_model_from_config", return_value=_TinyModel()),
+            patch("rfdetr.training.module_model.build_model", return_value=_TinyModel()),
             patch(
-                "rfdetr.training.module_model.build_criterion_from_config",
+                "rfdetr.training.module_model.build_criterion_and_postprocessors",
                 return_value=(_FakeCriterion(), _FakePostProcess()),
             ),
             patch("rfdetr.training.module_data.build_dataset", return_value=fake_dataset),
@@ -423,9 +423,9 @@ def test_ddp_spawn_multi_scale_mutation_propagates(base_model_config, base_train
     fake_dataset = _FakeDataset(length=20)
 
     with (
-        patch("rfdetr.training.module_model.build_model_from_config", return_value=_TinyModel()),
+        patch("rfdetr.training.module_model.build_model", return_value=_TinyModel()),
         patch(
-            "rfdetr.training.module_model.build_criterion_from_config",
+            "rfdetr.training.module_model.build_criterion_and_postprocessors",
             return_value=(_FakeCriterion(), _FakePostProcess()),
         ),
     ):

--- a/tests/utilities/test_state_dict.py
+++ b/tests/utilities/test_state_dict.py
@@ -176,6 +176,148 @@ class TestValidateCheckpointCompatibility:
             validate_checkpoint_compatibility(checkpoint, model_args)
 
     # ------------------------------------------------------------------
+    # patch_size inferred from projection weight (no "args" key)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "ckpt_patch_size,model_patch_size,should_raise",
+        [
+            pytest.param(16, 12, True, id="ckpt_16_model_12_raises"),
+            pytest.param(14, 16, True, id="ckpt_14_model_16_raises"),
+            pytest.param(16, 16, False, id="matching_16_no_raise"),
+        ],
+    )
+    def test_patch_size_inferred_from_projection_weight(
+        self, ckpt_patch_size: int, model_patch_size: int, should_raise: bool
+    ) -> None:
+        """Projection weight shape used to infer ckpt patch_size when 'args' key absent.
+
+        Regression test for #965 — pretrained COCO weights lack 'args', so the
+        shape-based fallback must fire before load_state_dict raises a cryptic RuntimeError.
+        """
+        proj_key = "backbone.0.encoder.encoder.embeddings.patch_embeddings.projection.weight"
+        proj_weight = torch.zeros(384, 3, ckpt_patch_size, ckpt_patch_size)
+        checkpoint = {"model": {proj_key: proj_weight}}  # no "args" key
+        model_args = SimpleNamespace(patch_size=model_patch_size)
+
+        if should_raise:
+            with pytest.raises(
+                ValueError,
+                match=rf"patch_size={ckpt_patch_size}.*patch_size={model_patch_size}"
+                rf"|patch_size={model_patch_size}.*patch_size={ckpt_patch_size}",
+            ):
+                validate_checkpoint_compatibility(checkpoint, model_args)
+        else:
+            validate_checkpoint_compatibility(checkpoint, model_args)  # must not raise
+
+    @pytest.mark.parametrize(
+        "checkpoint,model_args_kwargs",
+        [
+            pytest.param(
+                {},
+                {"patch_size": 16},
+                id="no_model_key_skips",
+            ),
+            pytest.param(
+                {"model": {}},
+                {"patch_size": 16},
+                id="no_projection_key_skips",
+            ),
+            pytest.param(
+                {
+                    "model": {
+                        "backbone.0.encoder.encoder.embeddings.patch_embeddings.projection.weight": torch.zeros(
+                            384, 3, 16, 16
+                        )
+                    }
+                },
+                {},
+                id="model_no_patch_size_attr_skips",
+            ),
+            pytest.param(
+                {
+                    "model": {
+                        "backbone.0.encoder.encoder.embeddings.patch_embeddings.projection.weight": torch.zeros(
+                            384, 3
+                        )  # 2D — not a Conv2d weight; rank guard must skip cleanly
+                    }
+                },
+                {"patch_size": 16},
+                id="proj_weight_2d_skips",
+            ),
+            pytest.param(
+                {
+                    "model": {
+                        "backbone.0.encoder.encoder.embeddings.patch_embeddings.projection.weight": torch.zeros(
+                            384, 3, 16
+                        )  # 3D — not a Conv2d weight; rank guard must skip cleanly
+                    }
+                },
+                {"patch_size": 16},
+                id="proj_weight_3d_skips",
+            ),
+            pytest.param(
+                {
+                    "model": {
+                        "backbone.0.encoder.encoder.embeddings.patch_embeddings.projection.weight": torch.zeros(
+                            384, 3, 16, 16, 16
+                        )  # 5D — Conv3d-like; rank guard (== 4) must skip cleanly
+                    }
+                },
+                {"patch_size": 8},
+                id="proj_weight_5d_skips",
+            ),
+            pytest.param(
+                {
+                    "args": SimpleNamespace(patch_size=14),
+                    "model": {
+                        "backbone.0.encoder.encoder.embeddings.patch_embeddings.projection.weight": torch.zeros(
+                            384, 3, 16, 16
+                        )  # projection suggests 16, but args.patch_size=14 takes precedence
+                    },
+                },
+                {"patch_size": 14},
+                id="args_patch_size_suppresses_projection_inference",
+            ),
+            pytest.param(
+                {
+                    "args": {"patch_size": 14},  # PTL-style dict args (not SimpleNamespace)
+                    "model": {
+                        "backbone.0.encoder.encoder.embeddings.patch_embeddings.projection.weight": torch.zeros(
+                            384, 3, 16, 16
+                        )  # projection suggests 16, but dict args["patch_size"]=14 takes precedence
+                    },
+                },
+                {"patch_size": 14},
+                id="dict_args_patch_size_suppresses_projection_inference",
+            ),
+        ],
+    )
+    def test_projection_inference_silently_skips_when_incomplete(
+        self, checkpoint: dict, model_args_kwargs: dict
+    ) -> None:
+        """Shape-based patch_size check is skipped when key or attribute is absent.
+
+        Verifies backward compatibility: missing projection key, missing model key,
+        model_args without patch_size attribute, non-4D projection weights, or an
+        explicit args.patch_size (SimpleNamespace or dict) must all be handled without error.
+        """
+        model_args = SimpleNamespace(**model_args_kwargs)
+        validate_checkpoint_compatibility(checkpoint, model_args)  # must not raise
+
+    def test_non_square_projection_kernel_skips_check(self) -> None:
+        """Non-square patch projection kernel is skipped — patch_size cannot be inferred reliably.
+
+        Guards against hypothetical future backbones with non-square Conv2d kernels
+        where shape[-1] would not equal patch_size.
+        """
+        proj_key = "backbone.0.encoder.encoder.embeddings.patch_embeddings.projection.weight"
+        proj_weight = torch.zeros(384, 3, 16, 14)  # non-square: h=16, w=14
+        checkpoint = {"model": {proj_key: proj_weight}}
+        model_args = SimpleNamespace(patch_size=16)
+        validate_checkpoint_compatibility(checkpoint, model_args)  # must not raise
+
+    # ------------------------------------------------------------------
     # class-count mismatch warnings
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
## ⚠️ Breaking Changes

- **`source_image` moved from `data` to `metadata`.** `predict()` now stores the original input image in `detections.metadata["source_image"]` instead of `detections.data["source_image"]`. This fixes `IndexError` when boolean- or integer-indexing `sv.Detections` with `include_source_image=True` (the default) — supervision indexes every value in `data` by the detection mask, but passes `metadata` through unchanged. Update any code that reads the source image: (#972)

    ```python
    # Before (1.6.3–1.6.4)
    image = detections.data["source_image"]

    # After (1.6.5+)
    image = detections.metadata["source_image"]
    ```

## 🔧 Fixed

- **Fixed segmentation training crash on T4 and P100 GPUs.** cuDNN engine selection fails for depthwise convolution backward on some CUDA stacks (Kaggle, Colab). The previous workaround only disabled cuDNN in the forward pass; backward kernels still ran with cuDNN enabled. A custom `autograd.Function` now disables cuDNN in both forward and backward. (#967)

- **Fixed EMA segmentation mAP logged from base metrics.** `ema_segm_mAP_50_95` and `ema_segm_mAP_50` were computed from the base (non-EMA) metric accumulator instead of the EMA accumulator, producing misleading validation scores for segmentation models. Both metrics now use the correct EMA source. (#980)

- **Fixed `BestModelCallback` losing best EMA score on resume.** The `_best_ema` value was not persisted in `state_dict()`, so resuming training reset the EMA best-model tracker and could overwrite a better earlier checkpoint. (#973)

- **Fixed `positional_encoding_size` not updating with custom resolution.** Setting `resolution` at construction time (e.g. `RFDETRLarge(resolution=640)`) did not update the positional encoding grid size, causing shape mismatches during forward. A model validator now auto-syncs `positional_encoding_size` when a custom resolution is provided. (#956)

- **Fixed pretrained weight loading crash with custom resolution.** Loading COCO pretrained weights into a model with a non-default resolution failed because the DINOv2 positional embeddings had an incompatible shape. Pretrained PE tensors are now bicubic-interpolated to match the target grid before loading. (#964)

    ```python
    # This now works — PE is automatically interpolated from 560px grid to 640px
    model = RFDETRLarge(resolution=640)
    ```

- **Fixed cryptic error on `patch_size` mismatch.** When loading checkpoints without explicit `args.patch_size`, the first error was an opaque `RuntimeError` from `load_state_dict`. The compatibility check now infers `patch_size` from the DINOv2 projection weight shape and raises a descriptive `ValueError` explaining the mismatch. (#971)

- **Fixed `source_shape` causing `TypeError` on `sv.Detections` iteration.** `predict()` stored `source_shape` as a Python `tuple`, which `sv.Detections` cannot index per-detection. It is now an `np.ndarray` of shape `(N, 2)` with dtype `int64`, where each row is `[height, width]`. (#966)

- **Fixed spurious "class_id out of range" warning for background class.** RF-DETR uses `num_classes + 1` logits internally; class index `num_classes` is the background/no-object class and is expected. Background-class detections now map `class_name` to `"__background__"` without a warning. (#970)

---

## 🏆 Contributors

Welcome to our new contributors, and thank you to everyone who helped with this release:

- **Md Faruk Alam** (@farukalamai) ([LinkedIn](https://linkedin.com/in/farukalamai))— *cuDNN depthwise conv backward fix for T4/P100*
- **M. Fazri Nizar** (@mfazrinizar) ([LinkedIn](https://linkedin.com/in/mfazrinizar)) — *EMA segmentation metrics fix*
- **Jirka Borovec** (@Borda) ([LinkedIn](https://www.linkedin.com/in/jirka-borovec)) — *release coordination, reviews*

*Automated contributions: @copilot-swe-agent[bot], @pre-commit-ci[bot]*

---

**Full changelog**: https://github.com/roboflow/rf-detr/compare/1.6.4...1.6.5