### PR TITLE
chore(pre-commit): add docformatter hook with 120-char wrap

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,7 @@ repos:
     rev: v1.7.7
     hooks:
       - id: docformatter
+        language_version: python3.10
         additional_dependencies: [tomli]
         args: ["--in-place"]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,6 @@ repos:
     rev: v1.7.7
     hooks:
       - id: docformatter
-        language_version: python3.10
         additional_dependencies: [tomli]
         args: ["--in-place"]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,14 @@ repos:
       - id: ruff-format
         exclude: ^notebooks/.*\.py$
 
+  - repo: https://github.com/PyCQA/docformatter
+    rev: v1.7.7
+    hooks:
+      - id: docformatter
+        language_version: python3.10
+        additional_dependencies: [tomli]
+        args: ["--in-place"]
+
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.20.2
     hooks:

--- a/docs/hooks/cookbooks_cards.py
+++ b/docs/hooks/cookbooks_cards.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """MkDocs hook for exposing cookbook card data to documentation templates."""
 
 from pathlib import Path

--- a/docs/hooks/package_version.py
+++ b/docs/hooks/package_version.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """MkDocs hooks for exposing package metadata to documentation templates."""
 
 import sys

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,10 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "notebooks/*.py" = ["E402"]  # cell-local imports are intentional in percent-format scripts
 
+[tool.docformatter]
+wrap-summaries = 120
+wrap-descriptions = 120
+
 [tool.pytest.ini_options]
 addopts = [
     "-v",                   # verbose output

--- a/src/rfdetr/__init__.py
+++ b/src/rfdetr/__init__.py
@@ -20,7 +20,8 @@ while the shim directories are present).
 hint) instead of the cryptic default ``ModuleNotFoundError: No module named 'rfdetr.util'``.
 
 To complete Phase 2, delete ``src/rfdetr/util/`` and ``src/rfdetr/deploy/`` and bump ``_REMOVED_IN_V17`` (or rename it)
-to reflect the new version boundary."""
+to reflect the new version boundary.
+"""
 
 import importlib
 import importlib.abc

--- a/src/rfdetr/__main__.py
+++ b/src/rfdetr/__main__.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Entrypoint for ``python -m rfdetr``."""
 
 from rfdetr.cli import main

--- a/src/rfdetr/_namespace.py
+++ b/src/rfdetr/_namespace.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Package-private helper: build a self-contained namespace from Pydantic configs.
 
 Replaces the previous shim in ``_args.py`` that called the deprecated ``populate_args()`` function from ``main.py``.

--- a/src/rfdetr/assets/coco_classes.py
+++ b/src/rfdetr/assets/coco_classes.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """COCO class ID to name mapping and flat class name list."""
 
 COCO_CLASSES = {

--- a/src/rfdetr/assets/model_weights.py
+++ b/src/rfdetr/assets/model_weights.py
@@ -3,9 +3,7 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
-"""
-Model weights abstraction and download system.
+"""Model weights abstraction and download system.
 
 Provides forward-compatible pattern for model weights across rf-detr and rf-detr-plus packages. External packages (like
 rf-detr-plus) should inherit from ModelWeightsBase to ensure compile-time interface compatibility.
@@ -20,7 +18,8 @@ Critical Strategic Decisions:
 Download Priority Order:
     1. Local ModelWeights.from_filename() - rf-detr's built-in models
     2. rfdetr_plus.assets.ModelWeights.from_filename() - lazy import if not found locally
-    3. PLATFORM_MODELS dict - legacy fallback for backward compatibility"""
+    3. PLATFORM_MODELS dict - legacy fallback for backward compatibility
+"""
 
 import os
 from dataclasses import dataclass
@@ -38,8 +37,7 @@ _DEFAULT_CACHE_DIR = "~/.roboflow/models"
 
 @dataclass(frozen=True)
 class ModelWeightAsset:
-    """
-    Dataclass representing a model asset with download information.
+    """Dataclass representing a model asset with download information.
 
     This is the standard format for model assets across rf-detr packages. Both rf-detr and rf-detr-plus should use this
     structure for compatibility.
@@ -63,8 +61,7 @@ class ModelWeightAsset:
 
 
 class ModelWeightsBase(Enum):
-    """
-    Base class for model weight registries.
+    """Base class for model weight registries.
 
     This base class ensures compile-time compatibility between rf-detr and rf-detr-plus. Both packages should inherit
     from this class to ensure they have the same interface.
@@ -112,8 +109,7 @@ class ModelWeightsBase(Enum):
 
     @classmethod
     def from_filename(cls, filename: str) -> Optional[ModelWeightAsset]:
-        """
-        Get ModelWeightAsset by filename.
+        """Get ModelWeightAsset by filename.
 
         Args:
             filename: The model filename (e.g., 'rf-detr-base.pth')
@@ -133,8 +129,7 @@ class ModelWeightsBase(Enum):
 
     @classmethod
     def get_url(cls, filename: str) -> Optional[str]:
-        """
-        Get download URL for a model by filename.
+        """Get download URL for a model by filename.
 
         Args:
             filename: The model filename
@@ -147,8 +142,7 @@ class ModelWeightsBase(Enum):
 
     @classmethod
     def get_md5(cls, filename: str) -> Optional[str]:
-        """
-        Get expected MD5 hash for a model by filename.
+        """Get expected MD5 hash for a model by filename.
 
         Args:
             filename: The model filename
@@ -161,8 +155,7 @@ class ModelWeightsBase(Enum):
 
     @classmethod
     def list_models(cls) -> list[str]:
-        """
-        List all available model filenames.
+        """List all available model filenames.
 
         Returns:
             List of model filenames
@@ -171,8 +164,7 @@ class ModelWeightsBase(Enum):
 
 
 class ModelWeights(ModelWeightsBase):
-    """
-    Enumeration of available RF-DETR model assets.
+    """Enumeration of available RF-DETR model assets.
 
     Inherits from ModelWeightsBase to ensure compatibility with rf-detr-plus.
 
@@ -308,8 +300,7 @@ def download_pretrain_weights(
     redownload: bool = False,
     validate_md5: bool = True,
 ) -> None:
-    """
-    Download pretrained weights with optional MD5 validation.
+    """Download pretrained weights with optional MD5 validation.
 
     Download Priority Order:
         The function searches for models in the following order, stopping at the first match:
@@ -397,8 +388,7 @@ def download_pretrain_weights(
 
 
 def validate_pretrain_weights(pretrain_weights: str, strict: bool = False) -> bool:
-    """
-    Validate MD5 hash of pretrained weights file.
+    """Validate MD5 hash of pretrained weights file.
 
     Args:
         pretrain_weights: Path to the pretrained weights file

--- a/src/rfdetr/cli/__init__.py
+++ b/src/rfdetr/cli/__init__.py
@@ -3,11 +3,11 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """RF-DETR CLI package.
 
 The ``rfdetr`` console script and ``python -m rfdetr`` both invoke :func:`main`, which runs
-:class:`~rfdetr.training.cli.RFDETRCli` (Lightning CLI with jsonargparse)."""
+:class:`~rfdetr.training.cli.RFDETRCli` (Lightning CLI with jsonargparse).
+"""
 
 from rfdetr.training.cli import main
 

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -17,10 +17,9 @@ EncoderName: TypeAlias = Literal["dinov2_windowed_small", "dinov2_windowed_base"
 
 
 class PretrainWeightsCompatibilityWarning(UserWarning):
-    """Warning emitted when ``ModelConfig`` overrides are likely to prevent the variant's
-    published pretrained weights from loading into the model — leaving large portions
-    of the model randomly initialized and typically producing much lower accuracy.
-    """
+    """Warning emitted when ``ModelConfig`` overrides are likely to prevent the variant's published pretrained weights
+    from loading into the model — leaving large portions of the model randomly initialized and typically producing much
+    lower accuracy."""
 
 
 def _detect_device() -> str:
@@ -54,9 +53,9 @@ DEVICE: str = _detect_device()
 
 
 class BaseConfig(BaseModel):
-    """
-    Base configuration class that validates input parameters against the defined model schema. If any unknown fields are
-    provided, a ValueError is raised listing the unknown and available parameters.
+    """Base configuration class that validates input parameters against the defined model schema.
+
+    If any unknown fields are provided, a ValueError is raised listing the unknown and available parameters.
     """
 
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid", validate_assignment=True)
@@ -394,9 +393,7 @@ class ModelConfig(BaseConfig):
 
 
 class RFDETRBaseConfig(ModelConfig):
-    """
-    The configuration for an RF-DETR Base model.
-    """
+    """The configuration for an RF-DETR Base model."""
 
     encoder: EncoderName = "dinov2_windowed_small"
     hidden_dim: int = 256
@@ -416,9 +413,7 @@ class RFDETRBaseConfig(ModelConfig):
 
 
 class RFDETRLargeDeprecatedConfig(RFDETRBaseConfig):
-    """
-    The configuration for an RF-DETR Large model.
-    """
+    """The configuration for an RF-DETR Large model."""
 
     encoder: EncoderName = "dinov2_windowed_base"
     hidden_dim: int = 384
@@ -430,9 +425,7 @@ class RFDETRLargeDeprecatedConfig(RFDETRBaseConfig):
 
 
 class RFDETRNanoConfig(RFDETRBaseConfig):
-    """
-    The configuration for an RF-DETR Nano model.
-    """
+    """The configuration for an RF-DETR Nano model."""
 
     out_feature_indexes: List[int] = [3, 6, 9, 12]
     num_windows: int = 2
@@ -444,9 +437,7 @@ class RFDETRNanoConfig(RFDETRBaseConfig):
 
 
 class RFDETRSmallConfig(RFDETRBaseConfig):
-    """
-    The configuration for an RF-DETR Small model.
-    """
+    """The configuration for an RF-DETR Small model."""
 
     out_feature_indexes: List[int] = [3, 6, 9, 12]
     num_windows: int = 2
@@ -458,9 +449,7 @@ class RFDETRSmallConfig(RFDETRBaseConfig):
 
 
 class RFDETRMediumConfig(RFDETRBaseConfig):
-    """
-    The configuration for an RF-DETR Medium model.
-    """
+    """The configuration for an RF-DETR Medium model."""
 
     out_feature_indexes: List[int] = [3, 6, 9, 12]
     num_windows: int = 2
@@ -784,10 +773,8 @@ class TrainConfig(BaseModel):
     @field_validator("dataset_dir", "output_dir", mode="after")
     @classmethod
     def expand_paths(cls, v: str) -> str:
-        """
-        Expand user paths (e.g., '~' or paths with separators) but leave simple filenames (like 'rf-detr-base.pth')
-        unchanged so they can match hosted model keys.
-        """
+        """Expand user paths (e.g., '~' or paths with separators) but leave simple filenames (like 'rf-detr-base.pth')
+        unchanged so they can match hosted model keys."""
         if v is None:
             return v
         return os.path.realpath(os.path.expanduser(v))

--- a/src/rfdetr/datasets/_develop.py
+++ b/src/rfdetr/datasets/_develop.py
@@ -3,11 +3,11 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Private developer tools for testing and benchmarking RF-DETR.
 
 These utilities are intended for internal use by developers and test suites. They are not part of the public API and may
-change without notice."""
+change without notice.
+"""
 
 from __future__ import annotations
 

--- a/src/rfdetr/datasets/aug_config.py
+++ b/src/rfdetr/datasets/aug_config.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Augmentation presets and default configuration for RF-DETR training.
 
 Import a preset and pass it as ``aug_config`` to your training call:
@@ -80,7 +79,8 @@ instead of Albumentations.
 | ``GaussNoise`` | ``K.RandomGaussianNoise`` | Upper bound of ``std_range`` used as fixed std |
 
 **Phase 1 limitation**: Segmentation models (``segmentation_head=True``) skip GPU augmentation; CPU Albumentations are
-used instead. Mask support is planned for Phase 2."""
+used instead. Mask support is planned for Phase 2.
+"""
 
 # ---------------------------------------------------------------------------
 # Default configuration (backward-compatible baseline)

--- a/src/rfdetr/datasets/coco.py
+++ b/src/rfdetr/datasets/coco.py
@@ -12,9 +12,7 @@
 # Copied from DETR (https://github.com/facebookresearch/detr)
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 # ------------------------------------------------------------------------
-
-"""
-COCO dataset which returns image_id for evaluation.
+"""COCO dataset which returns image_id for evaluation.
 
 Mostly copy-paste from https://github.com/pytorch/vision/blob/13b35ff/references/detection/coco_utils.py
 """
@@ -481,8 +479,7 @@ def make_coco_transforms_square_div_64(
     aug_config: Optional[Dict[str, Dict[str, Any]]] = None,
     gpu_postprocess: bool = False,
 ) -> Compose:
-    """
-    Create COCO transforms with square resizing where the output size is divisible by 64.
+    """Create COCO transforms with square resizing where the output size is divisible by 64.
 
     This function builds a torchvision-style transform pipeline for COCO images that resizes them to square shapes
     suitable for models that require spatial dimensions divisible by 64. It supports multi-scale training and optional

--- a/src/rfdetr/datasets/kornia_transforms.py
+++ b/src/rfdetr/datasets/kornia_transforms.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Kornia-based GPU augmentation pipeline for RF-DETR training.
 
 This module provides GPU-side augmentation as an alternative to the CPU-based Albumentations pipeline.  All transforms

--- a/src/rfdetr/datasets/o365.py
+++ b/src/rfdetr/datasets/o365.py
@@ -6,7 +6,6 @@
 # Copied and modified from LW-DETR (https://github.com/Atten4Vis/LW-DETR)
 # Copyright (c) 2024 Baidu. All Rights Reserved.
 # ------------------------------------------------------------------------
-
 """Dataset file for Object365."""
 
 from pathlib import Path

--- a/src/rfdetr/datasets/transforms.py
+++ b/src/rfdetr/datasets/transforms.py
@@ -12,10 +12,7 @@
 # Copied from DETR (https://github.com/facebookresearch/detr)
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 # ------------------------------------------------------------------------
-
-"""
-Transforms and data augmentation for both image + bbox.
-"""
+"""Transforms and data augmentation for both image + bbox."""
 
 from __future__ import annotations
 

--- a/src/rfdetr/datasets/yolo.py
+++ b/src/rfdetr/datasets/yolo.py
@@ -469,8 +469,7 @@ def _build_coco_api_from_samples(classes: list[str], dataset: Any) -> Any:
 
 
 def is_valid_yolo_dataset(dataset_dir: str) -> bool:
-    """
-    Checks if the specified dataset directory is in yolo format.
+    """Checks if the specified dataset directory is in yolo format.
 
     We accept a dataset to be in yolo format if the following conditions are met:
     - The dataset_dir contains a data.yaml or data.yml file
@@ -494,8 +493,7 @@ def is_valid_yolo_dataset(dataset_dir: str) -> bool:
 
 
 class ConvertYolo:
-    """
-    Converts supervision Detections to the target dict format expected by RF-DETR.
+    """Converts supervision Detections to the target dict format expected by RF-DETR.
 
     Args:
         include_masks: whether to include segmentation masks
@@ -529,8 +527,7 @@ class ConvertYolo:
         self.include_masks = include_masks
 
     def __call__(self, image: Image.Image, target: dict) -> tuple:
-        """
-        Convert image and YOLO detections to RF-DETR format.
+        """Convert image and YOLO detections to RF-DETR format.
 
         Args:
             image: PIL Image

--- a/src/rfdetr/deploy/__init__.py
+++ b/src/rfdetr/deploy/__init__.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Backward-compatibility shim — rfdetr.deploy is deprecated; use rfdetr.export."""
 
 import sys

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -119,7 +119,6 @@ def _validate_shape_dims(
         ValueError: If ``shape`` cannot be unpacked as a two-element sequence, if either
             dimension is a bool, float, or other non-integer type, if either dimension is not positive, or if either
             dimension is not divisible by ``block_size``.
-
     """
     try:
         height, width = shape  # type: ignore[misc]
@@ -162,7 +161,6 @@ def _resolve_patch_size(patch_size: int | None, model_config: object, caller: st
     Raises:
         ValueError: If the resolved or provided ``patch_size`` is not a positive integer,
             or if a caller-provided value disagrees with ``model_config.patch_size``.
-
     """
     if patch_size is None:
         patch_size = getattr(model_config, "patch_size", 14)
@@ -203,9 +201,8 @@ def _ensure_model_on_device(model_ctx: Any) -> None:
 
 
 class RFDETR:
-    """The base RF-DETR class implements the core methods for training RF-DETR models,
-    running inference on the models, optimising models, and uploading trained models for deployment.
-    """
+    """The base RF-DETR class implements the core methods for training RF-DETR models, running inference on the models,
+    optimising models, and uploading trained models for deployment."""
 
     means = [0.485, 0.456, 0.406]
     stds = [0.229, 0.224, 0.225]
@@ -418,7 +415,6 @@ class RFDETR:
 
         Raises:
             ValueError: If ``device`` is not a valid torch device specifier.
-
         """
         if device is None:
             return None, None
@@ -480,7 +476,6 @@ class RFDETR:
                 ``pip install "rfdetr[train,loggers]"``.
             ValueError: If ``resolution`` is not a positive integer or is not
                 divisible by ``patch_size * num_windows`` for the model variant.
-
         """
         # Both imports are grouped in a single try block because they both live in
         # the `rfdetr[train]` extras group — a missing `pytorch_lightning` (or any
@@ -1157,7 +1152,6 @@ class RFDETR:
 
         Returns:
             ModelContext with model, postprocess, device, resolution, args, and class_names attributes.
-
         """
         return _build_model_context(config)
 
@@ -1168,7 +1162,6 @@ class RFDETR:
         Returns:
             A list of class name strings, 0-indexed.  When no custom class names are embedded in the checkpoint, returns
             the standard 80 COCO class names.
-
         """
         if hasattr(self.model, "class_names") and self.model.class_names is not None:
             return list(self.model.class_names)
@@ -1236,7 +1229,6 @@ class RFDETR:
                 if either dimension does not support the ``__index__`` protocol (e.g. ``float``) or is a ``bool``, if
                 either dimension is zero or negative, if either dimension is not divisible by ``patch_size *
                 num_windows``, or if ``patch_size`` is not a positive integer.
-
         """
         import supervision as sv
 
@@ -1466,7 +1458,6 @@ class RFDETR:
         Raises:
             ValueError: If the `api_key` is not provided and not found in the
                 environment variable `ROBOFLOW_API_KEY`, or if the `size` is not set for custom architectures.
-
         """
         from roboflow import Roboflow
 

--- a/src/rfdetr/evaluation/__init__.py
+++ b/src/rfdetr/evaluation/__init__.py
@@ -3,5 +3,4 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Framework-agnostic evaluation utilities for RF-DETR."""

--- a/src/rfdetr/evaluation/coco_eval.py
+++ b/src/rfdetr/evaluation/coco_eval.py
@@ -12,13 +12,13 @@
 # Copied from DETR (https://github.com/facebookresearch/detr)
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 # ------------------------------------------------------------------------
-
 """COCO evaluator for ONNX/TRT export benchmarking.
 
 Provides :class:`CocoEvaluator` used by :mod:`rfdetr.export.benchmark` to compute mAP during ONNX and TensorRT inference
 benchmarks.
 
-Mostly copy-paste from https://github.com/pytorch/vision/blob/edfd5a7/references/detection/coco_eval.py"""
+Mostly copy-paste from https://github.com/pytorch/vision/blob/edfd5a7/references/detection/coco_eval.py
+"""
 
 import contextlib
 import copy

--- a/src/rfdetr/evaluation/f1_sweep.py
+++ b/src/rfdetr/evaluation/f1_sweep.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Confidence-threshold sweep for precision/recall/F1 computation."""
 
 from typing import Any

--- a/src/rfdetr/evaluation/matching.py
+++ b/src/rfdetr/evaluation/matching.py
@@ -13,7 +13,6 @@
 # Copied from DETR (https://github.com/facebookresearch/detr)
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 # ------------------------------------------------------------------------
-
 """Greedy matching and accumulation functions for evaluation metrics."""
 
 from typing import Any

--- a/src/rfdetr/export/__init__.py
+++ b/src/rfdetr/export/__init__.py
@@ -3,5 +3,4 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Model export utilities — ONNX, TensorRT, and TFLite."""

--- a/src/rfdetr/export/_onnx/__init__.py
+++ b/src/rfdetr/export/_onnx/__init__.py
@@ -7,10 +7,7 @@
 # Copyright (c) 2024 Baidu. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
-"""
-onnx optimizer and symbolic registry
-"""
+"""Onnx optimizer and symbolic registry."""
 
 from rfdetr.export._onnx import exporter, symbolic
 from rfdetr.export._onnx.exporter import OnnxOptimizer

--- a/src/rfdetr/export/_onnx/exporter.py
+++ b/src/rfdetr/export/_onnx/exporter.py
@@ -6,10 +6,7 @@
 # Copied and modified from LW-DETR (https://github.com/Atten4Vis/LW-DETR)
 # Copyright (c) 2024 Baidu. All Rights Reserved.
 # ------------------------------------------------------------------------
-
-"""
-ONNX export, simplification, and OnnxOptimizer.
-"""
+"""ONNX export, simplification, and OnnxOptimizer."""
 
 import inspect
 import json
@@ -220,7 +217,7 @@ class OnnxOptimizer:
         G_LOGGER.severity = severity
 
     def load_onnx(self, onnx_path: str):
-        """Load onnx from file"""
+        """Load onnx from file."""
         assert os.path.isfile(onnx_path), f"not found onnx file: {onnx_path}"
         onnx_graph = onnx.load(onnx_path)
         G_LOGGER.info(f"load onnx file: {onnx_path}")
@@ -282,12 +279,11 @@ class OnnxOptimizer:
             return onnx_graph
 
     def resize_fix(self):
-        """
-        This function loops through the graph looking for Resize nodes that uses scales for resize (has 3 inputs). It
-        substitutes found Resize with Resize that takes the size of the output tensor instead of scales. It adds
-        Shape->Slice->Concat
-                Shape->Slice----^     subgraph to the graph to extract the shape of the output tensor.
-        This fix is required for the dynamic shape support.
+        """This function loops through the graph looking for Resize nodes that uses scales for resize (has 3 inputs).
+
+        It substitutes found Resize with Resize that takes the size of the output tensor instead of scales. It adds
+        Shape->Slice->Concat         Shape->Slice----^     subgraph to the graph to extract the shape of the output
+        tensor. This fix is required for the dynamic shape support.
         """
         resized_node_count = 0
         for node in self.graph.nodes:

--- a/src/rfdetr/export/_onnx/inference.py
+++ b/src/rfdetr/export/_onnx/inference.py
@@ -3,12 +3,12 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """ONNX Runtime inference helpers for RF-DETR exported models.
 
 These functions handle session creation, image preprocessing, and detection decoding without requiring PyTorch or
 the RF-DETR training stack — only ``onnxruntime``, ``numpy``, ``supervision``, and ``Pillow`` are needed at inference
-time."""
+time.
+"""
 
 from __future__ import annotations
 

--- a/src/rfdetr/export/_onnx/symbolic.py
+++ b/src/rfdetr/export/_onnx/symbolic.py
@@ -6,9 +6,7 @@
 # Copied and modified from LW-DETR (https://github.com/Atten4Vis/LW-DETR)
 # Copyright (c) 2024 Baidu. All Rights Reserved.
 # ------------------------------------------------------------------------
-"""
-CustomOpSymbolicRegistry class
-"""
+"""CustomOpSymbolicRegistry class."""
 
 
 class CustomOpSymbolicRegistry:

--- a/src/rfdetr/export/_tensorrt.py
+++ b/src/rfdetr/export/_tensorrt.py
@@ -6,7 +6,6 @@
 # Copied and modified from LW-DETR (https://github.com/Atten4Vis/LW-DETR)
 # Copyright (c) 2024 Baidu. All Rights Reserved.
 # ------------------------------------------------------------------------
-
 """
 TensorRT export helpers: trtexec invocation and output parsing.
 """

--- a/src/rfdetr/export/_tflite/__init__.py
+++ b/src/rfdetr/export/_tflite/__init__.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """TFLite export: ONNX → TFLite conversion via onnx2tf."""
 
 from rfdetr.export._tflite.converter import _check_onnx2tf_available, export_tflite

--- a/src/rfdetr/export/_tflite/converter.py
+++ b/src/rfdetr/export/_tflite/converter.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """ONNX → TFLite conversion using the ``onnx2tf`` library.
 
 ``onnx2tf`` (PINTO0309) converts an ONNX graph to TFLite.  **Version 2.4.0 or later is required** — earlier 1.x releases
@@ -57,7 +56,8 @@ Note:
 Note:
     Segmentation models additionally emit a ``masks`` output.  FP32, FP16, and dynamic-range INT8 all match the PyTorch
     baseline closely (INT8 mask fidelity is marginally lower).  Verified on the non-plus segmentation
-    variants: Nano, Small, Medium, Large, and Preview."""
+    variants: Nano, Small, Medium, Large, and Preview.
+"""
 
 from __future__ import annotations
 

--- a/src/rfdetr/export/_tflite/inference.py
+++ b/src/rfdetr/export/_tflite/inference.py
@@ -3,12 +3,12 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """TFLite inference helpers for RF-DETR exported models.
 
 These functions handle interpreter creation, image preprocessing, and decoding of detection and segmentation-mask
 outputs without requiring PyTorch or the RF-DETR training stack: only ``tflite-runtime`` (or ``tensorflow``), ``numpy``,
-``supervision``, and ``Pillow`` are needed at inference time."""
+``supervision``, and ``Pillow`` are needed at inference time.
+"""
 
 from __future__ import annotations
 

--- a/src/rfdetr/export/benchmark.py
+++ b/src/rfdetr/export/benchmark.py
@@ -6,11 +6,11 @@
 # Copied and modified from LW-DETR (https://github.com/Atten4Vis/LW-DETR)
 # Copyright (c) 2024 Baidu. All Rights Reserved.
 # ------------------------------------------------------------------------
+"""This tool provides performance benchmarks by using ONNX Runtime and TensorRT to run inference on a given model with
+the COCO validation set.
 
+It offers reliable measurements of inference latency using ONNX Runtime or TensorRT on the device.
 """
-This tool provides performance benchmarks by using ONNX Runtime and TensorRT to run inference on a given model with
-the COCO validation set. It offers reliable measurements of inference latency using ONNX Runtime or TensorRT on the
-device."""
 
 import contextlib
 import json
@@ -174,7 +174,7 @@ def infer_engine(model, coco_evaluator, time_profile, prefix, img_list, device, 
 
 
 class TRTInference(object):
-    """TensorRT inference engine"""
+    """TensorRT inference engine."""
 
     def __init__(
         self, engine_path="dino.engine", device="cuda:0", sync_mode: bool = False, max_batch_size=32, verbose=False
@@ -220,7 +220,7 @@ class TRTInference(object):
         return blob
 
     def load_engine(self, path):
-        """load engine"""
+        """Load engine."""
         trt.init_libnvinfer_plugins(self.logger, "")
         with open(path, "rb") as f, trt.Runtime(self.logger) as runtime:
             return runtime.deserialize_cuda_engine(f.read())
@@ -244,7 +244,7 @@ class TRTInference(object):
         return names
 
     def get_bindings(self, engine, context, max_batch_size=32, device=None):
-        """build binddings"""
+        """Build binddings."""
         Binding = namedtuple("Binding", ("name", "dtype", "shape", "data", "ptr"))
         bindings = OrderedDict()
 

--- a/src/rfdetr/export/main.py
+++ b/src/rfdetr/export/main.py
@@ -6,10 +6,7 @@
 # Copied and modified from LW-DETR (https://github.com/Atten4Vis/LW-DETR)
 # Copyright (c) 2024 Baidu. All Rights Reserved.
 # ------------------------------------------------------------------------
-
-"""
-CLI orchestrator for ONNX and TensorRT model export.
-"""
+"""CLI orchestrator for ONNX and TensorRT model export."""
 
 import os
 import random

--- a/src/rfdetr/export/protocols.py
+++ b/src/rfdetr/export/protocols.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Exporter protocol — enables dependency-inversion for model export."""
 
 from pathlib import Path

--- a/src/rfdetr/models/_defaults.py
+++ b/src/rfdetr/models/_defaults.py
@@ -3,12 +3,12 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Hardcoded architectural constants not exposed in ModelConfig or TrainConfig.
 
 These values correspond to the ``build_namespace()`` defaults in ``_namespace.py`` that have no corresponding config
 field.  Making them explicit in a frozen dataclass enables testing, documentation, and (future) overrides without
-touching config validation."""
+touching config validation.
+"""
 
 from __future__ import annotations
 

--- a/src/rfdetr/models/_types.py
+++ b/src/rfdetr/models/_types.py
@@ -3,14 +3,14 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Shared type protocols for RF-DETR model builder functions.
 
 The ``BuilderArgs`` protocol documents the minimum attribute set consumed by ``build_model()``, ``build_backbone()``,
 ``build_transformer()``, and ``build_criterion_and_postprocessors()``.  It is satisfied structurally by any object that
 exposes the required attributes — including the ``SimpleNamespace`` produced by
 :func:`rfdetr._namespace.build_namespace` and, after Item #1 is complete, by
-``ModelConfig``/``TrainConfig`` directly."""
+``ModelConfig``/``TrainConfig`` directly.
+"""
 
 from __future__ import annotations
 

--- a/src/rfdetr/models/backbone/__init__.py
+++ b/src/rfdetr/models/backbone/__init__.py
@@ -23,7 +23,7 @@ class Joiner(nn.Sequential):
         self._export = False
 
     def forward(self, tensor_list: NestedTensor):
-        """ """
+        """"""
         x = self[0](tensor_list)
         pos = []
         for x_ in x:

--- a/src/rfdetr/models/backbone/backbone.py
+++ b/src/rfdetr/models/backbone/backbone.py
@@ -12,10 +12,7 @@
 # Copied from DETR (https://github.com/facebookresearch/detr)
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 # ------------------------------------------------------------------------
-
-"""
-Backbone modules.
-"""
+"""Backbone modules."""
 
 import torch
 import torch.nn.functional as F  # noqa: N812
@@ -134,7 +131,7 @@ class Backbone(BackboneBase):
             self.encoder = self.encoder.merge_and_unload()
 
     def forward(self, tensor_list: NestedTensor):
-        """ """
+        """"""
         # (H, W, B, C)
         feats = self.encoder(tensor_list.tensors)
         feats = self.projector(feats)
@@ -185,8 +182,7 @@ class Backbone(BackboneBase):
 
 
 def get_dinov2_lr_decay_rate(name: str, lr_decay_rate: float = 1.0, num_layers: int = 12) -> float:
-    """
-    Calculate lr decay rate for different ViT blocks.
+    """Calculate lr decay rate for different ViT blocks.
 
     Args:
         name: Parameter name.

--- a/src/rfdetr/models/backbone/dinov2_with_windowed_attn.py
+++ b/src/rfdetr/models/backbone/dinov2_with_windowed_attn.py
@@ -29,7 +29,8 @@ Helper functions copied locally:
     ``get_aligned_output_features_output_indices`` and
     ``find_pruneable_heads_and_indices`` were removed from the transformers v5 public API.  Private copies
     (``_get_aligned_output_features_output_indices`` and ``_find_pruneable_heads_and_indices``)
-    are kept in this module."""
+    are kept in this module.
+"""
 
 import collections.abc
 import math
@@ -284,10 +285,9 @@ class WindowedDinov2WithRegistersConfig(BackboneConfigMixin, PretrainedConfig):
 
 
 class Dinov2WithRegistersPatchEmbeddings(nn.Module):
-    """
-    This class turns `pixel_values` of shape `(batch_size, num_channels, height, width)` into the initial
-    `hidden_states` (patch embeddings) of shape `(batch_size, seq_length, hidden_size)` to be consumed by a Transformer.
-    """
+    """This class turns `pixel_values` of shape `(batch_size, num_channels, height, width)` into the initial
+    `hidden_states` (patch embeddings) of shape `(batch_size, seq_length, hidden_size)` to be consumed by a
+    Transformer."""
 
     def __init__(self, config):
         super().__init__()
@@ -316,9 +316,7 @@ class Dinov2WithRegistersPatchEmbeddings(nn.Module):
 
 
 class WindowedDinov2WithRegistersEmbeddings(nn.Module):
-    """
-    Construct the CLS token, mask token, register tokens, position and patch embeddings.
-    """
+    """Construct the CLS token, mask token, register tokens, position and patch embeddings."""
 
     def __init__(self, config: WindowedDinov2WithRegistersConfig) -> None:
         super().__init__()
@@ -338,8 +336,7 @@ class WindowedDinov2WithRegistersEmbeddings(nn.Module):
         self.config = config
 
     def interpolate_pos_encoding(self, embeddings: torch.Tensor, height: int, width: int) -> torch.Tensor:
-        """
-        This method allows to interpolate the pre-trained position encodings, to be able to use the model on higher
+        """This method allows to interpolate the pre-trained position encodings, to be able to use the model on higher
         resolution images. This implementation supports torch.jit tracing while maintaining backwards compatibility with
         the original implementation.
 
@@ -568,10 +565,8 @@ class Dinov2WithRegistersSdpaSelfAttention(Dinov2WithRegistersSelfAttention):
 
 
 class Dinov2WithRegistersSelfOutput(nn.Module):
-    """
-    The residual connection is defined in Dinov2WithRegistersLayer instead of here (as is the case with other models),
-    due to the layernorm applied before each block.
-    """
+    """The residual connection is defined in Dinov2WithRegistersLayer instead of here (as is the case with other
+    models), due to the layernorm applied before each block."""
 
     def __init__(self, config: WindowedDinov2WithRegistersConfig) -> None:
         super().__init__()
@@ -639,8 +634,7 @@ class Dinov2WithRegistersLayerScale(nn.Module):
 
 
 def drop_path(input: torch.Tensor, drop_prob: float = 0.0, training: bool = False) -> torch.Tensor:
-    """
-    Drop paths (Stochastic Depth) per sample (when applied in main path of residual blocks).
+    """Drop paths (Stochastic Depth) per sample (when applied in main path of residual blocks).
 
     Comment by Ross Wightman: This is the same as the DropConnect impl I created for EfficientNet, etc networks,
     however, the original name is misleading as 'Drop Connect' is a different form of dropout in a separate paper... See
@@ -842,10 +836,8 @@ class WindowedDinov2WithRegistersEncoder(nn.Module):
 
 
 class WindowedDinov2WithRegistersPreTrainedModel(PreTrainedModel):
-    """
-    An abstract class to handle weights initialization and a simple interface for downloading and loading pretrained
-    models.
-    """
+    """An abstract class to handle weights initialization and a simple interface for downloading and loading pretrained
+    models."""
 
     config_class = WindowedDinov2WithRegistersConfig
     base_model_prefix = "dinov2_with_registers"
@@ -855,7 +847,7 @@ class WindowedDinov2WithRegistersPreTrainedModel(PreTrainedModel):
     _supports_sdpa = True
 
     def _init_weights(self, module: Union[nn.Linear, nn.Conv2d, nn.LayerNorm]) -> None:
-        """Initialize the weights"""
+        """Initialize the weights."""
         if isinstance(module, (nn.Linear, nn.Conv2d)):
             # Upcast the input in `fp32` and cast it back to desired `dtype` to avoid
             # `trunc_normal_cpu` not implemented in `half` issues
@@ -934,8 +926,9 @@ class WindowedDinov2WithRegistersModel(WindowedDinov2WithRegistersPreTrainedMode
         return self.embeddings.patch_embeddings
 
     def _prune_heads(self, heads_to_prune: Dict[int, List[int]]) -> None:
-        """
-        Prunes heads of the model. heads_to_prune: dict of {layer_num: list of heads to prune in this layer} See base
+        """Prunes heads of the model.
+
+        heads_to_prune: dict of {layer_num: list of heads to prune in this layer} See base
         class PreTrainedModel
         """
         for layer, heads in heads_to_prune.items():
@@ -1102,8 +1095,8 @@ class WindowedDinov2WithRegistersForImageClassification(WindowedDinov2WithRegist
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
     ) -> Union[tuple, ImageClassifierOutput]:
-        r"""
-        labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
+        r"""Labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
+
             Labels for computing the image classification/regression loss. Indices should be in `[0, ...,
             config.num_labels - 1]`. If `config.num_labels == 1` a regression loss is computed (Mean-Square loss), If
             `config.num_labels > 1` a classification loss is computed (Cross-Entropy).

--- a/src/rfdetr/models/backbone/projector.py
+++ b/src/rfdetr/models/backbone/projector.py
@@ -9,10 +9,7 @@
 # Modified from ViTDet (https://github.com/facebookresearch/detectron2/tree/main/projects/ViTDet)
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 # ------------------------------------------------------------------------
-
-"""
-Projector
-"""
+"""Projector."""
 
 from typing import Callable, Optional, Sequence, Union
 
@@ -23,9 +20,9 @@ import torch.nn.functional as F  # noqa: N812
 
 
 class LayerNorm(nn.Module):
-    """
-    A LayerNorm variant, popularized by Transformers, that performs point-wise mean and variance normalization over the
-    channel dimension for inputs that have shape (batch_size, channels, height, width).
+    """A LayerNorm variant, popularized by Transformers, that performs point-wise mean and variance normalization over
+    the channel dimension for inputs that have shape (batch_size, channels, height, width).
+
     https://github.com/facebookresearch/ConvNeXt/blob/d1fa8f6fef0a165b27399986cc2bdacc92777e40/models/convnext.py#L119
     """
 
@@ -68,7 +65,7 @@ def get_norm(norm: Optional[Union[str, Callable[[int], nn.Module]]], out_channel
 
 
 def get_activation(name, inplace=False):
-    """get activation"""
+    """Get activation."""
     if name == "silu":
         module = nn.SiLU(inplace=inplace)
     elif name == "relu":
@@ -83,7 +80,7 @@ def get_activation(name, inplace=False):
 
 
 class ConvX(nn.Module):
-    """Conv-bn module"""
+    """Conv-bn module."""
 
     def __init__(
         self,
@@ -118,7 +115,7 @@ class ConvX(nn.Module):
         self.act = get_activation(act, inplace=True)
 
     def forward(self, x):
-        """forward"""
+        """forward."""
         out = self.act(self.bn(self.conv(x.contiguous())))
         return out
 
@@ -127,7 +124,7 @@ class Bottleneck(nn.Module):
     """Standard bottleneck."""
 
     def __init__(self, c1, c2, shortcut=True, g=1, k=(3, 3), e=0.5, act="silu", layer_norm=False, rms_norm=False):
-        """ch_in, ch_out, shortcut, groups, kernels, expand"""
+        """ch_in, ch_out, shortcut, groups, kernels, expand."""
         super().__init__()
         c_ = int(c2 * e)  # hidden channels
         self.cv1 = ConvX(c1, c_, k[0], 1, act=act, layer_norm=layer_norm, rms_norm=rms_norm)
@@ -143,7 +140,7 @@ class C2f(nn.Module):
     """Faster Implementation of CSP Bottleneck with 2 convolutions."""
 
     def __init__(self, c1, c2, n=1, shortcut=False, g=1, e=0.5, act="silu", layer_norm=False, rms_norm=False):
-        """ch_in, ch_out, number, shortcut, groups, expansion"""
+        """ch_in, ch_out, number, shortcut, groups, expansion."""
         super().__init__()
         self.c = int(c2 * e)  # hidden channels
         self.cv1 = ConvX(c1, 2 * self.c, 1, 1, act=act, layer_norm=layer_norm, rms_norm=rms_norm)
@@ -163,9 +160,9 @@ class C2f(nn.Module):
 
 
 class MultiScaleProjector(nn.Module):
-    """
-    This module implements MultiScaleProjector in :paper:`lwdetr`. It creates pyramid features built on top of the input
-    feature map.
+    """This module implements MultiScaleProjector in :paper:`lwdetr`.
+
+    It creates pyramid features built on top of the input feature map.
     """
 
     def __init__(
@@ -310,6 +307,6 @@ class SimpleProjector(nn.Module):
         self.ln = get_norm("LN", out_dim)
 
     def forward(self, x):
-        """forward"""
+        """forward."""
         out = self.ln(self.convx2(self.convx1(x[0])))
         return [out]

--- a/src/rfdetr/models/criterion.py
+++ b/src/rfdetr/models/criterion.py
@@ -7,7 +7,6 @@
 # Original copyrights: LW-DETR (Baidu), Conditional DETR (Microsoft),
 # DETR (Facebook), Deformable DETR (SenseTime)
 # ------------------------------------------------------------------------
-
 """Loss functions and criterion for RF-DETR training."""
 
 import torch
@@ -82,8 +81,7 @@ def dice_loss(
     targets: torch.Tensor,
     num_masks: float,
 ):
-    """
-    Compute the DICE loss, similar to generalized IOU for masks
+    """Compute the DICE loss, similar to generalized IOU for masks.
 
     Args:
         inputs: A float tensor of arbitrary shape.
@@ -128,7 +126,9 @@ sigmoid_ce_loss_jit = torch.jit.script(sigmoid_ce_loss)  # type: torch.jit.Scrip
 
 
 class SetCriterion(nn.Module):
-    """This class computes the loss for Conditional DETR. The process happens in two steps:
+    """This class computes the loss for Conditional DETR.
+
+    The process happens in two steps:
     1) we compute Hungarian assignment between ground truth boxes and the outputs of the model.
     2) we supervise each pair of matched ground-truth / prediction (supervise class and box).
     """
@@ -148,6 +148,7 @@ class SetCriterion(nn.Module):
         mask_point_sample_ratio: int = 16,
     ):
         """Create the criterion.
+
         Parameters:
             num_classes: number of object categories, omitting the special no-object category
             matcher: module able to compute a matching between targets and proposals
@@ -170,9 +171,8 @@ class SetCriterion(nn.Module):
         self.mask_point_sample_ratio = mask_point_sample_ratio
 
     def loss_labels(self, outputs, targets, indices, num_boxes, log=True):
-        """Classification loss (Binary focal loss)
-        targets dicts must contain the key "labels" containing a tensor of dim [nb_target_boxes]
-        """
+        """Classification loss (Binary focal loss) targets dicts must contain the key "labels" containing a tensor of
+        dim [nb_target_boxes]"""
         assert "pred_logits" in outputs
         src_logits = outputs["pred_logits"]
 
@@ -316,8 +316,10 @@ class SetCriterion(nn.Module):
 
     @torch.no_grad()
     def loss_cardinality(self, outputs, targets, indices, num_boxes):
-        """Compute the cardinality error, ie the absolute error in the number of predicted non-empty boxes
-        This is not really a loss, it is intended for logging purposes only. It doesn't propagate gradients
+        """Compute the cardinality error, ie the absolute error in the number of predicted non-empty boxes This is not
+        really a loss, it is intended for logging purposes only.
+
+        It doesn't propagate gradients
         """
         pred_logits = outputs["pred_logits"]
         device = pred_logits.device
@@ -329,10 +331,9 @@ class SetCriterion(nn.Module):
         return losses
 
     def loss_boxes(self, outputs, targets, indices, num_boxes):
-        """Compute the losses related to the bounding boxes, the L1 regression loss and the GIoU loss
-        targets dicts must contain the key "boxes" containing a tensor of dim [nb_target_boxes, 4]
-        The target boxes are expected in format (center_x, center_y, w, h), normalized by the image size.
-        """
+        """Compute the losses related to the bounding boxes, the L1 regression loss and the GIoU loss targets dicts must
+        contain the key "boxes" containing a tensor of dim [nb_target_boxes, 4] The target boxes are expected in format
+        (center_x, center_y, w, h), normalized by the image size."""
         assert "pred_boxes" in outputs
         idx = self._get_src_permutation_idx(indices)
         src_boxes = outputs["pred_boxes"][idx]
@@ -354,6 +355,7 @@ class SetCriterion(nn.Module):
 
     def loss_masks(self, outputs, targets, indices, num_boxes):
         """Compute BCE-with-logits and Dice losses for segmentation masks on matched pairs.
+
         Expects outputs to contain 'pred_masks' of shape [B, Q, H, W] and targets with key 'masks'.
         """
         assert "pred_masks" in outputs, "pred_masks missing in model outputs"
@@ -473,6 +475,7 @@ class SetCriterion(nn.Module):
 
     def forward(self, outputs, targets):
         """This performs the loss computation.
+
         Parameters:
              outputs: dict of tensors, see the output specification of the model for the format
              targets: list of dicts, such that len(targets) == batch_size.

--- a/src/rfdetr/models/heads/__init__.py
+++ b/src/rfdetr/models/heads/__init__.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Detection and segmentation head subpackage."""
 
 from rfdetr.models.heads.segmentation import DepthwiseConvBlock, MLPBlock, SegmentationHead

--- a/src/rfdetr/models/heads/detection.py
+++ b/src/rfdetr/models/heads/detection.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Detection head: bounding-box regression + classification projections."""
 
 import torch.nn as nn

--- a/src/rfdetr/models/heads/segmentation.py
+++ b/src/rfdetr/models/heads/segmentation.py
@@ -134,7 +134,7 @@ class _DepthwiseConvWithoutCuDNN(torch.autograd.Function):
 
 
 class DepthwiseConvBlock(nn.Module):
-    r"""Simplified ConvNeXt block without the MLP subnet"""
+    r"""Simplified ConvNeXt block without the MLP subnet."""
 
     def __init__(self, dim, layer_scale_init_value=0):
         super().__init__()
@@ -327,9 +327,8 @@ class SegmentationHead(nn.Module):
 
 
 def point_sample(input: torch.Tensor, point_coords: torch.Tensor, **kwargs: Any) -> torch.Tensor:
-    """
-    A wrapper around :func:`~rfdetr.utilities.tensors._bilinear_grid_sample` to support 3D point_coords tensors. Unlike
-    :func:`torch.nn.functional.grid_sample` it assumes `point_coords` to lie inside [0, 1] x [0, 1] square.
+    """A wrapper around :func:`~rfdetr.utilities.tensors._bilinear_grid_sample` to support 3D point_coords tensors.
+    Unlike :func:`torch.nn.functional.grid_sample` it assumes `point_coords` to lie inside [0, 1] x [0, 1] square.
 
     Args:
         input: A tensor of shape (N, C, H, W) that contains features map on a H x W grid.
@@ -401,10 +400,9 @@ def get_uncertain_point_coords_with_randomness(
     oversample_ratio: int = 3,
     importance_sample_ratio: float = 0.75,
 ) -> torch.Tensor:
-    """
-    Sample points in [0, 1] x [0, 1] coordinate space based on their uncertainty. The unceratinties
-        are calculated for each point using 'uncertainty_func' function that takes point's logit prediction as input.
-    See PointRend paper for details.
+    """Sample points in [0, 1] x [0, 1] coordinate space based on their uncertainty. The unceratinties are calculated
+    for each point using 'uncertainty_func' function that takes point's logit prediction as input. See PointRend paper
+    for details.
 
     Args:
         coarse_logits: A tensor of shape (N, C, Hmask, Wmask) or (N, 1, Hmask, Wmask) for
@@ -450,9 +448,8 @@ def get_uncertain_point_coords_with_randomness(
 
 
 def calculate_uncertainty(logits: torch.Tensor) -> torch.Tensor:
-    """
-    We estimate uncertainty as L1 distance between 0.0 and the logit prediction in 'logits' for the
-        foreground class in `classes`.
+    """We estimate uncertainty as L1 distance between 0.0 and the logit prediction in 'logits' for the foreground class
+    in `classes`.
 
     Args:
         logits: A tensor of shape (R, 1, ...) for class-specific or

--- a/src/rfdetr/models/lwdetr.py
+++ b/src/rfdetr/models/lwdetr.py
@@ -15,10 +15,7 @@
 # Modified from Deformable DETR (https://github.com/fundamentalvision/Deformable-DETR)
 # Copyright (c) 2020 SenseTime. All Rights Reserved.
 # ------------------------------------------------------------------------
-
-"""
-LW-DETR model and criterion classes
-"""
+"""LW-DETR model and criterion classes."""
 
 import copy
 import math
@@ -84,7 +81,7 @@ def _resize_linear(linear: nn.Linear, num_classes: int) -> nn.Linear:
 
 
 class LWDETR(nn.Module):
-    """This is the Group DETR v3 module that performs object detection"""
+    """This is the Group DETR v3 module that performs object detection."""
 
     def __init__(
         self,
@@ -100,6 +97,7 @@ class LWDETR(nn.Module):
         bbox_reparam=False,
     ):
         """Initializes the model.
+
         Parameters:
             backbone: torch module of the backbone to be used. See backbone.py
             transformer: torch module of the transformer architecture. See transformer.py
@@ -186,6 +184,7 @@ class LWDETR(nn.Module):
 
     def forward(self, samples: NestedTensor, targets=None):
         """The forward expects a NestedTensor, which consists of:
+
            - samples.tensor: batched images, of shape [batch_size x 3 x H x W]
            - samples.mask: a binary mask of shape [batch_size x H x W], containing 1 on padded pixels
 

--- a/src/rfdetr/models/matcher.py
+++ b/src/rfdetr/models/matcher.py
@@ -15,10 +15,7 @@
 # Modified from Deformable DETR (https://github.com/fundamentalvision/Deformable-DETR)
 # Copyright (c) 2020 SenseTime. All Rights Reserved.
 # ------------------------------------------------------------------------
-
-"""
-Modules to compute the matching cost and solve the corresponding LSAP.
-"""
+"""Modules to compute the matching cost and solve the corresponding LSAP."""
 
 import numpy as np
 import torch
@@ -35,10 +32,11 @@ _SANITIZED_COST_MARGIN = 1.0
 
 
 class HungarianMatcher(nn.Module):
-    """This class computes an assignment between the targets and the predictions of the network
-    For efficiency reasons, the targets don't include the no_object. Because of this, in general,
-    there are more predictions than targets. In this case, we do a 1-to-1 matching of the best predictions, while the
-    others are un-matched (and thus treated as non-objects).
+    """This class computes an assignment between the targets and the predictions of the network For efficiency reasons,
+    the targets don't include the no_object.
+
+    Because of this, in general, there are more predictions than targets. In this case, we do a 1-to-1 matching of the
+    best predictions, while the others are un-matched (and thus treated as non-objects).
     """
 
     def __init__(

--- a/src/rfdetr/models/math.py
+++ b/src/rfdetr/models/math.py
@@ -7,7 +7,6 @@
 # Original copyrights: LW-DETR (Baidu), Conditional DETR (Microsoft),
 # DETR (Facebook), Deformable DETR (SenseTime)
 # ------------------------------------------------------------------------
-
 """Mathematical building blocks: MLP, inverse_sigmoid, accuracy, interpolate."""
 
 from typing import List, Optional, Tuple

--- a/src/rfdetr/models/ops/functions/__init__.py
+++ b/src/rfdetr/models/ops/functions/__init__.py
@@ -11,9 +11,7 @@
 # ------------------------------------------------------------------------------------------------
 # Modified from https://github.com/chengdazhi/Deformable-Convolution-V2-PyTorch/tree/pytorch_1.0.0
 # ------------------------------------------------------------------------------------------------
-"""
-ms_deform_attn_func
-"""
+"""ms_deform_attn_func."""
 
 from rfdetr.models.ops.functions.ms_deform_attn_func import ms_deform_attn_core_pytorch
 

--- a/src/rfdetr/models/ops/functions/ms_deform_attn_func.py
+++ b/src/rfdetr/models/ops/functions/ms_deform_attn_func.py
@@ -11,9 +11,7 @@
 # ------------------------------------------------------------------------------------------------
 # Modified from https://github.com/chengdazhi/Deformable-Convolution-V2-PyTorch/tree/pytorch_1.0.0
 # ------------------------------------------------------------------------------------------------
-"""
-ms_deform_attn_func
-"""
+"""ms_deform_attn_func."""
 
 from __future__ import absolute_import, division, print_function
 

--- a/src/rfdetr/models/ops/modules/ms_deform_attn.py
+++ b/src/rfdetr/models/ops/modules/ms_deform_attn.py
@@ -11,9 +11,7 @@
 # ------------------------------------------------------------------------------------------------
 # Modified from https://github.com/chengdazhi/Deformable-Convolution-V2-PyTorch/tree/pytorch_1.0.0
 # ------------------------------------------------------------------------------------------------
-"""
-Multi-Scale Deformable Attention Module
-"""
+"""Multi-Scale Deformable Attention Module."""
 
 from __future__ import absolute_import, division, print_function
 
@@ -35,16 +33,12 @@ def _is_power_of_2(n):
 
 
 class MSDeformAttn(nn.Module):
-    """Multi-Scale Deformable Attention Module"""
+    """Multi-Scale Deformable Attention Module."""
 
     def __init__(self, d_model=256, n_levels=4, n_heads=8, n_points=4):
-        """
-        Multi-Scale Deformable Attention Module
-        :param d_model      hidden dimension
-        :param n_levels     number of feature levels
-        :param n_heads      number of attention heads
-        :param n_points     number of sampling points per attention head per feature level
-        """
+        """Multi-Scale Deformable Attention Module :param d_model      hidden dimension :param n_levels     number of
+        feature levels :param n_heads      number of attention heads :param n_points     number of sampling points per
+        attention head per feature level."""
         super().__init__()
         if d_model % n_heads != 0:
             raise ValueError("d_model must be divisible by n_heads, but got {} and {}".format(d_model, n_heads))
@@ -74,7 +68,7 @@ class MSDeformAttn(nn.Module):
         self._export = False
 
     def export(self):
-        """export mode"""
+        """Export mode."""
         self._export = True
 
     def _reset_parameters(self):

--- a/src/rfdetr/models/position_encoding.py
+++ b/src/rfdetr/models/position_encoding.py
@@ -12,10 +12,7 @@
 # Copied from DETR (https://github.com/facebookresearch/detr)
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 # ------------------------------------------------------------------------
-
-"""
-Various positional encodings for the transformer.
-"""
+"""Various positional encodings for the transformer."""
 
 import math
 
@@ -26,10 +23,8 @@ from rfdetr.utilities.tensors import NestedTensor
 
 
 class PositionEmbeddingSine(nn.Module):
-    """
-    This is a more standard version of the position embedding, very similar to the one used by the Attention is all you
-    need paper, generalized to work on images.
-    """
+    """This is a more standard version of the position embedding, very similar to the one used by the Attention is all
+    you need paper, generalized to work on images."""
 
     def __init__(self, num_pos_feats=64, temperature=10000, normalize=False, scale=None):
         super().__init__()
@@ -102,9 +97,7 @@ class PositionEmbeddingSine(nn.Module):
 
 
 class PositionEmbeddingLearned(nn.Module):
-    """
-    Absolute pos embedding, learned.
-    """
+    """Absolute pos embedding, learned."""
 
     def __init__(self, num_pos_feats=256):
         super().__init__()

--- a/src/rfdetr/models/postprocess.py
+++ b/src/rfdetr/models/postprocess.py
@@ -7,7 +7,6 @@
 # Original copyrights: LW-DETR (Baidu), Conditional DETR (Microsoft),
 # DETR (Facebook), Deformable DETR (SenseTime)
 # ------------------------------------------------------------------------
-
 """Post-processing module for converting model outputs to COCO API format."""
 
 import torch
@@ -18,7 +17,7 @@ from rfdetr.utilities import box_ops
 
 
 class PostProcess(nn.Module):
-    """This module converts the model's output into the format expected by the coco api"""
+    """This module converts the model's output into the format expected by the coco api."""
 
     def __init__(self, num_select=300) -> None:
         super().__init__()

--- a/src/rfdetr/models/segmentation_head.py
+++ b/src/rfdetr/models/segmentation_head.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Backward-compatibility shim — rfdetr.models.segmentation_head is deprecated; use rfdetr.models.heads.segmentation."""
 
 from rfdetr.utilities.decorators import _warn_deprecated_module

--- a/src/rfdetr/models/transformer.py
+++ b/src/rfdetr/models/transformer.py
@@ -12,9 +12,7 @@
 # Modified from DETR (https://github.com/facebookresearch/detr)
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 # ------------------------------------------------------------------------
-"""
-Transformer class
-"""
+"""Transformer class."""
 
 import copy
 import math
@@ -669,7 +667,7 @@ def build_transformer(args):
 
 
 def _get_activation_fn(activation):
-    """Return an activation function given a string"""
+    """Return an activation function given a string."""
     if activation == "relu":
         return F.relu
     if activation == "gelu":

--- a/src/rfdetr/models/weights.py
+++ b/src/rfdetr/models/weights.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Shared weight-loading and LoRA application utilities.
 
 Provides the canonical implementations of pretrained checkpoint loading and LoRA adapter injection, used by both the L1
@@ -11,7 +10,8 @@ inference facade (``rfdetr.detr``) and the L2 LightningModule (``rfdetr.training
 
 The weight-loading logic is taken from ``RFDETRModelModule._load_pretrain_weights`` in ``module_model.py`` (more
 complete: Pydantic-aware user-override detection, auto-alignment for fine-tuned checkpoints) and augmented with
-class-name extraction from ``detr.py:_load_pretrain_weights_into``."""
+class-name extraction from ``detr.py:_load_pretrain_weights_into``.
+"""
 
 from __future__ import annotations
 

--- a/src/rfdetr/training/__init__.py
+++ b/src/rfdetr/training/__init__.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """RF-DETR training package (PyTorch Lightning).
 
 Provides the Lightning module, data module, callbacks, and CLI for training and evaluation.

--- a/src/rfdetr/training/callbacks/__init__.py
+++ b/src/rfdetr/training/callbacks/__init__.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Lightning callbacks for RF-DETR training."""
 
 from rfdetr.training.callbacks.best_model import BestModelCallback, RFDETREarlyStopping

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Best-model checkpointing and early stopping callbacks for RF-DETR Lightning training."""
 
 from __future__ import annotations

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """COCOEvalCallback — torchmetrics-based mAP and F1 evaluation."""
 
 import contextlib

--- a/src/rfdetr/training/callbacks/drop_schedule.py
+++ b/src/rfdetr/training/callbacks/drop_schedule.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Drop-path / dropout schedule callback for RF-DETR Lightning training."""
 
 from __future__ import annotations

--- a/src/rfdetr/training/callbacks/ema.py
+++ b/src/rfdetr/training/callbacks/ema.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Exponential Moving Average callback compatible with ``ModelEma``."""
 
 from __future__ import annotations

--- a/src/rfdetr/training/checkpoint.py
+++ b/src/rfdetr/training/checkpoint.py
@@ -3,14 +3,14 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Checkpoint conversion utilities for the PTL training stack.
 
 Provides :func:`convert_legacy_checkpoint` to convert RF-DETR ``*.pth`` checkpoints (produced by the pre-PTL
 ``engine.py`` training loop) into the ``*.ckpt`` format expected by ``pytorch_lightning.Trainer``.
 
 Auto-detection of legacy format at load time is handled by
-:meth:`rfdetr.training.module_model.RFDETRModelModule.on_load_checkpoint`."""
+:meth:`rfdetr.training.module_model.RFDETRModelModule.on_load_checkpoint`.
+"""
 
 from __future__ import annotations
 

--- a/src/rfdetr/training/cli.py
+++ b/src/rfdetr/training/cli.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """LightningCLI entry point for RF-DETR training and evaluation.
 
 Provides the ``rfdetr`` command with auto-generated subcommands::
@@ -15,7 +14,8 @@ Provides the ``rfdetr`` command with auto-generated subcommands::
 
 Both ``RFDETRModelModule`` and ``RFDETRDataModule`` share the same ``(model_config, train_config)`` constructor
 signature.  ``link_arguments`` eliminates the duplication so the user specifies each config group once; the datamodule
-receives the same values automatically at parse time."""
+receives the same values automatically at parse time.
+"""
 
 from pytorch_lightning.cli import LightningArgumentParser, LightningCLI
 

--- a/src/rfdetr/training/drop_schedule.py
+++ b/src/rfdetr/training/drop_schedule.py
@@ -7,7 +7,6 @@
 # Copyright (c) 2024 Baidu. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Drop-path / dropout schedule utilities."""
 
 from typing import Literal
@@ -23,7 +22,7 @@ def drop_scheduler(
     mode: Literal["standard", "early", "late"] = "standard",
     schedule: Literal["constant", "linear"] = "constant",
 ) -> np.ndarray:
-    """drop scheduler"""
+    """Drop scheduler."""
     assert mode in ["standard", "early", "late"]
     if mode == "standard":
         return np.full(epochs * niter_per_ep, drop_rate)

--- a/src/rfdetr/training/model_ema.py
+++ b/src/rfdetr/training/model_ema.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """EMA model and best-metric tracking utilities (moved from rfdetr.util.utils)."""
 
 import json
@@ -15,7 +14,7 @@ import torch
 
 
 class ModelEma(torch.nn.Module):
-    """EMA Model"""
+    """EMA Model."""
 
     def __init__(
         self,

--- a/src/rfdetr/training/module_data.py
+++ b/src/rfdetr/training/module_data.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """LightningDataModule for RF-DETR dataset construction and loaders."""
 
 from typing import Any, List, Optional, Tuple

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """LightningModule for RF-DETR training and validation."""
 
 from __future__ import annotations

--- a/src/rfdetr/training/param_groups.py
+++ b/src/rfdetr/training/param_groups.py
@@ -6,7 +6,7 @@
 # Copied and modified from LW-DETR (https://github.com/Atten4Vis/LW-DETR)
 # Copyright (c) 2024 Baidu. All Rights Reserved.
 # ------------------------------------------------------------------------
-"""Functions to get params dict"""
+"""Functions to get params dict."""
 
 from typing import Any, Dict, List, cast
 
@@ -19,8 +19,7 @@ logger = get_logger()
 
 
 def get_vit_lr_decay_rate(name: str, lr_decay_rate: float = 1.0, num_layers: int = 12) -> float:
-    """
-    Calculate lr decay rate for different ViT blocks.
+    """Calculate lr decay rate for different ViT blocks.
 
     Args:
         name: parameter name.
@@ -41,8 +40,7 @@ def get_vit_lr_decay_rate(name: str, lr_decay_rate: float = 1.0, num_layers: int
 
 
 def get_vit_weight_decay_rate(name: str, weight_decay_rate: float = 1.0) -> float:
-    """
-    Calculate weight decay rate for different ViT parameters.
+    """Calculate weight decay rate for different ViT parameters.
 
     Args:
         name: parameter name.

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Trainer factory — assembles a PTL Trainer from RF-DETR configs."""
 
 import warnings

--- a/src/rfdetr/util/box_ops.py
+++ b/src/rfdetr/util/box_ops.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Deprecated: use ``rfdetr.utilities.box_ops`` instead."""
 
 from rfdetr.utilities.decorators import _warn_deprecated_module

--- a/src/rfdetr/util/coco_classes.py
+++ b/src/rfdetr/util/coco_classes.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Deprecated: use ``rfdetr.assets.coco_classes`` instead."""
 
 from rfdetr.utilities.decorators import _warn_deprecated_module

--- a/src/rfdetr/util/drop_scheduler.py
+++ b/src/rfdetr/util/drop_scheduler.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Backward-compatibility shim — rfdetr.util.drop_scheduler is deprecated; use rfdetr.training.drop_schedule."""
 
 from rfdetr.utilities.decorators import _warn_deprecated_module

--- a/src/rfdetr/util/files.py
+++ b/src/rfdetr/util/files.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Deprecated: use ``rfdetr.utilities.files`` instead."""
 
 from rfdetr.utilities.decorators import _warn_deprecated_module

--- a/src/rfdetr/util/get_param_dicts.py
+++ b/src/rfdetr/util/get_param_dicts.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Backward-compatibility shim — rfdetr.util.get_param_dicts is deprecated; use rfdetr.training.param_groups."""
 
 from rfdetr.utilities.decorators import _warn_deprecated_module

--- a/src/rfdetr/util/logger.py
+++ b/src/rfdetr/util/logger.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Deprecated: use ``rfdetr.utilities.logger`` instead."""
 
 from rfdetr.utilities.decorators import _warn_deprecated_module

--- a/src/rfdetr/util/misc.py
+++ b/src/rfdetr/util/misc.py
@@ -14,7 +14,6 @@
 # Copied from DETR (https://github.com/facebookresearch/detr)
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 # ------------------------------------------------------------------------
-
 """Deprecated: most symbols have moved to ``rfdetr.utilities``.
 
 ``accuracy``, ``inverse_sigmoid``, and ``interpolate`` now live in ``rfdetr.models.math`` and are re-exported here for

--- a/src/rfdetr/util/package.py
+++ b/src/rfdetr/util/package.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Deprecated: use ``rfdetr.utilities.package`` instead."""
 
 from rfdetr.utilities.decorators import _warn_deprecated_module

--- a/src/rfdetr/util/utils.py
+++ b/src/rfdetr/util/utils.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Deprecated: use ``rfdetr.utilities`` or ``rfdetr.training.model_ema`` instead."""
 
 from rfdetr.utilities.decorators import _warn_deprecated_module

--- a/src/rfdetr/util/visualize.py
+++ b/src/rfdetr/util/visualize.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Deprecated: use ``rfdetr.visualize.data`` instead."""
 
 from rfdetr.utilities.decorators import _warn_deprecated_module

--- a/src/rfdetr/utilities/__init__.py
+++ b/src/rfdetr/utilities/__init__.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Utility functions and helpers."""
 
 from rfdetr.utilities import box_ops

--- a/src/rfdetr/utilities/box_ops.py
+++ b/src/rfdetr/utilities/box_ops.py
@@ -14,7 +14,6 @@
 # Copied from DETR (https://github.com/facebookresearch/detr)
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 # ------------------------------------------------------------------------
-
 """Utilities for bounding box manipulation and GIoU."""
 
 import torch

--- a/src/rfdetr/utilities/decorators.py
+++ b/src/rfdetr/utilities/decorators.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Deprecation utilities and decorators."""
 
 import warnings

--- a/src/rfdetr/utilities/distributed.py
+++ b/src/rfdetr/utilities/distributed.py
@@ -10,7 +10,6 @@
 # Copied from DETR (https://github.com/facebookresearch/detr)
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 # ------------------------------------------------------------------------
-
 """Distributed-training helpers (world-size, rank, all_gather, reduce_dict)."""
 
 import pickle

--- a/src/rfdetr/utilities/files.py
+++ b/src/rfdetr/utilities/files.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """File download and MD5 validation helpers."""
 
 import hashlib

--- a/src/rfdetr/utilities/logger.py
+++ b/src/rfdetr/utilities/logger.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Shared logger factory for RF-DETR modules."""
 
 import logging

--- a/src/rfdetr/utilities/package.py
+++ b/src/rfdetr/utilities/package.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Package version and git-status helpers."""
 
 import os

--- a/src/rfdetr/utilities/reproducibility.py
+++ b/src/rfdetr/utilities/reproducibility.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Reproducibility helpers: seed all RNGs consistently."""
 
 import random

--- a/src/rfdetr/utilities/state_dict.py
+++ b/src/rfdetr/utilities/state_dict.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Checkpoint and state-dict helpers."""
 
 import os

--- a/src/rfdetr/utilities/tensors.py
+++ b/src/rfdetr/utilities/tensors.py
@@ -10,7 +10,6 @@
 # Copied from DETR (https://github.com/facebookresearch/detr)
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 # ------------------------------------------------------------------------
-
 """Tensor utilities: NestedTensor, collate_fn, and helpers."""
 
 from functools import partial

--- a/src/rfdetr/variants.py
+++ b/src/rfdetr/variants.py
@@ -7,7 +7,8 @@
 
 All classes inherit from :class:`~rfdetr.detr.RFDETR` which remains defined in ``rfdetr.detr``. Backward-compatible
 access from ``rfdetr.detr`` is provided via lazy ``__getattr__`` re-exports, so importing ``rfdetr.variants`` no longer
-depends on a fragile eager ``detr -> variants`` import sequence."""
+depends on a fragile eager ``detr -> variants`` import sequence.
+"""
 
 from __future__ import annotations
 
@@ -66,27 +67,21 @@ class RFDETRBase(RFDETR):
 
 
 class RFDETRNano(RFDETR):
-    """
-    Train an RF-DETR Nano model.
-    """
+    """Train an RF-DETR Nano model."""
 
     size = "rfdetr-nano"
     _model_config_class = RFDETRNanoConfig
 
 
 class RFDETRSmall(RFDETR):
-    """
-    Train an RF-DETR Small model.
-    """
+    """Train an RF-DETR Small model."""
 
     size = "rfdetr-small"
     _model_config_class = RFDETRSmallConfig
 
 
 class RFDETRMedium(RFDETR):
-    """
-    Train an RF-DETR Medium model.
-    """
+    """Train an RF-DETR Medium model."""
 
     size = "rfdetr-medium"
     _model_config_class = RFDETRMediumConfig

--- a/src/rfdetr/visualize/__init__.py
+++ b/src/rfdetr/visualize/__init__.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Visualization utilities for RF-DETR."""
 
 from rfdetr.visualize.data import save_gt_predictions_visualization

--- a/src/rfdetr/visualize/data.py
+++ b/src/rfdetr/visualize/data.py
@@ -26,8 +26,7 @@ def save_gt_predictions_visualization(
     pred_ious: list[float | None],
     save_dir: Path,
 ) -> None:
-    """
-    Save a visualization image showing both GT and prediction boxes.
+    """Save a visualization image showing both GT and prediction boxes.
 
     Boxes are labeled with class ID and confidence (for predictions). For predictions with known IoU, the IoU value is
     also shown.

--- a/src/rfdetr/visualize/training.py
+++ b/src/rfdetr/visualize/training.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Post-training metrics plotting utilities.
 
 Reads the ``metrics.csv`` written by PTL's ``CSVLogger`` (always present after a ``build_trainer``-based run) and saves

--- a/tests/assets/test_downloads.py
+++ b/tests/assets/test_downloads.py
@@ -124,8 +124,8 @@ class TestDownloadPretrainWeights:
     def test_redownload_flag_forces_download_despite_incorrect_md5(self, mock_file_operations):
         """Test that redownload=True triggers download even when MD5 is incorrect.
 
-        Verifies the force-redownload path where the user explicitly wants to overwrite an existing file (e.g. a
-        fine-tuned checkpoint) with the original registry weights.
+        Verifies the force-redownload path where the user explicitly wants to overwrite an existing file (e.g. a fine-
+        tuned checkpoint) with the original registry weights.
         """
         mock_file_operations["exists"].return_value = True
         mock_file_operations["validate"].return_value = False  # Incorrect MD5

--- a/tests/benchmarks/test_inference_coco.py
+++ b/tests/benchmarks/test_inference_coco.py
@@ -22,7 +22,8 @@ Test functions:
   segmentation models (Nano through 2XLarge).
 - :func:`test_inference_detection_ptl_predict` — ``trainer.predict()`` exercises
   the PTL predict loop (50 samples) then asserts mAP via ``Trainer.validate``.
-- :func:`test_inference_segmentation_ptl_predict` — same for segmentation models."""
+- :func:`test_inference_segmentation_ptl_predict` — same for segmentation models.
+"""
 
 import os
 from pathlib import Path

--- a/tests/cli/test_configs.py
+++ b/tests/cli/test_configs.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Tests for YAML config files in configs/ — PTL Ch4/T6.
 
 Verifies that every example YAML config file:

--- a/tests/cli/test_legacy_cli.py
+++ b/tests/cli/test_legacy_cli.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Tests for the CLI entry point configuration."""
 
 import pathlib
@@ -22,7 +21,7 @@ class TestEntryPoint:
         return m.group(1)
 
     def test_entry_point_value(self):
-        """rfdetr entry point must be rfdetr.cli:main."""
+        """Rfdetr entry point must be rfdetr.cli:main."""
         assert self._read_entry_point() == "rfdetr.cli:main"
 
     def test_entry_point_not_legacy(self):

--- a/tests/cli/test_smoke.py
+++ b/tests/cli/test_smoke.py
@@ -3,14 +3,14 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """CLI smoke tests and YAML roundtrip tests — PTL Ch4/T7.
 
 Smoke tests run RFDETRCli in-process with args=['--help'] / ['fit', '--help'] / ['validate', '--help'] and assert
 SystemExit(0) — no subprocess needed.
 
 YAML roundtrip tests load each example config with yaml.safe_load, import the class_path, construct the config object
-with the YAML init_args, and verify every specified field survived the round-trip."""
+with the YAML init_args, and verify every specified field survived the round-trip.
+"""
 
 import importlib
 import pathlib
@@ -68,22 +68,22 @@ def _instantiate(class_path: str, init_args: dict) -> object:
 
 
 class TestCLIHelp:
-    """rfdetr --help and subcommand --help must exit 0."""
+    """Rfdetr --help and subcommand --help must exit 0."""
 
     def test_top_level_help(self):
-        """rfdetr --help exits with code 0."""
+        """Rfdetr --help exits with code 0."""
         assert _run_cli("--help") == 0
 
     def test_fit_help(self):
-        """rfdetr fit --help exits with code 0."""
+        """Rfdetr fit --help exits with code 0."""
         assert _run_cli("fit", "--help") == 0
 
     def test_validate_help(self):
-        """rfdetr validate --help exits with code 0."""
+        """Rfdetr validate --help exits with code 0."""
         assert _run_cli("validate", "--help") == 0
 
     def test_fit_help_exposes_model_config(self):
-        """rfdetr fit --help output lists model.model_config arguments."""
+        """Rfdetr fit --help output lists model.model_config arguments."""
         import io
         import sys
 
@@ -97,7 +97,7 @@ class TestCLIHelp:
         assert "model_config" in buf.getvalue()
 
     def test_fit_help_exposes_train_config(self):
-        """rfdetr fit --help output lists model.train_config arguments."""
+        """Rfdetr fit --help output lists model.train_config arguments."""
         import io
         import sys
 

--- a/tests/datasets/test_augmentations.py
+++ b/tests/datasets/test_augmentations.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Tests for Albumentations augmentation wrappers."""
 
 from unittest import mock

--- a/tests/datasets/test_coco.py
+++ b/tests/datasets/test_coco.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Regression tests for COCO dataset handling.
 
 Tests cover:
@@ -145,9 +144,8 @@ class TestLoadClassesHierarchy:
         assert result == ["dog", "cat"]
 
     def test_category_named_none_does_not_empty_list(self, tmp_path: Path) -> None:
-        """If a category is literally named 'none' and all supercategories
-        are placeholders, the loader must return all class names instead of [].
-        """
+        """If a category is literally named 'none' and all supercategories are placeholders, the loader must return all
+        class names instead of []."""
         categories = [
             {"id": 1, "name": "none", "supercategory": "none"},
             {"id": 2, "name": "dog", "supercategory": "none"},
@@ -257,7 +255,7 @@ class TestBuildO365RawGpuBackend:
             return result, mock_transform, mock_sq_transform
 
     def test_cpu_backend_no_warning(self):
-        """cpu backend does not call logger.warning with O365 content."""
+        """Cpu backend does not call logger.warning with O365 content."""
         from unittest.mock import patch
 
         with patch("rfdetr.datasets.o365.logger") as mock_logger:
@@ -266,7 +264,7 @@ class TestBuildO365RawGpuBackend:
         assert len(o365_warns) == 0, "cpu backend must not warn about O365 GPU augmentation"
 
     def test_auto_backend_emits_warning(self):
-        """auto + CUDA + kornia available: logger.warning about O365 Phase 1 limitation."""
+        """Auto + CUDA + kornia available: logger.warning about O365 Phase 1 limitation."""
         import sys
         from unittest.mock import MagicMock, patch
 
@@ -280,7 +278,7 @@ class TestBuildO365RawGpuBackend:
         assert len(o365_warns) >= 1, "auto backend must warn about O365 GPU aug limitation"
 
     def test_auto_backend_no_cuda_no_warning(self):
-        """auto + no CUDA: resolves to cpu, no O365 warning emitted."""
+        """Auto + no CUDA: resolves to cpu, no O365 warning emitted."""
         from unittest.mock import patch
 
         with (
@@ -292,13 +290,13 @@ class TestBuildO365RawGpuBackend:
         assert len(o365_warns) == 0, "auto + no CUDA must not warn about O365 GPU aug"
 
     def test_gpu_postprocess_false_for_cpu_backend(self):
-        """cpu backend passes gpu_postprocess=False (or omits it) to make_coco_transforms."""
+        """Cpu backend passes gpu_postprocess=False (or omits it) to make_coco_transforms."""
         _, mock_transform, _ = self._call_build_o365_raw("cpu")
         call_kwargs = mock_transform.call_args.kwargs if mock_transform.call_args else {}
         assert call_kwargs.get("gpu_postprocess", False) is False
 
     def test_gpu_postprocess_true_for_auto_backend(self):
-        """auto + CUDA + kornia available: gpu_postprocess=True passed to make_coco_transforms."""
+        """Auto + CUDA + kornia available: gpu_postprocess=True passed to make_coco_transforms."""
         import sys
         from unittest.mock import MagicMock, patch
 
@@ -311,7 +309,7 @@ class TestBuildO365RawGpuBackend:
         assert call_kwargs.get("gpu_postprocess", False) is True
 
     def test_gpu_postprocess_false_for_auto_no_cuda(self):
-        """auto + no CUDA: gpu_postprocess=False so CPU Normalize is retained."""
+        """Auto + no CUDA: gpu_postprocess=False so CPU Normalize is retained."""
         from unittest.mock import patch
 
         with patch("rfdetr.datasets.kornia_transforms._has_cuda_device", return_value=False):
@@ -326,7 +324,7 @@ class TestBuildO365RawGpuBackend:
         mock_transform.assert_not_called()
 
     def test_gpu_backend_no_cuda_raises_runtime_error(self):
-        """gpu backend must fail fast when CUDA is unavailable."""
+        """Gpu backend must fail fast when CUDA is unavailable."""
         from unittest.mock import patch
 
         with (
@@ -336,7 +334,7 @@ class TestBuildO365RawGpuBackend:
             self._call_build_o365_raw("gpu")
 
     def test_gpu_backend_no_kornia_raises_import_error(self):
-        """gpu backend must raise with install hint when kornia is missing."""
+        """Gpu backend must raise with install hint when kornia is missing."""
         from unittest.mock import patch
 
         original_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
@@ -358,7 +356,7 @@ class TestBuildRoboflowFromCocoBackendResolution:
     """Roboflow COCO builder should resolve backend for gpu_postprocess consistently."""
 
     def test_auto_no_cuda_keeps_cpu_normalize(self):
-        """auto + no CUDA must set gpu_postprocess=False."""
+        """Auto + no CUDA must set gpu_postprocess=False."""
         from unittest.mock import MagicMock, patch
 
         from rfdetr.datasets.coco import build_roboflow_from_coco

--- a/tests/datasets/test_coco_resize_config.py
+++ b/tests/datasets/test_coco_resize_config.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Characterization tests for _build_train_resize_config."""
 
 import pytest
@@ -46,7 +45,7 @@ class TestBuildTrainResizeConfigStructure:
 
 
 class TestBuildTrainResizeConfigSquareSingleScale:
-    """square=True, single scale — OneOf[Resize] + Sequential[..., OneOf[RandomSizedCrop]]."""
+    """Square=True, single scale — OneOf[Resize] + Sequential[..., OneOf[RandomSizedCrop]]."""
 
     def test_option_a_is_oneof_wrapping_single_resize(self):
         result = _build_train_resize_config([640], square=True)
@@ -86,7 +85,7 @@ class TestBuildTrainResizeConfigSquareSingleScale:
 
 
 class TestBuildTrainResizeConfigSquareMultiScale:
-    """square=True, multiple scales — OneOf[Resize] + Sequential[..., OneOf[RandomSizedCrop]]."""
+    """Square=True, multiple scales — OneOf[Resize] + Sequential[..., OneOf[RandomSizedCrop]]."""
 
     def test_option_a_is_oneof_of_resizes(self):
         result = _build_train_resize_config([480, 640], square=True)
@@ -126,7 +125,7 @@ class TestBuildTrainResizeConfigSquareMultiScale:
 
 
 class TestBuildTrainResizeConfigNonSquareSingleScale:
-    """square=False, single scale — SmallestMaxSize uses scalar, default cap 1333."""
+    """Square=False, single scale — SmallestMaxSize uses scalar, default cap 1333."""
 
     def test_option_a_uses_scalar_size(self):
         result = _build_train_resize_config([640], square=False)
@@ -161,7 +160,7 @@ class TestBuildTrainResizeConfigNonSquareSingleScale:
 
 
 class TestBuildTrainResizeConfigNonSquareMultiScale:
-    """square=False, multiple scales — SmallestMaxSize uses list directly."""
+    """Square=False, multiple scales — SmallestMaxSize uses list directly."""
 
     def test_option_a_uses_list_size(self):
         result = _build_train_resize_config([480, 640], square=False)

--- a/tests/datasets/test_coco_rle.py
+++ b/tests/datasets/test_coco_rle.py
@@ -3,11 +3,11 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Tests for native RLE annotation support in the COCO dataset pipeline.
 
 Verifies that :func:`convert_coco_poly_to_mask` and :class:`ConvertCoco` correctly handle compressed RLE, uncompressed
-RLE, and polygon segmentation formats — including mixed annotations within the same image."""
+RLE, and polygon segmentation formats — including mixed annotations within the same image.
+"""
 
 import numpy as np
 import pycocotools.mask as mask_util

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -3,11 +3,11 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Tests for Kornia GPU augmentation pipeline builder and bbox utilities.
 
 All tests in this module are CPU-compatible — Kornia operates on CPU tensors identically to GPU tensors, so no
-``@pytest.mark.gpu`` is needed."""
+``@pytest.mark.gpu`` is needed.
+"""
 
 import pytest
 import torch
@@ -26,8 +26,8 @@ from rfdetr.datasets.aug_config import (
 
 
 class TestBuildKorniaPipeline:
-    """build_kornia_pipeline returns a valid pipeline for every preset and
-    rejects unknown transform keys with a clear error."""
+    """build_kornia_pipeline returns a valid pipeline for every preset and rejects unknown transform keys with a clear
+    error."""
 
     @pytest.fixture(autouse=True)
     def _require_kornia(self):

--- a/tests/datasets/test_save_grids.py
+++ b/tests/datasets/test_save_grids.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Tests for DatasetGridSaver — verifies that annotated grid images are written without OpenCV layout errors across all
 supported OpenCV versions."""
 

--- a/tests/datasets/test_synthetic.py
+++ b/tests/datasets/test_synthetic.py
@@ -594,9 +594,8 @@ class TestDrawSyntheticShapeEdgeCases:
         ],
     )
     def test_degenerate_size_returns_polygon_without_crashing(self, shape, size, expected_n_coords):
-        """draw_synthetic_shape with size=0 or size=1 must not raise and must
-        return the expected number of flat coordinate values.
-        """
+        """draw_synthetic_shape with size=0 or size=1 must not raise and must return the expected number of flat
+        coordinate values."""
         img = np.zeros((100, 100, 3), dtype=np.uint8)
         _, poly = draw_synthetic_shape(img, shape, sv.Color.WHITE, (50, 50), size)
         assert len(poly) == expected_n_coords

--- a/tests/datasets/test_yolo.py
+++ b/tests/datasets/test_yolo.py
@@ -112,7 +112,7 @@ class TestBuildRoboflowFromYoloAugConfig:
         assert kwargs["data_file"] == str(tmp_path / "data.yml")
 
     def test_auto_no_cuda_sets_gpu_postprocess_false(self) -> None:
-        """auto + no CUDA must keep CPU normalize by passing gpu_postprocess=False."""
+        """Auto + no CUDA must keep CPU normalize by passing gpu_postprocess=False."""
         args = self._make_args(square_resize_div_64=False, aug_config=None)
         args.augmentation_backend = "auto"
         with (

--- a/tests/export/test_onnx_notes.py
+++ b/tests/export/test_onnx_notes.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Tests for the ``notes`` parameter in :func:`~rfdetr.export._onnx.exporter.export_onnx`."""
 
 import json
@@ -142,7 +141,7 @@ class TestExportOnnxNotes:
             _export_tiny_model(tmp_path, notes=float("nan"))
 
     def test_notes_is_keyword_only(self, tmp_path: Path) -> None:
-        """notes must be passed as a keyword argument; positional use raises TypeError."""
+        """Notes must be passed as a keyword argument; positional use raises TypeError."""
         model = _TinyModel().eval()
         input_tensor = torch.randn(1, 3, 32, 32)
         with pytest.raises(TypeError):

--- a/tests/export/test_tensorrt_export.py
+++ b/tests/export/test_tensorrt_export.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Tests for TensorRT export helpers."""
 
 import subprocess

--- a/tests/export/test_tflite_export.py
+++ b/tests/export/test_tflite_export.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Tests for the ONNX → TFLite export pipeline.
 
 Tests cover:
@@ -330,7 +329,7 @@ class TestExportTfliteConverter:
         fake_onnx2tf: Any,
         mock_prepare_calib: Any,
     ) -> None:
-        """int8 export derives a dynamic-range model and avoids onnx2tf's -oiqt path.
+        """Int8 export derives a dynamic-range model and avoids onnx2tf's -oiqt path.
 
         onnx2tf's ``output_integer_quantized_tflite`` (-oiqt) only yields static quantization, which RF-DETR's
         transformer activations do not survive. The converter instead builds dynamic-range INT8 from the SavedModel via

--- a/tests/export/test_tflite_inference.py
+++ b/tests/export/test_tflite_inference.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Tests for TFLite inference helpers.
 
 Covers:
@@ -233,7 +232,7 @@ class TestRunInference:
         assert len(dets) == 0
 
     def test_boxes_in_pixel_space(self, rgb_image: Path) -> None:
-        """xyxy coordinates are scaled to image pixel dimensions, not 0–1 range."""
+        """Xyxy coordinates are scaled to image pixel dimensions, not 0–1 range."""
         img_size = (200, 100)  # (width, height) for PIL
         PILImage.new("RGB", img_size, color=(100, 150, 200)).save(rgb_image)
 
@@ -331,7 +330,7 @@ class TestSigmoidScoring:
         assert len(dets) == 0
 
     def test_multiclass_class_id_is_argmax_of_logits(self, rgb_image: Path) -> None:
-        """argmax of sigmoid equals argmax of logits; query with [5,2,1,...] gets class_id==0."""
+        """Argmax of sigmoid equals argmax of logits; query with [5,2,1,...] gets class_id==0."""
         # Shape (1, 10, 82): first query has logits [5, 2, 1, 0, ...], rest are -100
         logits = np.full((1, 10, 82), -100.0, dtype=np.float32)
         logits[0, 0, 0] = 5.0

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,5 +3,4 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Test helper utilities and classes."""

--- a/tests/models/backbone/test_backbone_export.py
+++ b/tests/models/backbone/test_backbone_export.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Tests for backbone export behavior."""
 
 import sys

--- a/tests/models/backbone/test_windowed_dino.py
+++ b/tests/models/backbone/test_windowed_dino.py
@@ -19,9 +19,9 @@ from rfdetr.models.backbone.dinov2_with_windowed_attn import (
 
 
 def test_window_partition_forward_rectangular_preserves_shapes():
-    """
-    Regression test for WindowedDinov2WithRegistersEmbeddings.forward with rectangular input. Ensures window
-    partitioning logic correctly handles H != W.
+    """Regression test for WindowedDinov2WithRegistersEmbeddings.forward with rectangular input.
+
+    Ensures window partitioning logic correctly handles H != W.
     """
     # Params: H_patches=6, W_patches=4, num_windows=2 -> 3x2 patches per window
     batch_size, hidden_size, patch_size, num_windows = 1, 64, 16, 2
@@ -62,10 +62,10 @@ def test_window_partition_forward_rectangular_preserves_shapes():
     ],
 )
 def test_window_partition_nonsquare_does_not_raise(hp, wp, num_windows):
-    """
-    Before the fix, the reshape used num_h_patches_per_window for the width dimension, so the total element count
-    mismatched and PyTorch raised a RuntimeError for any non-square image.  The fix replaces that variable with
-    num_w_patches_per_window, making the operation valid for all shapes.
+    """Before the fix, the reshape used num_h_patches_per_window for the width dimension, so the total element count
+    mismatched and PyTorch raised a RuntimeError for any non-square image.
+
+    The fix replaces that variable with num_w_patches_per_window, making the operation valid for all shapes.
     """
     hidden_size, patch_size, nr = 32, 16, 0
     h, w = hp * patch_size, wp * patch_size
@@ -89,15 +89,11 @@ def test_window_partition_nonsquare_does_not_raise(hp, wp, num_windows):
 
 
 def test_window_partition_correct_window_content():
-    """
-    Verifies that after windowing each window contains the spatially correct patch tokens — not just that the shape is
-    right.
+    """Verifies that after windowing each window contains the spatially correct patch tokens — not just that the shape
+    is right.
 
-    Layout with hp=4, wp=6, num_windows=2 (2x2 grid of windows):
-      Window (0,0): rows 0-1, cols 0-2
-      Window (0,1): rows 0-1, cols 3-5
-      Window (1,0): rows 2-3, cols 0-2
-      Window (1,1): rows 2-3, cols 3-5
+    Layout with hp=4, wp=6, num_windows=2 (2x2 grid of windows):   Window (0,0): rows 0-1, cols 0-2   Window (0,1): rows
+    0-1, cols 3-5   Window (1,0): rows 2-3, cols 0-2   Window (1,1): rows 2-3, cols 3-5
 
     Before the fix the reshape used num_h_patches_per_window for the width dim so it raised an error and never produced
     window content at all.
@@ -207,12 +203,11 @@ def test_buggy_reshape_raises_for_nonsquare():
 
 
 def test_buggy_reshape_silent_corruption_for_nonsquare():
-    """
-    When hidden_size happens to make the total element count divisible by the buggy target shape, PyTorch does NOT raise
-    — instead the last dimension is inflated, which silently corrupts the tensor layout.
+    """When hidden_size happens to make the total element count divisible by the buggy target shape, PyTorch does NOT
+    raise — instead the last dimension is inflated, which silently corrupts the tensor layout.
 
-    Pre-fix with hp=4, wp=6, hidden_size=8, num_windows=2:
-      total elements = 1*4*6*8 = 192 buggy fixed dims = 2*2*2*2 = 16  →  last dim inferred as 192/16 = 12 (not 8)
+    Pre-fix with hp=4, wp=6, hidden_size=8, num_windows=2:   total elements = 1*4*6*8 = 192 buggy fixed dims = 2*2*2*2 =
+    16  →  last dim inferred as 192/16 = 12 (not 8)
 
     The fix ensures the correct reshape always yields a last dim equal to hidden_size.
     """

--- a/tests/models/test_builder_characterization.py
+++ b/tests/models/test_builder_characterization.py
@@ -3,13 +3,13 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Characterization tests for build_model() and build_criterion_and_postprocessors().
 
 These tests pin the current behavior of the legacy namespace-based builder functions. They serve as a safety net during
 the config-native builder refactoring: any change that alters these outputs is a regression.
 
-All tests in this file must pass against the CURRENT codebase."""
+All tests in this file must pass against the CURRENT codebase.
+"""
 
 import pytest
 import torch

--- a/tests/models/test_builders.py
+++ b/tests/models/test_builders.py
@@ -3,12 +3,12 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Characterization tests for config-native builder functions.
 
 These tests validate build_model_from_config() and build_criterion_from_config() which accept Pydantic config objects
 directly instead of requiring a pre-built SimpleNamespace. If these functions cannot be imported, all tests skip via the
-module-level pytestmark."""
+module-level pytestmark.
+"""
 
 import pytest
 

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -150,7 +150,7 @@ class TestTrainConfigT42PromotedFields:
     # --- device field removed ---
 
     def test_device_not_in_model_fields(self):
-        """device must not appear in TrainConfig.model_fields (PTL auto-detects accelerator)."""
+        """Device must not appear in TrainConfig.model_fields (PTL auto-detects accelerator)."""
         assert "device" not in TrainConfig.model_fields
 
     def test_device_kwarg_silently_ignored(self, tmp_path):
@@ -166,7 +166,7 @@ class TestTrainConfigT42PromotedFields:
         assert self._tc(tmp_path).clip_max_norm == pytest.approx(0.1)
 
     def test_seed_default_is_none(self, tmp_path):
-        """seed defaults to None (no seeding)."""
+        """Seed defaults to None (no seeding)."""
         assert self._tc(tmp_path).seed is None
 
     def test_sync_bn_default_is_false(self, tmp_path):
@@ -259,7 +259,7 @@ class TestTrainConfigT42PromotedFields:
         ],
     )
     def test_interval_and_prefetch_reject_non_positive_values(self, tmp_path, field, value):
-        """eval/EMA intervals and prefetch_factor must be >= 1 when provided."""
+        """Eval/EMA intervals and prefetch_factor must be >= 1 when provided."""
         with pytest.raises((ValueError, ValidationError)):
             self._tc(tmp_path, **{field: value})
 
@@ -643,9 +643,8 @@ class TestPretrainWeightsCompatibilityWarning:
         assert self._capture(ModelConfig, **sample_model_config) == []
 
     def test_breaking_field_with_default_factory_skips_comparison(self) -> None:
-        """A subclass whose breaking field uses ``default_factory`` (so ``.default`` is
-        ``PydanticUndefined``) must be silently skipped — we have nothing to compare against.
-        """
+        """A subclass whose breaking field uses ``default_factory`` (so ``.default`` is ``PydanticUndefined``) must be
+        silently skipped — we have nothing to compare against."""
         from pydantic import Field
 
         class _DefaultFactoryConfig(RFDETRNanoConfig):

--- a/tests/models/test_detection_head.py
+++ b/tests/models/test_detection_head.py
@@ -3,11 +3,11 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Regression tests for _resize_linear() and LWDETR.reinitialize_detection_head().
 
 These tests guard against the out_features staleness bug where in-place .data mutation did not update
-nn.Linear.out_features, causing ONNX export to emit stale (pre-fine-tuning) class counts."""
+nn.Linear.out_features, causing ONNX export to emit stale (pre-fine-tuning) class counts.
+"""
 
 from unittest.mock import MagicMock
 
@@ -83,7 +83,7 @@ class TestResizeLinear:
         assert torch.allclose(result.bias.data, linear.bias.data)
 
     def test_no_bias_returns_no_bias(self) -> None:
-        """bias=False input: returned module has bias=None and out_features is correct."""
+        """Bias=False input: returned module has bias=None and out_features is correct."""
         linear = nn.Linear(256, 91, bias=False)
         result = _resize_linear(linear, 8)
         assert result.out_features == 8, f"Expected out_features=8, got {result.out_features}"

--- a/tests/models/test_export.py
+++ b/tests/models/test_export.py
@@ -3,16 +3,15 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
-"""
-Tests for model export functionality.
+"""Tests for model export functionality.
 
 Use cases covered:
 - Segmentation outputs must be present in both train/eval modes to avoid export crashes.
 - Export should not change the original model's training state.
 - CLI export path (deploy.export.main) must include 'masks' in output_names for
   segmentation models, call make_infer_image with the correct individual args, and call export_onnx with args.output_dir
-  as the first argument."""
+  as the first argument.
+"""
 
 import importlib.util
 import inspect
@@ -189,9 +188,8 @@ def test_rfdetr_export_dynamic_batch_forwards_dynamic_axes(
     dynamic_batch: bool,
     segmentation_head: bool,
 ) -> None:
-    """`RFDETR.export(..., dynamic_batch=True)` must pass a non-None `dynamic_axes` dict
-    to `export_onnx`; `dynamic_batch=False` must pass `None`.
-    """
+    """`RFDETR.export(..., dynamic_batch=True)` must pass a non-None `dynamic_axes` dict to `export_onnx`;
+    `dynamic_batch=False` must pass `None`."""
 
     model = types.SimpleNamespace(
         model=types.SimpleNamespace(
@@ -278,8 +276,7 @@ def test_segmentation_outputs_present_in_train_and_eval(mode: Literal["train", "
 
 
 class TestCliExportMain:
-    """
-    Unit tests for deploy.export.main() (CLI export path).
+    """Unit tests for deploy.export.main() (CLI export path).
 
     Three bugs were present before the fix:
     1. output_names omitted 'masks' for segmentation models.
@@ -326,8 +323,7 @@ class TestCliExportMain:
 
     @staticmethod
     def _run(args: types.SimpleNamespace) -> tuple[dict, dict]:
-        """
-        Run deploy.export.main(args) with all heavy dependencies mocked.
+        """Run deploy.export.main(args) with all heavy dependencies mocked.
 
         Stubs out build_model, make_infer_image, and export_onnx, and injects mock onnx/onnxsim modules so the export
         module can be imported even when those optional packages are not installed.
@@ -404,12 +400,11 @@ class TestCliExportMain:
         backbone_only: bool,
         expected_output_names: list[str],
     ) -> None:
-        """
-        export_onnx must receive the correct output_names for every model type.
+        """export_onnx must receive the correct output_names for every model type.
 
         Before the fix, deploy/export.py line 253 used:
 
-            output_names = ['features'] if args.backbone_only else ['dets', 'labels']
+        output_names = ['features'] if args.backbone_only else ['dets', 'labels']
 
         which always omitted 'masks' for segmentation models.
         """
@@ -424,12 +419,12 @@ class TestCliExportMain:
         assert actual == expected_output_names, f"expected output_names={expected_output_names}, got {actual!r}"
 
     def test_make_infer_image_receives_individual_fields(self, output_dir: str) -> None:
-        """
-        make_infer_image must be called with (infer_dir, shape, batch_size, device), not with the whole args Namespace.
+        """make_infer_image must be called with (infer_dir, shape, batch_size, device), not with the whole args
+        Namespace.
 
         Before the fix, deploy/export.py line 251 used:
 
-            input_tensors = make_infer_image(args, device)
+        input_tensors = make_infer_image(args, device)
         """
         shape = (640, 640)
         batch_size = 2
@@ -446,13 +441,12 @@ class TestCliExportMain:
         assert pos[:3] == (infer_dir, shape, batch_size), f"expected (infer_dir, shape, batch_size), got {pos[:3]!r}"
 
     def test_export_onnx_receives_output_dir_and_kwargs(self, output_dir: str) -> None:
-        """
-        export_onnx must be called as export_onnx(output_dir, model, ...) with backbone_only, verbose, and opset_version
-        forwarded as keyword args.
+        """export_onnx must be called as export_onnx(output_dir, model, ...) with backbone_only, verbose, and
+        opset_version forwarded as keyword args.
 
         Before the fix, deploy/export.py line 294 used:
 
-            export_onnx(model, args, input_names, input_tensors, output_names, dynamic_axes)
+        export_onnx(model, args, input_names, input_tensors, output_names, dynamic_axes)
 
         which swapped output_dir/model and dropped all keyword args.
         """
@@ -610,7 +604,7 @@ class TestExportPatchSize:
     def test_export_invalid_patch_size_raises(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_patch_size: int
     ) -> None:
-        """export() must raise ValueError when patch_size is not a positive integer."""
+        """Export() must raise ValueError when patch_size is not a positive integer."""
         model = self._scaffold(monkeypatch, tmp_path, patch_size=14, num_windows=4)
         # Keep model_config.patch_size consistent with the patch_size argument for this test
         model.model_config.patch_size = bad_patch_size
@@ -620,7 +614,7 @@ class TestExportPatchSize:
     def test_export_shape_must_be_divisible_by_block_size(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """export() must reject shapes not divisible by patch_size * num_windows."""
+        """Export() must reject shapes not divisible by patch_size * num_windows."""
         # patch_size=16, num_windows=2 → block_size=32; shape (48, 64): 48 % 32 != 0
         model = self._scaffold(monkeypatch, tmp_path, patch_size=16, num_windows=2)
         with pytest.raises(ValueError, match="divisible by 32"):
@@ -638,13 +632,13 @@ class TestExportPatchSize:
     def test_export_negative_or_zero_shape_raises(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_shape: tuple[int, int]
     ) -> None:
-        """export() must reject non-positive shape dimensions (Python -N % M == 0 wraps silently)."""
+        """Export() must reject non-positive shape dimensions (Python -N % M == 0 wraps silently)."""
         model = self._scaffold(monkeypatch, tmp_path, patch_size=16, num_windows=2)
         with pytest.raises(ValueError, match="positive integers"):
             _detr_module.RFDETR.export(model, output_dir=str(tmp_path), shape=bad_shape)
 
     def test_export_shape_valid_for_block_size(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        """export() accepts shape divisible by patch_size * num_windows without error."""
+        """Export() accepts shape divisible by patch_size * num_windows without error."""
         # patch_size=16, num_windows=2 → block_size=32; shape (64, 64) is valid
         model = self._scaffold(monkeypatch, tmp_path, patch_size=16, num_windows=2)
         # Should not raise
@@ -654,7 +648,7 @@ class TestExportPatchSize:
     def test_export_bool_patch_size_raises(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_patch_size: bool
     ) -> None:
-        """export() must reject bool values for patch_size (isinstance(True, int) is True)."""
+        """Export() must reject bool values for patch_size (isinstance(True, int) is True)."""
         model = self._scaffold(monkeypatch, tmp_path, patch_size=14, num_windows=1)
         with pytest.raises(ValueError, match="patch_size must be a positive integer"):
             _detr_module.RFDETR.export(model, output_dir=str(tmp_path), patch_size=bad_patch_size)
@@ -680,7 +674,7 @@ class TestExportPatchSize:
     def test_export_invalid_shape_type_raises(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_shape: tuple
     ) -> None:
-        """export() must raise ValueError for float, bool, or wrong-arity shape tuples."""
+        """Export() must raise ValueError for float, bool, or wrong-arity shape tuples."""
         model = self._scaffold(monkeypatch, tmp_path, patch_size=14, num_windows=1)
         with pytest.raises(ValueError, match="shape"):
             _detr_module.RFDETR.export(model, output_dir=str(tmp_path), shape=bad_shape)
@@ -689,7 +683,7 @@ class TestExportPatchSize:
     def test_export_invalid_num_windows_raises(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_num_windows: int
     ) -> None:
-        """export() must raise ValueError when model_config.num_windows is not a positive integer."""
+        """Export() must raise ValueError when model_config.num_windows is not a positive integer."""
         model = self._scaffold(monkeypatch, tmp_path, patch_size=14, num_windows=1)
         model.model_config.num_windows = bad_num_windows
         with pytest.raises(ValueError, match="num_windows must be a positive integer"):
@@ -698,7 +692,7 @@ class TestExportPatchSize:
     def test_export_default_resolution_not_divisible_by_block_size_raises(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """export() with shape=None must raise ValueError when model.resolution % block_size != 0."""
+        """Export() with shape=None must raise ValueError when model.resolution % block_size != 0."""
         # patch_size=14, num_windows=3 → block_size=42; scaffold sets resolution=84 (42*2) which is valid
         # Override resolution to 50 (not divisible by 42) to trigger the check
         model = self._scaffold(monkeypatch, tmp_path, patch_size=14, num_windows=3)

--- a/tests/models/test_from_checkpoint.py
+++ b/tests/models/test_from_checkpoint.py
@@ -3,11 +3,11 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Tests for RFDETR.from_checkpoint classmethod.
 
 The inference logic is isolated by patching ``torch.load`` and the target model class inside ``rfdetr.variants`` (or
-``rfdetr.platform.models`` for plus models).  No model weights are downloaded or GPU memory allocated."""
+``rfdetr.platform.models`` for plus models).  No model weights are downloaded or GPU memory allocated.
+"""
 
 from __future__ import annotations
 
@@ -44,8 +44,7 @@ def _dict(pretrain_weights: str, num_classes: int = 80) -> dict:
 
 
 def _call_from_checkpoint(ckpt: dict, path: Path, cls_patch_target: str, **kwargs):
-    """
-    Invoke RFDETR.from_checkpoint with torch.load mocked to return *ckpt* and the model class at *cls_patch_target*
+    """Invoke RFDETR.from_checkpoint with torch.load mocked to return *ckpt* and the model class at *cls_patch_target*
     replaced by a MagicMock.
 
     Returns:
@@ -213,7 +212,7 @@ class TestFromCheckpointEdgeCases:
 
     @pytest.mark.skipif(HAS_PLUS, reason="rfdetr_plus is installed — guard not active")
     def test_characterization_xlarge_without_plus_raises_import_error(self, tmp_path: Path) -> None:
-        """xlarge checkpoint without rfdetr_plus raises ImportError instead of wrong class."""
+        """Xlarge checkpoint without rfdetr_plus raises ImportError instead of wrong class."""
         for weights in ("rf-detr-xlarge.pth", "rf-detr-xxlarge.pth"):
             ckpt = _ns(weights)
             with patch("rfdetr.detr.torch.load", return_value=ckpt):

--- a/tests/models/test_matcher.py
+++ b/tests/models/test_matcher.py
@@ -191,11 +191,11 @@ class TestHungarianMatcherNonFiniteCosts:
         matcher: HungarianMatcher,
         standard_target: dict[str, torch.Tensor],
     ) -> None:
-        """Sanitization runs on the full cost matrix before splitting by group, so
-        non-finite entries must be handled correctly when ``group_detr > 1``.
+        """Sanitization runs on the full cost matrix before splitting by group, so non-finite entries must be handled
+        correctly when ``group_detr > 1``.
 
-        4 queries, 2 groups of 2. Query 0 has a NaN box; query 2 (the best valid
-        match in group 1) must be selected across groups.
+        4 queries, 2 groups of 2. Query 0 has a NaN box; query 2 (the best valid match in group 1) must be selected
+        across groups.
         """
         nan = float("nan")
         outputs = {

--- a/tests/models/test_optimize_for_inference.py
+++ b/tests/models/test_optimize_for_inference.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Tests for RFDETR.optimize_for_inference()."""
 
 from types import SimpleNamespace
@@ -49,7 +48,7 @@ class _FakeRFDETR(RFDETR):
 
 
 class TestOptimizeForInferenceDtype:
-    """dtype coercion and validation tests."""
+    """Dtype coercion and validation tests."""
 
     def test_string_dtype_float32_is_accepted(self) -> None:
         """Passing dtype='float32' (str) should be coerced to torch.float32."""

--- a/tests/models/test_predict.py
+++ b/tests/models/test_predict.py
@@ -365,7 +365,7 @@ class TestPredictShape:
         ],
     )
     def test_predict_shape_accepts_integer_like_types(self, int_shape: tuple) -> None:
-        """predict() accepts integer-like types (numpy, torch) via the __index__ protocol."""
+        """Predict() accepts integer-like types (numpy, torch) via the __index__ protocol."""
         from unittest.mock import patch
 
         import torchvision.transforms.functional as F  # noqa: N812
@@ -387,7 +387,7 @@ class TestPredictShape:
         ],
     )
     def test_predict_shape_not_divisible_by_14_raises(self, bad_shape: tuple[int, int]) -> None:
-        """predict() must reject shapes with dimensions not divisible by 14."""
+        """Predict() must reject shapes with dimensions not divisible by 14."""
         model = _DummyRFDETR()
         img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
         with pytest.raises(ValueError, match="divisible by 14"):
@@ -408,7 +408,7 @@ class TestPredictShape:
         ],
     )
     def test_predict_shape_invalid_raises(self, bad_shape: tuple[int | float | bool, ...]) -> None:
-        """predict() must raise ValueError for invalid shape values."""
+        """Predict() must raise ValueError for invalid shape values."""
         model = _DummyRFDETR()
         img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
         with pytest.raises(ValueError, match="shape"):
@@ -416,7 +416,7 @@ class TestPredictShape:
 
 
 class TestPredictPatchSize:
-    """predict() patch_size resolution and validation tests."""
+    """Predict() patch_size resolution and validation tests."""
 
     def _make_model_with_config(self, patch_size: int, num_windows: int) -> _DummyRFDETR:
         """Return a _DummyRFDETR whose model_config carries patch_size and num_windows."""
@@ -427,7 +427,7 @@ class TestPredictPatchSize:
         return model
 
     def test_predict_defaults_patch_size_from_model_config(self) -> None:
-        """predict() reads patch_size from model_config when not provided by the caller."""
+        """Predict() reads patch_size from model_config when not provided by the caller."""
         # patch_size=16, num_windows=2 → block_size=32; shape=(64,64) is valid
         model = self._make_model_with_config(patch_size=16, num_windows=2)
         img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
@@ -435,7 +435,7 @@ class TestPredictPatchSize:
         model.predict(img, shape=(64, 64))
 
     def test_predict_shape_must_be_divisible_by_block_size(self) -> None:
-        """predict() rejects shapes not divisible by patch_size * num_windows."""
+        """Predict() rejects shapes not divisible by patch_size * num_windows."""
         # patch_size=16, num_windows=2 → block_size=32; shape (48, 64) fails (48%32==16)
         model = self._make_model_with_config(patch_size=16, num_windows=2)
         img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
@@ -444,14 +444,14 @@ class TestPredictPatchSize:
 
     @pytest.mark.parametrize("bad_patch_size", [0, -1, True, False])
     def test_predict_invalid_patch_size_raises(self, bad_patch_size: int) -> None:
-        """predict() must raise ValueError when patch_size is not a positive integer."""
+        """Predict() must raise ValueError when patch_size is not a positive integer."""
         model = _DummyRFDETR()
         img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
         with pytest.raises(ValueError, match="patch_size must be a positive integer"):
             model.predict(img, patch_size=bad_patch_size)  # type: ignore[arg-type]
 
     def test_predict_patch_size_mismatch_raises(self) -> None:
-        """predict() must raise ValueError when caller's patch_size != model_config.patch_size."""
+        """Predict() must raise ValueError when caller's patch_size != model_config.patch_size."""
         # model has patch_size=16; passing patch_size=14 should raise immediately
         model = self._make_model_with_config(patch_size=16, num_windows=1)
         img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
@@ -468,7 +468,7 @@ class TestPredictPatchSize:
 
     @pytest.mark.parametrize("bad_num_windows", [0, -1, True])
     def test_predict_invalid_num_windows_raises(self, bad_num_windows: int) -> None:
-        """predict() must raise ValueError when model_config.num_windows is not a positive integer."""
+        """Predict() must raise ValueError when model_config.num_windows is not a positive integer."""
         model = self._make_model_with_config(patch_size=14, num_windows=1)
         model.model_config.num_windows = bad_num_windows
         img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
@@ -476,7 +476,7 @@ class TestPredictPatchSize:
             model.predict(img, shape=(14, 14))
 
     def test_predict_default_resolution_not_divisible_by_block_size_raises(self) -> None:
-        """predict() with shape=None must raise ValueError when model.resolution % block_size != 0."""
+        """Predict() with shape=None must raise ValueError when model.resolution % block_size != 0."""
         # patch_size=14, num_windows=1 → block_size=14; set resolution=25 (not divisible)
         model = self._make_model_with_config(patch_size=14, num_windows=1)
         model.model.resolution = 25
@@ -499,7 +499,7 @@ class TestPredictClassNameData:
         return model
 
     def test_class_name_key_present_in_detections_data(self) -> None:
-        """predict() must include 'class_name' in detections.data when class_names is set."""
+        """Predict() must include 'class_name' in detections.data when class_names is set."""
         model = self._make_model_with_class_names(["cat", "dog"], labels=[0])
         img = PIL.Image.new("RGB", (28, 28))
         detections = model.predict(img)
@@ -665,7 +665,8 @@ class TestPredictClassNameData:
         When num_classes=90 and class_names has 80 entries, class_id 18 must resolve to 'dog' (COCO category 18), not
         'sheep' (COCO_CLASS_NAMES[18] via 0-indexed lookup).
 
-        Regression test for https://github.com/roboflow/rf-detr/issues/988.
+        Regression test for
+        https://github.com/roboflow/rf-detr/issues/988.
         """
         from rfdetr.assets.coco_classes import COCO_CLASS_NAMES
 
@@ -687,7 +688,9 @@ class TestPredictClassNameData:
         RF-DETR pretrained checkpoints (e.g. RFDETRSegSmall) can have dataset_file='roboflow' even though they were
         trained on COCO. The fix must not depend on dataset_file value.
 
-        Regression test for https://github.com/roboflow/rf-detr/issues/988 (post-revert follow-up).
+        Regression test for
+        https://github.com/roboflow/rf-detr/issues/988
+        (post-revert follow-up).
         """
         from rfdetr.assets.coco_classes import COCO_CLASS_NAMES
 
@@ -743,7 +746,7 @@ class TestPredictClassNameData:
         )
 
     def test_coco_names_without_model_args_fires_warning(self) -> None:
-        """predict() must warn when COCO class_names present but model has no 'args' attribute.
+        """Predict() must warn when COCO class_names present but model has no 'args' attribute.
 
         Without args, num_logit_slots falls back to n so _is_coco_pretrained stays False. The warning is the caller's
         only signal that sparse COCO-ID mapping cannot activate, which may cause wrong class names for pretrained COCO

--- a/tests/models/test_segmentation_head.py
+++ b/tests/models/test_segmentation_head.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Tests for DepthwiseConvBlock and _DepthwiseConvWithoutCuDNN (segmentation head)."""
 
 from contextlib import contextmanager

--- a/tests/models/test_validate_shape_dims.py
+++ b/tests/models/test_validate_shape_dims.py
@@ -3,11 +3,11 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Unit tests for :func:`rfdetr.detr._validate_shape_dims` and :func:`rfdetr.detr._resolve_patch_size`.
 
 Tests call each helper directly so each validation path has a single focused test without the export/predict scaffolding
-overhead."""
+overhead.
+"""
 
 from types import SimpleNamespace
 

--- a/tests/models/test_weights.py
+++ b/tests/models/test_weights.py
@@ -3,11 +3,11 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Unit tests for ``rfdetr.models.weights`` — the unified weight-loading and LoRA module.
 
 These tests cover ``load_pretrain_weights`` and ``apply_lora`` directly, exercising the unified logic extracted from
-``detr.py`` and ``module_model.py``."""
+``detr.py`` and ``module_model.py``.
+"""
 
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
@@ -500,8 +500,7 @@ class TestApplyLora:
 
 
 def _labelled_query_tensor(num_queries: int, group_detr: int, dim: int = 2) -> torch.Tensor:
-    """Build a query embedding tensor where row ``g * num_queries + q`` encodes
-    ``[g * 100 + q, 0, ...]``.
+    """Build a query embedding tensor where row ``g * num_queries + q`` encodes ``[g * 100 + q, 0, ...]``.
 
     This lets tests check the per-group ordering of the result without floating-point
     fuzz: the first column carries the (group, query) identity directly.
@@ -620,7 +619,7 @@ class TestSliceQueryParamPerGroup:
         tgt_g: int,
         expected_labels: list[int],
     ) -> None:
-        """min(target, ckpt) along each axis produces the correct per-group prefix."""
+        """Min(target, ckpt) along each axis produces the correct per-group prefix."""
         from rfdetr.models.weights import _slice_query_param_per_group
 
         tensor = _labelled_query_tensor(num_queries=ckpt_nq, group_detr=ckpt_g)
@@ -739,7 +738,7 @@ class TestLoadPretrainWeightsPerGroupQuerySlice:
         assert query_feat[:, 0].int().tolist() == expected
 
     def test_decreasing_group_detr_drops_tail_groups(self, monkeypatch, tmp_path):
-        """checkpoint(nq=4, g=3) → model(nq=4, g=2): tail group dropped, retained groups intact."""
+        """Checkpoint(nq=4, g=3) → model(nq=4, g=2): tail group dropped, retained groups intact."""
         from rfdetr.models.weights import load_pretrain_weights
 
         mc = RFDETRBaseConfig(

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Regression tests for _namespace_from_configs() config forwarding."""
 
 import sys
@@ -17,8 +16,8 @@ from rfdetr.models._types import BuilderArgs
 
 
 class TestNamespaceForwarding:
-    """Verify that _namespace_from_configs() forwards TrainConfig fields that were
-    previously hardcoded to wrong defaults."""
+    """Verify that _namespace_from_configs() forwards TrainConfig fields that were previously hardcoded to wrong
+    defaults."""
 
     def _make_ns(self: "TestNamespaceForwarding", **tc_kwargs: Any) -> Any:
         """Build a namespace for tests with minimal default TrainConfig values."""
@@ -71,7 +70,7 @@ class TestNamespaceProtocol:
         assert isinstance(ns, BuilderArgs)
 
     def test_namespace_is_builderargs_instance(self) -> None:
-        """isinstance() check passes on all supported Python versions.
+        """Isinstance() check passes on all supported Python versions.
 
         On Python 3.10/3.11 this is a structural no-op (no method members to check).  On 3.12+ it verifies attribute
         presence.  The test documents the intent regardless of Python version.

--- a/tests/training/conftest.py
+++ b/tests/training/conftest.py
@@ -3,11 +3,11 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Package-level pytest fixtures for tests/training/.
 
 Provides cross-test cleanup that prevents class-level state from leaking between individual tests in the training/ test
-package, plus shared config factory fixtures used across multiple test modules."""
+package, plus shared config factory fixtures used across multiple test modules.
+"""
 
 import pytest
 

--- a/tests/training/helpers.py
+++ b/tests/training/helpers.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Shared test helpers for the rfdetr.training test suite.
 
 Plain classes and functions (not pytest fixtures) shared across multiple test modules to avoid verbatim duplication.

--- a/tests/training/test_args.py
+++ b/tests/training/test_args.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Unit tests for _namespace_from_configs — the canonical config-to-Namespace mapping."""
 
 import pytest
@@ -72,7 +71,7 @@ class TestNamespaceFromConfigs:
         assert args.fp16_eval is True
 
     def test_seed_falls_back_to_legacy_default_when_unset(self, base_model_config, base_train_config):
-        """seed defaults to 42 in the namespace when TrainConfig.seed is None."""
+        """Seed defaults to 42 in the namespace when TrainConfig.seed is None."""
         tc = base_train_config(seed=None)
         args = _namespace_from_configs(base_model_config(), tc)
         assert args.seed == 42
@@ -93,7 +92,7 @@ class TestNamespaceFromConfigs:
         assert args.num_queries == 300
 
     def test_resume_none_becomes_empty_string(self, base_model_config, base_train_config):
-        """resume=None (the default) is converted to '' for the Namespace."""
+        """Resume=None (the default) is converted to '' for the Namespace."""
         tc = base_train_config()
         assert tc.resume is None
         args = _namespace_from_configs(base_model_config(), tc)

--- a/tests/training/test_best_model_callback.py
+++ b/tests/training/test_best_model_callback.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Unit tests for :class:`BestModelCallback` and :class:`RFDETREarlyStopping`."""
 
 from __future__ import annotations
@@ -710,7 +709,10 @@ class TestBestModelCallback:
         assert isinstance(ckpt["args"], dict)
 
     def test_regular_checkpoint_has_ptl_state_dict_key(self, tmp_path: Path) -> None:
-        """Saved regular checkpoint must include 'state_dict' with model. prefix."""
+        """Saved regular checkpoint must include 'state_dict' with model.
+
+        prefix.
+        """
         cb = BestModelCallback(output_dir=str(tmp_path))
         trainer = _make_trainer({"val/mAP_50_95": 0.5})
         pl_module = _make_pl_module()
@@ -746,7 +748,10 @@ class TestBestModelCallback:
         assert ckpt.get("pytorch-lightning_version") == ptl_version
 
     def test_ema_checkpoint_has_ptl_state_dict_key(self, tmp_path: Path) -> None:
-        """Saved EMA checkpoint must include 'state_dict' with model. prefix."""
+        """Saved EMA checkpoint must include 'state_dict' with model.
+
+        prefix.
+        """
         cb = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
         trainer = _make_trainer({"val/mAP_50_95": 0.4, "val/ema_mAP_50_95": 0.6})
         pl_module = _make_pl_module()
@@ -1027,7 +1032,7 @@ class TestRFDETREarlyStopping:
         assert cb.wait_count == 3
 
     def test_stops_after_patience_exceeded(self) -> None:
-        """patience=3 with 3 no-improvement epochs triggers stop."""
+        """Patience=3 with 3 no-improvement epochs triggers stop."""
         cb = RFDETREarlyStopping(patience=3, min_delta=0.001)
         pl_module = _make_pl_module()
 

--- a/tests/training/test_build_trainer.py
+++ b/tests/training/test_build_trainer.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Tests for build_trainer() — PTL Ch3/T5 (callbacks) and Ch4/T1 (precision, loggers, trainer kwargs)."""
 
 import warnings
@@ -231,12 +230,12 @@ class TestBuildTrainerPrecision:
     """build_trainer() must resolve training precision from model_config.amp + device caps."""
 
     def test_amp_false_gives_32_true(self, tmp_path):
-        """amp=False always produces '32-true' regardless of device."""
+        """Amp=False always produces '32-true' regardless of device."""
         trainer = build_trainer(_tc(tmp_path, use_ema=False), _mc(amp=False))
         assert trainer.precision == "32-true"
 
     def test_amp_true_cpu_gives_32_true(self, tmp_path):
-        """amp=True on CPU (no CUDA, no MPS) must fall back to '32-true'."""
+        """Amp=True on CPU (no CUDA, no MPS) must fall back to '32-true'."""
         import unittest.mock as mock
 
         with (
@@ -247,7 +246,7 @@ class TestBuildTrainerPrecision:
         assert trainer.precision == "32-true"
 
     def test_amp_true_cuda_no_bf16_gives_16_mixed(self, tmp_path):
-        """amp=True with CUDA but no bf16 support must produce '16-mixed'."""
+        """Amp=True with CUDA but no bf16 support must produce '16-mixed'."""
         import unittest.mock as mock
 
         captured: dict = {}
@@ -265,7 +264,7 @@ class TestBuildTrainerPrecision:
         assert captured["precision"] == "16-mixed"
 
     def test_amp_true_cuda_bf16_supported_gives_bf16_mixed(self, tmp_path):
-        """amp=True with CUDA + bf16 hardware produces 'bf16-mixed'."""
+        """Amp=True with CUDA + bf16 hardware produces 'bf16-mixed'."""
         import unittest.mock as mock
 
         captured: dict = {}
@@ -478,7 +477,7 @@ class TestBuildTrainerLoggers:
         assert any(isinstance(lg, CSVLogger) for lg in trainer.loggers)
 
     def test_clearml_flag_raises_not_implemented(self, tmp_path):
-        """clearml=True must raise NotImplementedError (not yet supported)."""
+        """Clearml=True must raise NotImplementedError (not yet supported)."""
         with pytest.raises(NotImplementedError, match="ClearML"):
             build_trainer(
                 _tc(tmp_path, clearml=True, use_ema=False),
@@ -661,7 +660,7 @@ class TestBuildTrainerSegmentationDDP:
     """build_trainer() must enable find_unused_parameters when segmentation_head=True + strategy='ddp'."""
 
     def test_ddp_segmentation_enables_find_unused_parameters(self, tmp_path):
-        """strategy='ddp' + segmentation_head=True must produce DDPStrategy(find_unused_parameters=True).
+        """Strategy='ddp' + segmentation_head=True must produce DDPStrategy(find_unused_parameters=True).
 
         The segmentation head's sparse_forward() leaves parameters unused on some forward steps.  Plain DDP raises
         RuntimeError unless find_unused_parameters is enabled.
@@ -686,7 +685,7 @@ class TestBuildTrainerSegmentationDDP:
         assert strategy_obj._ddp_kwargs.get("find_unused_parameters") is True
 
     def test_ddp_no_segmentation_strategy_unchanged(self, tmp_path):
-        """strategy='ddp' without segmentation_head must pass the string through unchanged.
+        """Strategy='ddp' without segmentation_head must pass the string through unchanged.
 
         Only the segmentation path needs find_unused_parameters; standard detection DDP must not be wrapped
         unnecessarily to avoid the autograd-graph traversal overhead on every backward pass.

--- a/tests/training/test_cli.py
+++ b/tests/training/test_cli.py
@@ -3,12 +3,12 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Tests for RFDETRCli — PTL Ch4/T4.
 
 Verifies that the CLI module is correctly structured: importable, subclasses LightningCLI, overrides
 add_arguments_to_parser, and exposes a callable main() entry point.  CLI integration / smoke tests (--help subprocess,
-YAML roundtrip) live in T4-7."""
+YAML roundtrip) live in T4-7.
+"""
 
 import pytest
 
@@ -29,7 +29,7 @@ class TestRFDETRCliStructure:
         from rfdetr.training.cli import RFDETRCli  # noqa: F401
 
     def test_main_importable(self):
-        """main() can be imported from rfdetr.training.cli."""
+        """Main() can be imported from rfdetr.training.cli."""
         from rfdetr.training.cli import main  # noqa: F401
 
     def test_rfdetr_cli_is_lightning_cli_subclass(self):
@@ -41,7 +41,7 @@ class TestRFDETRCliStructure:
         assert issubclass(RFDETRCli, LightningCLI)
 
     def test_main_is_callable(self):
-        """main must be a callable (function, not e.g. a string)."""
+        """Main must be a callable (function, not e.g. a string)."""
         from rfdetr.training.cli import main
 
         assert callable(main)

--- a/tests/training/test_coco_eval_callback.py
+++ b/tests/training/test_coco_eval_callback.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Unit tests for COCOEvalCallback."""
 
 from unittest.mock import MagicMock, patch
@@ -70,7 +69,7 @@ def _minimal_metrics(pfx: str = "", max_dets: int = 500) -> dict:
 
 
 class TestSetup:
-    """setup() creates map_metric with correct configuration."""
+    """Setup() creates map_metric with correct configuration."""
 
     def test_init_defaults_notebook_flag_to_false_without_ipython(self) -> None:
         """Constructor sets _in_notebook=False when IPython import is unavailable."""
@@ -153,8 +152,8 @@ class TestOnFitStart:
         assert cb._class_names == []
 
     def test_cat_id_to_name_uses_label2cat_when_available(self) -> None:
-        """When coco.label2cat is present (remap_category_ids=True) the mapping
-        uses 0-based remapped label IDs so class names align with predictions."""
+        """When coco.label2cat is present (remap_category_ids=True) the mapping uses 0-based remapped label IDs so class
+        names align with predictions."""
         coco = MagicMock()
         coco.cats = {1: {"name": "fish"}, 2: {"name": "shark"}}
         # label2cat: remapped_label → original_cat_id  (cat2label inverse)
@@ -474,8 +473,8 @@ class TestOnValidationEpochEnd:
         assert not any(k.startswith("val/AP/") for k in logged_keys)
 
     def test_callback_metrics_updated_for_model_checkpoint(self) -> None:
-        """Core metrics written to trainer.callback_metrics each epoch so
-        ModelCheckpoint / BestModelCallback detect improvement.
+        """Core metrics written to trainer.callback_metrics each epoch so ModelCheckpoint / BestModelCallback detect
+        improvement.
 
         pl_module.log() from a callback's on_validation_epoch_end goes only to logged_metrics (external loggers), not
         callback_metrics.
@@ -514,8 +513,10 @@ class TestOnValidationEpochEnd:
         assert "val/ema_mAR" in trainer.callback_metrics
 
     def test_ema_segm_metrics_use_ema_values_not_base(self) -> None:
-        """EMA segmentation metrics must come from map_metric_ema, not the
-        base map_metric.  Regression test for #978."""
+        """EMA segmentation metrics must come from map_metric_ema, not the base map_metric.
+
+        Regression test for #978.
+        """
         cb = COCOEvalCallback(max_dets=500, segmentation=True)
         trainer = _make_trainer()
         trainer.callback_metrics = {}
@@ -550,9 +551,10 @@ class TestOnValidationEpochEnd:
         assert logged["val/ema_segm_mAP_50"].item() == pytest.approx(0.65)
 
     def test_ghost_class_with_negative_ar_sentinel_is_filtered(self) -> None:
-        """A class where both ap=-1 and ar=-1 (negative sentinels, not NaN) must
-        be excluded from the per-class table.  The old filter checked for NaN
-        only, so ar=-1 (a valid float) escaped the guard."""
+        """A class where both ap=-1 and ar=-1 (negative sentinels, not NaN) must be excluded from the per-class table.
+
+        The old filter checked for NaN only, so ar=-1 (a valid float) escaped the guard.
+        """
         cb = COCOEvalCallback()
         cb._cat_id_to_name = {0: "fish"}
         trainer = _make_trainer()
@@ -585,8 +587,8 @@ class TestOnTestEpochEnd:
     """Test-loop-specific behaviour of on_test_epoch_end."""
 
     def test_no_ema_aliases_for_test(self) -> None:
-        """test/ema_* aliases are NOT logged — test always runs with EMA weights
-        via the RFDETREMACallback swap so test/mAP_50 is already the EMA result."""
+        """test/ema_* aliases are NOT logged — test always runs with EMA weights via the RFDETREMACallback swap so
+        test/mAP_50 is already the EMA result."""
         cb = COCOEvalCallback(max_dets=500)
         cb.setup(_make_trainer(), _make_pl_module(), stage="test")
         cb.map_metric = MagicMock(name="map_metric")
@@ -692,7 +694,7 @@ class TestConvertTargets:
         assert boxes[0, 3].item() == pytest.approx(160.0)
 
     def test_labels_passed_through(self) -> None:
-        """labels tensor is preserved unchanged."""
+        """Labels tensor is preserved unchanged."""
         cb = COCOEvalCallback()
         targets = [
             {
@@ -705,7 +707,7 @@ class TestConvertTargets:
         assert out[0]["labels"][0].item() == 7
 
     def test_masks_passed_through_as_bool(self) -> None:
-        """masks tensor is cast to bool and included in output."""
+        """Masks tensor is cast to bool and included in output."""
         cb = COCOEvalCallback()
         targets = [
             {
@@ -720,7 +722,7 @@ class TestConvertTargets:
         assert out[0]["masks"].dtype == torch.bool
 
     def test_iscrowd_passed_through(self) -> None:
-        """iscrowd tensor is included when present."""
+        """Iscrowd tensor is included when present."""
         cb = COCOEvalCallback()
         targets = [
             {

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Tests for Chapter 5 / Phase 7+8 (updated Phase 3):
 
 1. ``TestRFDETRTrainPTL``           — RFDETR.train() delegates to PTL build_trainer().fit()
@@ -256,7 +255,7 @@ class TestRFDETRTrainPTL:
         assert mock_self.model.class_names == []
 
     def test_device_kwarg_cpu_no_warning(self, tmp_path, patch_lit):
-        """device='cpu' is consumed without a DeprecationWarning."""
+        """Device='cpu' is consumed without a DeprecationWarning."""
         mock_self = _make_rfdetr_self(tmp_path)
         p_mod, p_dm, p_bt, *_ = patch_lit
         with p_mod, p_dm, p_bt, warnings.catch_warnings(record=True) as w:
@@ -266,7 +265,7 @@ class TestRFDETRTrainPTL:
         mock_self.get_train_config.assert_called_once_with()
 
     def test_device_kwarg_cuda_forwards_gpu_accelerator_without_devices(self, tmp_path, patch_lit):
-        """device='cuda' is mapped to accelerator='gpu' without explicit devices override."""
+        """Device='cuda' is mapped to accelerator='gpu' without explicit devices override."""
         mock_self = _make_rfdetr_self(tmp_path)
         p_mod, p_dm, p_bt, *_ = patch_lit
         with p_mod, p_dm, p_bt, warnings.catch_warnings(record=True) as w:
@@ -286,7 +285,7 @@ class TestRFDETRTrainPTL:
         mock_self.get_train_config.assert_called_once_with()
 
     def test_callbacks_none_no_warning(self, tmp_path, patch_lit):
-        """callbacks=None produces no DeprecationWarning."""
+        """Callbacks=None produces no DeprecationWarning."""
         mock_self = _make_rfdetr_self(tmp_path)
         p_mod, p_dm, p_bt, *_ = patch_lit
         with p_mod, p_dm, p_bt, warnings.catch_warnings(record=True) as w:
@@ -295,7 +294,7 @@ class TestRFDETRTrainPTL:
         assert not any(issubclass(x.category, DeprecationWarning) for x in w)
 
     def test_callbacks_empty_dict_no_warning(self, tmp_path, patch_lit):
-        """callbacks={} (falsy dict) produces no DeprecationWarning."""
+        """Callbacks={} (falsy dict) produces no DeprecationWarning."""
         mock_self = _make_rfdetr_self(tmp_path)
         p_mod, p_dm, p_bt, *_ = patch_lit
         with p_mod, p_dm, p_bt, warnings.catch_warnings(record=True) as w:
@@ -366,7 +365,7 @@ class TestRFDETRTrainPTL:
         mock_self.get_train_config.assert_called_once_with()
 
     def test_device_not_forwarded_to_get_train_config(self, tmp_path, patch_lit):
-        """device= is popped and not passed on to get_train_config."""
+        """Device= is popped and not passed on to get_train_config."""
         mock_self = _make_rfdetr_self(tmp_path)
         p_mod, p_dm, p_bt, *_ = patch_lit
         with p_mod, p_dm, p_bt:
@@ -437,7 +436,7 @@ class TestRFDETRTrainPTLAbsorption:
     """RFDETR.train() absorbs legacy kwargs and routes through PTL build_trainer()."""
 
     def test_device_cpu_absorbed_as_accelerator_cpu(self, tmp_path, patch_lit):
-        """device='cpu' is absorbed and forwarded to build_trainer as accelerator='cpu'."""
+        """Device='cpu' is absorbed and forwarded to build_trainer as accelerator='cpu'."""
         mock_self = _make_rfdetr_self(tmp_path)
         p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = patch_lit
         with p_mod, p_dm, p_bt:
@@ -446,7 +445,7 @@ class TestRFDETRTrainPTLAbsorption:
         mock_bt.assert_called_once_with(config, mock_self.model_config, accelerator="cpu")
 
     def test_device_cuda_absorbed_as_accelerator_gpu(self, tmp_path, patch_lit):
-        """device='cuda' forwards accelerator='gpu' without a devices kwarg."""
+        """Device='cuda' forwards accelerator='gpu' without a devices kwarg."""
         mock_self = _make_rfdetr_self(tmp_path)
         p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = patch_lit
         with p_mod, p_dm, p_bt:
@@ -456,7 +455,7 @@ class TestRFDETRTrainPTLAbsorption:
         assert "devices" not in mock_bt.call_args.kwargs
 
     def test_device_cuda_index_absorbed_as_accelerator_gpu_devices_list(self, tmp_path, patch_lit):
-        """device='cuda:1' forwards accelerator='gpu' and devices=[1]."""
+        """Device='cuda:1' forwards accelerator='gpu' and devices=[1]."""
         mock_self = _make_rfdetr_self(tmp_path)
         p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = patch_lit
         with p_mod, p_dm, p_bt:
@@ -496,7 +495,7 @@ class TestRFDETRTrainPTLAbsorption:
         assert "devices" not in mock_bt.call_args.kwargs
 
     def test_callbacks_empty_dict_no_error(self, tmp_path, patch_lit):
-        """callbacks={} is accepted without error."""
+        """Callbacks={} is accepted without error."""
         mock_self = _make_rfdetr_self(tmp_path)
         p_mod, p_dm, p_bt, *_ = patch_lit
         with p_mod, p_dm, p_bt:
@@ -627,7 +626,7 @@ class TestResolutionKwarg:
     """RFDETR.train(resolution=...) applies, validates, and syncs the resolution override."""
 
     def test_updates_model_config_resolution(self, tmp_path, patch_lit):
-        """resolution kwarg is applied to model_config.resolution before training."""
+        """Resolution kwarg is applied to model_config.resolution before training."""
         mock_self = _make_rfdetr_self(tmp_path)
         block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
         valid_resolution = block_size * 11  # guaranteed divisible and different from default
@@ -663,7 +662,7 @@ class TestResolutionKwarg:
         assert mock_self.model_config.positional_encoding_size == expected_pe
 
     def test_does_not_reach_get_train_config(self, tmp_path, patch_lit):
-        """resolution kwarg is popped before get_train_config is called."""
+        """Resolution kwarg is popped before get_train_config is called."""
         mock_self = _make_rfdetr_self(tmp_path)
         block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
         p_mod, p_dm, p_bt, *_ = patch_lit
@@ -672,7 +671,7 @@ class TestResolutionKwarg:
         assert "resolution" not in mock_self.get_train_config.call_args.kwargs
 
     def test_indivisible_raises_value_error(self, tmp_path, patch_lit):
-        """resolution not divisible by patch_size * num_windows raises ValueError."""
+        """Resolution not divisible by patch_size * num_windows raises ValueError."""
         mock_self = _make_rfdetr_self(tmp_path)
         block_size = mock_self.model_config.patch_size * mock_self.model_config.num_windows
         indivisible = block_size * 10 + 1  # guaranteed not divisible by block_size
@@ -709,7 +708,7 @@ class TestResolutionKwarg:
             RFDETR.train(mock_self, resolution=bad_resolution)
 
     def test_syncs_model_resolution_attribute(self, tmp_path, patch_lit):
-        """resolution kwarg sets model.resolution so predict()/export() see the new resolution.
+        """Resolution kwarg sets model.resolution so predict()/export() see the new resolution.
 
         Regression test for #952 — keeps the cached inference/export context in sync after a resolution override in
         train().
@@ -723,7 +722,7 @@ class TestResolutionKwarg:
         assert mock_self.model.resolution == new_resolution
 
     def test_syncs_model_args_resolution_and_pe(self, tmp_path, patch_lit):
-        """resolution kwarg updates model.args.resolution and model.args.positional_encoding_size.
+        """Resolution kwarg updates model.args.resolution and model.args.positional_encoding_size.
 
         For formula-derived configs (PE == resolution // patch_size), both fields in model.args must be kept consistent
         with model_config so export/deployment pipelines use the correct values.  Regression test for #952.
@@ -853,7 +852,7 @@ class TestConvertLegacyCheckpoint:
         assert ckpt["hyper_parameters"] == {"lr": pytest.approx(1e-4), "epochs": 100}
 
     def test_args_none_gives_empty_hyper_parameters(self, tmp_path, patch_lit):
-        """args=None produces an empty hyper_parameters dict."""
+        """Args=None produces an empty hyper_parameters dict."""
         src = _make_legacy_pth(tmp_path, args_value=None)
         dst = str(tmp_path / "out.ckpt")
         convert_legacy_checkpoint(src, dst)
@@ -1372,9 +1371,8 @@ def _make_detr_checkpoint(
 
 
 class TestLoadPretrainWeightsInto:
-    """Tests for load_pretrain_weights (models/weights.py) — checkpoint compatibility
-    validation exercised when RFDETRNano(pretrain_weights=...) is called (issue #806).
-    """
+    """Tests for load_pretrain_weights (models/weights.py) — checkpoint compatibility validation exercised when
+    RFDETRNano(pretrain_weights=...) is called (issue #806)."""
 
     @pytest.fixture(autouse=True)
     def _patch_download(self, monkeypatch):

--- a/tests/training/test_drop_path_callback.py
+++ b/tests/training/test_drop_path_callback.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Unit tests for :class:`rfdetr.training.callbacks.drop_schedule.DropPathCallback`."""
 
 from __future__ import annotations
@@ -75,7 +74,7 @@ class TestOnTrainStart:
         np.testing.assert_array_equal(cb._dp_schedule, expected)
 
     def test_do_schedule_matches_drop_scheduler_standard(self) -> None:
-        """dropout schedule matches ``drop_scheduler`` for standard mode."""
+        """Dropout schedule matches ``drop_scheduler`` for standard mode."""
         cb = DropPathCallback(dropout=0.1)
         trainer = _make_mock_trainer(estimated_stepping_batches=50)
         pl_module = _make_mock_pl_module(epochs=5)

--- a/tests/training/test_ema_callback.py
+++ b/tests/training/test_ema_callback.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Unit and parity tests for RFDETREMACallback."""
 
 from __future__ import annotations
@@ -57,8 +56,8 @@ class TestAvgFnDecayFormula:
         assert torch.allclose(result, expected, atol=1e-7)
 
     def test_tau_warmup_at_step_1(self) -> None:
-        """At the first call (num_averaged=0) with tau>0 the effective decay
-        uses updates=1 matching ModelEma's 1-indexed counter."""
+        """At the first call (num_averaged=0) with tau>0 the effective decay uses updates=1 matching ModelEma's
+        1-indexed counter."""
         decay = 0.993
         tau = 100
         cb = RFDETREMACallback(decay=decay, tau=tau)
@@ -167,7 +166,10 @@ class TestUpdateInterval:
     """Verify update_interval_steps throttles EMA updates on step hooks."""
 
     def test_updates_only_on_interval_steps(self) -> None:
-        """update_interval_steps=2 updates on steps 2, 4, ... only."""
+        """update_interval_steps=2 updates on steps 2, 4, ...
+
+        only.
+        """
         cb = RFDETREMACallback(update_interval_steps=2)
         cb._average_model = MagicMock()
 

--- a/tests/training/test_load_pretrain_weights.py
+++ b/tests/training/test_load_pretrain_weights.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Regression tests for fine-tuned checkpoint weight destruction.
 
 When a user loads a fine-tuned N-class checkpoint but has ``num_classes`` configured to a LARGER value (e.g. default
@@ -17,7 +16,8 @@ to the user-override-aware logic that auto-aligns to the checkpoint when the use
 
 These tests exercise ``rfdetr.models.weights.load_pretrain_weights`` directly, which is the unified function that
 replaced the two prior separate implementations (``detr.py:_load_pretrain_weights_into`` and
-``module_model.py:RFDETRModelModule._load_pretrain_weights``)."""
+``module_model.py:RFDETRModelModule._load_pretrain_weights``).
+"""
 
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call
@@ -392,9 +392,8 @@ class TestLoadPretrainWeightsPEInterpolation:
 
 
 class TestL1FacadePEInterpolationEndToEnd:
-    """Regression for instantiating an RF-DETR L1 facade variant with a
-    custom ``resolution`` and a checkpoint trained at the variant's default
-    resolution must not raise ``RuntimeError`` from a PE shape mismatch.
+    """Regression for instantiating an RF-DETR L1 facade variant with a custom ``resolution`` and a checkpoint trained
+    at the variant's default resolution must not raise ``RuntimeError`` from a PE shape mismatch.
 
     In v1.6.5 the L1 facade (``RFDETRLarge``, ``RFDETRNano``, ...) used a private ``_load_pretrain_weights_into`` helper
     in ``detr.py`` that bypassed the PE bicubic-interpolation added to ``models.weights.load_pretrain_weights`` Code
@@ -409,8 +408,8 @@ class TestL1FacadePEInterpolationEndToEnd:
     """
 
     def test_rfdetr_nano_loads_default_pe_checkpoint_at_custom_resolution(self, tmp_path):
-        """Saving an RFDETRNano state_dict at default resolution and loading at
-        a higher resolution must succeed via PE interpolation in the L1 facade.
+        """Saving an RFDETRNano state_dict at default resolution and loading at a higher resolution must succeed via PE
+        interpolation in the L1 facade.
 
         Mirrors the user-reported scenario in https://github.com/roboflow/rf-detr/issues/990 (PE size mismatch ``[1,
         1937, 384]`` vs ``[1, 6401, 384]`` raised from ``LWDETR.load_state_dict``), reduced to RFDETRNano for test
@@ -465,8 +464,8 @@ class TestL1FacadePEInterpolationEndToEnd:
         )
 
     def test_rfdetr_seg_nano_loads_default_pe_checkpoint_at_custom_resolution(self, tmp_path):
-        """Saving an RFDETRSegNano state_dict at default resolution and loading at
-        a higher resolution must succeed via PE interpolation in the L1 facade.
+        """Saving an RFDETRSegNano state_dict at default resolution and loading at a higher resolution must succeed via
+        PE interpolation in the L1 facade.
 
         Regression for https://github.com/roboflow/rf-detr/issues/1023 — the segmentation model variant
         (``RFDETRSegNano``) raised ``RuntimeError: size mismatch for

--- a/tests/training/test_metrics_csv.py
+++ b/tests/training/test_metrics_csv.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Integration tests: metrics.csv contains all columns used by plot_metrics().
 
 Runs a minimal PTL training loop (1 epoch, 2 batches each) using mocked model internals so no real dataset or GPU is
@@ -123,7 +122,7 @@ class TestDetectionMetricsCSV:
         assert not all_nan, f"EMA columns with all-NaN values: {sorted(all_nan)}"
 
     def test_train_loss_is_unscaled(self, base_model_config, base_train_config):
-        """train/loss must be logged at the raw criterion scale, not divided by grad_accum_steps.
+        """Train/loss must be logged at the raw criterion scale, not divided by grad_accum_steps.
 
         With grad_accum_steps=4 the old code divided the logged value by 4, making train/loss ~4× smaller than val/loss.
         After the fix the logged value equals the raw weighted criterion output so both losses are on the same scale.

--- a/tests/training/test_module_data.py
+++ b/tests/training/test_module_data.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Comprehensive unit tests for RFDETRDataModule (LightningDataModule wrapper)."""
 
 from unittest.mock import MagicMock, patch
@@ -191,9 +190,8 @@ class TestInit:
         assert dm._persistent_workers is False
 
     def test_ddp_notebook_preserves_num_workers(self, build_datamodule, base_train_config):
-        """ddp_notebook keeps num_workers as configured (spawn-based DDP
-        children initialise CUDA fresh; DataLoader fork workers are CPU-only
-        and never touch CUDA, so nested forks are safe)."""
+        """ddp_notebook keeps num_workers as configured (spawn-based DDP children initialise CUDA fresh; DataLoader fork
+        workers are CPU-only and never touch CUDA, so nested forks are safe)."""
         tc = base_train_config(num_workers=4, strategy="ddp_notebook")
         dm = build_datamodule(train_config=tc)
         assert dm._num_workers == 4
@@ -208,7 +206,7 @@ class TestInit:
 
 
 class TestSetup:
-    """setup(stage) builds the correct dataset(s) for each PTL stage."""
+    """Setup(stage) builds the correct dataset(s) for each PTL stage."""
 
     def _setup_with_mock(self, tmp_path, stage, dataset_file="roboflow", **train_overrides):
         """Helper: construct DataModule and call setup(stage) with build_dataset mocked."""
@@ -230,26 +228,26 @@ class TestSetup:
         return dm, fake_train, fake_val, fake_test
 
     def test_fit_builds_train_and_val(self, tmp_path):
-        """setup('fit') populates both _dataset_train and _dataset_val."""
+        """Setup('fit') populates both _dataset_train and _dataset_val."""
         dm, fake_train, fake_val, _ = self._setup_with_mock(tmp_path, "fit")
         assert dm._dataset_train is fake_train
         assert dm._dataset_val is fake_val
         assert dm._dataset_test is None
 
     def test_validate_builds_only_val(self, tmp_path):
-        """setup('validate') populates only _dataset_val."""
+        """Setup('validate') populates only _dataset_val."""
         dm, _, fake_val, _ = self._setup_with_mock(tmp_path, "validate")
         assert dm._dataset_train is None
         assert dm._dataset_val is fake_val
         assert dm._dataset_test is None
 
     def test_test_stage_roboflow_uses_test_split(self, tmp_path):
-        """setup('test') requests 'test' split when dataset_file=='roboflow'."""
+        """Setup('test') requests 'test' split when dataset_file=='roboflow'."""
         dm, _, _, fake_test = self._setup_with_mock(tmp_path, "test", dataset_file="roboflow")
         assert dm._dataset_test is fake_test
 
     def test_test_stage_non_roboflow_uses_val_split(self, tmp_path):
-        """setup('test') falls back to 'val' split for non-roboflow datasets."""
+        """Setup('test') falls back to 'val' split for non-roboflow datasets."""
         mc = _base_model_config()
         tc = _base_train_config(tmp_path, dataset_file="coco")
         from rfdetr.training.module_data import RFDETRDataModule
@@ -268,7 +266,7 @@ class TestSetup:
         assert "test" not in requested_splits
 
     def test_fit_does_not_rebuild_if_already_set(self, tmp_path):
-        """setup('fit') skips building if datasets are already populated."""
+        """Setup('fit') skips building if datasets are already populated."""
         mc = _base_model_config()
         tc = _base_train_config(tmp_path)
         from rfdetr.training.module_data import RFDETRDataModule
@@ -287,14 +285,14 @@ class TestSetup:
         assert dm._dataset_val is existing_val
 
     def test_predict_stage_builds_val_dataset(self, tmp_path):
-        """setup('predict') populates _dataset_val with the 'val' split."""
+        """Setup('predict') populates _dataset_val with the 'val' split."""
         dm, _, fake_val, _ = self._setup_with_mock(tmp_path, "predict")
         assert dm._dataset_val is fake_val
         assert dm._dataset_train is None
         assert dm._dataset_test is None
 
     def test_predict_stage_does_not_rebuild_existing_val(self, tmp_path):
-        """setup('predict') skips building when _dataset_val is already set."""
+        """Setup('predict') skips building when _dataset_val is already set."""
         mc = _base_model_config()
         tc = _base_train_config(tmp_path)
         from rfdetr.training.module_data import RFDETRDataModule
@@ -498,7 +496,7 @@ class TestGradAccumAlignedDataset:
         ],
     )
     def test_length_always_multiple_of_pad_unit(self, n, eff_bs, world_size):
-        """len(wrapped) % (eff_bs * world_size) == 0 for all inputs."""
+        """Len(wrapped) % (eff_bs * world_size) == 0 for all inputs."""
         from rfdetr.training.module_data import GradAccumAlignedDataset
 
         ds = self._make_dataset(n)
@@ -810,7 +808,7 @@ class TestBackendResolution:
         return dm
 
     def test_auto_no_cuda_falls_back_to_cpu(self, tmp_path):
-        """auto + no CUDA: _kornia_pipeline stays None, no error."""
+        """Auto + no CUDA: _kornia_pipeline stays None, no error."""
         dm = self._build_dm_with_backend(tmp_path, "auto")
         with patch("rfdetr.training.module_data._has_cuda_device", return_value=False):
             dm = self._setup_with_mock_build(dm)
@@ -819,7 +817,7 @@ class TestBackendResolution:
         )
 
     def test_auto_no_kornia_falls_back_to_cpu(self, tmp_path):
-        """auto + CUDA available but kornia not installed: fallback to CPU."""
+        """Auto + CUDA available but kornia not installed: fallback to CPU."""
         dm = self._build_dm_with_backend(tmp_path, "auto")
 
         original_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
@@ -840,7 +838,7 @@ class TestBackendResolution:
         )
 
     def test_gpu_no_cuda_raises_runtime_error(self, tmp_path):
-        """gpu + no CUDA: must raise RuntimeError."""
+        """Gpu + no CUDA: must raise RuntimeError."""
         dm = self._build_dm_with_backend(tmp_path, "gpu")
         with (
             patch("rfdetr.training.module_data._has_cuda_device", return_value=False),
@@ -849,7 +847,7 @@ class TestBackendResolution:
             self._setup_with_mock_build(dm)
 
     def test_gpu_no_kornia_raises_import_error(self, tmp_path):
-        """gpu + CUDA but no kornia: must raise ImportError with install hint."""
+        """Gpu + CUDA but no kornia: must raise ImportError with install hint."""
         dm = self._build_dm_with_backend(tmp_path, "gpu")
 
         original_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
@@ -902,7 +900,7 @@ class TestBackendResolution:
         )
 
     def test_auto_no_cuda_does_not_strip_cpu_normalize(self, tmp_path):
-        """auto + no CUDA: gpu_postprocess must be False so CPU Normalize is retained."""
+        """Auto + no CUDA: gpu_postprocess must be False so CPU Normalize is retained."""
         dm = self._build_dm_with_backend(tmp_path, "auto")
         captured_gpu_postprocess = {}
 
@@ -970,8 +968,8 @@ class TestOnAfterBatchTransfer:
     def _make_kornia_batch(self, batch_size=2, h=16, w=16):
         """Build a batch with xyxy boxes suitable for on_after_batch_transfer.
 
-        Returns (NestedTensor, targets) where boxes are in absolute xyxy format and pixel values are in [0, 1]
-        (pre-normalization).
+        Returns (NestedTensor, targets) where boxes are in absolute xyxy format and pixel values are in [0, 1] (pre-
+        normalization).
         """
         tensors = torch.rand(batch_size, 3, h, w)  # [0, 1] range
         mask = torch.zeros(batch_size, h, w, dtype=torch.bool)

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Comprehensive unit tests for RFDETRModelModule (LightningModule wrapper)."""
 
 from types import SimpleNamespace
@@ -142,9 +141,8 @@ def make_batch():
 
 
 class TestInit:
-    """Tests for RFDETRModelModule.__init__ — covers attribute assignment and
-    delegation to build_model() / build_criterion_and_postprocessors()
-    when pretrain_weights is None."""
+    """Tests for RFDETRModelModule.__init__ — covers attribute assignment and delegation to build_model() /
+    build_criterion_and_postprocessors() when pretrain_weights is None."""
 
     def test_model_is_set(self, build_module):
         """__init__ must assign the built model to module.model."""
@@ -194,7 +192,7 @@ class TestInit:
     @patch("rfdetr.training.module_model.torch.compile")
     @patch("rfdetr.config.DEVICE", "cuda")
     def test_compile_disabled_when_train_accelerator_is_cpu(self, _mock_compile: MagicMock, tmp_path):
-        """compile stays disabled when training is explicitly forced to CPU."""
+        """Compile stays disabled when training is explicitly forced to CPU."""
         mc = _base_model_config(compile=True)
         tc = _base_train_config(tmp_path, multi_scale=False, accelerator="cpu")
         _build_module(model_config=mc, train_config=tc, tmp_path=tmp_path)
@@ -202,9 +200,9 @@ class TestInit:
 
 
 class TestLoadPretrainWeights:
-    """Tests for _load_pretrain_weights() — covers checkpoint validation, detection-head
-    reinitialization on class-count mismatch, query-embedding trimming, re-download on
-    corruption, and class-name extraction from checkpoint metadata."""
+    """Tests for _load_pretrain_weights() — covers checkpoint validation, detection-head reinitialization on class-count
+    mismatch, query-embedding trimming, re-download on corruption, and class-name extraction from checkpoint
+    metadata."""
 
     def _make_checkpoint(self, num_classes_in_ckpt=91, num_queries=300, group_detr=13):
         """Build a fake checkpoint dict."""
@@ -337,8 +335,8 @@ class TestLoadPretrainWeights:
     def test_download_before_load_when_weights_absent(
         self, mock_torch_load, mock_validate, mock_download, mock_isfile, base_model_config, build_module
     ):
-        """download_pretrain_weights must be called before torch.load so a fresh
-        environment (e.g. Colab) downloads weights automatically.
+        """download_pretrain_weights must be called before torch.load so a fresh environment (e.g. Colab) downloads
+        weights automatically.
 
         Regression test: previously download was only called as an except-block fallback, but ModelWeights.from_filename
         received the absolute path and returned None, causing a silent no-op and a FileNotFoundError.
@@ -436,9 +434,8 @@ class TestLoadPretrainWeights:
 
 
 class TestApplyLora:
-    """Tests for _apply_lora() — verifies that PEFT LoraConfig is constructed with the
-    correct target modules and that the backbone encoder is replaced in-place with the
-    wrapped PEFT model."""
+    """Tests for _apply_lora() — verifies that PEFT LoraConfig is constructed with the correct target modules and that
+    the backbone encoder is replaced in-place with the wrapped PEFT model."""
 
     def _build_module_with_backbone(self, tmp_path):
         """Build module with a mock backbone that exposes backbone[0].encoder."""
@@ -534,9 +531,8 @@ class TestOnFitStart:
 
 
 class TestOnTrainBatchStart:
-    """Tests for on_train_batch_start() — covers multi-scale interpolation of
-    NestedTensor inputs and verifies regularization scheduling is delegated to
-    DropPathCallback."""
+    """Tests for on_train_batch_start() — covers multi-scale interpolation of NestedTensor inputs and verifies
+    regularization scheduling is delegated to DropPathCallback."""
 
     def _setup_module(
         self,
@@ -614,9 +610,8 @@ class TestOnTrainBatchStart:
 
 
 class TestTrainingStep:
-    """Tests for training_step() — covers weighted loss aggregation, per-loss logging
-    under the train/ prefix, prog_bar visibility, scalar tensor output, and that losses
-    absent from weight_dict are excluded from the total."""
+    """Tests for training_step() — covers weighted loss aggregation, per-loss logging under the train/ prefix, prog_bar
+    visibility, scalar tensor output, and that losses absent from weight_dict are excluded from the total."""
 
     def _run_step(self, tmp_path, loss_dict=None, weight_dict=None, accumulate_grad_batches=1):
         module, fake_model, fake_criterion, _ = _build_module(tmp_path=tmp_path)
@@ -711,8 +706,8 @@ class TestTrainingStep:
 
 
 class TestValidationStep:
-    """Tests for validation_step() — verifies output dict shape, postprocessor
-    invocation with correct original sizes, and val/loss logging."""
+    """Tests for validation_step() — verifies output dict shape, postprocessor invocation with correct original sizes,
+    and val/loss logging."""
 
     def _run_val_step(self, tmp_path):
         module, fake_model, fake_criterion, fake_pp = _build_module(tmp_path=tmp_path)
@@ -766,8 +761,8 @@ class TestValidationStep:
 
 
 class TestTestStep:
-    """Tests for test_step() — verifies output dict shape, postprocessor
-    invocation with correct original sizes, and test/loss logging.
+    """Tests for test_step() — verifies output dict shape, postprocessor invocation with correct original sizes, and
+    test/loss logging.
 
     Mirrors :class:`TestValidationStep` since both steps share the same forward+postprocess logic and differ only in the
     logged metric prefix.
@@ -845,9 +840,8 @@ class TestTestStep:
 
 
 class TestConfigureOptimizers:
-    """Tests for configure_optimizers() — covers required output keys, AdamW optimizer
-    type, step-interval scheduler, LR lambda warmup ramp, and step-decay behaviour
-    before and after lr_drop."""
+    """Tests for configure_optimizers() — covers required output keys, AdamW optimizer type, step-interval scheduler, LR
+    lambda warmup ramp, and step-decay behaviour before and after lr_drop."""
 
     def _setup_module(self, tmp_path, **train_overrides):
         tc = _base_train_config(tmp_path, **train_overrides)
@@ -1077,9 +1071,8 @@ class TestClipGradients:
 
 
 class TestPredictStep:
-    """Tests for predict_step() — verifies that only samples (not targets) are passed
-    to the model, that postprocess receives the correct original sizes, and that the
-    postprocessor output is returned directly to the caller."""
+    """Tests for predict_step() — verifies that only samples (not targets) are passed to the model, that postprocess
+    receives the correct original sizes, and that the postprocessor output is returned directly to the caller."""
 
     def test_calls_postprocess_with_orig_sizes(self, build_module):
         """Postprocessor must receive a (batch, 2) tensor of original image sizes."""
@@ -1123,8 +1116,8 @@ class TestPredictStep:
 
 
 class TestReinitializeDetectionHead:
-    """Tests for reinitialize_detection_head() — verifies that the module delegates
-    to the underlying model and that arbitrary class counts are forwarded unchanged."""
+    """Tests for reinitialize_detection_head() — verifies that the module delegates to the underlying model and that
+    arbitrary class counts are forwarded unchanged."""
 
     def test_delegates_to_model(self, build_module):
         """Module must delegate head reinitialization to the underlying model."""
@@ -1152,8 +1145,8 @@ class TestReinitializeDetectionHead:
 
 
 class TestOnLoadCheckpoint:
-    """Tests for on_load_checkpoint() — covers legacy .pth normalisation and
-    positional-embedding interpolation for custom-resolution PTL checkpoints.
+    """Tests for on_load_checkpoint() — covers legacy .pth normalisation and positional-embedding interpolation for
+    custom-resolution PTL checkpoints.
 
     Regression: issue #998 — resume with custom resolution crashed because
     on_load_checkpoint did not interpolate PE before PTL applied the state dict.

--- a/tests/training/test_trainer.py
+++ b/tests/training/test_trainer.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Unit tests for build_trainer() — callback stack and config coercion."""
 
 import pytest

--- a/tests/training/test_trainer_smoke.py
+++ b/tests/training/test_trainer_smoke.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Smoke tests: Trainer(fast_dev_run=2).fit(module, datamodule) — T7.
 
 Verifies that the PTL training loop runs end-to-end without error for both detection and segmentation configurations.
@@ -301,10 +300,10 @@ class _DDPModule(RFDETRModelModule):
 class _MultiScaleCheckDDPModule(RFDETRModelModule):
     """DDP-safe module that asserts on_train_batch_start mutation reaches training_step.
 
-    With multi_scale=True and _FakeDataset's 32×32 images, on_train_batch_start interpolates samples.tensors to a
-    multi-scale resolution (≥392 for RFDETRBaseConfig resolution=560).  This module raises AssertionError in
-    training_step if the tensor height is still 32, meaning the in-place NestedTensor mutation did not propagate through
-    the PTL batch-hook chain.
+    With multi_scale=True and _FakeDataset's 32×32 images, on_train_batch_start interpolates samples.tensors to a multi-
+    scale resolution (≥392 for RFDETRBaseConfig resolution=560).  This module raises AssertionError in training_step if
+    the tensor height is still 32, meaning the in-place NestedTensor mutation did not propagate through the PTL batch-
+    hook chain.
 
     Must be defined at module level so pickle can look up the class by qualified name when ddp_spawn deserialises it in
     the child process.

--- a/tests/try_instantiate_all_models.py
+++ b/tests/try_instantiate_all_models.py
@@ -4,15 +4,14 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
-"""
-Comprehensive validation script to test model instantiation with all available weights.
+"""Comprehensive validation script to test model instantiation with all available weights.
 
 Tests detection and segmentation model classes from rf-detr by importing and instantiating them. Validates: imports,
 download, MD5 hash, model instantiation, and from_checkpoint round-trip.
 
 Usage:
-    python tests/try_instantiate_all_models.py"""
+    python tests/try_instantiate_all_models.py
+"""
 
 import argparse
 import os

--- a/tests/utilities/test_distributed.py
+++ b/tests/utilities/test_distributed.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Tests for distributed utility helpers."""
 
 from unittest.mock import patch

--- a/tests/utilities/test_file_validation.py
+++ b/tests/utilities/test_file_validation.py
@@ -17,40 +17,30 @@ from rfdetr.utilities.files import _compute_file_md5, _download_file, _validate_
 
 
 class _DummyTqdm:
-    """
-    Minimal tqdm stand-in for download tests.
+    """Minimal tqdm stand-in for download tests.
 
     This avoids real progress bars while preserving the context manager and `update` calls used by the downloader.
     """
 
     def __init__(self, **kwargs: object) -> None:
-        """
-        Store initialization kwargs for optional inspection.
-        """
+        """Store initialization kwargs for optional inspection."""
         self.kwargs = kwargs
 
     def __enter__(self) -> "_DummyTqdm":
-        """
-        Return self to satisfy context manager protocol.
-        """
+        """Return self to satisfy context manager protocol."""
         return self
 
     def __exit__(self, exc_type: object, exc: object, tb: object) -> bool:
-        """
-        Propagate exceptions raised inside the context.
-        """
+        """Propagate exceptions raised inside the context."""
         return False
 
     def update(self, size: int) -> None:
-        """
-        No-op progress update for compatibility with tqdm.
-        """
+        """No-op progress update for compatibility with tqdm."""
         return None
 
 
 class _FakeResponse:
-    """
-    Test double for requests responses used by the downloader.
+    """Test double for requests responses used by the downloader.
 
     Provides headers, iterable content chunks, and optional HTTP error behavior via `raise_for_status`.
     """
@@ -61,24 +51,18 @@ class _FakeResponse:
         headers: Optional[dict[str, str]] = None,
         raise_error: Optional[Exception] = None,
     ) -> None:
-        """
-        Initialize the fake response with content and metadata.
-        """
+        """Initialize the fake response with content and metadata."""
         self._content_chunks = list(content_chunks)
         self.headers = headers or {}
         self._raise_error = raise_error
 
     def raise_for_status(self) -> None:
-        """
-        Raise the configured HTTP error, if any.
-        """
+        """Raise the configured HTTP error, if any."""
         if self._raise_error is not None:
             raise self._raise_error
 
     def iter_content(self, chunk_size: int = 1024) -> Iterator[bytes]:
-        """
-        Yield the configured content chunks.
-        """
+        """Yield the configured content chunks."""
         for chunk in self._content_chunks:
             yield chunk
 

--- a/tests/utilities/test_package.py
+++ b/tests/utilities/test_package.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Tests for package metadata helpers and structural import paths."""
 
 import subprocess

--- a/tests/utilities/test_state_dict.py
+++ b/tests/utilities/test_state_dict.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Unit tests for rfdetr.utilities.state_dict."""
 
 import logging

--- a/tests/utilities/test_tensors.py
+++ b/tests/utilities/test_tensors.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-
 """Tests for rfdetr.utilities.tensors.
 
 Covers:
@@ -419,7 +418,9 @@ class TestNestedTensorBlockSize:
     """``nested_tensor_from_tensor_list`` with block_size rounds batch max H/W up.
 
     This is the collator-level pad for backbone divisibility.  The rounded-up strip must be marked as padding in the
-    mask so downstream attention skips it.  See https://github.com/roboflow/rf-detr/issues/983 for context.
+    mask so downstream attention skips it.  See
+    https://github.com/roboflow/rf-detr/issues/983
+    for context.
     """
 
     @staticmethod
@@ -440,7 +441,7 @@ class TestNestedTensorBlockSize:
         assert nested.mask[1, :, 180:].all().item() is True
 
     def test_block_size_rounds_up(self) -> None:
-        """batch-max is rounded up to the next multiple of block_size."""
+        """Batch-max is rounded up to the next multiple of block_size."""
         images = [self._image(3, 100, 200), self._image(3, 150, 180)]
         nested = nested_tensor_from_tensor_list(images, block_size=32)
         _, _, h, w = nested.tensors.shape


### PR DESCRIPTION
This pull request introduces `docformatter` as a pre-commit hook and configures its behavior in the `pyproject.toml` file. The main goal is to automate and standardize Python docstring formatting across the codebase.

**Pre-commit automation:**
* Added `docformatter` to `.pre-commit-config.yaml` to automatically format Python docstrings during pre-commit checks.

**Tool configuration:**
* Configured the `docformatter` tool in `pyproject.toml` to wrap docstring summaries and descriptions at 120 characters.