### PR TITLE
test: pin L1 facade end-to-end PE interpolation regression

### DIFF
--- a/tests/training/test_load_pretrain_weights.py
+++ b/tests/training/test_load_pretrain_weights.py
@@ -399,11 +399,6 @@ class TestLoadPretrainWeightsPEInterpolation:
         )
 
 
-# ---------------------------------------------------------------------------
-# Regression #990: L1 facade end-to-end PE interpolation on custom resolution
-# ---------------------------------------------------------------------------
-
-
 class TestL1FacadePEInterpolationEndToEnd:
     """Regression for instantiating an RF-DETR L1 facade variant with a
     custom ``resolution`` and a checkpoint trained at the variant's default
@@ -412,7 +407,7 @@ class TestL1FacadePEInterpolationEndToEnd:
     In v1.6.5 the L1 facade (``RFDETRLarge``, ``RFDETRNano``, ...) used a
     private ``_load_pretrain_weights_into`` helper in ``detr.py`` that bypassed
     the PE bicubic-interpolation added to ``models.weights.load_pretrain_weights``
-    in #964.  Code that wired the L1 facade through the unified loader landed
+    Code that wired the L1 facade through the unified loader landed
     later (``inference._build_model_context`` calling ``load_pretrain_weights``
     from ``models.weights``).  This test pins that wiring so a future refactor
     cannot reintroduce a divergent loader path that silently skips PE

--- a/tests/training/test_load_pretrain_weights.py
+++ b/tests/training/test_load_pretrain_weights.py
@@ -400,6 +400,82 @@ class TestLoadPretrainWeightsPEInterpolation:
 
 
 # ---------------------------------------------------------------------------
+# Regression #990: L1 facade end-to-end PE interpolation on custom resolution
+# ---------------------------------------------------------------------------
+
+
+class TestL1FacadePEInterpolationEndToEnd:
+    """Regression for #990 — instantiating an RF-DETR L1 facade variant with a
+    custom ``resolution`` and a checkpoint trained at the variant's default
+    resolution must not raise ``RuntimeError`` from a PE shape mismatch.
+
+    In v1.6.5 the L1 facade (``RFDETRLarge``, ``RFDETRNano``, ...) used a
+    private ``_load_pretrain_weights_into`` helper in ``detr.py`` that bypassed
+    the PE bicubic-interpolation added to ``models.weights.load_pretrain_weights``
+    in #964.  Code that wired the L1 facade through the unified loader landed
+    later (``inference._build_model_context`` calling ``load_pretrain_weights``
+    from ``models.weights``).  This test pins that wiring so a future refactor
+    cannot reintroduce a divergent loader path that silently skips PE
+    interpolation.
+    """
+
+    def test_rfdetr_nano_loads_default_pe_checkpoint_at_custom_resolution(self, tmp_path):
+        """Saving an RFDETRNano state_dict at default resolution and loading at
+        a higher resolution must succeed via PE interpolation in the L1 facade.
+
+        Mirrors the user-reported scenario in
+        https://github.com/roboflow/rf-detr/issues/990 (PE size mismatch
+        ``[1, 1937, 384]`` vs ``[1, 6401, 384]`` raised from
+        ``LWDETR.load_state_dict``), reduced to RFDETRNano for test speed.
+        """
+        from rfdetr import RFDETRNano
+
+        # 1. Build a default-resolution RFDETRNano (no pretrain, on CPU) so that
+        #    it produces a state_dict with the variant's native PE grid.
+        default_model = RFDETRNano(pretrain_weights=None, num_classes=2, device="cpu")
+        default_pe_grid = default_model.model_config.positional_encoding_size
+        assert default_pe_grid == 24, "RFDETRNano default PE grid must be 24×24"
+        default_state = default_model.model.model.state_dict()
+        default_pe = default_state[PE_KEY]
+        assert default_pe.shape == torch.Size([1, default_pe_grid * default_pe_grid + 1, 384])
+
+        # 2. Persist as a checkpoint that mimics what `model.train()` saves —
+        #    a top-level "model" key plus a SimpleNamespace "args" block.
+        ckpt_path = tmp_path / "user_finetuned.pth"
+        torch.save(
+            {
+                "model": dict(default_state),
+                "args": SimpleNamespace(class_names=["a", "b"], patch_size=16),
+            },
+            ckpt_path,
+        )
+
+        # 3. Re-instantiate at a NEW resolution.  Without PE interpolation in
+        #    the L1 facade path this raises ``RuntimeError: size mismatch for
+        #    backbone.0.encoder.encoder.embeddings.position_embeddings`` from
+        #    LWDETR.load_state_dict — exactly the user-reported failure.
+        new_resolution = 640
+        loaded = RFDETRNano(
+            pretrain_weights=str(ckpt_path),
+            resolution=new_resolution,
+            num_classes=2,
+            device="cpu",
+        )
+
+        # 4. The model_config validator must update PE proportionally to the
+        #    new resolution, and the loaded backbone PE parameter must have the
+        #    interpolated target shape (40 × 40 + 1 = 1601 tokens).
+        expected_pe_grid = new_resolution // 16
+        assert expected_pe_grid == 40
+        assert loaded.model_config.positional_encoding_size == expected_pe_grid
+        loaded_pe = loaded.model.model.state_dict()[PE_KEY]
+        assert loaded_pe.shape == torch.Size([1, expected_pe_grid * expected_pe_grid + 1, 384]), (
+            f"Backbone PE was not interpolated to the requested resolution; "
+            f"got shape {tuple(loaded_pe.shape)}, expected [1, {expected_pe_grid**2 + 1}, 384]."
+        )
+
+
+# ---------------------------------------------------------------------------
 # Deprecation: train_config argument
 # ---------------------------------------------------------------------------
 

--- a/tests/training/test_load_pretrain_weights.py
+++ b/tests/training/test_load_pretrain_weights.py
@@ -405,7 +405,7 @@ class TestLoadPretrainWeightsPEInterpolation:
 
 
 class TestL1FacadePEInterpolationEndToEnd:
-    """Regression for #990 — instantiating an RF-DETR L1 facade variant with a
+    """Regression for instantiating an RF-DETR L1 facade variant with a
     custom ``resolution`` and a checkpoint trained at the variant's default
     resolution must not raise ``RuntimeError`` from a PE shape mismatch.
 

--- a/tests/training/test_load_pretrain_weights.py
+++ b/tests/training/test_load_pretrain_weights.py
@@ -435,9 +435,11 @@ class TestL1FacadePEInterpolationEndToEnd:
         default_model = RFDETRNano(pretrain_weights=None, num_classes=2, device="cpu")
         default_pe_grid = default_model.model_config.positional_encoding_size
         assert default_pe_grid == 24, "RFDETRNano default PE grid must be 24×24"
+        patch_size = default_model.model_config.patch_size
         default_state = default_model.model.model.state_dict()
         default_pe = default_state[PE_KEY]
-        assert default_pe.shape == torch.Size([1, default_pe_grid * default_pe_grid + 1, 384])
+        pe_dim = default_pe.shape[-1]
+        assert default_pe.shape == torch.Size([1, default_pe_grid * default_pe_grid + 1, pe_dim])
 
         # 2. Persist as a checkpoint that mimics what `model.train()` saves —
         #    a top-level "model" key plus a SimpleNamespace "args" block.
@@ -445,7 +447,7 @@ class TestL1FacadePEInterpolationEndToEnd:
         torch.save(
             {
                 "model": dict(default_state),
-                "args": SimpleNamespace(class_names=["a", "b"], patch_size=16),
+                "args": SimpleNamespace(class_names=["a", "b"], patch_size=patch_size),
             },
             ckpt_path,
         )
@@ -465,13 +467,13 @@ class TestL1FacadePEInterpolationEndToEnd:
         # 4. The model_config validator must update PE proportionally to the
         #    new resolution, and the loaded backbone PE parameter must have the
         #    interpolated target shape (40 × 40 + 1 = 1601 tokens).
-        expected_pe_grid = new_resolution // 16
+        expected_pe_grid = new_resolution // patch_size
         assert expected_pe_grid == 40
         assert loaded.model_config.positional_encoding_size == expected_pe_grid
         loaded_pe = loaded.model.model.state_dict()[PE_KEY]
-        assert loaded_pe.shape == torch.Size([1, expected_pe_grid * expected_pe_grid + 1, 384]), (
+        assert loaded_pe.shape == torch.Size([1, expected_pe_grid * expected_pe_grid + 1, pe_dim]), (
             f"Backbone PE was not interpolated to the requested resolution; "
-            f"got shape {tuple(loaded_pe.shape)}, expected [1, {expected_pe_grid**2 + 1}, 384]."
+            f"got shape {tuple(loaded_pe.shape)}, expected [1, {expected_pe_grid**2 + 1}, {pe_dim}]."
         )
 
 


### PR DESCRIPTION
## What does this PR do?

Adds a single end-to-end regression test that constructs an RF-DETR L1 facade
(`RFDETRNano`) at one resolution, saves its `state_dict`, then reconstructs the
same facade at a different resolution with the saved checkpoint as
`pretrain_weights`, and asserts the backbone `position_embeddings` tensor was
interpolated to the new model's PE size during load.

This is the exact failure mode reported in #990 against **v1.6.5**:

```
RuntimeError: Error(s) in loading state_dict for LWDETR:
  size mismatch for backbone.0.encoder.encoder.embeddings.position_embeddings:
  copying a param with shape torch.Size([1, 1937, 384]) from checkpoint,
  the shape in current model is torch.Size([1, 6401, 384]).
```

I reproduced this on a clean `pip install rfdetr==1.6.5` (see "Testing"
below). On `develop` the bug is already fixed structurally by PR #850
(`f2b5d21`, 2026-03-23), which removed the divergent
`detr.py:_load_pretrain_weights_into` helper and routed the L1 facade through
the unified `rfdetr.models.weights.load_pretrain_weights`. PR #964
(`6d31084`, 2026-04-14) then added `_interpolate_position_embeddings` to that
unified loader. v1.6.5 cherry-picked #964 (as commit `4001861`) but did not
cherry-pick #850, so the L1 path in 1.6.5 still uses the legacy loader and
never reaches the PE interpolation code.

Therefore, this PR is test-only. It does not modify production code. It pins the L1
loader wiring on `develop` so any future regression that re-introduces a
facade-local loader bypassing PE interpolation is caught at the L1 level
rather than only at the PTL training level.

**Related Issue(s):** Closes #990

## Type of Change

- Other: test-only regression guard (no production code changes)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

New test class `TestL1FacadePEInterpolationEndToEnd` added to
`tests/training/test_load_pretrain_weights.py` with one test:
`test_rfdetr_nano_loads_default_pe_checkpoint_at_custom_resolution`. It
builds `RFDETRNano(pretrain_weights=None)` at the default resolution
(PE = 24×24+1 = 577), saves the state_dict to a tmp file with the minimal
`args` payload `load_pretrain_weights` expects (`class_names`, `patch_size`),
then constructs `RFDETRNano(pretrain_weights=<ckpt>, resolution=640)`
(PE = 40×40+1 = 1601) and asserts the loaded backbone PE has shape
`[1, 1601, 384]`. `Nano` is used instead of `Large` because it has the same
DINOv2 backbone keys, the same offending state-dict path, and runs in ~2s on
CPU; pretrained weights are not needed to exercise the bug, only a default-PE
checkpoint reloaded at a different resolution.


I also confirmed the test catches a regression: with
`_interpolate_position_embeddings` monkey-patched to a no-op, the new test
fails with the same `size mismatch for ...position_embeddings` RuntimeError
the issue reports.

Reproduction of the v1.6.5 bug on a clean install:

```bash
pip install "rfdetr==1.6.5" torch
```

Using Python script:

```python
import argparse, os, tempfile, torch
from rfdetr import RFDETRNano

m = RFDETRNano(pretrain_weights=None)               # default resolution
ckpt = os.path.join(tempfile.gettempdir(), "x.pth")
torch.save(
    {
        "model": m.model.model.state_dict(),
        "args": argparse.Namespace(class_names=["a", "b"], patch_size=16),
    },
    ckpt,
)
RFDETRNano(pretrain_weights=ckpt, resolution=640)   # raises RuntimeError on 1.6.5
```

Result on 1.6.5:

```
size mismatch for backbone.0.encoder.encoder.embeddings.position_embeddings:
  copying a param with shape torch.Size([1, 577, 384]) from checkpoint,
  the shape in current model is torch.Size([1, 1601, 384]).
```

Same call shape on `develop` succeeds, with the PE going from `[1, 577, 384]`
to `[1, 1601, 384]` via bicubic interpolation.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

**Why no source code fix on `develop`:** the legacy
`_load_pretrain_weights_into` no longer exists on `develop` after PR #850, so
there is nothing to patch. Adding code there would be dead code. The
user-facing fix for v1.6.5 itself is a release-engineering decision (either
ship a `develop`-based release or cherry-pick PR #850 onto the 1.6.5
branch); that is out of scope for this PR.

**Verifiable git evidence for the 1.6.5 / `develop` divergence:**

```
git ls-tree 41f400a src/rfdetr/inference.py        # absent in 1.6.5
git merge-base 41f400a f2b5d21                     # d69ed1f...  -> #850 not in 1.6.5 ancestry
git log --oneline d69ed1f..41f400a | grep 4001861  # confirms #964 cherry-pick is in 1.6.5
git log --oneline d69ed1f..41f400a | grep f2b5d21  # empty -> #850 wasn't cherry-picked
```
