### PR TITLE
chore(tflite): switch to sigmoid scoring, add shape-based output fallback

### DIFF
--- a/src/rfdetr/export/_tflite/inference.py
+++ b/src/rfdetr/export/_tflite/inference.py
@@ -26,24 +26,6 @@ from rfdetr.utilities.logger import get_logger
 logger = get_logger()
 
 
-def _softmax(x: np.ndarray) -> np.ndarray:
-    """Numerically stable softmax over the last axis.
-
-    Args:
-        x: Input array of arbitrary shape.
-
-    Returns:
-        Array of the same shape with softmax applied along the last axis.
-
-    Examples:
-        >>> import numpy as np
-        >>> np.round(_softmax(np.array([1.0, 2.0, 3.0])), 8).tolist()
-        [0.09003057, 0.24472847, 0.66524096]
-    """
-    e = np.exp(x - x.max(axis=-1, keepdims=True))
-    return np.asarray(e / e.sum(axis=-1, keepdims=True))
-
-
 def _create_interpreter(model_path: str | Path) -> Any:
     """Load a TFLite model, allocate tensors, and log I/O shapes.
 
@@ -106,7 +88,7 @@ def _run_inference(
     """
     inp_det = interp.get_input_details()
     out_det = interp.get_output_details()
-    _, H, W, C = inp_det[0]["shape"]  # noqa: N806
+    _, height, width, channels = inp_det[0]["shape"]
 
     expected_dtype = np.float32
     actual_dtype = inp_det[0]["dtype"]
@@ -118,13 +100,13 @@ def _run_inference(
 
     _imagenet_mean = [0.485, 0.456, 0.406]
     _imagenet_std = [0.229, 0.224, 0.225]
-    mean = np.array([_imagenet_mean[i % 3] for i in range(C)], dtype=np.float32)
-    std = np.array([_imagenet_std[i % 3] for i in range(C)], dtype=np.float32)
+    mean = np.array([_imagenet_mean[i % 3] for i in range(channels)], dtype=np.float32)
+    std = np.array([_imagenet_std[i % 3] for i in range(channels)], dtype=np.float32)
 
     pil_img = PILImage.open(image_path)
-    pil_mode = "L" if C == 1 else "RGB"
-    arr = np.array(pil_img.convert(pil_mode).resize((W, H)), dtype=np.float32) / 255.0
-    if arr.ndim == 2:  # "L" → (H, W); TFLite needs (H, W, 1)
+    pil_mode = "L" if channels == 1 else "RGB"
+    arr = np.array(pil_img.convert(pil_mode).resize((width, height)), dtype=np.float32) / 255.0
+    if arr.ndim == 2:  # "L" → (height, width); TFLite needs (height, width, 1)
         arr = arr[:, :, np.newaxis]
     inp_tensor = (arr - mean) / std
 
@@ -137,22 +119,53 @@ def _run_inference(
     boxes_idx = next((i for i, od in enumerate(out_det) if "dets" in str(od.get("name", ""))), None)
     logits_idx = next((i for i, od in enumerate(out_det) if "labels" in str(od.get("name", ""))), None)
     if boxes_idx is None or logits_idx is None:
-        missing_outputs = []
-        if boxes_idx is None:
-            missing_outputs.append("dets")
-        if logits_idx is None:
-            missing_outputs.append("labels")
-        missing = ", ".join(missing_outputs)
-        available = ", ".join(available_output_names)
-        raise ValueError(
-            f"Expected TFLite output tensor(s) {missing!r} not found. Available output tensor names: [{available}]"
+        # onnx2tf sometimes renames outputs to generic "Identity", "Identity_N" instead
+        # of preserving the original ONNX node names.  Fall back to shape-based matching:
+        # RF-DETR always exports exactly 2 outputs — boxes (*, 4) and logits (*, num_classes+1).
+        logger.debug(
+            "Name-based output matching failed (available: %s). Falling back to shape-based matching.",
+            available_output_names,
         )
+        shape_boxes_idx = next((i for i, od in enumerate(out_det) if od["shape"][-1] == 4), None)
+        shape_logits_idx = next((i for i, od in enumerate(out_det) if od["shape"][-1] != 4), None)
+        if shape_boxes_idx is not None and shape_logits_idx is not None:
+            boxes_idx = shape_boxes_idx
+            logits_idx = shape_logits_idx
+        elif len(out_det) == 2:
+            # Ambiguous shapes (e.g. num_classes==3 → logits dim==4 == boxes dim).
+            # onnx2tf preserves ONNX output order: index 0 = dets (boxes), index 1 = labels (logits).
+            logger.debug("Shape-based matching ambiguous. Using positional order (0=boxes, 1=logits).")
+            boxes_idx = 0
+            logits_idx = 1
+        else:
+            available_shapes = [list(od["shape"]) for od in out_det]
+            raise ValueError(
+                f"Shape-based TFLite output matching failed. Expected one tensor with last dim == 4 (boxes) "
+                f"and one with last dim != 4 (logits). Available output shapes: {available_shapes}"
+            )
     boxes_cwh = interp.get_tensor(out_det[boxes_idx]["index"])[0]  # (Q, 4) normalized cxcywh
-    logits = interp.get_tensor(out_det[logits_idx]["index"])[0]  # (Q, num_classes+1)
+    # Drop last logit column: RF-DETR adds +1 to num_classes (no-object slot, criterion.py:323).
+    # Keeping it causes class_id == len(class_names) → IndexError at display time.
+    logits = interp.get_tensor(out_det[logits_idx]["index"])[0, :, :-1]  # (Q, num_classes)
 
-    probs = _softmax(logits[:, :-1])  # drop background (last logit)
-    scores = probs.max(axis=-1)
-    cls = probs.argmax(axis=-1)
+    # RF-DETR uses per-class sigmoid (not softmax) — mirrors PostProcess.forward in postprocess.py.
+    logger.debug(
+        "Logits stats: shape=%s min=%.3f max=%.3f mean=%.3f",
+        logits.shape,
+        float(logits.min()),
+        float(logits.max()),
+        float(logits.mean()),
+    )
+    scores_all = 1.0 / (1.0 + np.exp(-logits.clip(-88, 88)))
+    scores = scores_all.max(axis=-1)
+    cls = scores_all.argmax(axis=-1)
+    logger.debug(
+        "Scores stats: min=%.3f max=%.3f — detections above threshold %.2f: %d",
+        float(scores.min()),
+        float(scores.max()),
+        threshold,
+        int((scores > threshold).sum()),
+    )
     keep = scores > threshold
 
     cx, cy, bw, bh = boxes_cwh[keep].T

--- a/src/rfdetr/export/_tflite/inference.py
+++ b/src/rfdetr/export/_tflite/inference.py
@@ -120,8 +120,10 @@ def _run_inference(
     logits_idx = next((i for i, od in enumerate(out_det) if "labels" in str(od.get("name", ""))), None)
     if boxes_idx is None or logits_idx is None:
         # onnx2tf sometimes renames outputs to generic "Identity", "Identity_N" instead
-        # of preserving the original ONNX node names.  Fall back to shape-based matching:
-        # RF-DETR always exports exactly 2 outputs — boxes (*, 4) and logits (*, num_classes+1).
+        # of preserving the original ONNX node names. Fall back to shape-based
+        # matching for the detection outputs only: boxes (*, 4) and logits
+        # (*, num_classes+1). Segmentation exports may include additional outputs
+        # such as masks; unnamed extra outputs are not resolved by this fallback.
         logger.debug(
             "Name-based output matching failed (available: %s). Falling back to shape-based matching.",
             available_output_names,

--- a/src/rfdetr/export/_tflite/inference.py
+++ b/src/rfdetr/export/_tflite/inference.py
@@ -128,11 +128,11 @@ def _run_inference(
             "Name-based output matching failed (available: %s). Falling back to shape-based matching.",
             available_output_names,
         )
-        shape_boxes_idx = next((i for i, od in enumerate(out_det) if od["shape"][-1] == 4), None)
-        shape_logits_idx = next((i for i, od in enumerate(out_det) if od["shape"][-1] != 4), None)
-        if shape_boxes_idx is not None and shape_logits_idx is not None:
-            boxes_idx = shape_boxes_idx
-            logits_idx = shape_logits_idx
+        shape_boxes_candidates = [i for i, od in enumerate(out_det) if len(od["shape"]) == 3 and od["shape"][-1] == 4]
+        shape_logits_candidates = [i for i, od in enumerate(out_det) if len(od["shape"]) == 3 and od["shape"][-1] != 4]
+        if len(shape_boxes_candidates) == 1 and len(shape_logits_candidates) == 1:
+            boxes_idx = shape_boxes_candidates[0]
+            logits_idx = shape_logits_candidates[0]
         elif len(out_det) == 2:
             # Ambiguous shapes (e.g. num_classes==3 → logits dim==4 == boxes dim).
             # onnx2tf preserves ONNX output order: index 0 = dets (boxes), index 1 = labels (logits).
@@ -142,8 +142,9 @@ def _run_inference(
         else:
             available_shapes = [list(od["shape"]) for od in out_det]
             raise ValueError(
-                f"Shape-based TFLite output matching failed. Expected one tensor with last dim == 4 (boxes) "
-                f"and one with last dim != 4 (logits). Available output shapes: {available_shapes}"
+                f"Shape-based TFLite output matching failed. Expected exactly one rank-3 tensor with "
+                f"last dim == 4 (boxes) and one rank-3 tensor with last dim != 4 (logits). "
+                f"Available output shapes: {available_shapes}"
             )
     boxes_cwh = interp.get_tensor(out_det[boxes_idx]["index"])[0]  # (Q, 4) normalized cxcywh
     # Drop last logit column: RF-DETR adds +1 to num_classes (no-object slot, criterion.py:323).

--- a/src/rfdetr/export/_tflite/inference.py
+++ b/src/rfdetr/export/_tflite/inference.py
@@ -158,7 +158,8 @@ def _run_inference(
         float(logits.max()),
         float(logits.mean()),
     )
-    scores_all = 1.0 / (1.0 + np.exp(-logits.clip(-88, 88)))
+    one = np.asarray(1, dtype=logits.dtype)
+    scores_all = one / (one + np.exp(-logits.clip(-88, 88)))
     scores = scores_all.max(axis=-1)
     cls = scores_all.argmax(axis=-1)
     logger.debug(

--- a/tests/export/test_tflite_inference.py
+++ b/tests/export/test_tflite_inference.py
@@ -39,8 +39,13 @@ def _make_boxes() -> np.ndarray:
 
 
 def _make_logits(high_conf_idx: int | None = 0) -> np.ndarray:
-    """Return (1, 10, 82) logits with one high-confidence entry when requested."""
-    logits = np.zeros((1, 10, 82), dtype=np.float32)
+    """Return (1, 10, 82) logits with one high-confidence entry when requested.
+
+    Background fill is -10.0 so sigmoid scores are near zero (~0.0001) for all
+    entries except the explicitly boosted one (logit=+10.0, sigmoid≈0.9999).
+    This ensures the helper works correctly under per-class sigmoid scoring.
+    """
+    logits = np.full((1, 10, 82), -10.0, dtype=np.float32)
     if high_conf_idx is not None:
         logits[0, high_conf_idx, 0] = 10.0
     return logits
@@ -286,3 +291,119 @@ class TestRunInference:
         interp.get_output_details.return_value = [_DET_OUTPUT, _LABEL_OUTPUT]
         with pytest.raises(ValueError, match="float32"):
             _run_inference(interp, rgb_image)
+
+
+# ---------------------------------------------------------------------------
+# TestSigmoidScoring
+# ---------------------------------------------------------------------------
+
+
+class TestSigmoidScoring:
+    """Tests for per-class sigmoid scoring introduced in _run_inference."""
+
+    @pytest.fixture()
+    def rgb_image(self, tmp_path: Path) -> Path:
+        """Write a small RGB JPEG to a temp file and return its path."""
+        p = tmp_path / "image.jpg"
+        _save_rgb_image(p)
+        return p
+
+    def test_high_logit_yields_confidence_near_one(self, rgb_image: Path) -> None:
+        """Logit of 10.0 produces sigmoid ≈ 0.9999; confidence[0] > 0.99."""
+        logits = _make_logits(high_conf_idx=0)  # logits[0, 0, 0] = 10.0
+        interp = _make_interp(logits=logits)
+        dets, _ = _run_inference(interp, rgb_image, threshold=0.3)
+        assert dets.confidence[0] > 0.99
+
+    def test_low_logit_filtered_at_threshold(self, rgb_image: Path) -> None:
+        """Logit of -10.0 produces sigmoid ≈ 0.0001; detection filtered at threshold=0.3."""
+        logits = np.full((1, 10, 82), -10.0, dtype=np.float32)
+        interp = _make_interp(logits=logits)
+        dets, _ = _run_inference(interp, rgb_image, threshold=0.3)
+        assert len(dets) == 0
+
+    def test_multiclass_class_id_is_argmax_of_logits(self, rgb_image: Path) -> None:
+        """argmax of sigmoid equals argmax of logits; query with [5,2,1,...] gets class_id==0."""
+        # Shape (1, 10, 82): first query has logits [5, 2, 1, 0, ...], rest are -100
+        logits = np.full((1, 10, 82), -100.0, dtype=np.float32)
+        logits[0, 0, 0] = 5.0
+        logits[0, 0, 1] = 2.0
+        logits[0, 0, 2] = 1.0
+        interp = _make_interp(logits=logits)
+        dets, _ = _run_inference(interp, rgb_image, threshold=0.3)
+        # argmax of sigmoid == argmax of logits because sigmoid is monotone increasing
+        assert dets.class_id[0] == 0
+
+
+# ---------------------------------------------------------------------------
+# TestShapeBasedOutputFallback
+# ---------------------------------------------------------------------------
+
+# Generic output detail dicts used across shape-based fallback tests.
+# Indices mirror the canonical ones so _make_interp's _get_tensor dispatch works.
+_GENERIC_DET_OUTPUT = {"shape": [1, 10, 4], "name": "Identity_0", "index": 1}
+_GENERIC_LABEL_OUTPUT = {"shape": [1, 10, 82], "name": "Identity_1", "index": 2}
+
+
+class TestShapeBasedOutputFallback:
+    """Tests for the shape-based output matching fallback in _run_inference."""
+
+    @pytest.fixture()
+    def rgb_image(self, tmp_path: Path) -> Path:
+        """Write a small RGB JPEG to a temp file and return its path."""
+        p = tmp_path / "image.jpg"
+        _save_rgb_image(p)
+        return p
+
+    def test_unambiguous_shapes_inferred_correctly(self, rgb_image: Path) -> None:
+        """Generic names with shapes [1,10,4] and [1,10,82] resolve without error."""
+        interp = _make_interp(
+            out_dets=[_GENERIC_DET_OUTPUT, _GENERIC_LABEL_OUTPUT],
+            logits=_make_logits(high_conf_idx=0),
+        )
+        dets, _ = _run_inference(interp, rgb_image, threshold=0.3)
+        assert isinstance(dets, sv.Detections)
+        assert len(dets) >= 1
+
+    def test_ambiguous_shapes_two_outputs_positional_fallback(self, rgb_image: Path) -> None:
+        """When both outputs have last-dim==4 (num_classes==3) and there are exactly 2, positional fallback is used."""
+        # num_classes=3 → logits shape last-dim==4; boxes last-dim==4 → ambiguous
+        # Positional order: index 0 = boxes (Identity_0, tensor index 1), index 1 = logits (Identity_1, tensor index 2)
+        ambiguous_dets = {"shape": [1, 10, 4], "name": "Identity_0", "index": 1}
+        ambiguous_labels = {"shape": [1, 10, 4], "name": "Identity_1", "index": 2}
+        # Build logits of shape (1, 10, 4) so last col is dropped → (10, 3) per-class
+        logits_ambiguous = np.full((1, 10, 4), -10.0, dtype=np.float32)
+        logits_ambiguous[0, 0, 0] = 10.0  # first query, first class → high confidence
+        interp = _make_interp(
+            out_dets=[ambiguous_dets, ambiguous_labels],
+            logits=logits_ambiguous,
+        )
+        dets, _ = _run_inference(interp, rgb_image, threshold=0.3)
+        assert isinstance(dets, sv.Detections)
+        assert len(dets) >= 1
+
+    def test_three_outputs_all_dim4_raises_value_error(self, rgb_image: Path) -> None:
+        """3 outputs all with last-dim==4 and no name match raises ValueError with expected message."""
+        # Need a third tensor index; extend _get_tensor via a custom mock
+        third_output = {"shape": [1, 10, 4], "name": "Identity_2", "index": 3}
+        boxes = _make_boxes()
+        logits = _make_logits()
+
+        def _get_tensor(index: int) -> np.ndarray:
+            if index == 1:
+                return boxes
+            if index in (2, 3):
+                return logits
+            raise ValueError(f"Unknown tensor index: {index}")
+
+        interp = mock.MagicMock()
+        interp.get_input_details.return_value = [{"shape": _INPUT_SHAPE, "index": 0, "dtype": np.float32}]
+        interp.get_output_details.return_value = [
+            {"shape": [1, 10, 4], "name": "Identity_0", "index": 1},
+            {"shape": [1, 10, 4], "name": "Identity_1", "index": 2},
+            third_output,
+        ]
+        interp.get_tensor.side_effect = _get_tensor
+
+        with pytest.raises(ValueError, match="Shape-based TFLite output matching failed"):
+            _run_inference(interp, rgb_image, threshold=0.3)

--- a/tests/export/test_tflite_inference.py
+++ b/tests/export/test_tflite_inference.py
@@ -407,3 +407,35 @@ class TestShapeBasedOutputFallback:
 
         with pytest.raises(ValueError, match="Shape-based TFLite output matching failed"):
             _run_inference(interp, rgb_image, threshold=0.3)
+
+    def test_three_outputs_with_rank4_masks_resolves_correctly(self, rgb_image: Path) -> None:
+        """3-output segmentation export (boxes/logits/masks) with generic names resolves without error.
+
+        Ensures the shape fallback ignores the rank-4 masks tensor and correctly
+        identifies boxes [1,Q,4] and logits [1,Q,C+1] as rank-3 candidates.
+        """
+        boxes = _make_boxes()
+        logits = _make_logits(high_conf_idx=0)
+        masks = np.zeros((1, 10, 28, 28), dtype=np.float32)
+
+        def _get_tensor(index: int) -> np.ndarray:
+            if index == 1:
+                return boxes
+            if index == 2:
+                return logits
+            if index == 3:
+                return masks
+            raise ValueError(f"Unknown tensor index: {index}")
+
+        interp = mock.MagicMock()
+        interp.get_input_details.return_value = [{"shape": _INPUT_SHAPE, "index": 0, "dtype": np.float32}]
+        interp.get_output_details.return_value = [
+            {"shape": [1, 10, 4], "name": "Identity_0", "index": 1},
+            {"shape": [1, 10, 82], "name": "Identity_1", "index": 2},
+            {"shape": [1, 10, 28, 28], "name": "Identity_2", "index": 3},
+        ]
+        interp.get_tensor.side_effect = _get_tensor
+
+        dets, _ = _run_inference(interp, rgb_image, threshold=0.3)
+        assert isinstance(dets, sv.Detections)
+        assert len(dets) >= 1


### PR DESCRIPTION
This pull request refactors and improves the TFLite inference logic for RF-DETR, focusing on more robust output tensor matching and switching from softmax to per-class sigmoid scoring for model outputs. It also updates the test suite to cover these changes, including new tests for the shape-based output fallback and sigmoid scoring.

**Inference logic improvements:**

* Replaces name-based output tensor matching with a robust fallback to shape-based matching in `_run_inference`, handling ambiguous cases and providing clear error messages when output identification fails.
* Switches postprocessing from softmax to per-class sigmoid scoring for logits, aligning with RF-DETR's intended behavior and preventing background class index errors. The `_softmax` helper is removed as it is no longer used. [[1]](diffhunk://#diff-b97d0660e2c271d5846f16dd227daa7803091b2df11a2bd71cfaace54bd4c820L29-L46) [[2]](diffhunk://#diff-b97d0660e2c271d5846f16dd227daa7803091b2df11a2bd71cfaace54bd4c820L140-R168)

**Test suite updates:**

* Updates and expands the test suite to cover per-class sigmoid scoring, including tests for high/low confidence, multiclass argmax, and correct filtering at thresholds. [[1]](diffhunk://#diff-da75c585a5cc5fbb90f2709ee8dceed044e64e5a40916b62377e2235dd0d08d3L42-R48) [[2]](diffhunk://#diff-da75c585a5cc5fbb90f2709ee8dceed044e64e5a40916b62377e2235dd0d08d3R294-R409)
* Adds comprehensive tests for the new shape-based output tensor fallback logic, including ambiguous and error cases.

**Code readability improvements:**

* Renames variables for clarity (e.g., `C` → `channels`, `H`/`W` → `height`/`width`) in `_run_inference` and related code. [[1]](diffhunk://#diff-b97d0660e2c271d5846f16dd227daa7803091b2df11a2bd71cfaace54bd4c820L109-R91) [[2]](diffhunk://#diff-b97d0660e2c271d5846f16dd227daa7803091b2df11a2bd71cfaace54bd4c820L121-R109)

---

- Replace `_softmax` helper with per-class sigmoid in `_run_inference` — mirrors `PostProcess.forward` in `postprocess.py`; drop last logit column at retrieval to prevent `class_id == len(class_names)` IndexError
- Add shape-based output matching fallback for onnx2tf models that rename outputs to generic "Identity_N" names; handles unambiguous shapes, 3-class (ambiguous) positional fallback, and raises `ValueError` with shape details on total failure
- Rename `H`/`W`/`C` variables to `height`/`width`/`channels`
- Fix `_make_logits` background fill from `0.0` to `-10.0` so existing threshold tests remain correct under sigmoid scoring
- Add `TestSigmoidScoring` (3 tests) and `TestShapeBasedOutputFallback` (3 tests)
