### PR TITLE
docs(chlog): inline CHANGELOG.md, fix /latest/ alias, fix meta ts artifact

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -4,7 +4,7 @@
 # Deploy matrix:
 #   push develop                    → mike deploy develop        (rfdetr.roboflow.com/develop/)
 #   push release/latest             → mike deploy latest         (rfdetr.roboflow.com/latest/)
-#   release published (stable/post) → mike deploy <base> latest  (rfdetr.roboflow.com/<base>/ — .postN stripped to base; RC/pre-release skipped)
+#   release published (stable/post) → mike deploy <base> latest  (rfdetr.roboflow.com/<base>/ + /latest/ alias → <base>; .postN stripped; RC/pre-release skipped)
 #
 # Every deploy also:
 #   - Copies robots.txt, llms.txt, llms-full.txt to gh-pages root
@@ -78,7 +78,7 @@ jobs:
         run: |
           TAG="${{ github.event.release.tag_name }}"
           DOC_VERSION="${TAG%.post*}"
-          uv run mike deploy --push "$DOC_VERSION"
+          uv run mike deploy --push --update-aliases "$DOC_VERSION" latest
 
       - name: 🏗️ Build docs for artifact
         run: uv run mkdocs build

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -4,7 +4,7 @@
 # Deploy matrix:
 #   push develop            → mike deploy develop          (rfdetr.roboflow.com/develop/)
 #   push release/latest     → mike deploy latest            (rfdetr.roboflow.com/latest/)
-#   release published        → mike deploy <tag>             (rfdetr.roboflow.com/<tag>/ only — does not move /latest/)
+#   release published        → mike deploy <tag> latest     (rfdetr.roboflow.com/<tag>/ + /latest/ alias → <tag>)
 #
 # Every deploy also:
 #   - Copies robots.txt, llms.txt, llms-full.txt to gh-pages root
@@ -75,7 +75,7 @@ jobs:
         if: github.event_name == 'release' && github.event.action == 'published'
         env:
           MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.GITHUB_TOKEN }}
-        run: uv run mike deploy --push ${{ github.event.release.tag_name }}
+        run: uv run mike deploy --push --update-aliases ${{ github.event.release.tag_name }} latest
 
       - name: 🏗️ Build docs for artifact
         run: uv run mkdocs build
@@ -106,13 +106,22 @@ jobs:
           cp /tmp/llms-full.txt llms-full.txt
           cp /tmp/indexnow.txt cace9ef287cb8d641db90d4295fcb1e1.txt
           git add robots.txt llms.txt llms-full.txt cace9ef287cb8d641db90d4295fcb1e1.txt
+          # Normalize versioned paths (/X.Y.Z/) to /latest/ so sitemap URLs are
+          # not blocked by the User-agent: * Disallow rules in robots.txt.
+          # latest/ may be a mike alias redirect (no sitemap.xml) — fall back to highest versioned dir.
+          SITEMAP_SRC=""
           if [ -f latest/sitemap.xml ]; then
-            # Normalize versioned paths (/X.Y.Z/) to /latest/ so sitemap URLs are
-            # not blocked by the User-agent: * Disallow rules in robots.txt.
-            sed 's|rfdetr\.roboflow\.com/[0-9][^/]*/|rfdetr.roboflow.com/latest/|g' latest/sitemap.xml > sitemap.xml
-            git add sitemap.xml
-          elif [ -f develop/sitemap.xml ]; then
-            sed 's|rfdetr\.roboflow\.com/develop/|rfdetr.roboflow.com/latest/|g' develop/sitemap.xml > sitemap.xml
+            SITEMAP_SRC="latest/sitemap.xml"
+          else
+            LATEST_VER=$(ls -d [0-9]* 2>/dev/null | grep -E '^[0-9]+\.[0-9]+' | sort -V | tail -1)
+            if [ -n "$LATEST_VER" ] && [ -f "$LATEST_VER/sitemap.xml" ]; then
+              SITEMAP_SRC="$LATEST_VER/sitemap.xml"
+            elif [ -f develop/sitemap.xml ]; then
+              SITEMAP_SRC="develop/sitemap.xml"
+            fi
+          fi
+          if [ -n "$SITEMAP_SRC" ]; then
+            sed 's|rfdetr\.roboflow\.com/[^/]*/|rfdetr.roboflow.com/latest/|g' "$SITEMAP_SRC" > sitemap.xml
             git add sitemap.xml
           fi
           git diff --staged --quiet || git commit -m "chore: update root static files and sitemap"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,4 +16,4 @@ Use the release feed to review versioned package changes, migration notes, and m
 
 ---
 
---8<-- "../CHANGELOG.md"
+--8<-- "CHANGELOG.md"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,4 +16,4 @@ Use the release feed to review versioned package changes, migration notes, and m
 
 ---
 
---8<-- "CHANGELOG.md"
+--8<-- "../CHANGELOG.md"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,18 +3,17 @@ title: Changelog
 description: RF-DETR release history and changelog.
 hide:
   - navigation
-  - toc
 ---
 
 # Changelog
 
-RF-DETR release notes are maintained on GitHub Releases. Use the release feed
-to review versioned package changes, migration notes, and model updates.
+RF-DETR release notes are maintained on [GitHub Releases](https://github.com/roboflow/rf-detr/releases).
+Use the release feed to review versioned package changes, migration notes, and model updates.
 
-## Release Notes
-
-- [View all RF-DETR releases on GitHub](https://github.com/roboflow/rf-detr/releases)
-- [Review the project changelog source](https://github.com/roboflow/rf-detr/blob/main/CHANGELOG.md)
 - [Install the latest PyPI package](https://pypi.org/project/rfdetr/)
+- [Migration guide](learn/migration.md) — upgrade steps between major versions
+- [Cookbooks](cookbooks.md) — runnable notebooks for training, fine-tuning, export, and deployment
 
-For migration guidance inside these docs, see the [migration guide](learn/migration.md).
+---
+
+--8<-- "CHANGELOG.md"

--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -216,7 +216,8 @@
   </script>
   {% else %}
   {# article:modified_time — content pages only; emit only when a full ISO-8601 date-time is available #}
-  {% if page.meta.git_revision_date_localized %}<meta property="article:modified_time" content="{{ page.meta.git_revision_date_localized | replace(' ', 'T') + '+00:00' }}">{% endif %}
+  {# striptags: plugin may return a <time> HTML element (Markup-safe); strip tags before embedding in content attr #}
+  {% if page.meta.git_revision_date_localized %}<meta property="article:modified_time" content="{{ page.meta.git_revision_date_localized | string | striptags | replace(' ', 'T') | e }}">{% endif %}
   {# JSON-LD: TechArticle — content pages #}
   <script type="application/ld+json">
   {
@@ -231,7 +232,7 @@
     "inLanguage": "en",
     "keywords": "RF-DETR, rfdetr, object detection, instance segmentation, computer vision, Roboflow",
     "datePublished": "2025-03-01",
-    {% if page.meta.git_revision_date_localized %}"dateModified": {{ (page.meta.git_revision_date_localized | replace(' ', 'T') + '+00:00') | tojson }},
+    {% if page.meta.git_revision_date_localized %}"dateModified": {{ page.meta.git_revision_date_localized | string | striptags | replace(' ', 'T') | tojson }},
     {% endif %}"image": {{ (page.meta.image | default(config.extra.og_image | default('https://rfdetr.roboflow.com/latest/assets/roboflow-logo.svg'))) | tojson }},
     "author": {"@type": "Organization", "name": "Roboflow", "url": "https://roboflow.com"},
     "publisher": {"@type": "Organization", "name": "Roboflow", "url": "https://roboflow.com"},


### PR DESCRIPTION
This pull request updates the documentation publishing workflow and improves the handling of versioned documentation, sitemap generation, and metadata in the docs. The main focus is on ensuring that the `/latest/` alias always points to the most recent release, updating the root sitemap reliably, and refining how modification dates are embedded in the documentation for SEO and social sharing.

**Documentation publishing and versioning improvements:**

* When a new release is published, the workflow now deploys both the release tag and updates the `latest` alias to point to that release, ensuring `/latest/` always reflects the most recent version. [[1]](diffhunk://#diff-dd751c654ce34c435239f846704cbba01f2aef90c73ad219db2d47789b369544L7-R7) [[2]](diffhunk://#diff-dd751c654ce34c435239f846704cbba01f2aef90c73ad219db2d47789b369544L78-R78)
* The sitemap generation logic is enhanced to handle cases where `latest/` is an alias (and may not have its own `sitemap.xml`). It now falls back to the highest versioned directory or `develop/` if needed, ensuring the root `sitemap.xml` always points to the current docs.

**Changelog and documentation content updates:**

* The `docs/changelog.md` is improved to include direct links to GitHub Releases, migration guides, and cookbooks, and now inlines the full changelog source for easier access.

**Metadata and SEO enhancements:**

* The HTML template for docs now strips any HTML tags from the `git_revision_date_localized` before embedding it in the `article:modified_time` meta tag and the JSON-LD `dateModified` property, ensuring clean ISO-8601 date formatting for search engines and social platforms. [[1]](diffhunk://#diff-c3312677b0caac6673f5c42cc23249bde89e20c325fc858ecbb5c0f5af56562dL219-R220) [[2]](diffhunk://#diff-c3312677b0caac6673f5c42cc23249bde89e20c325fc858ecbb5c0f5af56562dL234-R235)

---

- Replace redirect-stub changelog.md with --8<-- "CHANGELOG.md" snippet injection; add cookbooks + migration crosslinks; restore toc
- Release deploy step now runs --update-aliases <tag> latest so /latest/ redirects to published tag
- Sitemap fallback: when latest/ is a mike alias redirect (no sitemap.xml), use highest versioned dir then develop/
- main.html: striptags + e filter on git_revision_date_localized before embedding in content attr; tojson path same; removes duplicate +00:00 timezone suffix