### PR TITLE
refactor: consolidate `_IS_RFDETR_PLUS_AVAILABLE`

### DIFF
--- a/src/rfdetr/assets/model_weights.py
+++ b/src/rfdetr/assets/model_weights.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
+from rfdetr.platform import _IS_RFDETR_PLUS_AVAILABLE
 from rfdetr.utilities.files import _download_file, _validate_file_md5
 from rfdetr.utilities.logger import get_logger
 
@@ -348,14 +349,14 @@ def download_pretrain_weights(
     asset = ModelWeights.from_filename(model_name)
 
     # Only try rf-detr-plus if not found locally (lazy import)
-    if asset is None:
+    if asset is None and _IS_RFDETR_PLUS_AVAILABLE:
         try:
             from rfdetr_plus.assets import ModelWeights as PlusModelWeights
 
             asset = PlusModelWeights.from_filename(model_name)
-        except (ImportError, AttributeError):
-            # Package not installed or doesn't have assets module yet
-            pass
+        except ModuleNotFoundError as ex:
+            if ex.name not in {"rfdetr_plus", "rfdetr_plus.assets"}:
+                raise
 
     # Extract URL and MD5 from the asset if found
     if asset is not None:

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -304,18 +304,22 @@ class RFDETR:
         _plus_available = False
         _plus_symbols: dict[str, type[RFDETR]] = {}
         _plus_entries: list[tuple[str, type[RFDETR]]] = []
-        try:
-            import rfdetr.platform.models as platform_models
+        from rfdetr.platform import _IS_RFDETR_PLUS_AVAILABLE
 
-            for class_symbol in _CHECKPOINT_PLUS_MODEL_NAME_CLASS_SYMBOLS:
-                plus_obj = getattr(platform_models, class_symbol)
-                _plus_symbols[class_symbol] = plus_obj
-            _plus_entries = [
-                (name, _plus_symbols[class_symbol]) for name, class_symbol in _CHECKPOINT_PLUS_MODEL_MAP_ENTRIES
-            ]
-            _plus_available = True
-        except (ImportError, AttributeError):
-            _plus_symbols = {}
+        if _IS_RFDETR_PLUS_AVAILABLE:
+            try:
+                import rfdetr.platform.models as platform_models
+
+                for class_symbol in _CHECKPOINT_PLUS_MODEL_NAME_CLASS_SYMBOLS:
+                    plus_obj = getattr(platform_models, class_symbol)
+                    _plus_symbols[class_symbol] = plus_obj
+                _plus_entries = [
+                    (name, _plus_symbols[class_symbol]) for name, class_symbol in _CHECKPOINT_PLUS_MODEL_MAP_ENTRIES
+                ]
+                _plus_available = True
+            except ModuleNotFoundError as ex:
+                if ex.name not in {"rfdetr_plus", "rfdetr_plus.models"}:
+                    raise
 
         # weights_only=False is required because legacy checkpoints embed
         # argparse.Namespace objects that cannot be deserialised with

--- a/src/rfdetr/platform/__init__.py
+++ b/src/rfdetr/platform/__init__.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-import importlib
 import warnings
 
 _INSTALL_MSG = (
@@ -11,8 +10,12 @@ _INSTALL_MSG = (
     " Install it with `pip install rfdetr[plus]` (or `pip install rfdetr_plus` if supported)."
 )
 
+try:
+    import rfdetr_plus as _rfdetr_plus  # noqa: F401
 
-if importlib.util.find_spec("rfdetr_plus") is None:
+    _IS_RFDETR_PLUS_AVAILABLE: bool = True
+except ModuleNotFoundError:
+    _IS_RFDETR_PLUS_AVAILABLE = False
     warnings.warn(
         _INSTALL_MSG.format(name="platform model downloads"),
         ImportWarning,

--- a/src/rfdetr/platform/__init__.py
+++ b/src/rfdetr/platform/__init__.py
@@ -11,7 +11,10 @@ _INSTALL_MSG = (
     " Install it with `pip install rfdetr[plus]` (or `pip install rfdetr_plus` if supported)."
 )
 
-_IS_RFDETR_PLUS_AVAILABLE = importlib.util.find_spec("rfdetr_plus.models") is not None
+try:
+    _IS_RFDETR_PLUS_AVAILABLE = importlib.util.find_spec("rfdetr_plus.models") is not None
+except ImportError:
+    _IS_RFDETR_PLUS_AVAILABLE = False
 if not _IS_RFDETR_PLUS_AVAILABLE:
     warnings.warn(
         _INSTALL_MSG.format(name="platform model downloads"),

--- a/src/rfdetr/platform/__init__.py
+++ b/src/rfdetr/platform/__init__.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
+import importlib.util
 import warnings
 
 _INSTALL_MSG = (
@@ -10,12 +11,8 @@ _INSTALL_MSG = (
     " Install it with `pip install rfdetr[plus]` (or `pip install rfdetr_plus` if supported)."
 )
 
-try:
-    import rfdetr_plus as _rfdetr_plus  # noqa: F401
-
-    _IS_RFDETR_PLUS_AVAILABLE: bool = True
-except ModuleNotFoundError:
-    _IS_RFDETR_PLUS_AVAILABLE = False
+_IS_RFDETR_PLUS_AVAILABLE = importlib.util.find_spec("rfdetr_plus.models") is not None
+if not _IS_RFDETR_PLUS_AVAILABLE:
     warnings.warn(
         _INSTALL_MSG.format(name="platform model downloads"),
         ImportWarning,

--- a/src/rfdetr/platform/downloads.py
+++ b/src/rfdetr/platform/downloads.py
@@ -4,28 +4,23 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
-try:
-    from rfdetr_plus.models import downloads as _downloads
+# The availability check here avoids importing `rfdetr_plus` when the optional
+# dependency is not installed. Nested import-time dependencies continue to
+# propagate from inside this guarded path.
+from rfdetr.platform import _IS_RFDETR_PLUS_AVAILABLE
 
+if _IS_RFDETR_PLUS_AVAILABLE:
     try:
+        from rfdetr_plus.models import downloads as _downloads
+
         PLATFORM_MODELS = _downloads._PLATFORM_MODELS
     except AttributeError:
         PLATFORM_MODELS = _downloads.PLATFORM_MODELS
-except ImportError:
-    try:
-        from rfdetr_plus.models.downloads import PLATFORM_MODELS
-    except ImportError as ex:
+    except ModuleNotFoundError as ex:
         missing_name = getattr(ex, "name", "")
-        if missing_name.startswith("rfdetr_plus") or "rfdetr_plus" in str(ex):
-            import warnings
-
-            from rfdetr.platform import _INSTALL_MSG
-
-            warnings.warn(
-                _INSTALL_MSG.format(name="platform model downloads"),
-                ImportWarning,
-                stacklevel=2,
-            )
+        if missing_name in {"rfdetr_plus", "rfdetr_plus.models", "rfdetr_plus.models.downloads"}:
             PLATFORM_MODELS = {}
         else:
             raise
+else:
+    PLATFORM_MODELS = {}

--- a/src/rfdetr/platform/models.py
+++ b/src/rfdetr/platform/models.py
@@ -13,7 +13,7 @@ _PLUS_EXPORTS = {
     "RFDETRXLarge",
 }
 
-try:
+if _IS_RFDETR_PLUS_AVAILABLE:
     from rfdetr_plus.models import (
         RFDETR2XLarge,
         RFDETRXLarge,
@@ -23,9 +23,6 @@ try:
         "RFDETR2XLarge",
         "RFDETRXLarge",
     ]
-except ModuleNotFoundError as ex:
-    if ex.name not in ("rfdetr_plus", "rfdetr_plus.models"):
-        raise
 
 
 def __getattr__(name: str):

--- a/src/rfdetr/platform/models.py
+++ b/src/rfdetr/platform/models.py
@@ -4,14 +4,14 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
+from rfdetr.platform import _IS_RFDETR_PLUS_AVAILABLE
+
 __all__: list[str] = []
 
 _PLUS_EXPORTS = {
     "RFDETR2XLarge",
     "RFDETRXLarge",
 }
-
-_IS_RFDETR_PLUS_AVAILABLE = True
 
 try:
     from rfdetr_plus.models import (
@@ -26,18 +26,6 @@ try:
 except ModuleNotFoundError as ex:
     if ex.name not in ("rfdetr_plus", "rfdetr_plus.models"):
         raise
-
-    _IS_RFDETR_PLUS_AVAILABLE = False
-
-    import warnings
-
-    from rfdetr.platform import _INSTALL_MSG
-
-    warnings.warn(
-        _INSTALL_MSG.format(name="platform model downloads"),
-        ImportWarning,
-        stacklevel=2,
-    )
 
 
 def __getattr__(name: str):

--- a/src/rfdetr/platform/models.py
+++ b/src/rfdetr/platform/models.py
@@ -11,7 +11,7 @@ _PLUS_EXPORTS = {
     "RFDETRXLarge",
 }
 
-_PLUS_AVAILABLE = True
+_IS_RFDETR_PLUS_AVAILABLE = True
 
 try:
     from rfdetr_plus.models import (
@@ -27,7 +27,7 @@ except ModuleNotFoundError as ex:
     if ex.name not in ("rfdetr_plus", "rfdetr_plus.models"):
         raise
 
-    _PLUS_AVAILABLE = False
+    _IS_RFDETR_PLUS_AVAILABLE = False
 
     import warnings
 
@@ -43,7 +43,7 @@ except ModuleNotFoundError as ex:
 def __getattr__(name: str):
     """Lazy failure for missing plus exports: warn on import, raise on access."""
     # Only intercept plus-only symbols when the extra package is missing.
-    if name in _PLUS_EXPORTS and not _PLUS_AVAILABLE:
+    if name in _PLUS_EXPORTS and not _IS_RFDETR_PLUS_AVAILABLE:
         from rfdetr.platform import _INSTALL_MSG
 
         # Surface a clear install hint when someone explicitly requests a plus symbol.

--- a/tests/assets/test_downloads.py
+++ b/tests/assets/test_downloads.py
@@ -4,13 +4,13 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
-import sys
 from unittest.mock import Mock, patch
 
 import pytest
 
 from rfdetr.assets import ModelWeightAsset, ModelWeights
 from rfdetr.assets.model_weights import download_pretrain_weights
+from rfdetr.platform import _IS_RFDETR_PLUS_AVAILABLE
 
 
 # Module-level fixture for common file operation mocks
@@ -46,10 +46,7 @@ class TestDownloadPretrainWeights:
         assert call_kwargs["expected_md5"] is not None  # Should have MD5 hash
         assert len(call_kwargs["expected_md5"]) == 32  # Valid MD5 hash
 
-    @pytest.mark.skipif(
-        "rfdetr_plus" not in sys.modules and "rfdetr_plus.assets" not in sys.modules,
-        reason="rf-detr-plus not installed - skip priority test",
-    )
+    @pytest.mark.skipif(not _IS_RFDETR_PLUS_AVAILABLE, reason="rf-detr-plus not installed - skip priority test")
     def test_download_from_rfdetr_plus_when_available(self, mock_file_operations):
         """Test that rf-detr-plus models are prioritized when available.
 

--- a/tests/models/test_from_checkpoint.py
+++ b/tests/models/test_from_checkpoint.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from rfdetr.detr import RFDETR
-from rfdetr.platform.models import _IS_RFDETR_PLUS_AVAILABLE
+from rfdetr.platform import _IS_RFDETR_PLUS_AVAILABLE
 from rfdetr.variants import RFDETRSmall
 
 

--- a/tests/models/test_from_checkpoint.py
+++ b/tests/models/test_from_checkpoint.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from rfdetr.detr import RFDETR
-from rfdetr.platform.models import _IS_RFDETR_PLUS_AVAILABLE as HAS_PLUS
+from rfdetr.platform.models import _IS_RFDETR_PLUS_AVAILABLE
 from rfdetr.variants import RFDETRSmall
 
 
@@ -205,7 +205,7 @@ class TestFromCheckpointEdgeCases:
         call_kwargs = mock_cls.call_args.kwargs
         assert call_kwargs["num_classes"] == 5
 
-    @pytest.mark.skipif(HAS_PLUS, reason="rfdetr_plus is installed — guard not active")
+    @pytest.mark.skipif(_IS_RFDETR_PLUS_AVAILABLE, reason="rfdetr_plus is installed — guard not active")
     def test_characterization_xlarge_without_plus_raises_import_error(self, tmp_path: Path) -> None:
         """xlarge checkpoint without rfdetr_plus raises ImportError instead of wrong class."""
         for weights in ("rf-detr-xlarge.pth", "rf-detr-xxlarge.pth"):
@@ -349,7 +349,7 @@ class TestFromCheckpointModelName:
             model = RFDETR.from_checkpoint(tmp_path / "ckpt.pth")
         assert model.__class__.__name__ == expected_class
 
-    @pytest.mark.skipif(HAS_PLUS, reason="rfdetr_plus is installed — guard not active")
+    @pytest.mark.skipif(_IS_RFDETR_PLUS_AVAILABLE, reason="rfdetr_plus is installed — guard not active")
     @pytest.mark.parametrize("model_name", ["RFDETRXLarge", "RFDETR2XLarge"])
     def test_plus_model_name_without_plus_raises_import_error(self, tmp_path: Path, model_name: str) -> None:
         """Plus checkpoints using model_name raise install guidance without rfdetr_plus."""

--- a/tests/models/test_from_checkpoint.py
+++ b/tests/models/test_from_checkpoint.py
@@ -18,14 +18,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from rfdetr.detr import RFDETR
+from rfdetr.platform.models import _IS_RFDETR_PLUS_AVAILABLE as HAS_PLUS
 from rfdetr.variants import RFDETRSmall
-
-try:
-    import rfdetr.platform.models as _pm
-
-    HAS_PLUS = _pm._PLUS_AVAILABLE
-except ImportError:
-    HAS_PLUS = False
 
 
 def _ns(pretrain_weights: str, num_classes: int = 80) -> dict:


### PR DESCRIPTION
This pull request refactors how the codebase checks for the presence of the `rfdetr_plus` package, consolidating the logic into a single `_IS_RFDETR_PLUS_AVAILABLE` flag and updating all relevant imports and test guards to use this flag. This simplifies and centralizes the package availability check, making the code easier to maintain and less error-prone.

**Platform package availability refactor:**

* Introduced `_IS_RFDETR_PLUS_AVAILABLE` in `rfdetr.platform` as the single source of truth for whether `rfdetr_plus` is installed, replacing previous ad-hoc checks and the `_PLUS_AVAILABLE` variable. [[1]](diffhunk://#diff-2ecd06717cdd31ee1905c726f1a65d8655f59779579d481da992de14c4f2690aL6-R18) [[2]](diffhunk://#diff-7b4294569a30fdb127f1e85e61d257a8217aad6b08f0d25d0f24c428e130c5d7R7-L15)
* Updated `rfdetr.platform.models` to use `_IS_RFDETR_PLUS_AVAILABLE` for all plus-package availability checks and removed redundant warning logic.

**Test suite updates:**

* Updated `tests/models/test_from_checkpoint.py` to use `_IS_RFDETR_PLUS_AVAILABLE` instead of the old `HAS_PLUS`/`_PLUS_AVAILABLE` logic for `pytest.mark.skipif` guards, ensuring consistency with the new approach. [[1]](diffhunk://#diff-5d838164bd46f1094ea33fe7ef3db504b13a5b318d40e0145bffb48bade746b8R21-L29) [[2]](diffhunk://#diff-5d838164bd46f1094ea33fe7ef3db504b13a5b318d40e0145bffb48bade746b8L214-R208) [[3]](diffhunk://#diff-5d838164bd46f1094ea33fe7ef3db504b13a5b318d40e0145bffb48bade746b8L358-R352)