### PR TITLE
fix(predict): correct `class_name` for pretrained COCO models

### DIFF
--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -50,9 +50,6 @@ except Exception:
 
 logger = get_logger()
 
-# Sorted once at import time; used to map sparse COCO category IDs → class_names index.
-_SORTED_COCO_IDS: list[int] = sorted(COCO_CLASSES.keys())
-
 # ModelContext and _build_model_context are eagerly imported above (runtime use in get_model).
 _VARIANT_EXPORTS = (
     "RFDETRBase",

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -1405,11 +1405,11 @@ class RFDETR:
                 "predict(): model has no 'args' attribute — COCO sparse-ID mapping cannot activate; "
                 "class_ids are treated as 0-indexed (may be wrong for pretrained COCO checkpoints)"
             )
-        num_logit_slots: int = getattr(_model_args, "num_classes", n) if _model_args is not None else n
+        num_logit_slots: int = getattr(_model_args, "num_classes", n)
         _is_coco_pretrained = num_logit_slots > n and model_class_names == list(COCO_CLASS_NAMES)
         if _is_coco_pretrained:
             _class_id_to_name: dict[int, str] = {
-                coco_id: model_class_names[i] for i, coco_id in enumerate(_SORTED_COCO_IDS) if i < n
+                coco_id: model_class_names[i] for i, coco_id in enumerate(COCO_CLASSES) if i < n
             }
         else:
             _class_id_to_name = dict(enumerate(model_class_names))

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -30,7 +30,7 @@ import torchvision.transforms.functional as F  # noqa: N812
 import yaml
 from PIL import Image
 
-from rfdetr.assets.coco_classes import COCO_CLASS_NAMES
+from rfdetr.assets.coco_classes import COCO_CLASS_NAMES, COCO_CLASSES
 from rfdetr.assets.model_weights import download_pretrain_weights, get_model_cache_dir
 from rfdetr.config import (
     ModelConfig,
@@ -49,6 +49,9 @@ except Exception:
     pass
 
 logger = get_logger()
+
+# Sorted once at import time; used to map sparse COCO category IDs → class_names index.
+_SORTED_COCO_IDS: list[int] = sorted(COCO_CLASSES.keys())
 
 # ModelContext and _build_model_context are eagerly imported above (runtime use in get_model).
 _VARIANT_EXPORTS = (
@@ -1391,6 +1394,25 @@ class RFDETR:
 
         model_class_names = self.class_names
         n = len(model_class_names)
+        # Pretrained COCO models use COCO category IDs (1–90, with gaps) as class_ids,
+        # while class_names is a flat 0-indexed list of 80 entries. Detected when
+        # args.num_classes > len(class_names) AND class_names == COCO_CLASS_NAMES.
+        # Fine-tuned models remap category IDs to 0-based contiguous indices, so
+        # class_id i maps directly to class_names[i].
+        _model_args = getattr(self.model, "args", None)
+        if _model_args is None and model_class_names == list(COCO_CLASS_NAMES):
+            logger.warning_once(
+                "predict(): model has no 'args' attribute — COCO sparse-ID mapping cannot activate; "
+                "class_ids are treated as 0-indexed (may be wrong for pretrained COCO checkpoints)"
+            )
+        num_logit_slots: int = getattr(_model_args, "num_classes", n) if _model_args is not None else n
+        _is_coco_pretrained = num_logit_slots > n and model_class_names == list(COCO_CLASS_NAMES)
+        if _is_coco_pretrained:
+            _class_id_to_name: dict[int, str] = {
+                coco_id: model_class_names[i] for i, coco_id in enumerate(_SORTED_COCO_IDS) if i < n
+            }
+        else:
+            _class_id_to_name = dict(enumerate(model_class_names))
         detections_list = []
         for i, result in enumerate(results):
             scores = result["scores"]
@@ -1424,28 +1446,22 @@ class RFDETR:
             detections.data["source_shape"] = np.tile(np.array(orig_sizes[i], dtype=np.int64), (len(detections), 1))
 
             # Attach class names so callers can map class_id → name without a
-            # separate lookup.  class_id is always 0-indexed regardless of the
-            # original dataset format (COCO category IDs are remapped during
-            # training), so class_names[class_id] is the correct mapping.
-            # Always set data["class_name"] for a consistent interface.
+            # separate lookup. Always set data["class_name"] for a consistent interface.
             #
-            # RF-DETR uses num_classes + 1 logits internally; class index n is the
-            # background/no-object class and is expected — map it to "__background__"
-            # without warning.  Indices outside [0, n] are genuinely unexpected and
-            # still produce an empty string with a one-time warning.
+            # RF-DETR uses num_classes + 1 logits internally; class index num_logit_slots
+            # is the background/no-object class — map it to "__background__" without
+            # warning. IDs not in _class_id_to_name are genuinely unexpected and produce
+            # an empty string with a one-time warning.
             class_ids = detections.class_id if detections.class_id is not None else np.array([], dtype=int)
-            truly_oob = [cid for cid in class_ids if not (0 <= cid <= n)]
+            truly_oob = [cid for cid in class_ids if cid not in _class_id_to_name and cid != num_logit_slots]
             if truly_oob:
                 logger.warning_once(
                     "predict() encountered class_id values out of range [0, %d]: %s — mapping to empty string",
-                    n,
+                    num_logit_slots,
                     truly_oob[:5],
                 )
             detections.data["class_name"] = np.array(
-                [
-                    model_class_names[cid] if 0 <= cid < n else ("__background__" if cid == n else "")
-                    for cid in class_ids
-                ],
+                ["__background__" if cid == num_logit_slots else _class_id_to_name.get(cid, "") for cid in class_ids],
                 dtype=object,
             )
 

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -1448,10 +1448,11 @@ class RFDETR:
             # Attach class names so callers can map class_id → name without a
             # separate lookup. Always set data["class_name"] for a consistent interface.
             #
-            # RF-DETR uses num_classes + 1 logits internally; class index num_logit_slots
-            # is the background/no-object class — map it to "__background__" without
-            # warning. IDs not in _class_id_to_name are genuinely unexpected and produce
-            # an empty string with a one-time warning.
+            # For fine-tuned models, logit index num_logit_slots is the no-object slot —
+            # map it to "__background__" without warning. For COCO-pretrained models,
+            # background is implicit (filtered by threshold); class ID 90 is "toothbrush".
+            # IDs not in _class_id_to_name are genuinely unexpected and produce an empty
+            # string with a one-time warning.
             class_ids = detections.class_id if detections.class_id is not None else np.array([], dtype=int)
             truly_oob = [cid for cid in class_ids if cid not in _class_id_to_name and cid != num_logit_slots]
             if truly_oob:
@@ -1460,10 +1461,13 @@ class RFDETR:
                     num_logit_slots,
                     truly_oob[:5],
                 )
-            detections.data["class_name"] = np.array(
-                ["__background__" if cid == num_logit_slots else _class_id_to_name.get(cid, "") for cid in class_ids],
-                dtype=object,
-            )
+            if _is_coco_pretrained:
+                class_names = [_class_id_to_name.get(cid, "") for cid in class_ids]
+            else:
+                class_names = [
+                    "__background__" if cid == num_logit_slots else _class_id_to_name.get(cid, "") for cid in class_ids
+                ]
+            detections.data["class_name"] = np.array(class_names, dtype=object)
 
             detections_list.append(detections)
 

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -1259,6 +1259,15 @@ class RFDETR:
             ``detections.data["source_image"]`` to use
             ``detections.metadata["source_image"]``.
 
+        Note:
+            ``class_name`` mapping uses one of two modes depending on the checkpoint.
+            For pretrained COCO checkpoints (detected when
+            ``model.args.num_classes > len(class_names)`` and ``class_names`` matches
+            ``COCO_CLASS_NAMES``), raw COCO category IDs (1–90, sparse) are looked up
+            by category ID rather than by position — so ``class_id=18`` yields ``"dog"``,
+            not ``class_names[18]``. For fine-tuned models, ``class_id`` is a 0-based
+            index into ``class_names``.
+
         Raises:
             ValueError: If ``shape`` cannot be unpacked as a two-element sequence,
                 if either dimension does not support the ``__index__`` protocol

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -1463,8 +1463,7 @@ class RFDETR:
             truly_oob = [cid for cid in class_ids if cid not in _class_id_to_name and cid != num_logit_slots]
             if truly_oob:
                 logger.warning_once(
-                    "predict() encountered class_id values out of range [0, %d]: %s — mapping to empty string",
-                    num_logit_slots,
+                    "predict() encountered unmapped class_id(s): %s — mapping to empty string",
                     truly_oob[:5],
                 )
             if _is_coco_pretrained:

--- a/tests/models/test_predict.py
+++ b/tests/models/test_predict.py
@@ -632,8 +632,8 @@ class TestPredictClassNameData:
         model = self._make_model_with_class_names(["cat", "dog"], labels=[2])
         img = PIL.Image.new("RGB", (28, 28))
         model.predict(img)
-        oob_warnings = [msg for msg in logger._warned_once if "out of range" in msg]
-        assert not oob_warnings, "Background class (class_id == num_classes) must not trigger an out-of-range warning"
+        unmapped_warnings = [msg for msg in logger._warned_once if "unmapped class_id" in msg]
+        assert not unmapped_warnings, "Background class must not trigger unmapped-class-id warning"
 
     def test_truly_oob_class_id_still_maps_to_empty_string_and_warns(self) -> None:
         """A class_id strictly above num_classes still maps to empty string AND emits a warning.
@@ -655,8 +655,8 @@ class TestPredictClassNameData:
         img = PIL.Image.new("RGB", (28, 28))
         detections = model.predict(img)
         assert detections.data["class_name"][0] == "", "Truly OOB class_id (> num_classes) must produce empty string"
-        oob_warnings = [msg for msg in logger._warned_once if "out of range" in msg]
-        assert oob_warnings, "Truly OOB class_id (> num_classes) must trigger an out-of-range warning"
+        unmapped_warnings = [msg for msg in logger._warned_once if "unmapped class_id" in msg]
+        assert unmapped_warnings, "Truly OOB class_id (> num_classes) must trigger an unmapped-class-id warning"
 
     @pytest.mark.parametrize(
         ("class_id", "expected_name"),
@@ -824,8 +824,8 @@ class TestPredictClassNameData:
         detections = model.predict(img)
 
         assert detections.data["class_name"][0] == "", "COCO gap ID 12 (no such category) must produce empty string"
-        oob_warnings = [msg for msg in logger._warned_once if "out of range" in msg]
-        assert oob_warnings, "COCO gap ID 12 must trigger an out-of-range warning"
+        unmapped_warnings = [msg for msg in logger._warned_once if "unmapped class_id" in msg]
+        assert unmapped_warnings, "COCO gap ID 12 must trigger an unmapped-class-id warning"
 
     def test_coco_pretrained_class_id_90_maps_to_toothbrush_not_background(self) -> None:
         """COCO class ID 90 ('toothbrush') must not be mislabelled '__background__' in pretrained branch.
@@ -853,5 +853,5 @@ class TestPredictClassNameData:
         assert detections.data["class_name"][0] == "toothbrush", (
             f"COCO pretrained: class_id=90 must map to 'toothbrush', got '{detections.data['class_name'][0]}'"
         )
-        oob_warnings = [msg for msg in logger._warned_once if "out of range" in msg]
-        assert not oob_warnings, "class_id=90 (valid COCO category) must not trigger an out-of-range warning"
+        unmapped_warnings = [msg for msg in logger._warned_once if "unmapped class_id" in msg]
+        assert not unmapped_warnings, "class_id=90 (valid COCO category) must not trigger unmapped-class-id warning"

--- a/tests/models/test_predict.py
+++ b/tests/models/test_predict.py
@@ -749,3 +749,80 @@ class TestPredictClassNameData:
         assert detections.data["class_name"][0] == "custom_18", (
             f"Custom class names must use direct indexing; got '{detections.data['class_name'][0]}'"
         )
+
+    def test_coco_names_without_model_args_fires_warning(self) -> None:
+        """predict() must warn when COCO class_names present but model has no 'args' attribute.
+
+        Without args, num_logit_slots falls back to n so _is_coco_pretrained stays False.
+        The warning is the caller's only signal that sparse COCO-ID mapping cannot activate,
+        which may cause wrong class names for pretrained COCO checkpoints loaded without args.
+        """
+        from rfdetr.assets.coco_classes import COCO_CLASS_NAMES
+        from rfdetr.utilities.logger import get_logger
+
+        logger = get_logger()
+        logger._warned_once.clear()
+
+        no_args_model = _DummyModel(class_names=list(COCO_CLASS_NAMES), labels=[0])
+        # Do NOT set no_args_model.args — this is the scenario under test.
+        model = _DummyRFDETR()
+        model.model = no_args_model
+
+        img = PIL.Image.new("RGB", (28, 28))
+        model.predict(img)
+
+        coco_warnings = [msg for msg in logger._warned_once if "COCO sparse-ID mapping cannot activate" in msg]
+        assert coco_warnings, (
+            "predict() must emit a warning when class_names matches COCO_CLASS_NAMES "
+            "but model has no 'args' attribute (sparse-ID mapping cannot activate)"
+        )
+
+    def test_non_coco_names_without_model_args_no_warning_uses_direct_index(self) -> None:
+        """No warning and direct indexing for non-COCO class_names when model has no 'args'.
+
+        When model has no 'args' AND class_names != COCO_CLASS_NAMES, neither the COCO
+        warning nor sparse-ID mapping activates. class_id maps directly to class_names[class_id].
+        """
+        from rfdetr.utilities.logger import get_logger
+
+        logger = get_logger()
+        logger._warned_once.clear()
+
+        no_args_model = _DummyModel(class_names=["cat", "dog"], labels=[0])
+        # Do NOT set no_args_model.args.
+        model = _DummyRFDETR()
+        model.model = no_args_model
+
+        img = PIL.Image.new("RGB", (28, 28))
+        detections = model.predict(img)
+
+        coco_warnings = [msg for msg in logger._warned_once if "COCO" in msg]
+        assert not coco_warnings, "Non-COCO class_names with no args must not emit a COCO warning"
+        assert detections.data["class_name"][0] == "cat", (
+            f"Direct-index mapping: class_id=0 must map to 'cat', got '{detections.data['class_name'][0]}'"
+        )
+
+    def test_coco_pretrained_oob_gap_class_id_maps_to_empty_string_and_warns(self) -> None:
+        """COCO category gap ID 12 must produce empty string and OOB warning in pretrained branch.
+
+        COCO skips category ID 12 (gap between fire hydrant=11 and stop sign=13). A pretrained
+        model emitting cid=12 has no mapping in _class_id_to_name and must trigger the
+        out-of-range warning even in the COCO-pretrained branch.
+        """
+        from rfdetr.assets.coco_classes import COCO_CLASS_NAMES
+        from rfdetr.utilities.logger import get_logger
+
+        logger = get_logger()
+        logger._warned_once.clear()
+
+        coco_model = _DummyModel(class_names=list(COCO_CLASS_NAMES), labels=[12])
+        coco_model.args = SimpleNamespace(num_classes=90)
+        model = _DummyRFDETR()
+        model.model = coco_model
+
+        img = PIL.Image.new("RGB", (28, 28))
+        detections = model.predict(img)
+
+        assert detections.data["class_name"][0] == "", "COCO gap ID 12 (no such category) must produce empty string"
+        oob_warnings = [msg for msg in logger._warned_once if "out of range" in msg]
+        assert oob_warnings, "COCO gap ID 12 must trigger an out-of-range warning"

--- a/tests/models/test_predict.py
+++ b/tests/models/test_predict.py
@@ -657,3 +657,95 @@ class TestPredictClassNameData:
         assert detections.data["class_name"][0] == "", "Truly OOB class_id (> num_classes) must produce empty string"
         oob_warnings = [msg for msg in logger._warned_once if "out of range" in msg]
         assert oob_warnings, "Truly OOB class_id (> num_classes) must trigger an out-of-range warning"
+
+    @pytest.mark.parametrize(
+        ("class_id", "expected_name"),
+        [
+            pytest.param(18, "dog", id="coco_id_18_dog"),
+            pytest.param(27, "backpack", id="coco_id_27_backpack"),
+            pytest.param(3, "car", id="coco_id_3_car"),
+        ],
+    )
+    def test_coco_pretrained_sparse_id_mapping(self, class_id: int, expected_name: str) -> None:
+        """Pretrained COCO models use raw COCO category IDs (1-indexed, with gaps) as class_ids.
+
+        When num_classes=90 and class_names has 80 entries, class_id 18 must resolve to
+        'dog' (COCO category 18), not 'sheep' (COCO_CLASS_NAMES[18] via 0-indexed lookup).
+
+        Regression test for https://github.com/roboflow/rf-detr/issues/988.
+        """
+        from rfdetr.assets.coco_classes import COCO_CLASS_NAMES
+
+        coco_model = _DummyModel(class_names=list(COCO_CLASS_NAMES), labels=[class_id])
+        coco_model.args = SimpleNamespace(num_classes=90)
+        model = _DummyRFDETR()
+        model.model = coco_model
+
+        img = PIL.Image.new("RGB", (28, 28))
+        detections = model.predict(img)
+
+        assert detections.data["class_name"][0] == expected_name, (
+            f"class_id={class_id} must map to '{expected_name}', got '{detections.data['class_name'][0]}'"
+        )
+
+    def test_coco_pretrained_dataset_file_roboflow(self) -> None:
+        """Pretrained COCO weights packaged as dataset_file='roboflow' must still use sparse-ID mapping.
+
+        RF-DETR pretrained checkpoints (e.g. RFDETRSegSmall) can have dataset_file='roboflow'
+        even though they were trained on COCO. The fix must not depend on dataset_file value.
+
+        Regression test for https://github.com/roboflow/rf-detr/issues/988 (post-revert follow-up).
+        """
+        from rfdetr.assets.coco_classes import COCO_CLASS_NAMES
+
+        coco_model = _DummyModel(class_names=list(COCO_CLASS_NAMES), labels=[18])
+        coco_model.args = SimpleNamespace(num_classes=90, dataset_file="roboflow")
+        model = _DummyRFDETR()
+        model.model = coco_model
+
+        img = PIL.Image.new("RGB", (28, 28))
+        detections = model.predict(img)
+
+        assert detections.data["class_name"][0] == "dog", (
+            f"dataset_file='roboflow' COCO pretrained: class_id=18 must map to 'dog', "
+            f"got '{detections.data['class_name'][0]}'"
+        )
+
+    def test_finetuned_coco_names_uses_direct_indexing(self) -> None:
+        """Fine-tuned 80-class model with COCO names must use direct 0-indexed lookup, not sparse remap.
+
+        When num_classes == len(COCO_CLASS_NAMES) (not strictly greater), the COCO
+        sparse-ID branch must NOT activate.
+        """
+        from rfdetr.assets.coco_classes import COCO_CLASS_NAMES
+
+        coco_model = _DummyModel(class_names=list(COCO_CLASS_NAMES), labels=[18])
+        coco_model.args = SimpleNamespace(num_classes=80, dataset_file="coco")
+        model = _DummyRFDETR()
+        model.model = coco_model
+
+        img = PIL.Image.new("RGB", (28, 28))
+        detections = model.predict(img)
+
+        assert detections.data["class_name"][0] == COCO_CLASS_NAMES[18], (
+            f"Fine-tuned 80-class model must use direct indexing; got '{detections.data['class_name'][0]}'"
+        )
+
+    def test_custom_names_high_num_classes_no_coco_remap(self) -> None:
+        """Custom class_names with num_classes>80 must NOT activate sparse COCO remap.
+
+        Guard: a custom model with num_classes=90 but non-COCO class_names must use
+        direct 0-indexed mapping (class_names != COCO_CLASS_NAMES fails the guard).
+        """
+        custom_names = [f"custom_{i}" for i in range(80)]
+        coco_model = _DummyModel(class_names=custom_names, labels=[18])
+        coco_model.args = SimpleNamespace(num_classes=90)
+        model = _DummyRFDETR()
+        model.model = coco_model
+
+        img = PIL.Image.new("RGB", (28, 28))
+        detections = model.predict(img)
+
+        assert detections.data["class_name"][0] == "custom_18", (
+            f"Custom class names must use direct indexing; got '{detections.data['class_name'][0]}'"
+        )

--- a/tests/models/test_predict.py
+++ b/tests/models/test_predict.py
@@ -826,3 +826,32 @@ class TestPredictClassNameData:
         assert detections.data["class_name"][0] == "", "COCO gap ID 12 (no such category) must produce empty string"
         oob_warnings = [msg for msg in logger._warned_once if "out of range" in msg]
         assert oob_warnings, "COCO gap ID 12 must trigger an out-of-range warning"
+
+    def test_coco_pretrained_class_id_90_maps_to_toothbrush_not_background(self) -> None:
+        """COCO class ID 90 ('toothbrush') must not be mislabelled '__background__' in pretrained branch.
+
+        For COCO-pretrained models num_logit_slots==90, which is also a valid COCO category
+        (toothbrush). Background is implicit (below threshold), not a sentinel label.
+        The background sentinel check must be scoped to fine-tuned models only.
+
+        Regression test for HIGH-1 finding in /review of PR #1051.
+        """
+        from rfdetr.assets.coco_classes import COCO_CLASS_NAMES
+        from rfdetr.utilities.logger import get_logger
+
+        logger = get_logger()
+        logger._warned_once.clear()
+
+        coco_model = _DummyModel(class_names=list(COCO_CLASS_NAMES), labels=[90])
+        coco_model.args = SimpleNamespace(num_classes=90)
+        model = _DummyRFDETR()
+        model.model = coco_model
+
+        img = PIL.Image.new("RGB", (28, 28))
+        detections = model.predict(img)
+
+        assert detections.data["class_name"][0] == "toothbrush", (
+            f"COCO pretrained: class_id=90 must map to 'toothbrush', got '{detections.data['class_name'][0]}'"
+        )
+        oob_warnings = [msg for msg in logger._warned_once if "out of range" in msg]
+        assert not oob_warnings, "class_id=90 (valid COCO category) must not trigger an out-of-range warning"

--- a/tests/try_instantiate_all_models.py
+++ b/tests/try_instantiate_all_models.py
@@ -144,10 +144,11 @@ def _test_coco_class_name_mapping(model_instance: object) -> None:
     Issue #988: RFDETRSegSmall returned "sheep" for class_id=18 instead of "dog"
     because 0-indexed ``COCO_CLASS_NAMES[18]`` was used instead of the sparse-dict
     lookup ``COCO_CLASSES[18]``.  threshold=0 forces all top-k queries through so
-    every class ID in the output is covered.
+    every class ID in the output is covered.  Covers both detection and segmentation
+    nano variants (RFDETRNano, RFDETRSegNano).
 
     Args:
-        model_instance: An already-loaded pretrained COCO model instance.
+        model_instance: An already-loaded pretrained COCO model instance (det or seg).
 
     Raises:
         AssertionError: On any class-name mapping failure.
@@ -236,9 +237,9 @@ def main() -> None:
                 # `.size` and `.__name__` and run `isinstance(recovered, actual_cls)`.
                 _test_from_checkpoint(model_instance, actual_cls, instantiate_kwargs)
 
-                # Inference class-name regression for issue #988 — run on the
-                # lightest pretrained COCO model at default resolution only.
-                if actual_cls is RFDETRNano and res is None:
+                # Inference class-name regression for issue #988 — run on all
+                # nano-sized pretrained COCO models at default resolution only.
+                if "nano" in base_name.lower() and res is None:
                     _test_coco_class_name_mapping(model_instance)
 
                 succeeded += 1

--- a/tests/try_instantiate_all_models.py
+++ b/tests/try_instantiate_all_models.py
@@ -138,6 +138,65 @@ def _test_from_checkpoint(model_instance: object, actual_cls: type, extra_kwargs
         os.unlink(tmp_path)
 
 
+def _test_coco_class_name_mapping(model_instance: object) -> None:
+    """Verify predict() uses sparse COCO category-ID → class-name mapping.
+
+    Issue #988: RFDETRSegSmall returned "sheep" for class_id=18 instead of "dog"
+    because 0-indexed ``COCO_CLASS_NAMES[18]`` was used instead of the sparse-dict
+    lookup ``COCO_CLASSES[18]``.  threshold=0 forces all top-k queries through so
+    every class ID in the output is covered.
+
+    Args:
+        model_instance: An already-loaded pretrained COCO model instance.
+
+    Raises:
+        AssertionError: On any class-name mapping failure.
+    """
+    import PIL.Image
+
+    from rfdetr.assets.coco_classes import COCO_CLASS_NAMES, COCO_CLASSES
+
+    # Sanity-check model properties required for the pretrained COCO branch.
+    class_names = model_instance.class_names
+    assert class_names is not None, "Pretrained COCO model must have class_names set"
+    assert len(class_names) == len(COCO_CLASS_NAMES), (
+        f"Expected {len(COCO_CLASS_NAMES)} COCO class names, got {len(class_names)}"
+    )
+    assert class_names == list(COCO_CLASS_NAMES), "model.class_names must equal COCO_CLASS_NAMES"
+    num_classes = model_instance.model.args.num_classes
+    assert num_classes == 90, f"Pretrained COCO model must have num_classes=90, got {num_classes}"
+
+    # Run at threshold=0 to exercise all top-k output slots.
+    img = PIL.Image.new("RGB", (640, 640), color=(128, 128, 128))
+    detections = model_instance.predict(img, threshold=0.0)
+
+    assert "class_name" in detections.data, "data['class_name'] must be present after predict()"
+
+    # For every detection whose class_id is a valid COCO category, class_name must
+    # use sparse-ID lookup (COCO_CLASSES[class_id]), not 0-indexed lookup.
+    # Canonical regression case: class_id=18 → "dog", NOT "sheep" (COCO_CLASS_NAMES[18]).
+    for class_id, class_name in zip(detections.class_id, detections.data["class_name"]):
+        cid = int(class_id)
+        if cid in COCO_CLASSES:
+            expected = COCO_CLASSES[cid]
+            assert class_name == expected, (
+                f"Sparse COCO ID mapping broken (issue #988): "
+                f"class_id={cid} must map to '{expected}', got '{class_name}'"
+            )
+
+    # Regression for PR #1051 HIGH-1: no COCO-pretrained detection may carry
+    # '__background__' — background is implicit (below threshold), never a sentinel label.
+    background_labeled = [
+        (int(cid), name)
+        for cid, name in zip(detections.class_id, detections.data["class_name"])
+        if name == "__background__"
+    ]
+    assert not background_labeled, (
+        "COCO-pretrained predict() must never produce '__background__' class names "
+        f"(PR #1051 HIGH-1 regression); found: {background_labeled[:3]}"
+    )
+
+
 def main() -> None:
     """Download, validate, instantiate all models, and test from_checkpoint round-trip."""
     print("Model Instantiation & Download Validation\n")
@@ -176,6 +235,12 @@ def main() -> None:
                 # Pass the real class (not a partial) so `_test_from_checkpoint` can read
                 # `.size` and `.__name__` and run `isinstance(recovered, actual_cls)`.
                 _test_from_checkpoint(model_instance, actual_cls, instantiate_kwargs)
+
+                # Inference class-name regression for issue #988 — run on the
+                # lightest pretrained COCO model at default resolution only.
+                if actual_cls is RFDETRNano and res is None:
+                    _test_coco_class_name_mapping(model_instance)
+
                 succeeded += 1
             except Exception as ex:
                 # Fail-fast: surface the first failing model directly so CI logs the


### PR DESCRIPTION
This pull request fixes and improves how COCO class IDs are mapped to class names in predictions, especially for pretrained COCO models that use sparse category IDs (with gaps) rather than contiguous indices. It ensures correct class name assignment for both pretrained and fine-tuned models, and adds comprehensive tests to cover these scenarios and prevent regressions.

**COCO class ID mapping improvements:**

* Added logic in `predict` (in `rfdetr/detr.py`) to detect when a model is a pretrained COCO checkpoint (using sparse COCO category IDs) and properly map those IDs to class names, rather than assuming a direct index. This fixes incorrect class name assignments for COCO-pretrained models. [[1]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86R1397-R1415) [[2]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86L1427-R1464)
* Introduced `_SORTED_COCO_IDS` at import time for efficient mapping from COCO category IDs to class names. [[1]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86L33-R33) [[2]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86R53-R55)

**Testing and regression coverage:**

* Added multiple parameterized and scenario-specific tests to ensure correct class name mapping for:
  - Pretrained COCO models with sparse IDs,
  - Pretrained models with different `dataset_file` values,
  - Fine-tuned models with contiguous IDs,
  - Custom class names with high `num_classes`.
  These tests prevent regressions and cover edge cases reported in previous issues.

---

- Drop `_dataset_file in ("coco", None)` guard from `_is_coco_pretrained`: pretrained COCO checkpoints packaged via Roboflow have `dataset_file="roboflow"`, causing PR #1005 fix to never fire
- Two conditions now sufficient: `num_logit_slots > n` AND `class_names == COCO_CLASS_NAMES`
- Build sparse `_class_id_to_name` dict pairing sorted COCO IDs with class_names; raw ID 18 → "dog" instead of `class_names[18]` = "sheep"
- Add `_SORTED_COCO_IDS` module-level constant to avoid re-sorting on every predict() call
- Add 4 regression tests: sparse mapping (parametrized 3/18/27), dataset_file="roboflow" guard, fine-tuned direct-indexing guard, custom-names guard

resolves #988