### PR TITLE
ci(docs): add workflow_dispatch with target input

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
-          ref: ${{ inputs.target }}
+          ref: ${{ inputs.target || github.ref }}
 
       - name: 🐍 Install uv and set Python
         uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -48,6 +48,19 @@ jobs:
       url: https://rfdetr.roboflow.com/
     timeout-minutes: 10
     steps:
+      - name: 🔍 Validate dispatch target
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          TARGET="${{ inputs.target }}"
+          if [ "$TARGET" = "develop" ] || [ "$TARGET" = "release/latest" ]; then
+            echo "✓ Target '$TARGET' is valid"
+          elif echo "$TARGET" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(\.post[0-9]+)?$'; then
+            echo "✓ Target '$TARGET' is valid (version tag)"
+          else
+            echo "::error::Invalid target '$TARGET'. Must be 'develop', 'release/latest', or a version tag (e.g. '1.2.3' or '1.2.3.post1')"
+            exit 1
+          fi
+
       - name: 📥 Checkout the repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -30,7 +30,7 @@ on:
 
 # Ensure only one concurrent deployment
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref_name || github.event_name == 'workflow_dispatch' && inputs.target || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref_name || github.event_name == 'workflow_dispatch' && inputs.target || github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}
   cancel-in-progress: true
 
 # Restrict permissions by default

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -5,6 +5,9 @@
 #   push develop                    → mike deploy develop        (rfdetr.roboflow.com/develop/)
 #   push release/latest             → mike deploy latest         (rfdetr.roboflow.com/latest/)
 #   release published (stable/post) → mike deploy <base> latest  (rfdetr.roboflow.com/<base>/ + /latest/ alias → <base>; .postN stripped; RC/pre-release skipped)
+  #   workflow_dispatch target=develop         → same as push develop
+#   workflow_dispatch target=release/latest  → same as push release/latest (→ latest alias)
+#   workflow_dispatch target=<version tag>   → mike deploy <tag> latest
 #
 # Every deploy also:
 #   - Copies robots.txt, llms.txt, llms-full.txt to gh-pages root
@@ -18,10 +21,16 @@ on:
     branches: ["release/latest", "develop"]
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Deploy target: 'develop', 'release/latest', or a version tag (e.g. '1.2.3'). Determines both the checkout ref and the mike version label."
+        required: true
+        default: "release/latest"
 
 # Ensure only one concurrent deployment
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref}}
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref || github.event_name == 'workflow_dispatch' && inputs.target || github.run_id }}
   cancel-in-progress: true
 
 # Restrict permissions by default
@@ -43,6 +52,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
+          ref: ${{ inputs.target }}
 
       - name: 🐍 Install uv and set Python
         uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
@@ -80,6 +90,21 @@ jobs:
           DOC_VERSION="${TAG%.post*}"
           uv run mike deploy --push --update-aliases "$DOC_VERSION" latest
 
+      - name: 🚀 Deploy Docs (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TARGET="${{ inputs.target }}"
+          if [ "$TARGET" = "develop" ]; then
+            uv run mike deploy --push develop
+          elif [ "$TARGET" = "release/latest" ]; then
+            uv run mike deploy --push --update-aliases latest
+          else
+            DOC_VERSION="${TARGET%.post*}"
+            uv run mike deploy --push --update-aliases "$DOC_VERSION" latest
+          fi
+
       - name: 🏗️ Build docs for artifact
         run: uv run mkdocs build
 
@@ -97,7 +122,8 @@ jobs:
             github.ref == 'refs/heads/release/latest')) ||
           (github.event_name == 'release' &&
            github.event.action == 'published' &&
-           !github.event.release.prerelease)
+           !github.event.release.prerelease) ||
+          github.event_name == 'workflow_dispatch'
         run: |
           cp docs/root-static/robots.txt /tmp/robots.txt
           cp docs/root-static/llms.txt /tmp/llms.txt
@@ -142,7 +168,8 @@ jobs:
             github.ref == 'refs/heads/release/latest')) ||
           (github.event_name == 'release' &&
            github.event.action == 'published' &&
-           !github.event.release.prerelease)
+           !github.event.release.prerelease) ||
+          github.event_name == 'workflow_dispatch'
         run: |
           curl -s -o /dev/null -w "%{http_code}" -X POST "https://api.indexnow.org/IndexNow" \
             -H "Content-Type: application/json; charset=utf-8" \

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -102,7 +102,7 @@ jobs:
             uv run mike deploy --push --update-aliases latest
           else
             DOC_VERSION="${TARGET%.post*}"
-            uv run mike deploy --push --update-aliases "$DOC_VERSION" latest
+            uv run mike deploy --push --update-aliases "$DOC_VERSION"
           fi
 
       - name: 🏗️ Build docs for artifact

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -5,7 +5,7 @@
 #   push develop                    → mike deploy develop        (rfdetr.roboflow.com/develop/)
 #   push release/latest             → mike deploy latest         (rfdetr.roboflow.com/latest/)
 #   release published (stable/post) → mike deploy <base> latest  (rfdetr.roboflow.com/<base>/ + /latest/ alias → <base>; .postN stripped; RC/pre-release skipped)
-  #   workflow_dispatch target=develop         → same as push develop
+#   workflow_dispatch target=develop         → same as push develop
 #   workflow_dispatch target=release/latest  → same as push release/latest (→ latest alias)
 #   workflow_dispatch target=<version tag>   → mike deploy <tag> latest
 #

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -4,10 +4,10 @@
 # Deploy matrix:
 #   push develop                    → mike deploy develop        (rfdetr.roboflow.com/develop/)
 #   push release/latest             → mike deploy latest         (rfdetr.roboflow.com/latest/)
-#   release published (stable/post) → mike deploy <base> latest  (rfdetr.roboflow.com/<base>/ + /latest/ alias → <base>; .postN stripped; RC/pre-release skipped)
+#   release published (stable/post) → mike deploy <base>          (rfdetr.roboflow.com/<base>/; .postN stripped; RC/pre-release skipped)
 #   workflow_dispatch target=develop         → same as push develop
 #   workflow_dispatch target=release/latest  → same as push release/latest (→ latest alias)
-#   workflow_dispatch target=<version tag>   → mike deploy <tag> latest
+#   workflow_dispatch target=<version tag>   → mike deploy <tag>
 #
 # Every deploy also:
 #   - Copies robots.txt, llms.txt, llms-full.txt to gh-pages root
@@ -88,7 +88,7 @@ jobs:
         run: |
           TAG="${{ github.event.release.tag_name }}"
           DOC_VERSION="${TAG%.post*}"
-          uv run mike deploy --push --update-aliases "$DOC_VERSION" latest
+          uv run mike deploy --push "$DOC_VERSION"
 
       - name: 🚀 Deploy Docs (workflow_dispatch)
         if: github.event_name == 'workflow_dispatch'
@@ -102,7 +102,7 @@ jobs:
             uv run mike deploy --push --update-aliases latest
           else
             DOC_VERSION="${TARGET%.post*}"
-            uv run mike deploy --push --update-aliases "$DOC_VERSION"
+            uv run mike deploy --push "$DOC_VERSION"
           fi
 
       - name: 🏗️ Build docs for artifact

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -30,7 +30,7 @@ on:
 
 # Ensure only one concurrent deployment
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref || github.event_name == 'workflow_dispatch' && inputs.target || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref_name || github.event_name == 'workflow_dispatch' && inputs.target || github.run_id }}
   cancel-in-progress: true
 
 # Restrict permissions by default


### PR DESCRIPTION
This pull request enhances the documentation deployment workflow by adding support for manual deployments via the GitHub Actions "workflow_dispatch" event. It introduces input validation for deployment targets, updates deployment logic to handle different scenarios, and ensures concurrency and post-deployment steps are compatible with manual triggers.

**Manual deployment support and input validation:**

* Added a `workflow_dispatch` trigger with a `target` input to allow manual deployments to specific branches or version tags, and included input validation to ensure only valid targets are accepted. [[1]](diffhunk://#diff-dd751c654ce34c435239f846704cbba01f2aef90c73ad219db2d47789b369544R24-R33) [[2]](diffhunk://#diff-dd751c654ce34c435239f846704cbba01f2aef90c73ad219db2d47789b369544R51-R68)

**Deployment logic updates:**

* Updated deployment steps to handle manual dispatches, including logic to deploy to the correct target based on the input and to strip `.postN` from version tags as needed.

**Concurrency and post-deployment compatibility:**

* Modified the concurrency group and post-deployment steps to properly support and distinguish manual deployments, ensuring that resource locking and static file uploads work for workflow_dispatch events. [[1]](diffhunk://#diff-dd751c654ce34c435239f846704cbba01f2aef90c73ad219db2d47789b369544R24-R33) [[2]](diffhunk://#diff-dd751c654ce34c435239f846704cbba01f2aef90c73ad219db2d47789b369544L100-R139) [[3]](diffhunk://#diff-dd751c654ce34c435239f846704cbba01f2aef90c73ad219db2d47789b369544L145-R185)

**Documentation and comments:**

* Updated comments to clarify the deployment matrix, including how manual dispatches map to deployment targets and aliases.

---

- Add workflow_dispatch trigger with target input ('develop', 'release/latest', or version tag)
- Checkout uses target as ref; empty for push/release events (backward-compatible)
- Deploy step maps: develop→mike develop, release/latest→mike latest, tag→mike <tag> latest
- Concurrency group handles dispatch target to prevent duplicate deploys
- Root-static deploy and IndexNow ping also run on workflow_dispatch
