### PR TITLE
ci(docs): skip RC releases and map .postN to base version in docs deploy

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -4,7 +4,7 @@
 # Deploy matrix:
 #   push develop            → mike deploy develop          (rfdetr.roboflow.com/develop/)
 #   push release/latest     → mike deploy latest            (rfdetr.roboflow.com/latest/)
-#   release published        → mike deploy <tag>             (rfdetr.roboflow.com/<tag>/ only — does not move /latest/)
+#   release published (stable/post) → mike deploy <base>   (rfdetr.roboflow.com/<base>/ — .postN stripped to base; RC/pre-release skipped)
 #
 # Every deploy also:
 #   - Copies robots.txt, llms.txt, llms-full.txt to gh-pages root
@@ -72,10 +72,13 @@ jobs:
         run: uv run mike deploy --push --update-aliases latest
 
       - name: 🚀 Deploy Release Docs
-        if: github.event_name == 'release' && github.event.action == 'published'
+        if: github.event_name == 'release' && github.event.action == 'published' && !github.event.release.prerelease
         env:
           MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.GITHUB_TOKEN }}
-        run: uv run mike deploy --push ${{ github.event.release.tag_name }}
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          DOC_VERSION="${TAG%.post*}"
+          uv run mike deploy --push "$DOC_VERSION"
 
       - name: 🏗️ Build docs for artifact
         run: uv run mkdocs build
@@ -93,7 +96,8 @@ jobs:
            (github.ref == 'refs/heads/develop' ||
             github.ref == 'refs/heads/release/latest')) ||
           (github.event_name == 'release' &&
-           github.event.action == 'published')
+           github.event.action == 'published' &&
+           !github.event.release.prerelease)
         run: |
           cp docs/root-static/robots.txt /tmp/robots.txt
           cp docs/root-static/llms.txt /tmp/llms.txt
@@ -128,7 +132,8 @@ jobs:
            (github.ref == 'refs/heads/develop' ||
             github.ref == 'refs/heads/release/latest')) ||
           (github.event_name == 'release' &&
-           github.event.action == 'published')
+           github.event.action == 'published' &&
+           !github.event.release.prerelease)
         run: |
           curl -s -o /dev/null -w "%{http_code}" -X POST "https://api.indexnow.org/IndexNow" \
             -H "Content-Type: application/json; charset=utf-8" \


### PR DESCRIPTION
This pull request updates the documentation deployment workflow to improve how release documentation is published, especially for post-release and pre-release tags. The main focus is to ensure that only stable releases (not pre-releases or release candidates) trigger documentation deployment, and that post-release tags are handled correctly by stripping the `.postN` suffix.

Key improvements to release documentation publishing:

* Only stable releases now trigger documentation deployment; pre-releases and release candidates are skipped. [[1]](diffhunk://#diff-dd751c654ce34c435239f846704cbba01f2aef90c73ad219db2d47789b369544L75-R81) [[2]](diffhunk://#diff-dd751c654ce34c435239f846704cbba01f2aef90c73ad219db2d47789b369544L96-R100) [[3]](diffhunk://#diff-dd751c654ce34c435239f846704cbba01f2aef90c73ad219db2d47789b369544L131-R136)
* When deploying documentation for post-release tags (e.g., `v1.2.3.post1`), the `.postN` suffix is stripped so that docs are deployed under the base version (e.g., `v1.2.3`).
* Updated workflow comments to clarify the new deployment logic for stable and post-release tags.

---

- Add `!github.event.release.prerelease` guard to Deploy Release Docs, root static files, and IndexNow steps — RC/alpha/beta published releases no longer trigger a docs deployment
- Strip `.postN` suffix before `mike deploy` so 1.6.5.post1 overwrites the 1.6.5 slot instead of creating an orphaned version entry
