### PR TITLE
feat: skip_best_epochs parameter for training

### DIFF
--- a/docs/learn/train/training-parameters.md
+++ b/docs/learn/train/training-parameters.md
@@ -27,14 +27,14 @@ model.train(
 
 These are the essential parameters for training:
 
-| Parameter | Type | Default | Description |
+| Parameter          | Type  | Default    | Description                                                                                                                     |
 | ------------------ | ----- | ---------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `dataset_dir` | `str` | Required | Path to your dataset directory. RF-DETR auto-detects if it's in COCO or YOLO format. See [Dataset Formats](dataset-formats.md). |
-| `output_dir` | `str` | `"output"` | Directory where training artifacts (checkpoints, logs) are saved. |
-| `epochs` | `int` | `100` | Number of full passes over the training dataset. |
-| `batch_size` | `int` | `4` | Number of samples processed per iteration. Higher values require more GPU memory. |
-| `grad_accum_steps` | `int` | `4` | Accumulates gradients over multiple mini-batches. Use with `batch_size` to achieve effective batch size. |
-| `resume` | `str` | `None` | Path to a saved checkpoint to continue training. Restores model weights, optimizer state, and scheduler. |
+| `dataset_dir`      | `str` | Required   | Path to your dataset directory. RF-DETR auto-detects if it's in COCO or YOLO format. See [Dataset Formats](dataset-formats.md). |
+| `output_dir`       | `str` | `"output"` | Directory where training artifacts (checkpoints, logs) are saved.                                                               |
+| `epochs`           | `int` | `100`      | Number of full passes over the training dataset.                                                                                |
+| `batch_size`       | `int` | `4`        | Number of samples processed per iteration. Higher values require more GPU memory.                                               |
+| `grad_accum_steps` | `int` | `4`        | Accumulates gradients over multiple mini-batches. Use with `batch_size` to achieve effective batch size.                        |
+| `resume`           | `str` | `None`     | Path to a saved checkpoint to continue training. Restores model weights, optimizer state, and scheduler.                        |
 
 ### Understanding Batch Size
 
@@ -46,19 +46,19 @@ effective_batch_size = batch_size × grad_accum_steps × num_gpus
 
 Recommended configurations for different GPUs (targeting effective batch size of 16):
 
-| GPU | VRAM | `batch_size` | `grad_accum_steps` |
+| GPU      | VRAM    | `batch_size` | `grad_accum_steps` |
 | -------- | ------- | ------------ | ------------------ |
-| A100 | 40-80GB | 16 | 1 |
-| RTX 4090 | 24GB | 8 | 2 |
-| RTX 3090 | 24GB | 8 | 2 |
-| T4 | 16GB | 4 | 4 |
-| RTX 3070 | 8GB | 2 | 8 |
+| A100     | 40-80GB | 16           | 1                  |
+| RTX 4090 | 24GB    | 8            | 2                  |
+| RTX 3090 | 24GB    | 8            | 2                  |
+| T4       | 16GB    | 4            | 4                  |
+| RTX 3070 | 8GB     | 2            | 8                  |
 
 ## Learning Rate Parameters
 
-| Parameter | Type | Default | Description |
+| Parameter    | Type    | Default  | Description                                                                                                                                                          |
 | ------------ | ------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `lr` | `float` | `1e-4` | Learning rate for most parts of the model. |
+| `lr`         | `float` | `1e-4`   | Learning rate for most parts of the model.                                                                                                                           |
 | `lr_encoder` | `float` | `1.5e-4` | Learning rate specifically for the backbone encoder. Can be set lower than `lr` if you want to fine-tune the encoder more conservatively than the rest of the model. |
 
 !!! tip "Learning rate tips"
@@ -69,7 +69,7 @@ Recommended configurations for different GPUs (targeting effective batch size of
 
 ## Resolution Parameters
 
-| Parameter | Type | Default | Description |
+| Parameter    | Type  | Default         | Description                                                                                                                                                                                                                                                                                                                                                                                                   |
 | ------------ | ----- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `resolution` | `int` | Model-dependent | Input image resolution. Higher values can improve accuracy but require more memory. Each model has its own valid block size: current standard detection checkpoints use multiples of 32, current segmentation checkpoints use multiples of 24 (most variants) or 12 (`RFDETRSegNano`), and the definitive rule is that the resolution must be divisible by `patch_size * num_windows` for the selected model. |
 
@@ -82,22 +82,22 @@ For example, `RFDETRSegXLarge` uses `624x624`, which is valid because `624` is d
 
 ## Regularization Parameters
 
-| Parameter | Type | Default | Description |
+| Parameter      | Type    | Default | Description                                                                           |
 | -------------- | ------- | ------- | ------------------------------------------------------------------------------------- |
-| `weight_decay` | `float` | `1e-4` | L2 regularization coefficient. Helps prevent overfitting by penalizing large weights. |
+| `weight_decay` | `float` | `1e-4`  | L2 regularization coefficient. Helps prevent overfitting by penalizing large weights. |
 
 ## Hardware Parameters
 
-| Parameter | Type | Default | Description |
+| Parameter                | Type   | Default  | Description                                                                                                                           |
 | ------------------------ | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `device` | `str` | `"cuda"` | Device to run training on. Options: `"cuda"`, `"cpu"`, `"mps"` (Apple Silicon). |
-| `gradient_checkpointing` | `bool` | `False` | Re-computes parts of the forward pass during backpropagation to reduce memory usage. Lowers memory needs but increases training time. |
+| `device`                 | `str`  | `"cuda"` | Device to run training on. Options: `"cuda"`, `"cpu"`, `"mps"` (Apple Silicon).                                                       |
+| `gradient_checkpointing` | `bool` | `False`  | Re-computes parts of the forward pass during backpropagation to reduce memory usage. Lowers memory needs but increases training time. |
 
 ## EMA (Exponential Moving Average)
 
-| Parameter | Type | Default | Description |
+| Parameter | Type   | Default | Description                                                                                                          |
 | --------- | ------ | ------- | -------------------------------------------------------------------------------------------------------------------- |
-| `use_ema` | `bool` | `True` | Enables Exponential Moving Average of weights. Produces a smoothed checkpoint that often improves final performance. |
+| `use_ema` | `bool` | `True`  | Enables Exponential Moving Average of weights. Produces a smoothed checkpoint that often improves final performance. |
 
 !!! info "What is EMA?"
 
@@ -105,32 +105,32 @@ For example, `RFDETRSegXLarge` uses `624x624`, which is valid because `624` is d
 
 ## Checkpoint Parameters
 
-| Parameter | Type | Default | Description |
+| Parameter             | Type  | Default | Description                                                                                                                            |
 | --------------------- | ----- | ------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `checkpoint_interval` | `int` | `10` | Frequency (in epochs) at which model checkpoints are saved. More frequent saves provide better coverage but consume more storage. |
-| `skip_best_epochs` | `int` | `0` | Ignore the first N epochs when tracking best checkpoints and early-stopping patience. Useful when fine-tuning from a prior checkpoint. |
+| `checkpoint_interval` | `int` | `10`    | Frequency (in epochs) at which model checkpoints are saved. More frequent saves provide better coverage but consume more storage.      |
+| `skip_best_epochs`    | `int` | `0`     | Ignore the first N epochs when tracking best checkpoints and early-stopping patience. Useful when fine-tuning from a prior checkpoint. |
 
 ### Checkpoint Files
 
 During training, multiple checkpoints are saved:
 
-| File | Description |
+| File                          | Description                               |
 | ----------------------------- | ----------------------------------------- |
-| `checkpoint.pth` | Most recent checkpoint (for resuming) |
-| `checkpoint_<N>.pth` | Periodic checkpoint at epoch N |
-| `checkpoint_best_ema.pth` | Best validation performance (EMA weights) |
+| `checkpoint.pth`              | Most recent checkpoint (for resuming)     |
+| `checkpoint_<N>.pth`          | Periodic checkpoint at epoch N            |
+| `checkpoint_best_ema.pth`     | Best validation performance (EMA weights) |
 | `checkpoint_best_regular.pth` | Best validation performance (raw weights) |
-| `checkpoint_best_total.pth` | Final best model for inference |
+| `checkpoint_best_total.pth`   | Final best model for inference            |
 
 ## Early Stopping Parameters
 
-| Parameter | Type | Default | Description |
+| Parameter                  | Type    | Default | Description                                                                              |
 | -------------------------- | ------- | ------- | ---------------------------------------------------------------------------------------- |
-| `early_stopping` | `bool` | `False` | Enable early stopping based on validation mAP. |
-| `early_stopping_patience` | `int` | `10` | Number of epochs without improvement before stopping. |
-| `early_stopping_min_delta` | `float` | `0.001` | Minimum change in mAP to qualify as an improvement. |
-| `early_stopping_use_ema` | `bool` | `False` | Whether to track improvements using EMA model metrics. |
-| `skip_best_epochs` | `int` | `0` | Ignore the first N epochs (0..N-1) for best-model selection and early-stopping patience. |
+| `early_stopping`           | `bool`  | `False` | Enable early stopping based on validation mAP.                                           |
+| `early_stopping_patience`  | `int`   | `10`    | Number of epochs without improvement before stopping.                                    |
+| `early_stopping_min_delta` | `float` | `0.001` | Minimum change in mAP to qualify as an improvement.                                      |
+| `early_stopping_use_ema`   | `bool`  | `False` | Whether to track improvements using EMA model metrics.                                   |
+| `skip_best_epochs`         | `int`   | `0`     | Ignore the first N epochs (0..N-1) for best-model selection and early-stopping patience. |
 
 ### Early Stopping Example
 
@@ -162,12 +162,12 @@ This configuration will:
 
 ## Logging Parameters
 
-| Parameter | Type | Default | Description |
+| Parameter     | Type   | Default | Description                                                                                                                                                                                                 |
 | ------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `tensorboard` | `bool` | `True` | Enable TensorBoard logging. Requires `pip install "rfdetr[loggers]"`. If the `tensorboard` package is not installed, training continues with a `UserWarning` and TensorBoard output is silently suppressed. |
-| `wandb` | `bool` | `False` | Enable Weights & Biases logging. Requires `pip install "rfdetr[loggers]"`. |
-| `project` | `str` | `None` | Project name for W&B logging. |
-| `run` | `str` | `None` | Run name for W&B logging. If not specified, W&B assigns a random name. |
+| `tensorboard` | `bool` | `True`  | Enable TensorBoard logging. Requires `pip install "rfdetr[loggers]"`. If the `tensorboard` package is not installed, training continues with a `UserWarning` and TensorBoard output is silently suppressed. |
+| `wandb`       | `bool` | `False` | Enable Weights & Biases logging. Requires `pip install "rfdetr[loggers]"`.                                                                                                                                  |
+| `project`     | `str`  | `None`  | Project name for W&B logging.                                                                                                                                                                               |
+| `run`         | `str`  | `None`  | Run name for W&B logging. If not specified, W&B assigns a random name.                                                                                                                                      |
 
 ### Logging Example
 
@@ -184,12 +184,12 @@ model.train(
 
 ## Evaluation Parameters
 
-| Parameter | Type | Default | Description |
+| Parameter               | Type                | Default | Description                                                                                                        |
 | ----------------------- | ------------------- | ------- | ------------------------------------------------------------------------------------------------------------------ |
-| `eval_max_dets` | `int` | `500` | Maximum number of detections per image considered during COCO evaluation. Lower values speed up evaluation. |
-| `eval_interval` | `int` | `1` | Run COCO evaluation every N epochs. Set to a higher value to reduce evaluation overhead during long training runs. |
-| `log_per_class_metrics` | `bool` | `True` | Log per-class AP metrics to the console and loggers. Disable to reduce log verbosity when there are many classes. |
-| `progress_bar` | str \| bool \| None | `None` | Progress bar style: `"tqdm"`, `"rich"`, or `None`. Legacy booleans are still accepted. |
+| `eval_max_dets`         | `int`               | `500`   | Maximum number of detections per image considered during COCO evaluation. Lower values speed up evaluation.        |
+| `eval_interval`         | `int`               | `1`     | Run COCO evaluation every N epochs. Set to a higher value to reduce evaluation overhead during long training runs. |
+| `log_per_class_metrics` | `bool`              | `True`  | Log per-class AP metrics to the console and loggers. Disable to reduce log verbosity when there are many classes.  |
+| `progress_bar`          | str \| bool \| None | `None`  | Progress bar style: `"tqdm"`, `"rich"`, or `None`. Legacy booleans are still accepted.                             |
 
 ## Advanced Parameters
 
@@ -197,72 +197,72 @@ The parameters below are available for fine-grained control over training behavi
 
 ### Scheduler and Regularization
 
-| Parameter | Type | Default | Description |
+| Parameter       | Type    | Default  | Description                                                                                                 |
 | --------------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------- |
-| `lr_scheduler` | `str` | `"step"` | Learning rate scheduler type. Options: `"step"` (step decay at `lr_drop`) or `"cosine"` (cosine annealing). |
-| `lr_min_factor` | `float` | `0.0` | Floor for the cosine scheduler, expressed as a fraction of the initial LR. Ignored when using `"step"`. |
-| `warmup_epochs` | `float` | `0.0` | Number of epochs for linear learning rate warmup at the start of training. |
-| `drop_path` | `float` | `0.0` | Stochastic depth drop-path rate applied to the backbone. Higher values add more regularization. |
+| `lr_scheduler`  | `str`   | `"step"` | Learning rate scheduler type. Options: `"step"` (step decay at `lr_drop`) or `"cosine"` (cosine annealing). |
+| `lr_min_factor` | `float` | `0.0`    | Floor for the cosine scheduler, expressed as a fraction of the initial LR. Ignored when using `"step"`.     |
+| `warmup_epochs` | `float` | `0.0`    | Number of epochs for linear learning rate warmup at the start of training.                                  |
+| `drop_path`     | `float` | `0.0`    | Stochastic depth drop-path rate applied to the backbone. Higher values add more regularization.             |
 
 ### Runtime and Accelerator
 
-| Parameter | Type | Default | Description |
+| Parameter           | Type   | Default  | Description                                                                                      |
 | ------------------- | ------ | -------- | ------------------------------------------------------------------------------------------------ |
-| `accelerator` | `str` | `"auto"` | PyTorch Lightning accelerator selection. `"auto"` picks GPU if available, then MPS, then CPU. |
-| `seed` | `int` | `None` | Global random seed for reproducibility. `None` means no fixed seed is set. |
-| `fp16_eval` | `bool` | `False` | Run evaluation passes in FP16 precision. Reduces memory usage but may lower numerical precision. |
-| `compute_val_loss` | `bool` | `True` | Compute and log the detection loss on the validation set each epoch. |
-| `compute_test_loss` | `bool` | `True` | Compute and log the detection loss during the final test run. |
+| `accelerator`       | `str`  | `"auto"` | PyTorch Lightning accelerator selection. `"auto"` picks GPU if available, then MPS, then CPU.    |
+| `seed`              | `int`  | `None`   | Global random seed for reproducibility. `None` means no fixed seed is set.                       |
+| `fp16_eval`         | `bool` | `False`  | Run evaluation passes in FP16 precision. Reduces memory usage but may lower numerical precision. |
+| `compute_val_loss`  | `bool` | `True`   | Compute and log the detection loss on the validation set each epoch.                             |
+| `compute_test_loss` | `bool` | `True`   | Compute and log the detection loss during the final test run.                                    |
 
 ### DataLoader Tuning
 
-| Parameter | Type | Default | Description |
+| Parameter            | Type   | Default | Description                                                                                               |
 | -------------------- | ------ | ------- | --------------------------------------------------------------------------------------------------------- |
-| `pin_memory` | `bool` | `None` | Pin host memory in the DataLoader for faster GPU transfers. `None` defers to PyTorch Lightning's default. |
-| `persistent_workers` | `bool` | `None` | Keep DataLoader worker processes alive between epochs. `None` defers to PyTorch Lightning's default. |
-| `prefetch_factor` | `int` | `None` | Number of batches to prefetch per DataLoader worker. `None` uses PyTorch's built-in default. |
+| `pin_memory`         | `bool` | `None`  | Pin host memory in the DataLoader for faster GPU transfers. `None` defers to PyTorch Lightning's default. |
+| `persistent_workers` | `bool` | `None`  | Keep DataLoader worker processes alive between epochs. `None` defers to PyTorch Lightning's default.      |
+| `prefetch_factor`    | `int`  | `None`  | Number of batches to prefetch per DataLoader worker. `None` uses PyTorch's built-in default.              |
 
 ## Complete Parameter Reference
 
 Below is a summary table of all training parameters:
 
-| Parameter | Type | Default | Description |
+| Parameter                  | Type                | Default        | Description                                                                              |
 | -------------------------- | ------------------- | -------------- | ---------------------------------------------------------------------------------------- |
-| `dataset_dir` | str | Required | Path to COCO or YOLO formatted dataset with train/valid/test splits. |
-| `output_dir` | str | "output" | Directory for checkpoints, logs, and other training artifacts. |
-| `epochs` | int | 100 | Number of full passes over the dataset. |
-| `batch_size` | int | 4 | Samples per iteration. Balance with `grad_accum_steps`. |
-| `grad_accum_steps` | int | 4 | Gradient accumulation steps for effective larger batch sizes. |
-| `lr` | float | 1e-4 | Learning rate for the model (excluding encoder). |
-| `lr_encoder` | float | 1.5e-4 | Learning rate for the backbone encoder. |
-| `resolution` | int | Model-specific | Input image size (must be divisible by the selected model's `patch_size * num_windows`). |
-| `weight_decay` | float | 1e-4 | L2 regularization coefficient. |
-| `device` | str | "cuda" | Training device: cuda, cpu, or mps. |
-| `use_ema` | bool | True | Enable Exponential Moving Average of weights. |
-| `gradient_checkpointing` | bool | False | Trade compute for memory during backprop. |
-| `checkpoint_interval` | int | 10 | Save checkpoint every N epochs. |
-| `resume` | str | None | Path to checkpoint for resuming training. |
-| `tensorboard` | bool | True | Enable TensorBoard logging. |
-| `wandb` | bool | False | Enable Weights & Biases logging. |
-| `project` | str | None | W&B project name. |
-| `run` | str | None | W&B run name. |
-| `early_stopping` | bool | False | Enable early stopping. |
-| `early_stopping_patience` | int | 10 | Epochs without improvement before stopping. |
-| `early_stopping_min_delta` | float | 0.001 | Minimum mAP change to qualify as improvement. |
-| `early_stopping_use_ema` | bool | False | Use EMA model for early stopping metrics. |
-| `eval_max_dets` | int | 500 | Maximum detections per image considered during COCO evaluation. |
-| `eval_interval` | int | 1 | Run COCO evaluation every N epochs. |
-| `log_per_class_metrics` | bool | True | Log per-class AP metrics to the console and loggers. |
-| `progress_bar` | str \| bool \| None | None | Progress bar style: `"tqdm"`, `"rich"`, or `None`. Legacy booleans are still accepted. |
-| `accelerator` | str | "auto" | PyTorch Lightning accelerator. "auto" selects GPU/MPS/CPU automatically. |
-| `seed` | int | None | Random seed for reproducibility. None means no fixed seed. |
-| `lr_scheduler` | str | "step" | Learning rate scheduler type: "step" or "cosine". |
-| `lr_min_factor` | float | 0.0 | Minimum LR as a fraction of the initial LR (cosine scheduler floor). |
-| `warmup_epochs` | float | 0.0 | Number of linear warmup epochs at the start of training. |
-| `drop_path` | float | 0.0 | Stochastic depth drop-path rate for the backbone. |
-| `compute_val_loss` | bool | True | Compute and log loss during validation. |
-| `compute_test_loss` | bool | True | Compute and log loss during the test run. |
-| `fp16_eval` | bool | False | Run evaluation in FP16 precision to reduce memory usage. |
-| `pin_memory` | bool | None | Pin DataLoader memory. None defers to PyTorch Lightning's default. |
-| `persistent_workers` | bool | None | Keep DataLoader workers alive between epochs. None uses PTL default. |
-| `prefetch_factor` | int | None | Number of batches prefetched per worker. None uses PyTorch default. |
+| `dataset_dir`              | str                 | Required       | Path to COCO or YOLO formatted dataset with train/valid/test splits.                     |
+| `output_dir`               | str                 | "output"       | Directory for checkpoints, logs, and other training artifacts.                           |
+| `epochs`                   | int                 | 100            | Number of full passes over the dataset.                                                  |
+| `batch_size`               | int                 | 4              | Samples per iteration. Balance with `grad_accum_steps`.                                  |
+| `grad_accum_steps`         | int                 | 4              | Gradient accumulation steps for effective larger batch sizes.                            |
+| `lr`                       | float               | 1e-4           | Learning rate for the model (excluding encoder).                                         |
+| `lr_encoder`               | float               | 1.5e-4         | Learning rate for the backbone encoder.                                                  |
+| `resolution`               | int                 | Model-specific | Input image size (must be divisible by the selected model's `patch_size * num_windows`). |
+| `weight_decay`             | float               | 1e-4           | L2 regularization coefficient.                                                           |
+| `device`                   | str                 | "cuda"         | Training device: cuda, cpu, or mps.                                                      |
+| `use_ema`                  | bool                | True           | Enable Exponential Moving Average of weights.                                            |
+| `gradient_checkpointing`   | bool                | False          | Trade compute for memory during backprop.                                                |
+| `checkpoint_interval`      | int                 | 10             | Save checkpoint every N epochs.                                                          |
+| `resume`                   | str                 | None           | Path to checkpoint for resuming training.                                                |
+| `tensorboard`              | bool                | True           | Enable TensorBoard logging.                                                              |
+| `wandb`                    | bool                | False          | Enable Weights & Biases logging.                                                         |
+| `project`                  | str                 | None           | W&B project name.                                                                        |
+| `run`                      | str                 | None           | W&B run name.                                                                            |
+| `early_stopping`           | bool                | False          | Enable early stopping.                                                                   |
+| `early_stopping_patience`  | int                 | 10             | Epochs without improvement before stopping.                                              |
+| `early_stopping_min_delta` | float               | 0.001          | Minimum mAP change to qualify as improvement.                                            |
+| `early_stopping_use_ema`   | bool                | False          | Use EMA model for early stopping metrics.                                                |
+| `eval_max_dets`            | int                 | 500            | Maximum detections per image considered during COCO evaluation.                          |
+| `eval_interval`            | int                 | 1              | Run COCO evaluation every N epochs.                                                      |
+| `log_per_class_metrics`    | bool                | True           | Log per-class AP metrics to the console and loggers.                                     |
+| `progress_bar`             | str \| bool \| None | None           | Progress bar style: `"tqdm"`, `"rich"`, or `None`. Legacy booleans are still accepted.   |
+| `accelerator`              | str                 | "auto"         | PyTorch Lightning accelerator. "auto" selects GPU/MPS/CPU automatically.                 |
+| `seed`                     | int                 | None           | Random seed for reproducibility. None means no fixed seed.                               |
+| `lr_scheduler`             | str                 | "step"         | Learning rate scheduler type: "step" or "cosine".                                        |
+| `lr_min_factor`            | float               | 0.0            | Minimum LR as a fraction of the initial LR (cosine scheduler floor).                     |
+| `warmup_epochs`            | float               | 0.0            | Number of linear warmup epochs at the start of training.                                 |
+| `drop_path`                | float               | 0.0            | Stochastic depth drop-path rate for the backbone.                                        |
+| `compute_val_loss`         | bool                | True           | Compute and log loss during validation.                                                  |
+| `compute_test_loss`        | bool                | True           | Compute and log loss during the test run.                                                |
+| `fp16_eval`                | bool                | False          | Run evaluation in FP16 precision to reduce memory usage.                                 |
+| `pin_memory`               | bool                | None           | Pin DataLoader memory. None defers to PyTorch Lightning's default.                       |
+| `persistent_workers`       | bool                | None           | Keep DataLoader workers alive between epochs. None uses PTL default.                     |
+| `prefetch_factor`          | int                 | None           | Number of batches prefetched per worker. None uses PyTorch default.                      |

--- a/docs/learn/train/training-parameters.md
+++ b/docs/learn/train/training-parameters.md
@@ -105,9 +105,9 @@ For example, `RFDETRSegXLarge` uses `624x624`, which is valid because `624` is d
 
 ## Checkpoint Parameters
 
-| Parameter             | Type  | Default | Description                                                                                                                       |
-| --------------------- | ----- | ------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `checkpoint_interval` | `int` | `10`    | Frequency (in epochs) at which model checkpoints are saved. More frequent saves provide better coverage but consume more storage. |
+| Parameter             | Type  | Default | Description                                                                                                                            |
+| --------------------- | ----- | ------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `checkpoint_interval` | `int` | `10`    | Frequency (in epochs) at which model checkpoints are saved. More frequent saves provide better coverage but consume more storage.      |
 | `skip_best_epochs`    | `int` | `0`     | Ignore the first N epochs when tracking best checkpoints and early-stopping patience. Useful when fine-tuning from a prior checkpoint. |
 
 ### Checkpoint Files
@@ -124,12 +124,12 @@ During training, multiple checkpoints are saved:
 
 ## Early Stopping Parameters
 
-| Parameter                  | Type    | Default | Description                                            |
-| -------------------------- | ------- | ------- | ------------------------------------------------------ |
-| `early_stopping`           | `bool`  | `False` | Enable early stopping based on validation mAP.         |
-| `early_stopping_patience`  | `int`   | `10`    | Number of epochs without improvement before stopping.  |
-| `early_stopping_min_delta` | `float` | `0.001` | Minimum change in mAP to qualify as an improvement.    |
-| `early_stopping_use_ema`   | `bool`  | `False` | Whether to track improvements using EMA model metrics. |
+| Parameter                  | Type    | Default | Description                                                           |
+| -------------------------- | ------- | ------- | --------------------------------------------------------------------- |
+| `early_stopping`           | `bool`  | `False` | Enable early stopping based on validation mAP.                        |
+| `early_stopping_patience`  | `int`   | `10`    | Number of epochs without improvement before stopping.                 |
+| `early_stopping_min_delta` | `float` | `0.001` | Minimum change in mAP to qualify as an improvement.                   |
+| `early_stopping_use_ema`   | `bool`  | `False` | Whether to track improvements using EMA model metrics.                |
 | `skip_best_epochs`         | `int`   | `0`     | Delay best-model selection and early-stopping patience until epoch N. |
 
 ### Early Stopping Example

--- a/docs/learn/train/training-parameters.md
+++ b/docs/learn/train/training-parameters.md
@@ -27,14 +27,14 @@ model.train(
 
 These are the essential parameters for training:
 
-| Parameter          | Type  | Default    | Description                                                                                                                     |
+| Parameter | Type | Default | Description |
 | ------------------ | ----- | ---------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `dataset_dir`      | `str` | Required   | Path to your dataset directory. RF-DETR auto-detects if it's in COCO or YOLO format. See [Dataset Formats](dataset-formats.md). |
-| `output_dir`       | `str` | `"output"` | Directory where training artifacts (checkpoints, logs) are saved.                                                               |
-| `epochs`           | `int` | `100`      | Number of full passes over the training dataset.                                                                                |
-| `batch_size`       | `int` | `4`        | Number of samples processed per iteration. Higher values require more GPU memory.                                               |
-| `grad_accum_steps` | `int` | `4`        | Accumulates gradients over multiple mini-batches. Use with `batch_size` to achieve effective batch size.                        |
-| `resume`           | `str` | `None`     | Path to a saved checkpoint to continue training. Restores model weights, optimizer state, and scheduler.                        |
+| `dataset_dir` | `str` | Required | Path to your dataset directory. RF-DETR auto-detects if it's in COCO or YOLO format. See [Dataset Formats](dataset-formats.md). |
+| `output_dir` | `str` | `"output"` | Directory where training artifacts (checkpoints, logs) are saved. |
+| `epochs` | `int` | `100` | Number of full passes over the training dataset. |
+| `batch_size` | `int` | `4` | Number of samples processed per iteration. Higher values require more GPU memory. |
+| `grad_accum_steps` | `int` | `4` | Accumulates gradients over multiple mini-batches. Use with `batch_size` to achieve effective batch size. |
+| `resume` | `str` | `None` | Path to a saved checkpoint to continue training. Restores model weights, optimizer state, and scheduler. |
 
 ### Understanding Batch Size
 
@@ -46,19 +46,19 @@ effective_batch_size = batch_size × grad_accum_steps × num_gpus
 
 Recommended configurations for different GPUs (targeting effective batch size of 16):
 
-| GPU      | VRAM    | `batch_size` | `grad_accum_steps` |
+| GPU | VRAM | `batch_size` | `grad_accum_steps` |
 | -------- | ------- | ------------ | ------------------ |
-| A100     | 40-80GB | 16           | 1                  |
-| RTX 4090 | 24GB    | 8            | 2                  |
-| RTX 3090 | 24GB    | 8            | 2                  |
-| T4       | 16GB    | 4            | 4                  |
-| RTX 3070 | 8GB     | 2            | 8                  |
+| A100 | 40-80GB | 16 | 1 |
+| RTX 4090 | 24GB | 8 | 2 |
+| RTX 3090 | 24GB | 8 | 2 |
+| T4 | 16GB | 4 | 4 |
+| RTX 3070 | 8GB | 2 | 8 |
 
 ## Learning Rate Parameters
 
-| Parameter    | Type    | Default  | Description                                                                                                                                                          |
+| Parameter | Type | Default | Description |
 | ------------ | ------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `lr`         | `float` | `1e-4`   | Learning rate for most parts of the model.                                                                                                                           |
+| `lr` | `float` | `1e-4` | Learning rate for most parts of the model. |
 | `lr_encoder` | `float` | `1.5e-4` | Learning rate specifically for the backbone encoder. Can be set lower than `lr` if you want to fine-tune the encoder more conservatively than the rest of the model. |
 
 !!! tip "Learning rate tips"
@@ -69,7 +69,7 @@ Recommended configurations for different GPUs (targeting effective batch size of
 
 ## Resolution Parameters
 
-| Parameter    | Type  | Default         | Description                                                                                                                                                                                                                                                                                                                                                                                                   |
+| Parameter | Type | Default | Description |
 | ------------ | ----- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `resolution` | `int` | Model-dependent | Input image resolution. Higher values can improve accuracy but require more memory. Each model has its own valid block size: current standard detection checkpoints use multiples of 32, current segmentation checkpoints use multiples of 24 (most variants) or 12 (`RFDETRSegNano`), and the definitive rule is that the resolution must be divisible by `patch_size * num_windows` for the selected model. |
 
@@ -82,22 +82,22 @@ For example, `RFDETRSegXLarge` uses `624x624`, which is valid because `624` is d
 
 ## Regularization Parameters
 
-| Parameter      | Type    | Default | Description                                                                           |
+| Parameter | Type | Default | Description |
 | -------------- | ------- | ------- | ------------------------------------------------------------------------------------- |
-| `weight_decay` | `float` | `1e-4`  | L2 regularization coefficient. Helps prevent overfitting by penalizing large weights. |
+| `weight_decay` | `float` | `1e-4` | L2 regularization coefficient. Helps prevent overfitting by penalizing large weights. |
 
 ## Hardware Parameters
 
-| Parameter                | Type   | Default  | Description                                                                                                                           |
+| Parameter | Type | Default | Description |
 | ------------------------ | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `device`                 | `str`  | `"cuda"` | Device to run training on. Options: `"cuda"`, `"cpu"`, `"mps"` (Apple Silicon).                                                       |
-| `gradient_checkpointing` | `bool` | `False`  | Re-computes parts of the forward pass during backpropagation to reduce memory usage. Lowers memory needs but increases training time. |
+| `device` | `str` | `"cuda"` | Device to run training on. Options: `"cuda"`, `"cpu"`, `"mps"` (Apple Silicon). |
+| `gradient_checkpointing` | `bool` | `False` | Re-computes parts of the forward pass during backpropagation to reduce memory usage. Lowers memory needs but increases training time. |
 
 ## EMA (Exponential Moving Average)
 
-| Parameter | Type   | Default | Description                                                                                                          |
+| Parameter | Type | Default | Description |
 | --------- | ------ | ------- | -------------------------------------------------------------------------------------------------------------------- |
-| `use_ema` | `bool` | `True`  | Enables Exponential Moving Average of weights. Produces a smoothed checkpoint that often improves final performance. |
+| `use_ema` | `bool` | `True` | Enables Exponential Moving Average of weights. Produces a smoothed checkpoint that often improves final performance. |
 
 !!! info "What is EMA?"
 
@@ -105,32 +105,32 @@ For example, `RFDETRSegXLarge` uses `624x624`, which is valid because `624` is d
 
 ## Checkpoint Parameters
 
-| Parameter             | Type  | Default | Description                                                                                                                            |
+| Parameter | Type | Default | Description |
 | --------------------- | ----- | ------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `checkpoint_interval` | `int` | `10`    | Frequency (in epochs) at which model checkpoints are saved. More frequent saves provide better coverage but consume more storage.      |
-| `skip_best_epochs`    | `int` | `0`     | Ignore the first N epochs when tracking best checkpoints and early-stopping patience. Useful when fine-tuning from a prior checkpoint. |
+| `checkpoint_interval` | `int` | `10` | Frequency (in epochs) at which model checkpoints are saved. More frequent saves provide better coverage but consume more storage. |
+| `skip_best_epochs` | `int` | `0` | Ignore the first N epochs when tracking best checkpoints and early-stopping patience. Useful when fine-tuning from a prior checkpoint. |
 
 ### Checkpoint Files
 
 During training, multiple checkpoints are saved:
 
-| File                          | Description                               |
+| File | Description |
 | ----------------------------- | ----------------------------------------- |
-| `checkpoint.pth`              | Most recent checkpoint (for resuming)     |
-| `checkpoint_<N>.pth`          | Periodic checkpoint at epoch N            |
-| `checkpoint_best_ema.pth`     | Best validation performance (EMA weights) |
+| `checkpoint.pth` | Most recent checkpoint (for resuming) |
+| `checkpoint_<N>.pth` | Periodic checkpoint at epoch N |
+| `checkpoint_best_ema.pth` | Best validation performance (EMA weights) |
 | `checkpoint_best_regular.pth` | Best validation performance (raw weights) |
-| `checkpoint_best_total.pth`   | Final best model for inference            |
+| `checkpoint_best_total.pth` | Final best model for inference |
 
 ## Early Stopping Parameters
 
-| Parameter                  | Type    | Default | Description                                                                              |
+| Parameter | Type | Default | Description |
 | -------------------------- | ------- | ------- | ---------------------------------------------------------------------------------------- |
-| `early_stopping`           | `bool`  | `False` | Enable early stopping based on validation mAP.                                           |
-| `early_stopping_patience`  | `int`   | `10`    | Number of epochs without improvement before stopping.                                    |
-| `early_stopping_min_delta` | `float` | `0.001` | Minimum change in mAP to qualify as an improvement.                                      |
-| `early_stopping_use_ema`   | `bool`  | `False` | Whether to track improvements using EMA model metrics.                                   |
-| `skip_best_epochs`         | `int`   | `0`     | Ignore the first N epochs (0..N-1) for best-model selection and early-stopping patience. |
+| `early_stopping` | `bool` | `False` | Enable early stopping based on validation mAP. |
+| `early_stopping_patience` | `int` | `10` | Number of epochs without improvement before stopping. |
+| `early_stopping_min_delta` | `float` | `0.001` | Minimum change in mAP to qualify as an improvement. |
+| `early_stopping_use_ema` | `bool` | `False` | Whether to track improvements using EMA model metrics. |
+| `skip_best_epochs` | `int` | `0` | Ignore the first N epochs (0..N-1) for best-model selection and early-stopping patience. |
 
 ### Early Stopping Example
 
@@ -162,12 +162,12 @@ This configuration will:
 
 ## Logging Parameters
 
-| Parameter     | Type   | Default | Description                                                                                                                                                                                                 |
+| Parameter | Type | Default | Description |
 | ------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `tensorboard` | `bool` | `True`  | Enable TensorBoard logging. Requires `pip install "rfdetr[loggers]"`. If the `tensorboard` package is not installed, training continues with a `UserWarning` and TensorBoard output is silently suppressed. |
-| `wandb`       | `bool` | `False` | Enable Weights & Biases logging. Requires `pip install "rfdetr[loggers]"`.                                                                                                                                  |
-| `project`     | `str`  | `None`  | Project name for W&B logging.                                                                                                                                                                               |
-| `run`         | `str`  | `None`  | Run name for W&B logging. If not specified, W&B assigns a random name.                                                                                                                                      |
+| `tensorboard` | `bool` | `True` | Enable TensorBoard logging. Requires `pip install "rfdetr[loggers]"`. If the `tensorboard` package is not installed, training continues with a `UserWarning` and TensorBoard output is silently suppressed. |
+| `wandb` | `bool` | `False` | Enable Weights & Biases logging. Requires `pip install "rfdetr[loggers]"`. |
+| `project` | `str` | `None` | Project name for W&B logging. |
+| `run` | `str` | `None` | Run name for W&B logging. If not specified, W&B assigns a random name. |
 
 ### Logging Example
 
@@ -184,12 +184,12 @@ model.train(
 
 ## Evaluation Parameters
 
-| Parameter               | Type                | Default | Description                                                                                                        |
+| Parameter | Type | Default | Description |
 | ----------------------- | ------------------- | ------- | ------------------------------------------------------------------------------------------------------------------ |
-| `eval_max_dets`         | `int`               | `500`   | Maximum number of detections per image considered during COCO evaluation. Lower values speed up evaluation.        |
-| `eval_interval`         | `int`               | `1`     | Run COCO evaluation every N epochs. Set to a higher value to reduce evaluation overhead during long training runs. |
-| `log_per_class_metrics` | `bool`              | `True`  | Log per-class AP metrics to the console and loggers. Disable to reduce log verbosity when there are many classes.  |
-| `progress_bar`          | str \| bool \| None | `None`  | Progress bar style: `"tqdm"`, `"rich"`, or `None`. Legacy booleans are still accepted.                             |
+| `eval_max_dets` | `int` | `500` | Maximum number of detections per image considered during COCO evaluation. Lower values speed up evaluation. |
+| `eval_interval` | `int` | `1` | Run COCO evaluation every N epochs. Set to a higher value to reduce evaluation overhead during long training runs. |
+| `log_per_class_metrics` | `bool` | `True` | Log per-class AP metrics to the console and loggers. Disable to reduce log verbosity when there are many classes. |
+| `progress_bar` | str \| bool \| None | `None` | Progress bar style: `"tqdm"`, `"rich"`, or `None`. Legacy booleans are still accepted. |
 
 ## Advanced Parameters
 
@@ -197,72 +197,72 @@ The parameters below are available for fine-grained control over training behavi
 
 ### Scheduler and Regularization
 
-| Parameter       | Type    | Default  | Description                                                                                                 |
+| Parameter | Type | Default | Description |
 | --------------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------- |
-| `lr_scheduler`  | `str`   | `"step"` | Learning rate scheduler type. Options: `"step"` (step decay at `lr_drop`) or `"cosine"` (cosine annealing). |
-| `lr_min_factor` | `float` | `0.0`    | Floor for the cosine scheduler, expressed as a fraction of the initial LR. Ignored when using `"step"`.     |
-| `warmup_epochs` | `float` | `0.0`    | Number of epochs for linear learning rate warmup at the start of training.                                  |
-| `drop_path`     | `float` | `0.0`    | Stochastic depth drop-path rate applied to the backbone. Higher values add more regularization.             |
+| `lr_scheduler` | `str` | `"step"` | Learning rate scheduler type. Options: `"step"` (step decay at `lr_drop`) or `"cosine"` (cosine annealing). |
+| `lr_min_factor` | `float` | `0.0` | Floor for the cosine scheduler, expressed as a fraction of the initial LR. Ignored when using `"step"`. |
+| `warmup_epochs` | `float` | `0.0` | Number of epochs for linear learning rate warmup at the start of training. |
+| `drop_path` | `float` | `0.0` | Stochastic depth drop-path rate applied to the backbone. Higher values add more regularization. |
 
 ### Runtime and Accelerator
 
-| Parameter           | Type   | Default  | Description                                                                                      |
+| Parameter | Type | Default | Description |
 | ------------------- | ------ | -------- | ------------------------------------------------------------------------------------------------ |
-| `accelerator`       | `str`  | `"auto"` | PyTorch Lightning accelerator selection. `"auto"` picks GPU if available, then MPS, then CPU.    |
-| `seed`              | `int`  | `None`   | Global random seed for reproducibility. `None` means no fixed seed is set.                       |
-| `fp16_eval`         | `bool` | `False`  | Run evaluation passes in FP16 precision. Reduces memory usage but may lower numerical precision. |
-| `compute_val_loss`  | `bool` | `True`   | Compute and log the detection loss on the validation set each epoch.                             |
-| `compute_test_loss` | `bool` | `True`   | Compute and log the detection loss during the final test run.                                    |
+| `accelerator` | `str` | `"auto"` | PyTorch Lightning accelerator selection. `"auto"` picks GPU if available, then MPS, then CPU. |
+| `seed` | `int` | `None` | Global random seed for reproducibility. `None` means no fixed seed is set. |
+| `fp16_eval` | `bool` | `False` | Run evaluation passes in FP16 precision. Reduces memory usage but may lower numerical precision. |
+| `compute_val_loss` | `bool` | `True` | Compute and log the detection loss on the validation set each epoch. |
+| `compute_test_loss` | `bool` | `True` | Compute and log the detection loss during the final test run. |
 
 ### DataLoader Tuning
 
-| Parameter            | Type   | Default | Description                                                                                               |
+| Parameter | Type | Default | Description |
 | -------------------- | ------ | ------- | --------------------------------------------------------------------------------------------------------- |
-| `pin_memory`         | `bool` | `None`  | Pin host memory in the DataLoader for faster GPU transfers. `None` defers to PyTorch Lightning's default. |
-| `persistent_workers` | `bool` | `None`  | Keep DataLoader worker processes alive between epochs. `None` defers to PyTorch Lightning's default.      |
-| `prefetch_factor`    | `int`  | `None`  | Number of batches to prefetch per DataLoader worker. `None` uses PyTorch's built-in default.              |
+| `pin_memory` | `bool` | `None` | Pin host memory in the DataLoader for faster GPU transfers. `None` defers to PyTorch Lightning's default. |
+| `persistent_workers` | `bool` | `None` | Keep DataLoader worker processes alive between epochs. `None` defers to PyTorch Lightning's default. |
+| `prefetch_factor` | `int` | `None` | Number of batches to prefetch per DataLoader worker. `None` uses PyTorch's built-in default. |
 
 ## Complete Parameter Reference
 
 Below is a summary table of all training parameters:
 
-| Parameter                  | Type                | Default        | Description                                                                              |
+| Parameter | Type | Default | Description |
 | -------------------------- | ------------------- | -------------- | ---------------------------------------------------------------------------------------- |
-| `dataset_dir`              | str                 | Required       | Path to COCO or YOLO formatted dataset with train/valid/test splits.                     |
-| `output_dir`               | str                 | "output"       | Directory for checkpoints, logs, and other training artifacts.                           |
-| `epochs`                   | int                 | 100            | Number of full passes over the dataset.                                                  |
-| `batch_size`               | int                 | 4              | Samples per iteration. Balance with `grad_accum_steps`.                                  |
-| `grad_accum_steps`         | int                 | 4              | Gradient accumulation steps for effective larger batch sizes.                            |
-| `lr`                       | float               | 1e-4           | Learning rate for the model (excluding encoder).                                         |
-| `lr_encoder`               | float               | 1.5e-4         | Learning rate for the backbone encoder.                                                  |
-| `resolution`               | int                 | Model-specific | Input image size (must be divisible by the selected model's `patch_size * num_windows`). |
-| `weight_decay`             | float               | 1e-4           | L2 regularization coefficient.                                                           |
-| `device`                   | str                 | "cuda"         | Training device: cuda, cpu, or mps.                                                      |
-| `use_ema`                  | bool                | True           | Enable Exponential Moving Average of weights.                                            |
-| `gradient_checkpointing`   | bool                | False          | Trade compute for memory during backprop.                                                |
-| `checkpoint_interval`      | int                 | 10             | Save checkpoint every N epochs.                                                          |
-| `resume`                   | str                 | None           | Path to checkpoint for resuming training.                                                |
-| `tensorboard`              | bool                | True           | Enable TensorBoard logging.                                                              |
-| `wandb`                    | bool                | False          | Enable Weights & Biases logging.                                                         |
-| `project`                  | str                 | None           | W&B project name.                                                                        |
-| `run`                      | str                 | None           | W&B run name.                                                                            |
-| `early_stopping`           | bool                | False          | Enable early stopping.                                                                   |
-| `early_stopping_patience`  | int                 | 10             | Epochs without improvement before stopping.                                              |
-| `early_stopping_min_delta` | float               | 0.001          | Minimum mAP change to qualify as improvement.                                            |
-| `early_stopping_use_ema`   | bool                | False          | Use EMA model for early stopping metrics.                                                |
-| `eval_max_dets`            | int                 | 500            | Maximum detections per image considered during COCO evaluation.                          |
-| `eval_interval`            | int                 | 1              | Run COCO evaluation every N epochs.                                                      |
-| `log_per_class_metrics`    | bool                | True           | Log per-class AP metrics to the console and loggers.                                     |
-| `progress_bar`             | str \| bool \| None | None           | Progress bar style: `"tqdm"`, `"rich"`, or `None`. Legacy booleans are still accepted.   |
-| `accelerator`              | str                 | "auto"         | PyTorch Lightning accelerator. "auto" selects GPU/MPS/CPU automatically.                 |
-| `seed`                     | int                 | None           | Random seed for reproducibility. None means no fixed seed.                               |
-| `lr_scheduler`             | str                 | "step"         | Learning rate scheduler type: "step" or "cosine".                                        |
-| `lr_min_factor`            | float               | 0.0            | Minimum LR as a fraction of the initial LR (cosine scheduler floor).                     |
-| `warmup_epochs`            | float               | 0.0            | Number of linear warmup epochs at the start of training.                                 |
-| `drop_path`                | float               | 0.0            | Stochastic depth drop-path rate for the backbone.                                        |
-| `compute_val_loss`         | bool                | True           | Compute and log loss during validation.                                                  |
-| `compute_test_loss`        | bool                | True           | Compute and log loss during the test run.                                                |
-| `fp16_eval`                | bool                | False          | Run evaluation in FP16 precision to reduce memory usage.                                 |
-| `pin_memory`               | bool                | None           | Pin DataLoader memory. None defers to PyTorch Lightning's default.                       |
-| `persistent_workers`       | bool                | None           | Keep DataLoader workers alive between epochs. None uses PTL default.                     |
-| `prefetch_factor`          | int                 | None           | Number of batches prefetched per worker. None uses PyTorch default.                      |
+| `dataset_dir` | str | Required | Path to COCO or YOLO formatted dataset with train/valid/test splits. |
+| `output_dir` | str | "output" | Directory for checkpoints, logs, and other training artifacts. |
+| `epochs` | int | 100 | Number of full passes over the dataset. |
+| `batch_size` | int | 4 | Samples per iteration. Balance with `grad_accum_steps`. |
+| `grad_accum_steps` | int | 4 | Gradient accumulation steps for effective larger batch sizes. |
+| `lr` | float | 1e-4 | Learning rate for the model (excluding encoder). |
+| `lr_encoder` | float | 1.5e-4 | Learning rate for the backbone encoder. |
+| `resolution` | int | Model-specific | Input image size (must be divisible by the selected model's `patch_size * num_windows`). |
+| `weight_decay` | float | 1e-4 | L2 regularization coefficient. |
+| `device` | str | "cuda" | Training device: cuda, cpu, or mps. |
+| `use_ema` | bool | True | Enable Exponential Moving Average of weights. |
+| `gradient_checkpointing` | bool | False | Trade compute for memory during backprop. |
+| `checkpoint_interval` | int | 10 | Save checkpoint every N epochs. |
+| `resume` | str | None | Path to checkpoint for resuming training. |
+| `tensorboard` | bool | True | Enable TensorBoard logging. |
+| `wandb` | bool | False | Enable Weights & Biases logging. |
+| `project` | str | None | W&B project name. |
+| `run` | str | None | W&B run name. |
+| `early_stopping` | bool | False | Enable early stopping. |
+| `early_stopping_patience` | int | 10 | Epochs without improvement before stopping. |
+| `early_stopping_min_delta` | float | 0.001 | Minimum mAP change to qualify as improvement. |
+| `early_stopping_use_ema` | bool | False | Use EMA model for early stopping metrics. |
+| `eval_max_dets` | int | 500 | Maximum detections per image considered during COCO evaluation. |
+| `eval_interval` | int | 1 | Run COCO evaluation every N epochs. |
+| `log_per_class_metrics` | bool | True | Log per-class AP metrics to the console and loggers. |
+| `progress_bar` | str \| bool \| None | None | Progress bar style: `"tqdm"`, `"rich"`, or `None`. Legacy booleans are still accepted. |
+| `accelerator` | str | "auto" | PyTorch Lightning accelerator. "auto" selects GPU/MPS/CPU automatically. |
+| `seed` | int | None | Random seed for reproducibility. None means no fixed seed. |
+| `lr_scheduler` | str | "step" | Learning rate scheduler type: "step" or "cosine". |
+| `lr_min_factor` | float | 0.0 | Minimum LR as a fraction of the initial LR (cosine scheduler floor). |
+| `warmup_epochs` | float | 0.0 | Number of linear warmup epochs at the start of training. |
+| `drop_path` | float | 0.0 | Stochastic depth drop-path rate for the backbone. |
+| `compute_val_loss` | bool | True | Compute and log loss during validation. |
+| `compute_test_loss` | bool | True | Compute and log loss during the test run. |
+| `fp16_eval` | bool | False | Run evaluation in FP16 precision to reduce memory usage. |
+| `pin_memory` | bool | None | Pin DataLoader memory. None defers to PyTorch Lightning's default. |
+| `persistent_workers` | bool | None | Keep DataLoader workers alive between epochs. None uses PTL default. |
+| `prefetch_factor` | int | None | Number of batches prefetched per worker. None uses PyTorch default. |

--- a/docs/learn/train/training-parameters.md
+++ b/docs/learn/train/training-parameters.md
@@ -124,13 +124,13 @@ During training, multiple checkpoints are saved:
 
 ## Early Stopping Parameters
 
-| Parameter                  | Type    | Default | Description                                                           |
-| -------------------------- | ------- | ------- | --------------------------------------------------------------------- |
-| `early_stopping`           | `bool`  | `False` | Enable early stopping based on validation mAP.                        |
-| `early_stopping_patience`  | `int`   | `10`    | Number of epochs without improvement before stopping.                 |
-| `early_stopping_min_delta` | `float` | `0.001` | Minimum change in mAP to qualify as an improvement.                   |
-| `early_stopping_use_ema`   | `bool`  | `False` | Whether to track improvements using EMA model metrics.                |
-| `skip_best_epochs`         | `int`   | `0`     | Delay best-model selection and early-stopping patience until epoch N. |
+| Parameter                  | Type    | Default | Description                                                                              |
+| -------------------------- | ------- | ------- | ---------------------------------------------------------------------------------------- |
+| `early_stopping`           | `bool`  | `False` | Enable early stopping based on validation mAP.                                           |
+| `early_stopping_patience`  | `int`   | `10`    | Number of epochs without improvement before stopping.                                    |
+| `early_stopping_min_delta` | `float` | `0.001` | Minimum change in mAP to qualify as an improvement.                                      |
+| `early_stopping_use_ema`   | `bool`  | `False` | Whether to track improvements using EMA model metrics.                                   |
+| `skip_best_epochs`         | `int`   | `0`     | Ignore the first N epochs (0..N-1) for best-model selection and early-stopping patience. |
 
 ### Early Stopping Example
 

--- a/docs/learn/train/training-parameters.md
+++ b/docs/learn/train/training-parameters.md
@@ -108,6 +108,7 @@ For example, `RFDETRSegXLarge` uses `624x624`, which is valid because `624` is d
 | Parameter             | Type  | Default | Description                                                                                                                       |
 | --------------------- | ----- | ------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `checkpoint_interval` | `int` | `10`    | Frequency (in epochs) at which model checkpoints are saved. More frequent saves provide better coverage but consume more storage. |
+| `skip_best_epochs`    | `int` | `0`     | Ignore the first N epochs when tracking best checkpoints and early-stopping patience. Useful when fine-tuning from a prior checkpoint. |
 
 ### Checkpoint Files
 
@@ -129,6 +130,7 @@ During training, multiple checkpoints are saved:
 | `early_stopping_patience`  | `int`   | `10`    | Number of epochs without improvement before stopping.  |
 | `early_stopping_min_delta` | `float` | `0.001` | Minimum change in mAP to qualify as an improvement.    |
 | `early_stopping_use_ema`   | `bool`  | `False` | Whether to track improvements using EMA model metrics. |
+| `skip_best_epochs`         | `int`   | `0`     | Delay best-model selection and early-stopping patience until epoch N. |
 
 ### Early Stopping Example
 
@@ -140,12 +142,14 @@ model.train(
     early_stopping=True,
     early_stopping_patience=15,
     early_stopping_min_delta=0.005,
+    skip_best_epochs=3,
 )
 ```
 
 This configuration will:
 
 - Train for up to 200 epochs
+- Ignore epochs 0-2 for best-checkpoint tracking and patience counting
 - Stop early if mAP doesn't improve by at least 0.005 for 15 consecutive epochs
 
 ## Logging Parameters

--- a/docs/learn/train/training-parameters.md
+++ b/docs/learn/train/training-parameters.md
@@ -152,6 +152,14 @@ This configuration will:
 - Ignore epochs 0-2 for best-checkpoint tracking and patience counting
 - Stop early if mAP doesn't improve by at least 0.005 for 15 consecutive epochs
 
+!!! note "Transfer learning with `pretrain_weights`"
+
+    When fine-tuning from `pretrain_weights`, the pretrained model's epoch-0 validation mAP
+    can be artificially high relative to the training trajectory on the new dataset. This causes
+    `checkpoint_best_total.pth` to always contain the untrained pretrained weights and may
+    trigger early stopping prematurely. Use `skip_best_epochs` to defer best-checkpoint
+    selection and patience counting until the model has had time to adapt.
+
 ## Logging Parameters
 
 | Parameter     | Type   | Default | Description                                                                                                                                                                                                 |

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -466,6 +466,7 @@ class TrainConfig(BaseModel):
     ema_tau: int = 100
     lr_drop: int = 100
     checkpoint_interval: int = Field(default=10, ge=1)
+    skip_best_epochs: int = Field(default=0, ge=0)
     warmup_epochs: float = 0.0
     lr_vit_layer_decay: float = 0.8
     lr_component_decay: float = 0.7

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -97,7 +97,11 @@ class BestModelCallback(ModelCheckpoint):
         self._run_test = run_test
         self._best_ema: float = 0.0
         self._output_dir = Path(output_dir)
-        self._skip_best_epochs = max(0, int(skip_best_epochs))
+        if isinstance(skip_best_epochs, bool) or not isinstance(skip_best_epochs, int):
+            raise ValueError("skip_best_epochs must be a non-negative integer")
+        if skip_best_epochs < 0:
+            raise ValueError("skip_best_epochs must be greater than or equal to 0")
+        self._skip_best_epochs = skip_best_epochs
         # Stash current pl_module so _save_checkpoint (no pl_module param) can access it.
         self._current_pl_module: LightningModule | None = None
 

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -55,6 +55,8 @@ class BestModelCallback(ModelCheckpoint):
             EMA tracking.
         run_test: If ``True``, run ``trainer.test()`` on the best model at
             the end of training.
+        skip_best_epochs: Ignore validation metrics before this epoch when
+            tracking best regular and EMA checkpoints.
     """
 
     FILE_EXTENSION = ".pth"
@@ -65,6 +67,7 @@ class BestModelCallback(ModelCheckpoint):
         monitor_regular: str = "val/mAP_50_95",
         monitor_ema: str | None = None,
         run_test: bool = True,
+        skip_best_epochs: int = 0,
     ) -> None:
         super().__init__(
             dirpath=output_dir,
@@ -81,6 +84,7 @@ class BestModelCallback(ModelCheckpoint):
         self._run_test = run_test
         self._best_ema: float = 0.0
         self._output_dir = Path(output_dir)
+        self._skip_best_epochs = max(0, int(skip_best_epochs))
         # Stash current pl_module so _save_checkpoint (no pl_module param) can access it.
         self._current_pl_module: LightningModule | None = None
 
@@ -286,6 +290,8 @@ class BestModelCallback(ModelCheckpoint):
         """
         # Stash for use inside _save_checkpoint (which has no pl_module param).
         self._current_pl_module = pl_module
+        if trainer.current_epoch < self._skip_best_epochs:
+            return
         # Guard: only run checkpoint logic when the monitored metric was actually
         # logged this epoch (non-eval epochs with eval_interval > 1 skip COCO eval
         # so the key is absent from callback_metrics).
@@ -363,15 +369,20 @@ class BestModelCallback(ModelCheckpoint):
             cls_test_step = getattr(type(pl_module), "test_step", None)
             has_test_step = cls_test_step is not None and cls_test_step is not LightningModule.test_step
             if has_test_step:
+                if not total_path.exists():
+                    logger.warning(
+                        "Skipping trainer.test() because no best checkpoint was produced. "
+                        "Reduce skip_best_epochs or train for more epochs to enable best-model evaluation."
+                    )
+                    return
                 # Load best weights before test — mirrors legacy main.py:602-609.
-                if total_path.exists():
-                    ckpt = torch.load(total_path, map_location="cpu", weights_only=False)
-                    # Checkpoints always store plain keys; load into the unwrapped module
-                    # so compiled (OptimizedModule) and non-compiled models both work.
-                    _orig = getattr(pl_module.model, "_orig_mod", None)
-                    raw = _orig if isinstance(_orig, torch.nn.Module) else pl_module.model
-                    raw.load_state_dict(ckpt["model"], strict=True)
-                    logger.info("Loaded best weights from %s for test evaluation.", total_path)
+                ckpt = torch.load(total_path, map_location="cpu", weights_only=False)
+                # Checkpoints always store plain keys; load into the unwrapped module
+                # so compiled (OptimizedModule) and non-compiled models both work.
+                _orig = getattr(pl_module.model, "_orig_mod", None)
+                raw = _orig if isinstance(_orig, torch.nn.Module) else pl_module.model
+                raw.load_state_dict(ckpt["model"], strict=True)
+                logger.info("Loaded best weights from %s for test evaluation.", total_path)
                 trainer.test(pl_module, datamodule=trainer.datamodule, verbose=False)
 
 
@@ -401,6 +412,8 @@ class RFDETREarlyStopping(EarlyStopping):
         monitor_regular: Metric key for the regular model mAP.
         monitor_ema: Metric key for the EMA model mAP.
         verbose: If ``True``, log early stopping status each epoch.
+        skip_best_epochs: Ignore validation metrics before this epoch when
+            evaluating patience and best-score baselines.
     """
 
     _SYNTHETIC_MONITOR: str = "__rfdetr_effective_map__"
@@ -413,6 +426,7 @@ class RFDETREarlyStopping(EarlyStopping):
         monitor_regular: str = "val/mAP_50_95",
         monitor_ema: str = "val/ema_mAP_50_95",
         verbose: bool = True,
+        skip_best_epochs: int = 0,
     ) -> None:
         super().__init__(
             monitor=self._SYNTHETIC_MONITOR,
@@ -428,6 +442,7 @@ class RFDETREarlyStopping(EarlyStopping):
         self._monitor_regular = monitor_regular
         self._monitor_ema = monitor_ema
         self._use_ema = use_ema
+        self._skip_best_epochs = max(0, int(skip_best_epochs))
 
     def on_validation_end(self, trainer: Trainer, pl_module: LightningModule) -> None:
         """Compute effective mAP and delegate to parent stopping logic.
@@ -441,6 +456,9 @@ class RFDETREarlyStopping(EarlyStopping):
             trainer: The Lightning Trainer instance.
             pl_module: The ``RFDETRModelModule`` being trained.
         """
+        if trainer.current_epoch < self._skip_best_epochs:
+            return
+
         metrics = trainer.callback_metrics
         regular_tensor = metrics.get(self._monitor_regular)
         ema_tensor = metrics.get(self._monitor_ema)

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -98,7 +98,7 @@ class BestModelCallback(ModelCheckpoint):
         self._best_ema: float = 0.0
         self._output_dir = Path(output_dir)
         if isinstance(skip_best_epochs, bool) or not isinstance(skip_best_epochs, int):
-            raise ValueError("skip_best_epochs must be a non-negative integer")
+            raise TypeError("skip_best_epochs must be a non-negative integer")
         if skip_best_epochs < 0:
             raise ValueError("skip_best_epochs must be greater than or equal to 0")
         self._skip_best_epochs = skip_best_epochs

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -465,10 +465,15 @@ class RFDETREarlyStopping(EarlyStopping):
             strict=False,  # We inject the key ourselves; don't crash if temporarily absent.
             log_rank_zero_only=True,
         )
+        if isinstance(skip_best_epochs, bool) or not isinstance(skip_best_epochs, int):
+            raise TypeError("skip_best_epochs must be a non-negative integer")
+        if skip_best_epochs < 0:
+            raise ValueError("skip_best_epochs must be greater than or equal to 0")
+
         self._monitor_regular = monitor_regular
         self._monitor_ema = monitor_ema
         self._use_ema = use_ema
-        self._skip_best_epochs = max(0, int(skip_best_epochs))
+        self._skip_best_epochs = skip_best_epochs
 
     def on_validation_end(self, trainer: Trainer, pl_module: LightningModule) -> None:
         """Compute effective mAP and delegate to parent stopping logic.

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -55,8 +55,21 @@ class BestModelCallback(ModelCheckpoint):
             EMA tracking.
         run_test: If ``True``, run ``trainer.test()`` on the best model at
             the end of training.
-        skip_best_epochs: Ignore validation metrics before this epoch when
-            tracking best regular and EMA checkpoints.
+        skip_best_epochs: Ignore the first N epochs (0..N-1) when tracking
+            best regular and EMA checkpoints.  Useful when fine-tuning from
+            ``pretrain_weights``: the pretrained model's epoch-0 mAP can
+            artificially dominate best-checkpoint selection before training
+            adapts to the new dataset.
+
+    Examples:
+        Skip the first 3 epochs so pretrained weights do not dominate:
+
+        >>> import tempfile
+        >>> from rfdetr.training.callbacks.best_model import BestModelCallback
+        >>> with tempfile.TemporaryDirectory() as tmp:
+        ...     cb = BestModelCallback(output_dir=tmp, skip_best_epochs=3)
+        ...     cb._skip_best_epochs
+        3
     """
 
     FILE_EXTENSION = ".pth"
@@ -415,8 +428,18 @@ class RFDETREarlyStopping(EarlyStopping):
         monitor_regular: Metric key for the regular model mAP.
         monitor_ema: Metric key for the EMA model mAP.
         verbose: If ``True``, log early stopping status each epoch.
-        skip_best_epochs: Ignore validation metrics before this epoch when
-            evaluating patience and best-score baselines.
+        skip_best_epochs: Ignore the first N epochs (0..N-1) when evaluating
+            patience and best-score baselines.  Set this when fine-tuning from
+            ``pretrain_weights`` to avoid premature stopping before the model
+            adapts to the new dataset.
+
+    Examples:
+        Fine-tuning from pretrained weights — skip first 3 epochs:
+
+        >>> from rfdetr.training.callbacks.best_model import RFDETREarlyStopping
+        >>> cb = RFDETREarlyStopping(patience=10, skip_best_epochs=3)
+        >>> cb._skip_best_epochs
+        3
     """
 
     _SYNTHETIC_MONITOR: str = "__rfdetr_effective_map__"

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -288,7 +288,8 @@ class BestModelCallback(ModelCheckpoint):
             trainer: The Lightning Trainer instance.
             pl_module: The ``RFDETRModelModule`` being trained.
         """
-        # Stash for use inside _save_checkpoint (which has no pl_module param).
+        # Stash before the skip guard — eligible epochs still need this reference
+        # inside _save_checkpoint (which receives no pl_module param).
         self._current_pl_module = pl_module
         if trainer.current_epoch < self._skip_best_epochs:
             return
@@ -372,7 +373,9 @@ class BestModelCallback(ModelCheckpoint):
                 if not total_path.exists():
                     logger.warning(
                         "Skipping trainer.test() because no best checkpoint was produced. "
-                        "Reduce skip_best_epochs or train for more epochs to enable best-model evaluation."
+                        "Ensure the monitored metric is logged on evaluation epochs, that evaluation "
+                        "runs often enough, and that skip_best_epochs is smaller than the number of "
+                        "training epochs."
                     )
                     return
                 # Load best weights before test — mirrors legacy main.py:602-609.

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -248,6 +248,7 @@ def build_trainer(
             output_dir=tc.output_dir,
             monitor_ema="val/ema_mAP_50_95" if enable_ema else None,
             run_test=tc.run_test,
+            skip_best_epochs=tc.skip_best_epochs,
         )
     )
 
@@ -258,6 +259,7 @@ def build_trainer(
                 patience=tc.early_stopping_patience,
                 min_delta=tc.early_stopping_min_delta,
                 use_ema=tc.early_stopping_use_ema,
+                skip_best_epochs=tc.skip_best_epochs,
             )
         )
 

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -195,6 +195,10 @@ class TestTrainConfigT42PromotedFields:
         """eval_interval defaults to 1 (evaluate each epoch)."""
         assert self._tc(tmp_path).eval_interval == 1
 
+    def test_skip_best_epochs_default_is_zero(self, tmp_path):
+        """skip_best_epochs defaults to 0 for backward compatibility."""
+        assert self._tc(tmp_path).skip_best_epochs == 0
+
     def test_ema_update_interval_default_is_one(self, tmp_path):
         """ema_update_interval defaults to 1 (update every step)."""
         assert self._tc(tmp_path).ema_update_interval == 1
@@ -221,6 +225,7 @@ class TestTrainConfigT42PromotedFields:
             pytest.param("dont_save_weights", True, id="dont_save_weights"),
             pytest.param("run_test", True, id="run_test"),
             pytest.param("eval_interval", 3, id="eval_interval"),
+            pytest.param("skip_best_epochs", 3, id="skip_best_epochs"),
             pytest.param("ema_update_interval", 4, id="ema_update_interval"),
             pytest.param("compute_val_loss", False, id="compute_val_loss"),
             pytest.param("compute_test_loss", False, id="compute_test_loss"),
@@ -246,6 +251,7 @@ class TestTrainConfigT42PromotedFields:
         ("field", "value"),
         [
             pytest.param("eval_interval", 0, id="eval_interval_zero"),
+            pytest.param("skip_best_epochs", -1, id="skip_best_epochs_negative"),
             pytest.param("ema_update_interval", 0, id="ema_update_interval_zero"),
             pytest.param("prefetch_factor", 0, id="prefetch_factor_zero"),
         ],

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -221,6 +221,22 @@ class TestBestModelCallback:
         assert not (tmp_path / "checkpoint_best_regular.pth").exists()
         assert cb.best_model_score is None
 
+    @pytest.mark.parametrize(
+        "invalid_value, exc_type",
+        [
+            pytest.param(True, TypeError, id="bool_true"),
+            pytest.param(2.5, TypeError, id="float"),
+            pytest.param("3", TypeError, id="string"),
+            pytest.param(-1, ValueError, id="negative"),
+        ],
+    )
+    def test_skip_best_epochs_invalid_input_raises(
+        self, tmp_path: Path, invalid_value: object, exc_type: type[Exception]
+    ) -> None:
+        """BestModelCallback raises TypeError for non-int and ValueError for negative skip_best_epochs."""
+        with pytest.raises(exc_type):
+            BestModelCallback(output_dir=str(tmp_path), skip_best_epochs=invalid_value)  # type: ignore[arg-type]
+
     def test_regular_checkpoint_saved_on_improvement(self, tmp_path: Path) -> None:
         """Metric 0.5 > initial 0.0 causes checkpoint_best_regular.pth to be saved."""
         cb = BestModelCallback(output_dir=str(tmp_path))
@@ -981,6 +997,20 @@ class TestRFDETREarlyStopping:
 
         assert cb.best_score is not None
         assert cb.best_score.item() == pytest.approx(0.5)
+
+    @pytest.mark.parametrize(
+        "invalid_value, exc_type",
+        [
+            pytest.param(True, TypeError, id="bool_true"),
+            pytest.param(2.5, TypeError, id="float"),
+            pytest.param("3", TypeError, id="string"),
+            pytest.param(-1, ValueError, id="negative"),
+        ],
+    )
+    def test_skip_best_epochs_invalid_input_raises(self, invalid_value: object, exc_type: type[Exception]) -> None:
+        """RFDETREarlyStopping raises TypeError for non-int and ValueError for negative skip_best_epochs."""
+        with pytest.raises(exc_type):
+            RFDETREarlyStopping(patience=5, skip_best_epochs=invalid_value)  # type: ignore[arg-type]
 
     def test_no_stop_within_patience(self) -> None:
         """3 epochs with no improvement, patience=5 -- training continues."""

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -134,6 +134,50 @@ class _ResumeProbeCallback(Callback):
 class TestBestModelCallback:
     """Verify best-model checkpoint saving and selection."""
 
+    def test_skip_best_epochs_defers_regular_checkpoint_until_threshold(self, tmp_path: Path) -> None:
+        """Best checkpoint tracking should ignore metrics before skip_best_epochs."""
+        cb = BestModelCallback(output_dir=str(tmp_path), skip_best_epochs=2)
+        pl_module = _make_pl_module()
+
+        trainer_epoch0 = _make_trainer({"val/mAP_50_95": 0.9}, current_epoch=0)
+        cb.on_validation_end(trainer_epoch0, pl_module)
+
+        trainer_epoch1 = _make_trainer({"val/mAP_50_95": 0.8}, current_epoch=1)
+        cb.on_validation_end(trainer_epoch1, pl_module)
+
+        assert not (tmp_path / "checkpoint_best_regular.pth").exists()
+        assert cb.best_model_score is None
+
+        trainer_epoch2 = _make_trainer({"val/mAP_50_95": 0.7}, current_epoch=2)
+        cb.on_validation_end(trainer_epoch2, pl_module)
+
+        assert (tmp_path / "checkpoint_best_regular.pth").exists()
+        assert cb.best_model_score.item() == pytest.approx(0.7)
+
+    def test_skip_best_epochs_defers_ema_checkpoint_until_threshold(self, tmp_path: Path) -> None:
+        """EMA best tracking should ignore metrics before skip_best_epochs."""
+        cb = BestModelCallback(
+            output_dir=str(tmp_path),
+            monitor_ema="val/ema_mAP_50_95",
+            skip_best_epochs=2,
+        )
+        pl_module = _make_pl_module()
+
+        trainer_epoch0 = _make_trainer({"val/mAP_50_95": 0.5, "val/ema_mAP_50_95": 0.9}, current_epoch=0)
+        cb.on_validation_end(trainer_epoch0, pl_module)
+
+        trainer_epoch1 = _make_trainer({"val/mAP_50_95": 0.5, "val/ema_mAP_50_95": 0.8}, current_epoch=1)
+        cb.on_validation_end(trainer_epoch1, pl_module)
+
+        assert not (tmp_path / "checkpoint_best_ema.pth").exists()
+        assert cb._best_ema == pytest.approx(0.0)
+
+        trainer_epoch2 = _make_trainer({"val/mAP_50_95": 0.5, "val/ema_mAP_50_95": 0.7}, current_epoch=2)
+        cb.on_validation_end(trainer_epoch2, pl_module)
+
+        assert (tmp_path / "checkpoint_best_ema.pth").exists()
+        assert cb._best_ema == pytest.approx(0.7)
+
     def test_regular_checkpoint_saved_on_improvement(self, tmp_path: Path) -> None:
         """Metric 0.5 > initial 0.0 causes checkpoint_best_regular.pth to be saved."""
         cb = BestModelCallback(output_dir=str(tmp_path))
@@ -347,6 +391,27 @@ class TestBestModelCallback:
         cb.on_validation_end(trainer, pl_module)
         cb.on_fit_end(trainer, pl_module)
 
+        trainer.test.assert_not_called()
+
+    def test_run_test_true_without_best_checkpoint_skips_trainer_test(self, tmp_path: Path) -> None:
+        """run_test=True must not test final weights when no best checkpoint was produced."""
+        from pytorch_lightning import LightningModule
+
+        class _ModuleWithTestStep(LightningModule):
+            def test_step(self, batch: object, batch_idx: int) -> None: ...
+
+        pl_module = _ModuleWithTestStep()
+        pl_module.model = MagicMock()
+        pl_module.model.state_dict.return_value = {"w": torch.zeros(1)}
+        pl_module.train_config = {"lr": 0.001}
+
+        cb = BestModelCallback(output_dir=str(tmp_path), run_test=True, skip_best_epochs=2)
+        trainer = _make_trainer({"val/mAP_50_95": 0.5}, current_epoch=0)
+
+        cb.on_validation_end(trainer, pl_module)
+        cb.on_fit_end(trainer, pl_module)
+
+        assert not (tmp_path / "checkpoint_best_total.pth").exists()
         trainer.test.assert_not_called()
 
     def test_run_test_loads_best_weights_before_test(self, tmp_path: Path) -> None:
@@ -808,6 +873,44 @@ class TestBestModelCallback:
 
 class TestRFDETREarlyStopping:
     """Verify early stopping logic mirrors legacy EarlyStoppingCallback."""
+
+    def test_skip_best_epochs_ignores_patience_before_threshold(self) -> None:
+        """Patience counting should start only after skip_best_epochs is reached."""
+        cb = RFDETREarlyStopping(patience=1, min_delta=0.001, skip_best_epochs=2)
+        pl_module = _make_pl_module()
+
+        trainer_epoch0 = _make_trainer({"val/mAP_50_95": 0.9}, current_epoch=0)
+        cb.on_validation_end(trainer_epoch0, pl_module)
+        trainer_epoch1 = _make_trainer({"val/mAP_50_95": 0.8}, current_epoch=1)
+        cb.on_validation_end(trainer_epoch1, pl_module)
+
+        assert cb.wait_count == 0
+        assert trainer_epoch1.should_stop is False
+
+        trainer_epoch2 = _make_trainer({"val/mAP_50_95": 0.7}, current_epoch=2)
+        cb.on_validation_end(trainer_epoch2, pl_module)
+        assert cb.best_score.item() == pytest.approx(0.7)
+        assert cb.wait_count == 0
+
+        trainer_epoch3 = _make_trainer({"val/mAP_50_95": 0.7}, current_epoch=3)
+        cb.on_validation_end(trainer_epoch3, pl_module)
+        assert trainer_epoch3.should_stop is True
+
+    def test_skip_best_epochs_uses_first_eligible_epoch_as_baseline(self) -> None:
+        """A stronger skipped epoch must not block the first eligible epoch from becoming best."""
+        cb = RFDETREarlyStopping(patience=2, min_delta=0.001, skip_best_epochs=2)
+        pl_module = _make_pl_module()
+
+        trainer_epoch0 = _make_trainer({"val/mAP_50_95": 0.95}, current_epoch=0)
+        cb.on_validation_end(trainer_epoch0, pl_module)
+        trainer_epoch1 = _make_trainer({"val/mAP_50_95": 0.85}, current_epoch=1)
+        cb.on_validation_end(trainer_epoch1, pl_module)
+
+        trainer_epoch2 = _make_trainer({"val/mAP_50_95": 0.40}, current_epoch=2)
+        cb.on_validation_end(trainer_epoch2, pl_module)
+
+        assert cb.best_score.item() == pytest.approx(0.40)
+        assert cb.wait_count == 0
 
     def test_no_stop_within_patience(self) -> None:
         """3 epochs with no improvement, patience=5 -- training continues."""

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -134,49 +134,62 @@ class _ResumeProbeCallback(Callback):
 class TestBestModelCallback:
     """Verify best-model checkpoint saving and selection."""
 
-    def test_skip_best_epochs_defers_regular_checkpoint_until_threshold(self, tmp_path: Path) -> None:
-        """Best checkpoint tracking should ignore metrics before skip_best_epochs."""
-        cb = BestModelCallback(output_dir=str(tmp_path), skip_best_epochs=2)
+    @pytest.mark.parametrize(
+        "monitor_ema, metrics, checkpoint_file",
+        [
+            pytest.param(None, {"val/mAP_50_95": 0.9}, "checkpoint_best_regular.pth", id="regular"),
+            pytest.param(
+                "val/ema_mAP_50_95",
+                {"val/mAP_50_95": 0.5, "val/ema_mAP_50_95": 0.9},
+                "checkpoint_best_ema.pth",
+                id="ema",
+            ),
+        ],
+    )
+    def test_skip_best_epochs_no_checkpoint_during_skip_window(
+        self, tmp_path: Path, monitor_ema: str | None, metrics: dict, checkpoint_file: str
+    ) -> None:
+        """No checkpoint written for epochs before skip_best_epochs."""
+        cb = BestModelCallback(output_dir=str(tmp_path), monitor_ema=monitor_ema, skip_best_epochs=2)
         pl_module = _make_pl_module()
+        cb.on_validation_end(_make_trainer(metrics, current_epoch=0), pl_module)
+        cb.on_validation_end(_make_trainer(metrics, current_epoch=1), pl_module)
+        assert not (tmp_path / checkpoint_file).exists()
 
-        trainer_epoch0 = _make_trainer({"val/mAP_50_95": 0.9}, current_epoch=0)
-        cb.on_validation_end(trainer_epoch0, pl_module)
-
-        trainer_epoch1 = _make_trainer({"val/mAP_50_95": 0.8}, current_epoch=1)
-        cb.on_validation_end(trainer_epoch1, pl_module)
-
-        assert not (tmp_path / "checkpoint_best_regular.pth").exists()
-        assert cb.best_model_score is None
-
-        trainer_epoch2 = _make_trainer({"val/mAP_50_95": 0.7}, current_epoch=2)
-        cb.on_validation_end(trainer_epoch2, pl_module)
-
-        assert (tmp_path / "checkpoint_best_regular.pth").exists()
-        assert cb.best_model_score.item() == pytest.approx(0.7)
-
-    def test_skip_best_epochs_defers_ema_checkpoint_until_threshold(self, tmp_path: Path) -> None:
-        """EMA best tracking should ignore metrics before skip_best_epochs."""
-        cb = BestModelCallback(
-            output_dir=str(tmp_path),
-            monitor_ema="val/ema_mAP_50_95",
-            skip_best_epochs=2,
-        )
+    @pytest.mark.parametrize(
+        "monitor_ema, skip_metrics, eligible_metrics, checkpoint_file",
+        [
+            pytest.param(
+                None,
+                {"val/mAP_50_95": 0.9},
+                {"val/mAP_50_95": 0.7},
+                "checkpoint_best_regular.pth",
+                id="regular",
+            ),
+            pytest.param(
+                "val/ema_mAP_50_95",
+                {"val/mAP_50_95": 0.5, "val/ema_mAP_50_95": 0.9},
+                {"val/mAP_50_95": 0.5, "val/ema_mAP_50_95": 0.7},
+                "checkpoint_best_ema.pth",
+                id="ema",
+            ),
+        ],
+    )
+    def test_skip_best_epochs_checkpoint_saved_on_first_eligible_epoch(
+        self,
+        tmp_path: Path,
+        monitor_ema: str | None,
+        skip_metrics: dict,
+        eligible_metrics: dict,
+        checkpoint_file: str,
+    ) -> None:
+        """Checkpoint written on the first epoch at or after skip_best_epochs."""
+        cb = BestModelCallback(output_dir=str(tmp_path), monitor_ema=monitor_ema, skip_best_epochs=2)
         pl_module = _make_pl_module()
-
-        trainer_epoch0 = _make_trainer({"val/mAP_50_95": 0.5, "val/ema_mAP_50_95": 0.9}, current_epoch=0)
-        cb.on_validation_end(trainer_epoch0, pl_module)
-
-        trainer_epoch1 = _make_trainer({"val/mAP_50_95": 0.5, "val/ema_mAP_50_95": 0.8}, current_epoch=1)
-        cb.on_validation_end(trainer_epoch1, pl_module)
-
-        assert not (tmp_path / "checkpoint_best_ema.pth").exists()
-        assert cb._best_ema == pytest.approx(0.0)
-
-        trainer_epoch2 = _make_trainer({"val/mAP_50_95": 0.5, "val/ema_mAP_50_95": 0.7}, current_epoch=2)
-        cb.on_validation_end(trainer_epoch2, pl_module)
-
-        assert (tmp_path / "checkpoint_best_ema.pth").exists()
-        assert cb._best_ema == pytest.approx(0.7)
+        cb.on_validation_end(_make_trainer(skip_metrics, current_epoch=0), pl_module)
+        cb.on_validation_end(_make_trainer(skip_metrics, current_epoch=1), pl_module)
+        cb.on_validation_end(_make_trainer(eligible_metrics, current_epoch=2), pl_module)
+        assert (tmp_path / checkpoint_file).exists()
 
     @pytest.mark.parametrize(
         "kwargs",
@@ -904,27 +917,36 @@ class TestBestModelCallback:
 class TestRFDETREarlyStopping:
     """Verify early stopping logic mirrors legacy EarlyStoppingCallback."""
 
-    def test_skip_best_epochs_ignores_patience_before_threshold(self) -> None:
-        """Patience counting should start only after skip_best_epochs is reached."""
+    def test_patience_not_counted_during_skip_window(self) -> None:
+        """Patience wait_count stays 0 and training does not stop during skipped epochs."""
         cb = RFDETREarlyStopping(patience=1, min_delta=0.001, skip_best_epochs=2)
         pl_module = _make_pl_module()
-
-        trainer_epoch0 = _make_trainer({"val/mAP_50_95": 0.9}, current_epoch=0)
-        cb.on_validation_end(trainer_epoch0, pl_module)
-        trainer_epoch1 = _make_trainer({"val/mAP_50_95": 0.8}, current_epoch=1)
-        cb.on_validation_end(trainer_epoch1, pl_module)
-
+        cb.on_validation_end(_make_trainer({"val/mAP_50_95": 0.9}, current_epoch=0), pl_module)
+        trainer = _make_trainer({"val/mAP_50_95": 0.8}, current_epoch=1)
+        cb.on_validation_end(trainer, pl_module)
         assert cb.wait_count == 0
-        assert trainer_epoch1.should_stop is False
+        assert trainer.should_stop is False
 
-        trainer_epoch2 = _make_trainer({"val/mAP_50_95": 0.7}, current_epoch=2)
-        cb.on_validation_end(trainer_epoch2, pl_module)
+    def test_first_eligible_epoch_sets_baseline_with_zero_wait(self) -> None:
+        """First eligible epoch becomes best_score baseline; patience wait_count stays 0."""
+        cb = RFDETREarlyStopping(patience=1, min_delta=0.001, skip_best_epochs=2)
+        pl_module = _make_pl_module()
+        cb.on_validation_end(_make_trainer({"val/mAP_50_95": 0.9}, current_epoch=0), pl_module)
+        cb.on_validation_end(_make_trainer({"val/mAP_50_95": 0.8}, current_epoch=1), pl_module)
+        cb.on_validation_end(_make_trainer({"val/mAP_50_95": 0.7}, current_epoch=2), pl_module)
         assert cb.best_score.item() == pytest.approx(0.7)
         assert cb.wait_count == 0
 
-        trainer_epoch3 = _make_trainer({"val/mAP_50_95": 0.7}, current_epoch=3)
-        cb.on_validation_end(trainer_epoch3, pl_module)
-        assert trainer_epoch3.should_stop is True
+    def test_patience_triggers_stop_after_skip_window(self) -> None:
+        """Patience counts normally after skip window; triggers stop when exhausted."""
+        cb = RFDETREarlyStopping(patience=1, min_delta=0.001, skip_best_epochs=2)
+        pl_module = _make_pl_module()
+        cb.on_validation_end(_make_trainer({"val/mAP_50_95": 0.9}, current_epoch=0), pl_module)
+        cb.on_validation_end(_make_trainer({"val/mAP_50_95": 0.8}, current_epoch=1), pl_module)
+        cb.on_validation_end(_make_trainer({"val/mAP_50_95": 0.7}, current_epoch=2), pl_module)
+        trainer = _make_trainer({"val/mAP_50_95": 0.7}, current_epoch=3)
+        cb.on_validation_end(trainer, pl_module)
+        assert trainer.should_stop is True
 
     def test_skip_best_epochs_uses_first_eligible_epoch_as_baseline(self) -> None:
         """A stronger skipped epoch must not block the first eligible epoch from becoming best."""

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -178,6 +178,36 @@ class TestBestModelCallback:
         assert (tmp_path / "checkpoint_best_ema.pth").exists()
         assert cb._best_ema == pytest.approx(0.7)
 
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            pytest.param({}, id="default"),
+            pytest.param({"skip_best_epochs": 0}, id="explicit_zero"),
+        ],
+    )
+    def test_skip_best_epochs_zero_does_not_defer_epoch_zero(self, tmp_path: Path, kwargs: dict) -> None:
+        """skip_best_epochs=0 (explicit or default) makes epoch 0 eligible for checkpoint."""
+        cb = BestModelCallback(output_dir=str(tmp_path), **kwargs)
+        trainer = _make_trainer({"val/mAP_50_95": 0.5}, current_epoch=0)
+        pl_module = _make_pl_module()
+
+        cb.on_validation_end(trainer, pl_module)
+
+        assert (tmp_path / "checkpoint_best_regular.pth").exists()
+        assert cb.best_model_score is not None
+
+    def test_skip_best_epochs_exceeds_total_epochs_produces_no_checkpoint(self, tmp_path: Path) -> None:
+        """No checkpoint when skip_best_epochs >= total epochs (all epochs skipped)."""
+        cb = BestModelCallback(output_dir=str(tmp_path), skip_best_epochs=3)
+        pl_module = _make_pl_module()
+
+        for epoch in range(2):
+            trainer = _make_trainer({"val/mAP_50_95": 0.9}, current_epoch=epoch)
+            cb.on_validation_end(trainer, pl_module)
+
+        assert not (tmp_path / "checkpoint_best_regular.pth").exists()
+        assert cb.best_model_score is None
+
     def test_regular_checkpoint_saved_on_improvement(self, tmp_path: Path) -> None:
         """Metric 0.5 > initial 0.0 causes checkpoint_best_regular.pth to be saved."""
         cb = BestModelCallback(output_dir=str(tmp_path))
@@ -911,6 +941,24 @@ class TestRFDETREarlyStopping:
 
         assert cb.best_score.item() == pytest.approx(0.40)
         assert cb.wait_count == 0
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            pytest.param({}, id="default"),
+            pytest.param({"skip_best_epochs": 0}, id="explicit_zero"),
+        ],
+    )
+    def test_skip_best_epochs_zero_does_not_defer_epoch_zero(self, kwargs: dict) -> None:
+        """skip_best_epochs=0 (explicit or default) makes epoch 0 eligible for patience tracking."""
+        cb = RFDETREarlyStopping(patience=5, min_delta=0.001, **kwargs)
+        pl_module = _make_pl_module()
+
+        trainer = _make_trainer({"val/mAP_50_95": 0.5}, current_epoch=0)
+        cb.on_validation_end(trainer, pl_module)
+
+        assert cb.best_score is not None
+        assert cb.best_score.item() == pytest.approx(0.5)
 
     def test_no_stop_within_patience(self) -> None:
         """3 epochs with no improvement, patience=5 -- training continues."""

--- a/tests/training/test_build_trainer.py
+++ b/tests/training/test_build_trainer.py
@@ -90,6 +90,12 @@ class TestBuildTrainerCallbacks:
         types = [type(cb) for cb in trainer.callbacks]
         assert BestModelCallback in types
 
+    def test_skip_best_epochs_forwarded_to_best_model_callback(self, tmp_path):
+        """BestModelCallback receives skip_best_epochs from TrainConfig."""
+        trainer = build_trainer(_tc(tmp_path, use_ema=False, skip_best_epochs=3), _mc())
+        best_cb = next(cb for cb in trainer.callbacks if isinstance(cb, BestModelCallback))
+        assert best_cb._skip_best_epochs == 3
+
     def test_latest_model_checkpoint_present(self, tmp_path):
         """A ModelCheckpoint (not BestModelCallback) with every_n_epochs==1 is included when checkpoint_interval > 1."""
         trainer = build_trainer(_tc(tmp_path, use_ema=False, checkpoint_interval=2), _mc())
@@ -192,6 +198,12 @@ class TestBuildTrainerCallbacks:
         trainer = build_trainer(_tc(tmp_path, early_stopping=True), _mc())
         types = [type(cb) for cb in trainer.callbacks]
         assert RFDETREarlyStopping in types
+
+    def test_skip_best_epochs_forwarded_to_early_stopping(self, tmp_path):
+        """RFDETREarlyStopping receives skip_best_epochs from TrainConfig."""
+        trainer = build_trainer(_tc(tmp_path, early_stopping=True, skip_best_epochs=4), _mc())
+        early_stop_cb = next(cb for cb in trainer.callbacks if isinstance(cb, RFDETREarlyStopping))
+        assert early_stop_cb._skip_best_epochs == 4
 
     def test_no_early_stopping_when_disabled(self, tmp_path):
         """RFDETREarlyStopping is absent when early_stopping=False."""

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -376,6 +376,15 @@ class TestRFDETRTrainPTL:
         # get_train_config must have been called without device=
         assert "device" not in mock_self.get_train_config.call_args.kwargs
 
+    def test_skip_best_epochs_forwarded_to_get_train_config(self, tmp_path, patch_lit):
+        """Non-absorbed training kwargs must reach get_train_config unchanged."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        p_mod, p_dm, p_bt, *_ = patch_lit
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self, skip_best_epochs=3)
+
+        mock_self.get_train_config.assert_called_once_with(skip_best_epochs=3)
+
     def test_batch_size_auto_resolved_before_module_and_datamodule_build(self, tmp_path, patch_lit):
         """batch_size='auto' is resolved to ints before module/datamodule init."""
         mock_self = _make_rfdetr_self(tmp_path, batch_size="auto", grad_accum_steps=99)


### PR DESCRIPTION
## What does this PR do?

This PR adds `skip_best_epochs` to the training flow so the first `N` epochs do not influence best checkpoint selection or early stopping. This is useful when training starts from strong pretrained weights or a resumed checkpoint and the earliest validation scores would otherwise dominate best-model tracking too soon.

It also wires the option through the public training API, covers it with focused tests, documents it, and tightens one edge case in `BestModelCallback`: if no best checkpoint was produced, the callback now skips `trainer.test()` instead of evaluating the final in-memory weights as though they were the best model.

**Related Issue(s):** Closes #789

## Type of Change

- New feature (non-breaking change that adds functionality)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

Added and updated tests cover:

- `RFDETR.train(skip_best_epochs=...)` forwarding into `get_train_config()`
- `TrainConfig` defaulting, acceptance, and negative-value rejection
- trainer wiring into `BestModelCallback` and `RFDETREarlyStopping`
- checkpoint tracking and early stopping ignoring skipped epochs and using the first eligible epoch as the baseline
- skipping `trainer.test()` when no best checkpoint exists
- RFDETR Nano synthetic training smoke in the `rfdetr` conda environment

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)
