### PR TITLE
fix: interpolate PE in constructor path for custom resolution

### DIFF
--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -50,6 +50,7 @@ from rfdetr.config import (
 from rfdetr.datasets.coco import is_valid_coco_dataset
 from rfdetr.datasets.yolo import is_valid_yolo_dataset
 from rfdetr.models import PostProcess, build_model
+from rfdetr.models.weights import _interpolate_position_embeddings
 from rfdetr.utilities.decorators import deprecated
 from rfdetr.utilities.logger import get_logger
 from rfdetr.utilities.state_dict import _ckpt_args_get, validate_checkpoint_compatibility
@@ -166,6 +167,7 @@ def _load_pretrain_weights_into(nn_model: torch.nn.Module, args: Any) -> List[st
         if any(name.endswith(x) for x in query_param_names):
             checkpoint["model"][name] = checkpoint["model"][name][:num_desired_queries]
 
+    _interpolate_position_embeddings(checkpoint["model"], args.positional_encoding_size)
     nn_model.load_state_dict(checkpoint["model"], strict=False)
 
     # Only reinitialize back to configured size when intentionally reducing a

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -118,7 +118,11 @@ def _load_pretrain_weights_into(nn_model: torch.nn.Module, args: Any) -> List[st
     Args:
         nn_model: The model to load weights into.
         args: Namespace with ``pretrain_weights``, ``num_classes``,
-            ``num_queries``, and ``group_detr`` attributes.
+            ``num_queries``, ``group_detr``, and optionally
+            ``positional_encoding_size`` attributes. When
+            ``positional_encoding_size`` is present, checkpoint positional
+            embeddings are bicubic-interpolated to match before
+            ``load_state_dict``.
 
     Returns:
         List of class names extracted from the checkpoint, or empty list.
@@ -167,7 +171,9 @@ def _load_pretrain_weights_into(nn_model: torch.nn.Module, args: Any) -> List[st
         if any(name.endswith(x) for x in query_param_names):
             checkpoint["model"][name] = checkpoint["model"][name][:num_desired_queries]
 
-    _interpolate_position_embeddings(checkpoint["model"], args.positional_encoding_size)
+    pe_size = getattr(args, "positional_encoding_size", None)
+    if pe_size is not None:
+        _interpolate_position_embeddings(checkpoint["model"], pe_size)
     nn_model.load_state_dict(checkpoint["model"], strict=False)
 
     # Only reinitialize back to configured size when intentionally reducing a

--- a/tests/training/test_load_pretrain_weights.py
+++ b/tests/training/test_load_pretrain_weights.py
@@ -84,7 +84,7 @@ def _make_checkpoint(
 # ---------------------------------------------------------------------------
 
 
-def _make_detr_args(num_classes=90, num_queries=300, group_detr=13):
+def _make_detr_args(num_classes=90, num_queries=300, group_detr=13, positional_encoding_size=24):
     """Return a SimpleNamespace shaped like the args for _load_pretrain_weights_into."""
     return SimpleNamespace(
         pretrain_weights="/fake/weights.pth",
@@ -93,6 +93,7 @@ def _make_detr_args(num_classes=90, num_queries=300, group_detr=13):
         group_detr=group_detr,
         segmentation_head=False,
         patch_size=14,
+        positional_encoding_size=positional_encoding_size,
     )
 
 
@@ -535,3 +536,81 @@ class TestLoadPretrainWeightsPEInterpolation:
         assert any("not a perfect square" in str(args) for args in warning_calls), (
             f"Expected a 'not a perfect square' warning; got calls: {warning_calls}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Regression: PE interpolation for custom resolution — detr.py constructor path
+# ---------------------------------------------------------------------------
+
+
+class TestLoadPretrainWeightsIntoPEInterpolation:
+    """Regression for #1023/#1029 — PE interpolation missing from the constructor path.
+
+    ``_load_pretrain_weights_into`` (detr.py) must bicubic-interpolate the checkpoint's
+    DINOv2 positional embeddings to match ``args.positional_encoding_size`` before
+    calling ``load_state_dict``.  Without this, any ``RFDETR*(resolution=X)`` call
+    with a non-default resolution raises ``RuntimeError: size mismatch``.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _patch_download(self, monkeypatch):
+        """Suppress all download and file-existence side effects."""
+        monkeypatch.setattr("rfdetr.detr.download_pretrain_weights", lambda *a, **kw: None)
+        monkeypatch.setattr("rfdetr.detr.validate_pretrain_weights", lambda *a, **kw: None)
+        monkeypatch.setattr("rfdetr.detr.validate_checkpoint_compatibility", lambda *a, **kw: None)
+        monkeypatch.setattr("rfdetr.detr.os.path.isfile", lambda _: True)
+
+    @pytest.mark.parametrize(
+        "src_pe_size, tgt_pe_size",
+        [
+            pytest.param(24, 44, id="upscale_24x24_to_44x44"),  # 384px → 704px (patch=16)
+            pytest.param(40, 24, id="downscale_40x40_to_24x24"),  # 640px → 384px (patch=16)
+        ],
+    )
+    def test_pe_interpolated_in_constructor_path_regression(self, monkeypatch, src_pe_size, tgt_pe_size):
+        """Constructor path interpolates PE to match args.positional_encoding_size.
+
+        Regression for #1023/#1029: ``_load_pretrain_weights_into`` in detr.py
+        must not raise ``RuntimeError`` when the checkpoint PE grid differs from the
+        model's target PE size.
+        """
+        from rfdetr.detr import _load_pretrain_weights_into
+
+        dim = 384
+        src_n = src_pe_size * src_pe_size + 1
+        checkpoint = _make_checkpoint(num_classes=91)
+        checkpoint["model"][PE_KEY] = torch.randn(1, src_n, dim)
+        monkeypatch.setattr("rfdetr.detr.torch.load", lambda *a, **kw: checkpoint)
+
+        args = _make_detr_args(positional_encoding_size=tgt_pe_size)
+        fake_model = MagicMock()
+
+        _load_pretrain_weights_into(fake_model, args)
+
+        pe = checkpoint["model"][PE_KEY]
+        expected_n = tgt_pe_size * tgt_pe_size + 1
+        assert pe.shape == torch.Size([1, expected_n, dim]), (
+            f"Expected PE shape [1, {expected_n}, {dim}] after interpolation from "
+            f"{src_pe_size}x{src_pe_size} to {tgt_pe_size}x{tgt_pe_size}, got {tuple(pe.shape)}. "
+            "PE interpolation is missing from the _load_pretrain_weights_into constructor path."
+        )
+
+    def test_matching_pe_not_modified_in_constructor_path(self, monkeypatch):
+        """Same-resolution checkpoint PE is untouched in the constructor path."""
+        from rfdetr.detr import _load_pretrain_weights_into
+
+        pe_size = 24
+        dim = 384
+        original_pe = torch.randn(1, pe_size * pe_size + 1, dim)
+        checkpoint = _make_checkpoint(num_classes=91)
+        checkpoint["model"][PE_KEY] = original_pe.clone()
+        monkeypatch.setattr("rfdetr.detr.torch.load", lambda *a, **kw: checkpoint)
+
+        args = _make_detr_args(positional_encoding_size=pe_size)
+        fake_model = MagicMock()
+
+        _load_pretrain_weights_into(fake_model, args)
+
+        pe = checkpoint["model"][PE_KEY]
+        assert pe.shape == torch.Size([1, pe_size * pe_size + 1, dim]), "Matching PE must not be modified."
+        assert torch.equal(pe, original_pe), "Matching PE values must not be modified."

--- a/tests/training/test_load_pretrain_weights.py
+++ b/tests/training/test_load_pretrain_weights.py
@@ -563,8 +563,8 @@ class TestLoadPretrainWeightsIntoPEInterpolation:
     @pytest.mark.parametrize(
         "src_pe_size, tgt_pe_size",
         [
-            pytest.param(24, 44, id="upscale_24x24_to_44x44"),  # 384px → 704px (patch=16)
-            pytest.param(40, 24, id="downscale_40x40_to_24x24"),  # 640px → 384px (patch=16)
+            pytest.param(24, 44, id="upscale_pe_24x24_to_44x44"),
+            pytest.param(40, 24, id="downscale_pe_40x40_to_24x24"),
         ],
     )
     def test_pe_interpolated_in_constructor_path_regression(self, monkeypatch, src_pe_size, tgt_pe_size):


### PR DESCRIPTION
This pull request addresses a regression where positional embedding (PE) interpolation was missing from the model constructor path, which previously caused errors when loading pretrained weights with a different positional encoding size than the model expects. The fix ensures that PEs are correctly interpolated before loading the state dict, and adds regression tests to prevent similar issues in the future.

**Core bug fix:**

* The `_load_pretrain_weights_into` function in `detr.py` now calls `_interpolate_position_embeddings` to resize the checkpoint's positional embeddings to match `args.positional_encoding_size` before loading them into the model, preventing size mismatch errors when using non-default resolutions. [[1]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86R53) [[2]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86R170)

**Testing improvements:**

* The test helper `_make_detr_args` in `test_load_pretrain_weights.py` now accepts a `positional_encoding_size` argument to facilitate testing different PE sizes. [[1]](diffhunk://#diff-ba44fe99e958220f53c7e5e85f21741007bf32564d5ee87d0d49f5500a99d2b1L87-R87) [[2]](diffhunk://#diff-ba44fe99e958220f53c7e5e85f21741007bf32564d5ee87d0d49f5500a99d2b1R96)
* A new test class `TestLoadPretrainWeightsIntoPEInterpolation` has been added, which includes regression tests to verify that PE interpolation occurs correctly when source and target PE sizes differ, and that no unnecessary modification happens when PE sizes match.

---

- Import `_interpolate_position_embeddings` into `detr.py` and call it in `_load_pretrain_weights_into` before `load_state_dict`, mirroring the fix already present in `models/weights.py::load_pretrain_weights`
- Add `positional_encoding_size` param to `_make_detr_args` test helper
- Add `TestLoadPretrainWeightsIntoPEInterpolation` with upscale, downscale, and no-op cases covering the constructor path regression (#1023, #1029)