### PR TITLE
docs(geo): fix schema errors and expand GEO signals in MkDocs theme

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,7 @@ repos:
         # The hook runs in an isolated env without torch/torchvision/etc.
         # Full strict checking (matching pyproject.toml) runs in CI via ci-typing.yml.
         args: ["--ignore-missing-imports"]
+        exclude: ^docs/(hooks|scripts)/.*\.py$
         additional_dependencies:
           - "types-PyYAML"
           - "types-requests"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `predict()` storing `detections.data["source_shape"]` as a Python `tuple`, which caused `TypeError` whenever `sv.Detections` was iterated. The value is now an `np.ndarray` of shape `(N, 2)` and dtype `int64`. ([#966](https://github.com/roboflow/rf-detr/pull/966), [#963](https://github.com/roboflow/rf-detr/issues/963))
 - Fixed `predict()` emitting a misleading "class_id out of range" warning for the background/no-object class (class index `num_classes`). Background-class detections now map `data["class_name"]` to `"__background__"` without any warning. ([#970](https://github.com/roboflow/rf-detr/issues/970))
 
-
 ## [1.6.4] — 2026-04-10
 
 ### Changed

--- a/docs/hooks/package_version.py
+++ b/docs/hooks/package_version.py
@@ -1,0 +1,98 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+"""MkDocs hooks for exposing package metadata to documentation templates."""
+
+import sys
+from pathlib import Path
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli
+
+
+def _load_pyproject(pyproject_path: Path) -> dict[str, Any]:
+    """Load project metadata from a pyproject file.
+
+    Reads the TOML file in binary mode, matching the parser API. The returned
+    dictionary is used by MkDocs hooks to avoid duplicating package metadata.
+
+    Args:
+        pyproject_path: Path to the repository's pyproject file.
+
+    Returns:
+        Parsed pyproject data.
+
+    Raises:
+        FileNotFoundError: If the pyproject file does not exist.
+        tomllib.TOMLDecodeError: If the pyproject file is invalid TOML on Python 3.11+.
+        tomli.TOMLDecodeError: If the pyproject file is invalid TOML on Python 3.10.
+
+    Example:
+        >>> data = _load_pyproject(Path("pyproject.toml"))
+        >>> isinstance(data["project"]["version"], str)
+        True
+    """
+    with pyproject_path.open("rb") as pyproject_file:
+        if sys.version_info >= (3, 11):
+            return tomllib.load(pyproject_file)
+        return tomli.load(pyproject_file)
+
+
+def _read_project_version(pyproject_path: Path) -> str:
+    """Read the package version from pyproject project metadata.
+
+    Validates that the version exists and is a string before exposing it to the
+    documentation templates.
+
+    Args:
+        pyproject_path: Path to the repository's pyproject file.
+
+    Returns:
+        Package version from the ``[project]`` table.
+
+    Raises:
+        RuntimeError: If ``[project].version`` is missing or not a string.
+
+    Example:
+        >>> _read_project_version(Path("pyproject.toml"))
+        '1.6.0'
+    """
+    pyproject = _load_pyproject(pyproject_path)
+    version = pyproject.get("project", {}).get("version")
+    if not isinstance(version, str):
+        msg = f"Missing string [project].version in {pyproject_path}"
+        raise RuntimeError(msg)
+    return version
+
+
+def on_config(config: dict[str, Any]) -> dict[str, Any]:
+    """Expose the package version to MkDocs templates.
+
+    Adds ``config.extra.software_version`` so schema.org JSON-LD can stay in
+    sync with the package metadata in ``pyproject.toml``.
+
+    Args:
+        config: MkDocs configuration object.
+
+    Returns:
+        Updated MkDocs configuration object.
+
+    Raises:
+        RuntimeError: If package metadata cannot provide a valid version.
+
+    Example:
+        >>> cfg = {"extra": {}}
+        >>> updated = on_config(cfg)
+        >>> updated["extra"]["software_version"]
+        '1.6.0'
+    """
+    pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    extra = config.setdefault("extra", {})
+    extra["software_version"] = _read_project_version(pyproject_path)
+    return config

--- a/docs/index.md
+++ b/docs/index.md
@@ -138,7 +138,7 @@ RF-DETR achieves the best accuracy–latency trade-off among real-time object de
 ## Frequently Asked Questions
 
 **What is RF-DETR?**
-RF-DETR (Roboflow Detection Transformer) is a real-time object detection and instance segmentation model from Roboflow. It uses a DINOv2 vision transformer backbone and achieves state-of-the-art accuracy–latency trade-offs on COCO and RF100-VL.
+RF-DETR (Roboflow Detection Transformer) is a real-time object detection and instance segmentation model from Roboflow, accepted at ICLR 2026. It uses a DINOv2 vision transformer backbone and achieves state-of-the-art accuracy–latency trade-offs on COCO (60.1 AP50:95 for RF-DETR-2XL) and RF100-VL.
 
 **How does RF-DETR compare to YOLOv11?**
 RF-DETR-L achieves 56.5 AP50:95 on COCO at 6.8 ms latency on an NVIDIA T4, outperforming YOLOv11x (54.7 AP) at lower latency. The DINOv2 backbone gives RF-DETR stronger performance on domain-shift benchmarks such as RF100-VL.
@@ -157,3 +157,12 @@ Detection models (e.g., `RFDETRLarge`) output bounding boxes. Segmentation model
 
 **Is RF-DETR open source?**
 Yes. Core models (Nano through Large) and all training/inference code are released under the Apache 2.0 license. XLarge and 2XLarge models require the `rfdetr[plus]` package (PML 1.0 license).
+
+**How do I fine-tune RF-DETR on a custom dataset?**
+Call `RFDETR.train()` with your dataset directory in COCO JSON or YOLO format. Example: `model = RFDETRLarge(); model.train(dataset_dir='./dataset', epochs=50, batch_size=4)`. The model downloads pretrained weights automatically and resumes from the best checkpoint.
+
+**How do I export RF-DETR to ONNX or TensorRT?**
+Call `model.export(type='onnx')` or `model.export(type='tensorrt')` after training or loading a checkpoint. ONNX export works on CPU and produces a single `.onnx` file compatible with ONNX Runtime and OpenCV DNN. TensorRT export requires TensorRT and a CUDA GPU.
+
+**Which RF-DETR model size should I use?**
+RF-DETR-Nano (2.3 ms, 67.6 AP50 on COCO) is best for edge and real-time applications. RF-DETR-Large (6.8 ms, 56.5 AP50:95) offers the best accuracy–latency trade-off for server deployment. RF-DETR-2XLarge (17.2 ms, 60.1 AP50:95) maximizes accuracy when latency allows.

--- a/docs/index.md
+++ b/docs/index.md
@@ -147,7 +147,7 @@ RF-DETR-L achieves 56.5 AP50:95 on COCO at 6.8 ms latency on an NVIDIA T4, outpe
 A CUDA-capable GPU with at least 8 GB VRAM (e.g., NVIDIA RTX 3060, T4, A10) is recommended for fine-tuning. Smaller models (RF-DETR-N and RF-DETR-S) can fit in 6 GB VRAM with reduced batch size. CPU inference is supported for evaluation.
 
 **Which dataset formats does RF-DETR support?**
-RF-DETR supports COCO JSON and YOLO-format datasets (with `dataset_type: "yolo"`). Roboflow datasets export directly to both formats. Detection and segmentation datasets use the same format — the model variant determines the task.
+RF-DETR supports COCO JSON and YOLO-format datasets (with `dataset_file: "yolo"`). Roboflow datasets export directly to both formats. Detection and segmentation datasets use the same format — the model variant determines the task.
 
 **Can RF-DETR run in real time?**
 Yes. RF-DETR-N runs at 2.3 ms per frame on a T4 GPU (TensorRT FP16, batch 1), and RF-DETR-L at 6.8 ms — both well within real-time thresholds. ONNX and TFLite exports are available for edge deployment.

--- a/docs/index.md
+++ b/docs/index.md
@@ -159,10 +159,10 @@ Detection models (e.g., `RFDETRLarge`) output bounding boxes. Segmentation model
 Yes. Core models (Nano through Large) and all training/inference code are released under the Apache 2.0 license. XLarge and 2XLarge models require the `rfdetr[plus]` package (PML 1.0 license).
 
 **How do I fine-tune RF-DETR on a custom dataset?**
-Call `RFDETR.train()` with your dataset directory in COCO JSON or YOLO format. Example: `model = RFDETRLarge(); model.train(dataset_dir='./dataset', epochs=50, batch_size=4)`. The model downloads pretrained weights automatically and resumes from the best checkpoint.
+Instantiate a model and call `model.train(...)` with your dataset directory in COCO JSON or YOLO format. Example: `model = RFDETRLarge(); model.train(dataset_dir='./dataset', epochs=50, batch_size=4)`. The model downloads pretrained weights automatically and resumes from the best checkpoint.
 
 **How do I export RF-DETR to ONNX or TensorRT?**
-Call `model.export(type='onnx')` or `model.export(type='tensorrt')` after training or loading a checkpoint. ONNX export works on CPU and produces a single `.onnx` file compatible with ONNX Runtime and OpenCV DNN. TensorRT export requires TensorRT and a CUDA GPU.
+Call `model.export(format="onnx")` after training or loading a checkpoint. ONNX export works on CPU and produces a single `.onnx` file compatible with ONNX Runtime and OpenCV DNN. For TensorRT deployment, first export to ONNX and then convert the `.onnx` model with TensorRT tooling or helpers such as `trtexec`; this requires TensorRT and a CUDA GPU.
 
 **Which RF-DETR model size should I use?**
 RF-DETR-Nano (2.3 ms, 67.6 AP50 on COCO) is best for edge and real-time applications. RF-DETR-Large (6.8 ms, 56.5 AP50:95) offers the best accuracy–latency trade-off for server deployment. RF-DETR-2XLarge (17.2 ms, 60.1 AP50:95) maximizes accuracy when latency allows.

--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -62,7 +62,7 @@
         "operatingSystem": "Linux, macOS, Windows",
         "url": "{{ config.site_url }}",
         "downloadUrl": "https://pypi.org/project/rfdetr/",
-        "softwareVersion": "1.6.5",
+        "softwareVersion": {{ config.extra.software_version | tojson }},
         "releaseNotes": "https://github.com/roboflow/rf-detr/blob/main/CHANGELOG.md",
         "description": "RF-DETR is a real-time transformer architecture for object detection and instance segmentation by Roboflow. DINOv2 backbone, SOTA on COCO (60.1 AP50:95). ICLR 2026. Apache 2.0.",
         "featureList": [
@@ -176,7 +176,7 @@
         "name": "How do I export RF-DETR to ONNX or TensorRT?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Call model.export(format='onnx') or model.export(format='tflite') after training or loading a checkpoint. ONNX export produces a single .onnx file compatible with runtimes such as ONNX Runtime, and TFLite export is available for edge deployment."
+          "text": "Call model.export(format='onnx') after training or loading a checkpoint. ONNX export works on CPU and produces a single .onnx file compatible with ONNX Runtime and OpenCV DNN. For TensorRT deployment, first export to ONNX and then convert the .onnx model with TensorRT tooling such as trtexec; this requires TensorRT and a CUDA GPU."
         }
       },
       {

--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -35,6 +35,7 @@
     "@graph": [
       {
         "@type": "Organization",
+        "@id": "https://roboflow.com/#organization",
         "name": "Roboflow",
         "url": "https://roboflow.com",
         "logo": {
@@ -54,6 +55,7 @@
       },
       {
         "@type": "SoftwareApplication",
+        "@id": "{{ config.site_url }}#software",
         "name": "RF-DETR",
         "alternateName": "rfdetr",
         "applicationCategory": "DeveloperApplication",
@@ -91,6 +93,7 @@
       },
       {
         "@type": "WebSite",
+        "@id": "{{ config.site_url }}#website",
         "name": "RF-DETR Documentation",
         "url": "{{ config.site_url }}",
         "description": {{ config.site_description | tojson }},
@@ -188,9 +191,8 @@
   }
   </script>
   {% else %}
-  {# Derive parent URL by removing the last path segment from the canonical URL #}
-  {% set _canon_parts = page.canonical_url.rstrip('/').split('/') %}
-  {% set _parent_url = (_canon_parts[:-1] | join('/')) + '/' %}
+  {# article:modified_time — content pages only #}
+  {% if page.meta.git_revision_date_localized %}<meta property="article:modified_time" content="{{ page.meta.git_revision_date_localized }}">{% endif %}
   {# JSON-LD: TechArticle — content pages #}
   <script type="application/ld+json">
   {
@@ -200,7 +202,7 @@
     "description": {{ (page.meta.description | default(config.site_description)) | tojson }},
     "url": "{{ page.canonical_url }}",
     {% if page.meta.git_revision_date_localized %}"dateModified": {{ page.meta.git_revision_date_localized | tojson }},
-    {% endif %}{% if og_image_url %}"image": {{ og_image_url | tojson }},
+    {% endif %}{% if page.meta.image %}"image": {{ page.meta.image | tojson }},
     {% endif %}"author": {"@type": "Organization", "name": "Roboflow", "url": "https://roboflow.com"},
     "publisher": {"@type": "Organization", "name": "Roboflow", "url": "https://roboflow.com"},
     "mainEntityOfPage": {"@type": "WebPage", "@id": "{{ page.canonical_url }}"},
@@ -210,7 +212,7 @@
     }
   }
   </script>
-  {# JSON-LD: BreadcrumbList — content pages #}
+  {# JSON-LD: BreadcrumbList — content pages (2-level: root -> page) #}
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -221,25 +223,13 @@
         "position": 1,
         "name": "RF-DETR",
         "item": "{{ config.site_url }}"
-      }{% if page.parent %},
-      {
-        "@type": "ListItem",
-        "position": 2,
-        "name": {{ page.parent.title | tojson }},
-        "item": "{{ _parent_url }}"
       },
       {
         "@type": "ListItem",
-        "position": 3,
-        "name": {{ page.title | tojson }},
-        "item": "{{ page.canonical_url }}"
-      }{% else %},
-      {
-        "@type": "ListItem",
         "position": 2,
         "name": {{ page.title | tojson }},
         "item": "{{ page.canonical_url }}"
-      }{% endif %}
+      }
     ]
   }
   </script>

--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -176,7 +176,7 @@
         "name": "How do I export RF-DETR to ONNX or TensorRT?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Call model.export(type='onnx') or model.export(type='tensorrt') after training or loading a checkpoint. ONNX export works on CPU and produces a single .onnx file compatible with ONNX Runtime and OpenCV DNN. TensorRT export requires TensorRT and a CUDA GPU."
+          "text": "Call model.export(format='onnx') or model.export(format='tflite') after training or loading a checkpoint. ONNX export produces a single .onnx file compatible with runtimes such as ONNX Runtime, and TFLite export is available for edge deployment."
         }
       },
       {
@@ -184,15 +184,15 @@
         "name": "Which RF-DETR model size should I use?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "RF-DETR-Nano (2.3\u00a0ms, 63\u00a0AP50 on COCO) is best for edge and real-time applications. RF-DETR-Large (6.8\u00a0ms, 56.5\u00a0AP50:95) offers the best accuracy-latency trade-off for server deployment. RF-DETR-2XLarge (17.2\u00a0ms, 60.1\u00a0AP50:95) maximizes accuracy when latency allows."
+          "text": "RF-DETR-Nano (2.3\u00a0ms, 67.6\u00a0AP50 on COCO) is best for edge and real-time applications. RF-DETR-Large (6.8\u00a0ms, 56.5\u00a0AP50:95) offers the best accuracy-latency trade-off for server deployment. RF-DETR-2XLarge (17.2\u00a0ms, 60.1\u00a0AP50:95) maximizes accuracy when latency allows."
         }
       }
     ]
   }
   </script>
   {% else %}
-  {# article:modified_time — content pages only #}
-  {% if page.meta.git_revision_date_localized %}<meta property="article:modified_time" content="{{ page.meta.git_revision_date_localized }}">{% endif %}
+  {# article:modified_time — content pages only; emit only when a full ISO-8601 date-time is available #}
+  {% if page.meta.git_revision_date_localized and "T" in page.meta.git_revision_date_localized %}<meta property="article:modified_time" content="{{ page.meta.git_revision_date_localized }}">{% endif %}
   {# JSON-LD: TechArticle — content pages #}
   <script type="application/ld+json">
   {

--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -168,7 +168,7 @@
         "name": "How do I fine-tune RF-DETR on a custom dataset?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Call RFDETR.train() with your dataset directory in COCO JSON or YOLO format. Example: model = RFDETRLarge(); model.train(dataset_dir='./dataset', epochs=50, batch_size=4). The model downloads pretrained weights automatically and resumes from the best checkpoint."
+          "text": "Instantiate a model and call model.train(...) with your dataset directory in COCO JSON or YOLO format. Example: model = RFDETRLarge(); model.train(dataset_dir='./dataset', epochs=50, batch_size=4). The model downloads pretrained weights automatically and resumes from the best checkpoint."
         }
       },
       {

--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -1,12 +1,20 @@
 {% extends "base.html" %}
 
+{% block htmltitle %}
+  {% if page and page.is_homepage %}
+    <title>RF-DETR &mdash; Real-Time Object Detection &amp; Segmentation by Roboflow</title>
+  {% else %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}
+
 {% block extrahead %}
   {{ super() }}
 
   {% if page %}
   {% set og_image_url = page.meta.image | default(config.extra.og_image | default('')) %}
   {# Open Graph — all pages #}
-  <meta property="og:title" content="{{ page.title }} - {{ config.site_name }}">
+  <meta property="og:title" content="{% if page.is_homepage %}RF-DETR &mdash; Real-Time Object Detection &amp; Segmentation by Roboflow{% else %}{{ page.title }} - {{ config.site_name }}{% endif %}">
   <meta property="og:description" content="{{ page.meta.description | default(config.site_description) }}">
   <meta property="og:type" content="{% if page.is_homepage %}website{% else %}article{% endif %}">
   <meta property="og:url" content="{{ page.canonical_url }}">
@@ -15,11 +23,11 @@
   {# Twitter Card — all pages #}
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@roboflow">
-  <meta name="twitter:title" content="{{ page.title }} - {{ config.site_name }}">
+  <meta name="twitter:title" content="{% if page.is_homepage %}RF-DETR &mdash; Real-Time Object Detection &amp; Segmentation by Roboflow{% else %}{{ page.title }} - {{ config.site_name }}{% endif %}">
   <meta name="twitter:description" content="{{ page.meta.description | default(config.site_description) }}">
   {% if og_image_url %}<meta name="twitter:image" content="{{ og_image_url }}">{% endif %}
 
-  {# JSON-LD: Organization + SoftwareApplication — homepage only #}
+  {# JSON-LD: Organization + SoftwareApplication + WebSite — homepage only #}
   {% if page.is_homepage %}
   <script type="application/ld+json">
   {
@@ -29,13 +37,19 @@
         "@type": "Organization",
         "name": "Roboflow",
         "url": "https://roboflow.com",
-        "logo": "https://storage.googleapis.com/com-roboflow-marketing/rf-detr/rf_detr_1-4_latency_accuracy_object_detection.png",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "{{ page.canonical_url }}assets/roboflow-logo.svg",
+          "width": 400,
+          "height": 400
+        },
+        "description": "Roboflow is a computer vision platform for dataset management, model training, and deployment. Creator of RF-DETR, Supervision, and Roboflow Inference.",
         "sameAs": [
           "https://github.com/roboflow",
           "https://www.linkedin.com/company/roboflow-ai/",
           "https://twitter.com/roboflow",
           "https://www.youtube.com/@Roboflow",
-          "https://pypi.org/project/rfdetr/"
+          "https://en.wikipedia.org/wiki/Roboflow"
         ]
       },
       {
@@ -46,17 +60,41 @@
         "operatingSystem": "Linux, macOS, Windows",
         "url": "{{ config.site_url }}",
         "downloadUrl": "https://pypi.org/project/rfdetr/",
-        "description": "RF-DETR is a real-time transformer architecture for object detection and instance segmentation by Roboflow. DINOv2 backbone, SOTA on COCO. ICLR 2026.",
+        "softwareVersion": "1.6.5",
+        "releaseNotes": "https://github.com/roboflow/rf-detr/blob/main/CHANGELOG.md",
+        "description": "RF-DETR is a real-time transformer architecture for object detection and instance segmentation by Roboflow. DINOv2 backbone, SOTA on COCO (60.1 AP50:95). ICLR 2026. Apache 2.0.",
+        "featureList": [
+          "Real-time object detection",
+          "Instance segmentation",
+          "DINOv2 vision transformer backbone",
+          "ONNX and TensorRT FP16/INT8 export",
+          "Fine-tuning on custom COCO and YOLO datasets",
+          "Multi-GPU distributed training",
+          "EMA model averaging"
+        ],
         "author": {"@type": "Organization", "name": "Roboflow", "url": "https://roboflow.com"},
         "license": "https://www.apache.org/licenses/LICENSE-2.0",
         "codeRepository": "https://github.com/roboflow/rf-detr",
         "programmingLanguage": "Python",
-        "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"},
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD",
+          "availability": "https://schema.org/InStock",
+          "url": "https://pypi.org/project/rfdetr/"
+        },
         "sameAs": [
           "https://github.com/roboflow/rf-detr",
           "https://pypi.org/project/rfdetr/",
           "https://arxiv.org/abs/2511.09554"
         ]
+      },
+      {
+        "@type": "WebSite",
+        "name": "RF-DETR Documentation",
+        "url": "{{ config.site_url }}",
+        "description": {{ config.site_description | tojson }},
+        "publisher": {"@type": "Organization", "name": "Roboflow", "url": "https://roboflow.com"}
       }
     ]
   }
@@ -71,7 +109,7 @@
         "name": "What is RF-DETR?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "RF-DETR (Roboflow Detection Transformer) is a real-time object detection and instance segmentation model from Roboflow. It uses a DINOv2 vision transformer backbone and achieves state-of-the-art accuracy\u2013latency trade-offs on COCO and RF100-VL."
+          "text": "RF-DETR (Roboflow Detection Transformer) is a real-time object detection and instance segmentation model from Roboflow, accepted at ICLR 2026. It uses a DINOv2 vision transformer backbone and achieves state-of-the-art accuracy\u2013latency trade-offs on COCO (60.1 AP50:95 for RF-DETR-2XL) and RF100-VL."
         }
       },
       {
@@ -79,7 +117,7 @@
         "name": "How does RF-DETR compare to YOLOv11?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "RF-DETR-L achieves 56.5 AP50:95 on COCO at 6.8 ms latency on an NVIDIA T4, outperforming YOLOv11x (54.7 AP) at lower latency. The DINOv2 backbone gives RF-DETR stronger performance on domain-shift benchmarks such as RF100-VL."
+          "text": "RF-DETR-L achieves 56.5 AP50:95 on COCO at 6.8\u00a0ms latency on an NVIDIA T4, outperforming YOLOv11x (54.7 AP) at lower latency. The DINOv2 backbone gives RF-DETR stronger performance on domain-shift benchmarks such as RF100-VL."
         }
       },
       {
@@ -87,7 +125,7 @@
         "name": "What GPU is required to train RF-DETR?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "A CUDA-capable GPU with at least 8 GB VRAM is recommended for fine-tuning. Smaller models (RF-DETR-N and RF-DETR-S) can fit in 6 GB VRAM with reduced batch size. CPU inference is supported for evaluation."
+          "text": "A CUDA-capable GPU with at least 8\u00a0GB VRAM is recommended for fine-tuning. Smaller models (RF-DETR-N and RF-DETR-S) can fit in 6\u00a0GB VRAM with a reduced batch size. CPU inference is supported for evaluation."
         }
       },
       {
@@ -103,7 +141,7 @@
         "name": "Can RF-DETR run in real time?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Yes. RF-DETR-N runs at 2.3 ms per frame on a T4 GPU (TensorRT FP16, batch 1), and RF-DETR-L at 6.8 ms \u2014 both well within real-time thresholds. ONNX and TFLite exports are available for edge deployment."
+          "text": "Yes. RF-DETR-N runs at 2.3\u00a0ms per frame on a T4 GPU (TensorRT FP16, batch 1), and RF-DETR-L at 6.8\u00a0ms \u2014 both well within real-time thresholds. ONNX and TFLite exports are available for edge deployment."
         }
       },
       {
@@ -121,21 +159,55 @@
           "@type": "Answer",
           "text": "Yes. Core models (Nano through Large) and all training/inference code are released under the Apache 2.0 license. XLarge and 2XLarge models require the rfdetr[plus] package (PML 1.0 license)."
         }
+      },
+      {
+        "@type": "Question",
+        "name": "How do I fine-tune RF-DETR on a custom dataset?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Call RFDETR.train() with your dataset directory in COCO JSON or YOLO format. Example: model = RFDETRLarge(); model.train(dataset_dir='./dataset', epochs=50, batch_size=4). The model downloads pretrained weights automatically and resumes from the best checkpoint."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How do I export RF-DETR to ONNX or TensorRT?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Call model.export(type='onnx') or model.export(type='tensorrt') after training or loading a checkpoint. ONNX export works on CPU and produces a single .onnx file compatible with ONNX Runtime and OpenCV DNN. TensorRT export requires TensorRT and a CUDA GPU."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Which RF-DETR model size should I use?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "RF-DETR-Nano (2.3\u00a0ms, 63\u00a0AP50 on COCO) is best for edge and real-time applications. RF-DETR-Large (6.8\u00a0ms, 56.5\u00a0AP50:95) offers the best accuracy-latency trade-off for server deployment. RF-DETR-2XLarge (17.2\u00a0ms, 60.1\u00a0AP50:95) maximizes accuracy when latency allows."
+        }
       }
     ]
   }
   </script>
   {% else %}
+  {# Derive parent URL by removing the last path segment from the canonical URL #}
+  {% set _canon_parts = page.canonical_url.rstrip('/').split('/') %}
+  {% set _parent_url = (_canon_parts[:-1] | join('/')) + '/' %}
   {# JSON-LD: TechArticle — content pages #}
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",
     "headline": {{ page.title | tojson }},
-    "description": {{ page.meta.description | default(config.site_description) | tojson }},
+    "description": {{ (page.meta.description | default(config.site_description)) | tojson }},
     "url": "{{ page.canonical_url }}",
-    "author": {"@type": "Organization", "name": "Roboflow", "url": "https://roboflow.com"},
-    "publisher": {"@type": "Organization", "name": "Roboflow", "url": "https://roboflow.com"}
+    {% if page.meta.git_revision_date_localized %}"dateModified": {{ page.meta.git_revision_date_localized | tojson }},
+    {% endif %}{% if og_image_url %}"image": {{ og_image_url | tojson }},
+    {% endif %}"author": {"@type": "Organization", "name": "Roboflow", "url": "https://roboflow.com"},
+    "publisher": {"@type": "Organization", "name": "Roboflow", "url": "https://roboflow.com"},
+    "mainEntityOfPage": {"@type": "WebPage", "@id": "{{ page.canonical_url }}"},
+    "speakable": {
+      "@type": "SpeakableSpecification",
+      "cssSelector": [".md-content h1", ".md-typeset > p:first-child"]
+    }
   }
   </script>
   {# JSON-LD: BreadcrumbList — content pages #}
@@ -154,7 +226,7 @@
         "@type": "ListItem",
         "position": 2,
         "name": {{ page.parent.title | tojson }},
-        "item": "{{ config.site_url }}{{ page.parent.url }}"
+        "item": "{{ _parent_url }}"
       },
       {
         "@type": "ListItem",

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -106,7 +106,7 @@ plugins:
   - search
   - git-revision-date-localized:
       enable_creation_date: false
-      type: date
+      type: iso_date
   - mkdocstrings:
       default_handler: python
       handlers:

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -123,6 +123,9 @@ plugins:
             show_symbol_type_toc: true
             show_category_heading: true
 
+hooks:
+  - docs/hooks/package_version.py
+
 markdown_extensions:
   - admonition
   - pymdownx.details

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,6 +207,9 @@ ignore_missing_imports = false
 explicit_package_bases = true
 strict = true
 mypy_path = "src"
+exclude = [
+  "^docs/(hooks|scripts)/",
+]
 overrides = [
   { module = [
     "tests.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,8 @@ docs = [
     "mike>=2.0.0",
     "mkdocs-jupyter>=0.24.3",
     "mkdocs-git-committers-plugin-2>=2.4.1",
-    "mkdocs-git-revision-date-localized-plugin>=1.2.4"
+    "mkdocs-git-revision-date-localized-plugin>=1.2.4",
+    "tomli>=2.0; python_version < '3.11'",
 ]
 
 [project.urls]

--- a/root-static/robots.txt
+++ b/root-static/robots.txt
@@ -13,30 +13,17 @@ Disallow: /7.*/
 Disallow: /8.*/
 Disallow: /9.*/
 
+# AI crawlers — explicitly allow all paths including numeric-versioned ones.
+# Named groups are independent of User-agent: * — they do NOT inherit its Disallow rules.
+# Listing Allow: / here is sufficient; no Disallow needed.
 User-agent: GPTBot
-Allow: /
-
 User-agent: ClaudeBot
-Allow: /
-
 User-agent: PerplexityBot
-Allow: /
-
 User-agent: CCBot
-Allow: /
-
 User-agent: Google-Extended
-Allow: /
-
 User-agent: Bytespider
-Allow: /
-
 User-agent: GoogleOther
-Allow: /
-
 User-agent: OAI-SearchBot
-Allow: /
-
 User-agent: ChatGPT-User
 Allow: /
 

--- a/root-static/robots.txt
+++ b/root-static/robots.txt
@@ -34,4 +34,10 @@ Allow: /
 User-agent: GoogleOther
 Allow: /
 
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
 Sitemap: https://rfdetr.roboflow.com/latest/sitemap.xml


### PR DESCRIPTION
- Fix Organization logo: was pointing to benchmark chart PNG; replace with ImageObject wrapping the actual roboflow-logo.svg asset
- Add Wikipedia sameAs to Organization (verified entity exists)
- Add WebSite schema to homepage graph
- Expand SoftwareApplication: softwareVersion 1.6.5, releaseNotes, featureList, offers.availability/url
- Expand FAQPage: 7 → 10 questions (fine-tuning, ONNX export, model selection guide)
- Add TechArticle fields: dateModified (from git plugin), image, mainEntityOfPage, speakable CSS selectors
- Fix BreadcrumbList: level-2 item URL was duplicate of root; now derived from canonical URL by removing last path segment
- Fix og:title and twitter:title for homepage (was generic template string)
- Add htmltitle block override for keyword-rich homepage <title>
- Add OAI-SearchBot and ChatGPT-User to robots.txt allowlist
- Switch git-revision-date-localized type: date → iso_date for valid
  ISO 8601 dateModified values in schema
