### PR TITLE
chore: update PyTorch Lightning versions - skip compromised

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ lora = [
 ]
 train = [
     "peft",                            # LoRA backbone fine-tuning (available during training)
-    "pytorch_lightning>=2.6,<3,!=2.6.2,!=2.6.3",
+    "pytorch_lightning>=2.6,<3,!=2.6.2,!=2.6.3",  # Keep exclusions; see issue #1016 / related advisory for why 2.6.2 and 2.6.3 are blocked
     "torchmetrics[detection]>=1.2",
     "faster-coco-eval>=1.7.2",
     "pycocotools",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ lora = [
 ]
 train = [
     "peft",                            # LoRA backbone fine-tuning (available during training)
-    "pytorch_lightning>=2.6,<3",
+    "pytorch_lightning>=2.6,<3,!=2.6.2,!=2.6.3",
     "torchmetrics[detection]>=1.2",
     "faster-coco-eval>=1.7.2",
     "pycocotools",

--- a/src/rfdetr/visualize/data.py
+++ b/src/rfdetr/visualize/data.py
@@ -38,6 +38,7 @@ def save_gt_predictions_visualization(
 
     top_padding = 60
     image = np.zeros((image_height + top_padding, image_width, 3), dtype=np.uint8)
+    scene: Image.Image = Image.fromarray(image)
 
     gt_boxes_offset = [[x, y + top_padding, w, h] for x, y, w, h in gt_boxes]
     pred_boxes_offset = [[x, y + top_padding, w, h] for x, y, w, h in pred_boxes]
@@ -107,11 +108,11 @@ def save_gt_predictions_visualization(
             pred_labels.append(f"c{class_id}\nconf={conf:.3f}")
 
     if gt_detections is not None:
-        image = gt_box_annotator.annotate(scene=image, detections=gt_detections)
-        image = gt_label_annotator.annotate(scene=image, detections=gt_detections, labels=gt_labels)
+        scene = gt_box_annotator.annotate(scene=scene, detections=gt_detections)
+        scene = gt_label_annotator.annotate(scene=scene, detections=gt_detections, labels=gt_labels)
     if pred_detections is not None:
-        image = pred_box_annotator.annotate(scene=image, detections=pred_detections)
-        image = pred_label_annotator.annotate(scene=image, detections=pred_detections, labels=pred_labels)
+        scene = pred_box_annotator.annotate(scene=scene, detections=pred_detections)
+        scene = pred_label_annotator.annotate(scene=scene, detections=pred_detections, labels=pred_labels)
 
-    Image.fromarray(image).save(save_dir / f"{scenario_name}.png")
+    scene.save(save_dir / f"{scenario_name}.png")
     logger.info(f"Saved visualization to {save_dir}/{scenario_name}.png")


### PR DESCRIPTION
This pull request updates the `pytorch_lightning` dependency in the `lora` training extras to exclude versions 2.6.2 and 2.6.3, likely due to known issues or incompatibilities with those specific versions.

Dependency update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L54-R54): Modified the `lora` training dependencies to require `pytorch_lightning` version `>=2.6,<3`, but explicitly exclude versions `2.6.2` and `2.6.3`.

---

resolves #1016