### PR TITLE
fix: pad non-square resize outputs to multiples of patch_size * num_windows

### DIFF
--- a/src/rfdetr/datasets/coco.py
+++ b/src/rfdetr/datasets/coco.py
@@ -307,11 +307,30 @@ class ConvertCoco(object):
         return image, target
 
 
+def _pad_to_divisor_config(divisor: int) -> Dict[str, Any]:
+    """Albumentations ``PadIfNeeded`` config padding up to the next multiple of *divisor*.
+
+    ``min_height``/``min_width`` default to 1024 in Albumentations 2.x and conflict
+    with the divisor parameters; we pass ``None`` explicitly to disable them.
+    """
+    return {
+        "PadIfNeeded": {
+            "min_height": None,
+            "min_width": None,
+            "pad_height_divisor": divisor,
+            "pad_width_divisor": divisor,
+            "border_mode": 0,
+            "fill": 0,
+        }
+    }
+
+
 def _build_train_resize_config(
     scales: List[int],
     *,
     square: bool,
     max_size: Optional[int] = None,
+    divisor: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
     """Build the training resize pipeline as an Albumentations config list.
 
@@ -332,6 +351,10 @@ def _build_train_resize_config(
             ratio using ``A.SmallestMaxSize`` with an optional long-side cap.
         max_size: Maximum long-side size for non-square resizes.  Defaults to
             ``1333`` when *square* is ``False``.
+        divisor: When set and ``square`` is ``False``, append ``PadIfNeeded`` so
+            both spatial dimensions are rounded up to the next multiple of this
+            value.  Required for backbones that assert divisibility by
+            ``patch_size * num_windows``; see :issue:`983`.
 
     Returns:
         A single-element list containing a ``OneOf`` config entry.
@@ -361,24 +384,21 @@ def _build_train_resize_config(
         cap = max_size or 1333
         # SmallestMaxSize accepts a list and picks randomly — no OneOf needed
         size_param: Any = scales[0] if len(scales) == 1 else scales
-        option_a = {
-            "Sequential": {
-                "transforms": [
-                    {"SmallestMaxSize": {"max_size": size_param}},
-                    {"LongestMaxSize": {"max_size": cap}},
-                ]
-            }
-        }
-        option_b = {
-            "Sequential": {
-                "transforms": [
-                    {"SmallestMaxSize": {"max_size": [400, 500, 600]}},
-                    {"RandomCrop": {"height": 384, "width": 384}},
-                    {"SmallestMaxSize": {"max_size": size_param}},
-                    {"LongestMaxSize": {"max_size": cap}},
-                ]
-            }
-        }
+        option_a_transforms: List[Dict[str, Any]] = [
+            {"SmallestMaxSize": {"max_size": size_param}},
+            {"LongestMaxSize": {"max_size": cap}},
+        ]
+        option_b_transforms: List[Dict[str, Any]] = [
+            {"SmallestMaxSize": {"max_size": [400, 500, 600]}},
+            {"RandomCrop": {"height": 384, "width": 384}},
+            {"SmallestMaxSize": {"max_size": size_param}},
+            {"LongestMaxSize": {"max_size": cap}},
+        ]
+        if divisor is not None:
+            option_a_transforms.append(_pad_to_divisor_config(divisor))
+            option_b_transforms.append(_pad_to_divisor_config(divisor))
+        option_a = {"Sequential": {"transforms": option_a_transforms}}
+        option_b = {"Sequential": {"transforms": option_b_transforms}}
 
     return [{"OneOf": {"transforms": [option_a, option_b]}}]
 
@@ -455,10 +475,14 @@ def make_coco_transforms(
             scales = [scales[-1]]
         logger.info(f"Using multi-scale training with scales: {scales}")
 
+    # Backbones with windowed attention require H and W divisible by this block size;
+    # see dinov2_with_windowed_attn.py. Pad resize outputs to satisfy it.
+    block_size = patch_size * num_windows
+
     if image_set == "train":
         resolved_aug_config = aug_config if aug_config is not None else AUG_CONFIG
         resize_wrappers = AlbumentationsWrapper.from_config(
-            _build_train_resize_config(scales, square=False, max_size=1333)
+            _build_train_resize_config(scales, square=False, max_size=1333, divisor=block_size)
         )
         pipeline = [*resize_wrappers]
         if not gpu_postprocess:
@@ -474,6 +498,7 @@ def make_coco_transforms(
             [
                 {"SmallestMaxSize": {"max_size": resolution}},
                 {"LongestMaxSize": {"max_size": 1333}},
+                _pad_to_divisor_config(block_size),
             ]
         )
         return Compose([*resize_wrappers, to_image, to_float, normalize])

--- a/src/rfdetr/datasets/coco.py
+++ b/src/rfdetr/datasets/coco.py
@@ -308,10 +308,19 @@ class ConvertCoco(object):
 
 
 def _pad_to_divisor_config(divisor: int) -> Dict[str, Any]:
-    """Albumentations ``PadIfNeeded`` config padding up to the next multiple of *divisor*.
+    """Build an Albumentations ``PadIfNeeded`` config that rounds H and W up to a multiple of *divisor*.
 
-    ``min_height``/``min_width`` default to 1024 in Albumentations 2.x and conflict
-    with the divisor parameters; we pass ``None`` explicitly to disable them.
+    ``min_height``/``min_width`` default to ``1024`` in Albumentations 2.x and conflict
+    with the ``pad_*_divisor`` parameters, so they are set to ``None`` explicitly.
+
+    Args:
+        divisor: Target divisor for both spatial dimensions.  The output image is
+            zero-padded on the bottom/right edges so ``H % divisor == 0`` and
+            ``W % divisor == 0``.
+
+    Returns:
+        A single-transform config dict suitable for
+        :meth:`AlbumentationsWrapper.from_config`.
     """
     return {
         "PadIfNeeded": {

--- a/tests/datasets/test_augmentations.py
+++ b/tests/datasets/test_augmentations.py
@@ -1469,8 +1469,8 @@ class TestMakeCocoTransformsAugConfig:
     @pytest.mark.parametrize(
         "make_transforms,expected_resize_wrappers",
         [
-            # make_coco_transforms val: SmallestMaxSize + LongestMaxSize = 2 wrappers
-            pytest.param(make_coco_transforms, 2, id="make_coco_transforms"),
+            # make_coco_transforms val: SmallestMaxSize + LongestMaxSize + PadIfNeeded = 3 wrappers
+            pytest.param(make_coco_transforms, 3, id="make_coco_transforms"),
             # make_coco_transforms_square_div_64 val: Resize = 1 wrapper
             pytest.param(make_coco_transforms_square_div_64, 1, id="make_coco_transforms_square_div_64"),
         ],
@@ -1499,8 +1499,8 @@ class TestMakeCocoTransformsAugConfig:
     @pytest.mark.parametrize(
         "make_transforms,expected_resize_wrappers",
         [
-            # make_coco_transforms test: SmallestMaxSize + LongestMaxSize = 2 wrappers
-            pytest.param(make_coco_transforms, 2, id="make_coco_transforms"),
+            # make_coco_transforms test: SmallestMaxSize + LongestMaxSize + PadIfNeeded = 3 wrappers
+            pytest.param(make_coco_transforms, 3, id="make_coco_transforms"),
             # make_coco_transforms_square_div_64 test: Resize = 1 wrapper
             pytest.param(make_coco_transforms_square_div_64, 1, id="make_coco_transforms_square_div_64"),
         ],

--- a/tests/datasets/test_coco_resize_config.py
+++ b/tests/datasets/test_coco_resize_config.py
@@ -6,9 +6,13 @@
 
 """Characterization tests for _build_train_resize_config."""
 
+import numpy as np
 import pytest
+import torch
+from PIL import Image
 
-from rfdetr.datasets.coco import _build_train_resize_config
+from rfdetr.datasets.coco import _build_train_resize_config, make_coco_transforms
+from rfdetr.datasets.transforms import AlbumentationsWrapper
 
 
 class TestBuildTrainResizeConfigStructure:
@@ -195,3 +199,151 @@ class TestBuildTrainResizeConfigNonSquareMultiScale:
         option_b = result[0]["OneOf"]["transforms"][1]
         assert option_a["Sequential"]["transforms"][1] == {"LongestMaxSize": {"max_size": 1000}}
         assert option_b["Sequential"]["transforms"][3] == {"LongestMaxSize": {"max_size": 1000}}
+
+
+class TestBuildTrainResizeConfigDivisor:
+    """divisor param appends PadIfNeeded so outputs are divisible by the backbone block size."""
+
+    def _expected_pad(self, divisor: int) -> dict:
+        return {
+            "PadIfNeeded": {
+                "min_height": None,
+                "min_width": None,
+                "pad_height_divisor": divisor,
+                "pad_width_divisor": divisor,
+                "border_mode": 0,
+                "fill": 0,
+            }
+        }
+
+    def test_nonsquare_single_scale_appends_pad_to_option_a(self):
+        result = _build_train_resize_config([896], square=False, max_size=1333, divisor=32)
+        option_a = result[0]["OneOf"]["transforms"][0]
+        assert option_a["Sequential"]["transforms"][-1] == self._expected_pad(32)
+
+    def test_nonsquare_single_scale_appends_pad_to_option_b(self):
+        result = _build_train_resize_config([896], square=False, max_size=1333, divisor=32)
+        option_b = result[0]["OneOf"]["transforms"][1]
+        assert option_b["Sequential"]["transforms"][-1] == self._expected_pad(32)
+
+    def test_nonsquare_multiscale_appends_pad_to_both_options(self):
+        result = _build_train_resize_config([480, 640], square=False, divisor=56)
+        option_a = result[0]["OneOf"]["transforms"][0]
+        option_b = result[0]["OneOf"]["transforms"][1]
+        assert option_a["Sequential"]["transforms"][-1] == self._expected_pad(56)
+        assert option_b["Sequential"]["transforms"][-1] == self._expected_pad(56)
+
+    def test_divisor_none_preserves_old_behavior(self):
+        """Default divisor=None produces the same config as before the fix."""
+        result = _build_train_resize_config([896], square=False, max_size=1333)
+        option_a = result[0]["OneOf"]["transforms"][0]
+        for t in option_a["Sequential"]["transforms"]:
+            assert "PadIfNeeded" not in t
+
+    def test_square_branch_ignores_divisor(self):
+        """Square outputs are already fixed-size; no PadIfNeeded needed even if divisor is set."""
+        result = _build_train_resize_config([640], square=True, divisor=32)
+        option_b = result[0]["OneOf"]["transforms"][1]
+        for t in option_b["Sequential"]["transforms"]:
+            assert "PadIfNeeded" not in t
+
+
+class TestNonSquareResizeDivisibilityRegression:
+    """Regression test for issue #983.
+
+    When ``square_resize_div_64=False``, the training resize pipeline must produce
+    outputs with dimensions divisible by ``patch_size * num_windows``; otherwise
+    the windowed-attention backbone rejects the input.
+    """
+
+    @pytest.mark.parametrize(
+        "img_h,img_w",
+        [
+            pytest.param(1200, 800, id="portrait-3:2"),
+            pytest.param(800, 1200, id="landscape-3:2"),
+            pytest.param(1024, 768, id="4:3"),
+            pytest.param(1500, 500, id="wide-3:1"),
+            pytest.param(500, 1500, id="tall-1:3"),
+            pytest.param(777, 613, id="arbitrary-non-aligned"),
+        ],
+    )
+    def test_output_dims_divisible_by_block_size(self, img_h: int, img_w: int) -> None:
+        """For many random trials (covering both OneOf branches), output H/W are divisible by 32."""
+        patch_size, num_windows = 16, 2
+        divisor = patch_size * num_windows  # 32
+
+        wrappers = AlbumentationsWrapper.from_config(
+            _build_train_resize_config([896], square=False, max_size=1333, divisor=divisor)
+        )
+        assert len(wrappers) == 1
+        wrapper = wrappers[0]
+
+        image = Image.fromarray(np.random.RandomState(0).randint(0, 255, (img_h, img_w, 3), dtype=np.uint8))
+        target = {
+            "boxes": torch.zeros((0, 4)),
+            "labels": torch.zeros((0,), dtype=torch.long),
+        }
+
+        for seed in range(40):
+            np.random.seed(seed)
+            torch.manual_seed(seed)
+            aug_image, _ = wrapper(image, target)
+            w, h = aug_image.size
+            assert h % divisor == 0, f"seed={seed} input=({img_h},{img_w}) output_h={h} not divisible by {divisor}"
+            assert w % divisor == 0, f"seed={seed} input=({img_h},{img_w}) output_w={w} not divisible by {divisor}"
+
+    def test_make_coco_transforms_train_passes_divisor(self) -> None:
+        """End-to-end: make_coco_transforms(train) with patch_size=16, num_windows=2 produces dims divisible by 32."""
+        patch_size, num_windows = 16, 2
+        divisor = patch_size * num_windows
+
+        transform = make_coco_transforms(
+            image_set="train",
+            resolution=896,
+            multi_scale=False,
+            patch_size=patch_size,
+            num_windows=num_windows,
+        )
+
+        image = Image.fromarray(np.random.RandomState(0).randint(0, 255, (1024, 768, 3), dtype=np.uint8))
+        target = {
+            "boxes": torch.zeros((0, 4)),
+            "labels": torch.zeros((0,), dtype=torch.long),
+            "orig_size": torch.tensor([1024, 768]),
+            "size": torch.tensor([1024, 768]),
+        }
+
+        for seed in range(20):
+            np.random.seed(seed)
+            torch.manual_seed(seed)
+            out_image, _ = transform(image, target)
+            # After ToImage + ToDtype the tensor is CHW
+            _, h, w = out_image.shape
+            assert h % divisor == 0, f"seed={seed} output_h={h} not divisible by {divisor}"
+            assert w % divisor == 0, f"seed={seed} output_w={w} not divisible by {divisor}"
+
+    def test_make_coco_transforms_val_produces_divisible_dims(self) -> None:
+        """Val pipeline must also produce dims divisible by patch_size * num_windows."""
+        patch_size, num_windows = 16, 2
+        divisor = patch_size * num_windows
+
+        transform = make_coco_transforms(
+            image_set="val",
+            resolution=896,
+            multi_scale=False,
+            patch_size=patch_size,
+            num_windows=num_windows,
+        )
+
+        image = Image.fromarray(np.random.RandomState(0).randint(0, 255, (1024, 768, 3), dtype=np.uint8))
+        target = {
+            "boxes": torch.zeros((0, 4)),
+            "labels": torch.zeros((0,), dtype=torch.long),
+            "orig_size": torch.tensor([1024, 768]),
+            "size": torch.tensor([1024, 768]),
+        }
+
+        out_image, _ = transform(image, target)
+        _, h, w = out_image.shape
+        assert h % divisor == 0, f"val output_h={h} not divisible by {divisor}"
+        assert w % divisor == 0, f"val output_w={w} not divisible by {divisor}"


### PR DESCRIPTION
## What does this PR do?

Fixes an error when training with `square_resize_div_64=False`. The non-square training and validation resize pipelines (`SmallestMaxSize` then `LongestMaxSize`) did not guarantee output dimensions divisible by `patch_size * num_windows`, causing `WindowedDinov2WithRegistersEmbeddings.forward` to reject inputs with `"Input spatial dimensions must be divisible by patch_size * num_windows"`. Appends `PadIfNeeded` (with `pad_*_divisor` set to `patch_size * num_windows`) after the resize pair in both the train (`_build_train_resize_config`) and val/test branches of `make_coco_transforms`.

**Why padding is safe for the backbone:**

- `interpolate_pos_encoding` in DINOv2 is already dynamic, so it handles any `H x W` divisible by `patch_size`.
- The backbone encoder does not receive the `NestedTensor` mask (only downstream attention does), and the batch collate step already zero-pads images up to batch-max size. The divisor-pad is just one more small strip (at most `divisor - 1` pixels) on top of that existing padding.
- No changes to backbone, `NestedTensor`, windowed attention, or detection head.

**Fix and pipeline wiring:**

- Added private helper `_pad_to_divisor_config(divisor)` that builds an Albumentations `PadIfNeeded` config, with `min_height`/`min_width` set to `None` to avoid the 1024 default colliding with `pad_*_divisor`.
- Added `divisor: Optional[int] = None` kwarg to `_build_train_resize_config`. When set and `square=False`, the helper appends `PadIfNeeded` to both OneOf options.
- `make_coco_transforms` computes `block_size = patch_size * num_windows` and threads it into the train and val/test pipelines.
- The square branch (`make_coco_transforms_square_div_64`) and the `val_speed` branch are untouched since they already produce compliant dimensions.

**Related Issue(s):** Fixes #983

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

- Added `TestBuildTrainResizeConfigDivisor` (5 structural tests) covering the new `divisor` kwarg behavior for both non-square and square branches, plus backward compatibility when `divisor=None`.
- Added `TestNonSquareResizeDivisibilityRegression` (8 end-to-end regression tests) that feed images of varied aspect ratios (portrait, landscape, wide, tall, arbitrary non-aligned) through the resize wrapper and through `make_coco_transforms` (train and val) across 40 random seeds, asserting output `H` and `W` are divisible by 32 for `patch_size=16, num_windows=2`.
- Updated two existing count assertions in `tests/datasets/test_augmentations.py` since the val/test pipeline now has 3 resize wrappers instead of 2.
- All 271 tests in `tests/datasets/` pass locally.
- `pre-commit run` clean on touched files.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

The `max_size=1333` hardcoded cap in the non-square resize path is a separate latent concern (for very elongated aspect ratios it can shrink the shorter side below the configured resolution) but is out of scope here. This PR is narrowly focused on the divisibility bug in #983.
