### PR TITLE
test(tflite): mask ai_edge_litert in the interpreter mock fixture

### DIFF
--- a/tests/export/test_tflite_inference.py
+++ b/tests/export/test_tflite_inference.py
@@ -207,6 +207,59 @@ class TestCreateInterpreter:
         assert call_kwargs["model_path"] == "model.tflite"
         assert isinstance(call_kwargs["model_path"], str)
 
+    @pytest.fixture()
+    def _mock_ai_edge_litert(self):
+        """Inject a fake ai_edge_litert.interpreter into sys.modules and mask lower-priority backends.
+
+        Mirrors ``_mock_tflite_runtime`` for the first-priority backend so the
+        ``ai_edge_litert.interpreter`` branch of ``_create_interpreter`` can be exercised
+        independently of whether the real package is installed.
+        """
+        interp_instance = mock.MagicMock()
+        interp_instance.get_input_details.return_value = [{"shape": [1, 640, 640, 3], "dtype": np.float32}]
+        interp_instance.get_output_details.return_value = [
+            {"shape": [1, 300, 4], "name": "dets"},
+            {"shape": [1, 300, 81], "name": "labels"},
+        ]
+        interp_cls = mock.MagicMock(return_value=interp_instance)
+
+        import types
+
+        mod = types.ModuleType("ai_edge_litert.interpreter")
+        mod.Interpreter = interp_cls  # type: ignore[attr-defined]
+
+        parent_mod = types.ModuleType("ai_edge_litert")
+        parent_mod.interpreter = mod  # type: ignore[attr-defined]
+
+        with mock.patch.dict(
+            sys.modules,
+            {
+                "ai_edge_litert": parent_mod,
+                "ai_edge_litert.interpreter": mod,
+                "tflite_runtime": None,
+                "tflite_runtime.interpreter": None,
+            },
+        ):
+            yield interp_cls, interp_instance
+
+    def test_uses_ai_edge_litert_when_available(self, _mock_ai_edge_litert) -> None:
+        """ai_edge_litert is used as the first-priority backend when it is importable."""
+        interp_cls, _ = _mock_ai_edge_litert
+        _create_interpreter("model.tflite")
+        interp_cls.assert_called_once_with(model_path="model.tflite")
+
+    def test_ai_edge_litert_allocate_tensors_called(self, _mock_ai_edge_litert) -> None:
+        """allocate_tensors() is called after construction via the ai_edge_litert backend."""
+        _, interp_instance = _mock_ai_edge_litert
+        _create_interpreter("model.tflite")
+        interp_instance.allocate_tensors.assert_called_once()
+
+    def test_ai_edge_litert_returns_interpreter(self, _mock_ai_edge_litert) -> None:
+        """Return value is the ai_edge_litert interpreter instance."""
+        _, interp_instance = _mock_ai_edge_litert
+        result = _create_interpreter("model.tflite")
+        assert result is interp_instance
+
 
 # ---------------------------------------------------------------------------
 # TestRunInference

--- a/tests/export/test_tflite_inference.py
+++ b/tests/export/test_tflite_inference.py
@@ -99,11 +99,17 @@ class TestCreateInterpreter:
 
     @pytest.fixture()
     def _mock_tflite_runtime(self):
-        """Inject a fake tflite_runtime.interpreter into sys.modules.
+        """Inject a fake tflite_runtime.interpreter into sys.modules and mask ai_edge_litert.
+
+        ``_create_interpreter`` probes backends in priority order: ``ai_edge_litert`` first, then
+        ``tflite_runtime``, then ``tensorflow``. Masking ``ai_edge_litert`` and
+        ``ai_edge_litert.interpreter`` to ``None`` forces the import loop to fall through to the
+        ``tflite_runtime`` path so tests exercise that branch regardless of what is installed.
 
         Python's import machinery resolves ``import tflite_runtime.interpreter`` by looking up
-        ``sys.modules["tflite_runtime.interpreter"]`` directly. We also set the ``interpreter`` attribute on the parent
-        package mock so attribute-path resolution is consistent regardless of Python version.
+        ``sys.modules["tflite_runtime.interpreter"]`` directly. We also set the ``interpreter``
+        attribute on the parent package mock so attribute-path resolution is consistent regardless
+        of Python version.
         """
         interp_instance = mock.MagicMock()
         interp_instance.get_input_details.return_value = [{"shape": [1, 640, 640, 3], "dtype": np.float32}]

--- a/tests/export/test_tflite_inference.py
+++ b/tests/export/test_tflite_inference.py
@@ -93,6 +93,13 @@ def _save_grayscale_image(path: Path, size: tuple[int, int] = (64, 64)) -> None:
 # TestCreateInterpreter
 # ---------------------------------------------------------------------------
 
+# Shared masking entries for mock.patch.dict(sys.modules, ...) that force
+# ``_create_interpreter`` to skip the ai_edge_litert backend probe.
+_AI_EDGE_LITERT_MASK: dict[str, None] = {
+    "ai_edge_litert": None,
+    "ai_edge_litert.interpreter": None,
+}
+
 
 class TestCreateInterpreter:
     """Tests for ``_create_interpreter()``."""
@@ -129,14 +136,10 @@ class TestCreateInterpreter:
         parent_mod = types.ModuleType("tflite_runtime")
         parent_mod.interpreter = mod  # type: ignore[attr-defined]
 
-        # ``_create_interpreter`` prefers ai_edge_litert over tflite_runtime, so we mask the former
-        # in sys.modules. Without this, when ai_edge_litert is installed the real package is loaded
-        # and the mocked tflite_runtime Interpreter is never reached — the test fails.
         with mock.patch.dict(
             sys.modules,
             {
-                "ai_edge_litert": None,
-                "ai_edge_litert.interpreter": None,
+                **_AI_EDGE_LITERT_MASK,
                 "tflite_runtime": parent_mod,
                 "tflite_runtime.interpreter": mod,
             },
@@ -170,8 +173,7 @@ class TestCreateInterpreter:
         with mock.patch.dict(
             sys.modules,
             {
-                "ai_edge_litert": None,
-                "ai_edge_litert.interpreter": None,
+                **_AI_EDGE_LITERT_MASK,
                 "tflite_runtime": None,
                 "tflite_runtime.interpreter": None,
                 "tensorflow": tf_mod,

--- a/tests/export/test_tflite_inference.py
+++ b/tests/export/test_tflite_inference.py
@@ -146,8 +146,8 @@ class TestCreateInterpreter:
         ):
             yield interp_cls, interp_instance
 
-    def test_uses_tflite_runtime_when_available(self, _mock_tflite_runtime) -> None:
-        """Interpreter is constructed from tflite_runtime when it is importable."""
+    def test_uses_tflite_runtime_when_ai_edge_litert_absent(self, _mock_tflite_runtime) -> None:
+        """tflite_runtime is used as backend when ai_edge_litert is masked from the environment."""
         interp_cls, interp_instance = _mock_tflite_runtime
         _create_interpreter("model.tflite")
         interp_cls.assert_called_once_with(model_path="model.tflite")

--- a/tests/export/test_tflite_inference.py
+++ b/tests/export/test_tflite_inference.py
@@ -260,6 +260,21 @@ class TestCreateInterpreter:
         result = _create_interpreter("model.tflite")
         assert result is interp_instance
 
+    def test_raises_when_no_backend_available(self) -> None:
+        """ImportError with a helpful install message is raised when all backends are absent."""
+        with mock.patch.dict(
+            sys.modules,
+            {
+                **_AI_EDGE_LITERT_MASK,
+                "tflite_runtime": None,
+                "tflite_runtime.interpreter": None,
+                "tensorflow": None,
+                "tensorflow.lite": None,
+            },
+        ):
+            with pytest.raises(ImportError, match="TFLite inference requires"):
+                _create_interpreter("model.tflite")
+
 
 # ---------------------------------------------------------------------------
 # TestRunInference

--- a/tests/export/test_tflite_inference.py
+++ b/tests/export/test_tflite_inference.py
@@ -183,6 +183,7 @@ class TestCreateInterpreter:
             _create_interpreter("model.tflite")
 
         tf_interp_cls.assert_called_once_with(model_path="model.tflite")
+        interp_instance.allocate_tensors.assert_called_once()
 
     def test_returns_interpreter(self, _mock_tflite_runtime) -> None:
         """Return value is the interpreter instance (not the class)."""

--- a/tests/export/test_tflite_inference.py
+++ b/tests/export/test_tflite_inference.py
@@ -123,7 +123,17 @@ class TestCreateInterpreter:
         parent_mod = types.ModuleType("tflite_runtime")
         parent_mod.interpreter = mod  # type: ignore[attr-defined]
 
-        with mock.patch.dict(sys.modules, {"tflite_runtime": parent_mod, "tflite_runtime.interpreter": mod}):
+        # ``_create_interpreter`` tries ai_edge_litert before tflite_runtime, so mask it to force the
+        # tflite_runtime path even when ai_edge_litert is installed
+        with mock.patch.dict(
+            sys.modules,
+            {
+                "ai_edge_litert": None,
+                "ai_edge_litert.interpreter": None,
+                "tflite_runtime": parent_mod,
+                "tflite_runtime.interpreter": mod,
+            },
+        ):
             yield interp_cls, interp_instance
 
     def test_uses_tflite_runtime_when_available(self, _mock_tflite_runtime) -> None:

--- a/tests/export/test_tflite_inference.py
+++ b/tests/export/test_tflite_inference.py
@@ -123,8 +123,9 @@ class TestCreateInterpreter:
         parent_mod = types.ModuleType("tflite_runtime")
         parent_mod.interpreter = mod  # type: ignore[attr-defined]
 
-        # ``_create_interpreter`` tries ai_edge_litert before tflite_runtime, so mask it to force the
-        # tflite_runtime path even when ai_edge_litert is installed
+        # ``_create_interpreter`` prefers ai_edge_litert over tflite_runtime, so we mask the former
+        # in sys.modules. Without this, when ai_edge_litert is installed the real package is loaded
+        # and the mocked tflite_runtime Interpreter is never reached — the test fails.
         with mock.patch.dict(
             sys.modules,
             {


### PR DESCRIPTION
## What does this PR do?

Fixes the 5 `tests/export/test_tflite_inference.py::TestCreateInterpreter` tests that fail with `ValueError: Could not open 'model.tflite'` whenever `ai_edge_litert` is installed (Colab, a full TensorFlow install, or a dev env with `[tflite]`). CI's CPU job installs neither `tensorflow` nor `ai_edge_litert`, so the tests pass there and the breakage goes unnoticed; it only surfaces in TFLite-capable environments.

`_create_interpreter` (`rfdetr/export/_tflite/inference.py`) tries interpreter backends in order: `ai_edge_litert` -> `tflite_runtime` -> `tensorflow.lite`. The `_mock_tflite_runtime` fixture injected a fake `tflite_runtime` into `sys.modules` but left `ai_edge_litert` unmasked. So when `ai_edge_litert` is importable, the real `ai_edge_litert.Interpreter` is selected first and tries to open the placeholder `'model.tflite'`, raising the error. The sibling `test_falls_back_to_tensorflow_when_tflite_runtime_missing` already masks `ai_edge_litert`, which is why it passes.


Fixes #1068

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [ .] I have added/updated tests for this change

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x ] I have updated the documentation accordingly (if applicable)

## Additional Context

| Check | Before | After |
|---|---|---|
| `TestCreateInterpreter` (with `ai_edge_litert` installed) | 5 failed, 1 passed | 6 passed |

Reproduced and verified both locally and in a clean Colab with `ai_edge_litert` installed  
Colab link - https://colab.research.google.com/drive/1e3vC2e-mJq0UWUa8d6nH5Jdjv2WbF8HA?usp=sharing
