### PR TITLE
tests: add regression and integrity checks for benchmark download helpers

### DIFF
--- a/src/rfdetr/datasets/_develop.py
+++ b/src/rfdetr/datasets/_develop.py
@@ -36,6 +36,32 @@ _COCO_URLS = {
     "annotations": "http://images.cocodataset.org/annotations/annotations_trainval2017.zip",
 }
 
+_COCO_VAL_IMAGE_COUNT: int = 5000
+
+
+def _coco_val_images_complete(images_dir: Path) -> bool:
+    """Check whether the COCO val2017 image directory contains all expected images.
+
+    Returns ``False`` for a missing or empty directory so callers can trigger a
+    re-download without inspecting the directory manually.
+
+    Args:
+        images_dir: Path to the directory that should contain the val2017 images.
+
+    Returns:
+        ``True`` if *images_dir* exists and contains at least ``_COCO_VAL_IMAGE_COUNT``
+        files, ``False`` otherwise.
+
+    Examples:
+        >>> import tempfile
+        >>> with tempfile.TemporaryDirectory() as tmpdir:
+        ...     _coco_val_images_complete(Path(tmpdir) / "val2017")
+        False
+    """
+    if not images_dir.is_dir():
+        return False
+    return sum(1 for entry in images_dir.iterdir() if entry.is_file()) >= _COCO_VAL_IMAGE_COUNT
+
 
 class _SimpleDataset:
     """Simple synthetic dataset for testing augmentations and training loops.

--- a/src/rfdetr/datasets/_develop.py
+++ b/src/rfdetr/datasets/_develop.py
@@ -40,7 +40,7 @@ _COCO_VAL_IMAGE_COUNT: int = 5000
 
 
 def _coco_val_images_complete(images_dir: Path) -> bool:
-    """Check whether the COCO val2017 image directory contains all expected images.
+    """Check whether the COCO val2017 image directory contains the expected number of JPEG files.
 
     Returns ``False`` for a missing or empty directory so callers can trigger a
     re-download without inspecting the directory manually.
@@ -50,7 +50,12 @@ def _coco_val_images_complete(images_dir: Path) -> bool:
 
     Returns:
         ``True`` if *images_dir* exists and contains at least ``_COCO_VAL_IMAGE_COUNT``
-        files, ``False`` otherwise.
+        ``.jpg`` files, ``False`` otherwise.
+
+    Raises:
+        OSError: If *images_dir* exists but cannot be read (e.g. ``PermissionError``
+            when the directory is not accessible, or ``FileNotFoundError`` on a
+            TOCTOU race between the ``is_dir()`` check and ``iterdir()``).
 
     Examples:
         >>> import tempfile
@@ -60,7 +65,10 @@ def _coco_val_images_complete(images_dir: Path) -> bool:
     """
     if not images_dir.is_dir():
         return False
-    return sum(1 for entry in images_dir.iterdir() if entry.is_file()) >= _COCO_VAL_IMAGE_COUNT
+    return (
+        sum(1 for entry in images_dir.iterdir() if entry.is_file() and entry.suffix.lower() == ".jpg")
+        >= _COCO_VAL_IMAGE_COUNT
+    )
 
 
 def _nonempty_file_exists(path: Path) -> bool:

--- a/src/rfdetr/datasets/_develop.py
+++ b/src/rfdetr/datasets/_develop.py
@@ -63,6 +63,31 @@ def _coco_val_images_complete(images_dir: Path) -> bool:
     return sum(1 for entry in images_dir.iterdir() if entry.is_file()) >= _COCO_VAL_IMAGE_COUNT
 
 
+def _nonempty_file_exists(path: Path) -> bool:
+    """Check whether a file exists and contains at least one byte.
+
+    Returns ``False`` for a missing or empty file so callers can trigger a
+    re-download without inspecting the file manually.
+
+    Args:
+        path: Path to the file to check.
+
+    Returns:
+        ``True`` if *path* refers to an existing file with ``size > 0``,
+        ``False`` otherwise.
+
+    Examples:
+        >>> import tempfile
+        >>> with tempfile.TemporaryDirectory() as tmpdir:
+        ...     _nonempty_file_exists(Path(tmpdir) / "missing.json")
+        False
+    """
+    try:
+        return path.is_file() and path.stat().st_size > 0
+    except OSError:
+        return False
+
+
 class _SimpleDataset:
     """Simple synthetic dataset for testing augmentations and training loops.
 

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -12,6 +12,7 @@ from rfdetr.datasets._develop import (
     _coco_val_images_complete,
     _download_and_extract,
     _download_lock,
+    _nonempty_file_exists,
 )
 from rfdetr.utilities.reproducibility import seed_all
 
@@ -33,7 +34,7 @@ def download_coco_val() -> tuple[Path, Path]:
     with _download_lock(lock_path):
         if not _coco_val_images_complete(images_root):
             _download_and_extract(_COCO_URLS["val2017"], _DATA_DIR)
-        if not annotations_path.exists():
+        if not _nonempty_file_exists(annotations_path):
             _download_and_extract(_COCO_URLS["annotations"], _DATA_DIR)
 
     return images_root, annotations_path

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -9,6 +9,7 @@ import pytest
 
 from rfdetr.datasets._develop import (
     _COCO_URLS,
+    _coco_val_images_complete,
     _download_and_extract,
     _download_lock,
 )
@@ -30,7 +31,7 @@ def download_coco_val() -> tuple[Path, Path]:
 
     lock_path = _DATA_DIR / ".coco_download.lock"
     with _download_lock(lock_path):
-        if not images_root.exists():
+        if not _coco_val_images_complete(images_root):
             _download_and_extract(_COCO_URLS["val2017"], _DATA_DIR)
         if not annotations_path.exists():
             _download_and_extract(_COCO_URLS["annotations"], _DATA_DIR)

--- a/tests/benchmarks/test_develop_downloads.py
+++ b/tests/benchmarks/test_develop_downloads.py
@@ -1,0 +1,68 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Tests for private developer download helpers."""
+
+from pathlib import Path
+
+import pytest
+
+from rfdetr.datasets import _develop
+
+
+class TestCocoValImagesComplete:
+    """Regression coverage for interrupted COCO val2017 image downloads."""
+
+    def test_missing_directory_is_incomplete(self, tmp_path: Path) -> None:
+        """A missing image directory must trigger a download."""
+        assert not _develop._coco_val_images_complete(tmp_path / "val2017")
+
+    def test_empty_existing_directory_is_incomplete(self, tmp_path: Path) -> None:
+        """An empty ``val2017`` directory must not skip the image download."""
+        images_root = tmp_path / "val2017"
+        images_root.mkdir()
+
+        assert not _develop._coco_val_images_complete(images_root)
+
+    def test_too_few_images_is_incomplete(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A partial image directory must not skip the image download."""
+        monkeypatch.setattr(_develop, "_COCO_VAL_IMAGE_COUNT", 2)
+        images_root = tmp_path / "val2017"
+        images_root.mkdir()
+        (images_root / "000000000139.jpg").write_bytes(b"jpeg")
+
+        assert not _develop._coco_val_images_complete(images_root)
+
+    def test_expected_image_count_is_complete(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A directory with the expected image count is accepted."""
+        monkeypatch.setattr(_develop, "_COCO_VAL_IMAGE_COUNT", 2)
+        images_root = tmp_path / "val2017"
+        images_root.mkdir()
+        (images_root / "000000000139.jpg").write_bytes(b"jpeg")
+        (images_root / "000000000285.jpg").write_bytes(b"jpeg")
+
+        assert _develop._coco_val_images_complete(images_root)
+
+
+class TestNonemptyFileExists:
+    """Coverage for file integrity checks used by benchmark downloads."""
+
+    def test_missing_file_is_false(self, tmp_path: Path) -> None:
+        """Missing files must trigger a download."""
+        assert not _develop._nonempty_file_exists(tmp_path / "instances_val2017.json")
+
+    def test_empty_file_is_false(self, tmp_path: Path) -> None:
+        """Empty files must trigger a download."""
+        annotations_path = tmp_path / "instances_val2017.json"
+        annotations_path.write_text("")
+
+        assert not _develop._nonempty_file_exists(annotations_path)
+
+    def test_nonempty_file_is_true(self, tmp_path: Path) -> None:
+        """Non-empty files are accepted."""
+        annotations_path = tmp_path / "instances_val2017.json"
+        annotations_path.write_text("{}")
+
+        assert _develop._nonempty_file_exists(annotations_path)

--- a/tests/benchmarks/test_develop_downloads.py
+++ b/tests/benchmarks/test_develop_downloads.py
@@ -46,23 +46,27 @@ class TestCocoValImagesComplete:
         assert _develop._coco_val_images_complete(images_root)
 
 
-class TestNonemptyFileExists:
-    """Coverage for file integrity checks used by benchmark downloads."""
+class TestAnnotationFilePreconditions:
+    """Coverage for annotation file preconditions used by benchmark downloads."""
 
-    def test_missing_file_is_false(self, tmp_path: Path) -> None:
+    def test_missing_file_is_incomplete(self, tmp_path: Path) -> None:
         """Missing files must trigger a download."""
-        assert not _develop._nonempty_file_exists(tmp_path / "instances_val2017.json")
+        annotations_path = tmp_path / "instances_val2017.json"
 
-    def test_empty_file_is_false(self, tmp_path: Path) -> None:
+        assert not annotations_path.exists()
+
+    def test_empty_file_is_incomplete(self, tmp_path: Path) -> None:
         """Empty files must trigger a download."""
         annotations_path = tmp_path / "instances_val2017.json"
         annotations_path.write_text("")
 
-        assert not _develop._nonempty_file_exists(annotations_path)
+        assert annotations_path.is_file()
+        assert annotations_path.stat().st_size == 0
 
-    def test_nonempty_file_is_true(self, tmp_path: Path) -> None:
+    def test_nonempty_file_is_complete(self, tmp_path: Path) -> None:
         """Non-empty files are accepted."""
         annotations_path = tmp_path / "instances_val2017.json"
         annotations_path.write_text("{}")
 
-        assert _develop._nonempty_file_exists(annotations_path)
+        assert annotations_path.is_file()
+        assert annotations_path.stat().st_size > 0

--- a/tests/benchmarks/test_develop_downloads.py
+++ b/tests/benchmarks/test_develop_downloads.py
@@ -12,7 +12,12 @@ from unittest.mock import patch
 
 import pytest
 
-from rfdetr.datasets import _develop
+from rfdetr.datasets._develop import (
+    _coco_val_images_complete,
+    _download_and_extract,
+    _download_lock,
+    _nonempty_file_exists,
+)
 
 
 class TestCocoValImagesComplete:
@@ -20,14 +25,14 @@ class TestCocoValImagesComplete:
 
     def test_missing_directory_is_incomplete(self, tmp_path: Path) -> None:
         """A missing image directory must trigger a download."""
-        assert not _develop._coco_val_images_complete(tmp_path / "val2017")
+        assert not _coco_val_images_complete(tmp_path / "val2017")
 
     def test_empty_existing_directory_is_incomplete(self, tmp_path: Path) -> None:
         """An empty ``val2017`` directory must not skip the image download."""
         images_root = tmp_path / "val2017"
         images_root.mkdir()
 
-        assert not _develop._coco_val_images_complete(images_root)
+        assert not _coco_val_images_complete(images_root)
 
     @pytest.mark.parametrize(
         "file_count,expected",
@@ -41,13 +46,15 @@ class TestCocoValImagesComplete:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, file_count: int, expected: bool
     ) -> None:
         """Directory completeness reflects the >= threshold semantics."""
-        monkeypatch.setattr(_develop, "_COCO_VAL_IMAGE_COUNT", 2)
+        import rfdetr.datasets._develop as _develop_mod
+
+        monkeypatch.setattr(_develop_mod, "_COCO_VAL_IMAGE_COUNT", 2)
         images_root = tmp_path / "val2017"
         images_root.mkdir()
         for i in range(file_count):
             (images_root / f"{i:012d}.jpg").write_bytes(b"jpeg")
 
-        assert _develop._coco_val_images_complete(images_root) is expected
+        assert _coco_val_images_complete(images_root) is expected
 
 
 class TestNonemptyFileExists:
@@ -57,21 +64,21 @@ class TestNonemptyFileExists:
         """A missing annotation file must trigger a download."""
         annotations_path = tmp_path / "instances_val2017.json"
 
-        assert not _develop._nonempty_file_exists(annotations_path)
+        assert not _nonempty_file_exists(annotations_path)
 
     def test_empty_file_is_incomplete(self, tmp_path: Path) -> None:
         """An empty annotation file must trigger a re-download."""
         annotations_path = tmp_path / "instances_val2017.json"
         annotations_path.write_bytes(b"")
 
-        assert not _develop._nonempty_file_exists(annotations_path)
+        assert not _nonempty_file_exists(annotations_path)
 
     def test_nonempty_file_is_complete(self, tmp_path: Path) -> None:
         """A non-empty annotation file is accepted without re-download."""
         annotations_path = tmp_path / "instances_val2017.json"
         annotations_path.write_bytes(b"{}")
 
-        assert _develop._nonempty_file_exists(annotations_path)
+        assert _nonempty_file_exists(annotations_path)
 
 
 class TestDownloadLock:
@@ -83,7 +90,7 @@ class TestDownloadLock:
         lock_path.touch()
 
         with pytest.raises(TimeoutError):
-            with _develop._download_lock(lock_path, timeout_s=0, poll_s=0):
+            with _download_lock(lock_path, timeout_s=0, poll_s=0):
                 pass
 
 
@@ -108,4 +115,4 @@ class TestDownloadAndExtract:
 
         with patch("rfdetr.datasets._develop.urlretrieve", side_effect=fake_urlretrieve):
             with pytest.raises(RuntimeError, match="Unsafe path detected"):
-                _develop._download_and_extract(url, tmp_path)
+                _download_and_extract(url, tmp_path)

--- a/tests/benchmarks/test_develop_downloads.py
+++ b/tests/benchmarks/test_develop_downloads.py
@@ -5,7 +5,10 @@
 # ------------------------------------------------------------------------
 """Tests for private developer download helpers."""
 
+import io
+import zipfile
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -26,24 +29,25 @@ class TestCocoValImagesComplete:
 
         assert not _develop._coco_val_images_complete(images_root)
 
-    def test_too_few_images_is_incomplete(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A partial image directory must not skip the image download."""
+    @pytest.mark.parametrize(
+        "file_count,expected",
+        [
+            pytest.param(1, False, id="below_threshold_is_incomplete"),
+            pytest.param(2, True, id="at_threshold_is_complete"),
+            pytest.param(3, True, id="above_threshold_is_complete"),
+        ],
+    )
+    def test_file_count_threshold(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, file_count: int, expected: bool
+    ) -> None:
+        """Directory completeness reflects the >= threshold semantics."""
         monkeypatch.setattr(_develop, "_COCO_VAL_IMAGE_COUNT", 2)
         images_root = tmp_path / "val2017"
         images_root.mkdir()
-        (images_root / "000000000139.jpg").write_bytes(b"jpeg")
+        for i in range(file_count):
+            (images_root / f"{i:012d}.jpg").write_bytes(b"jpeg")
 
-        assert not _develop._coco_val_images_complete(images_root)
-
-    def test_expected_image_count_is_complete(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A directory with the expected image count is accepted."""
-        monkeypatch.setattr(_develop, "_COCO_VAL_IMAGE_COUNT", 2)
-        images_root = tmp_path / "val2017"
-        images_root.mkdir()
-        (images_root / "000000000139.jpg").write_bytes(b"jpeg")
-        (images_root / "000000000285.jpg").write_bytes(b"jpeg")
-
-        assert _develop._coco_val_images_complete(images_root)
+        assert _develop._coco_val_images_complete(images_root) is expected
 
 
 class TestNonemptyFileExists:
@@ -68,3 +72,40 @@ class TestNonemptyFileExists:
         annotations_path.write_bytes(b"{}")
 
         assert _develop._nonempty_file_exists(annotations_path)
+
+
+class TestDownloadLock:
+    """Coverage for the cross-process file-lock context manager."""
+
+    def test_timeout_raises_when_lock_held(self, tmp_path: Path) -> None:
+        """TimeoutError is raised immediately when the lock file already exists and timeout_s=0."""
+        lock_path = tmp_path / "test.lock"
+        lock_path.touch()
+
+        with pytest.raises(TimeoutError):
+            with _develop._download_lock(lock_path, timeout_s=0, poll_s=0):
+                pass
+
+
+class TestDownloadAndExtract:
+    """Coverage for the ZIP download-and-extract helper."""
+
+    def _make_zip(self, members: dict) -> bytes:
+        """Build an in-memory ZIP archive from a mapping of filename→content."""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            for name, content in members.items():
+                zf.writestr(name, content)
+        return buf.getvalue()
+
+    def test_path_traversal_raises_runtime_error(self, tmp_path: Path) -> None:
+        """A ZIP entry escaping dest_dir must raise RuntimeError (path-traversal guard)."""
+        zip_bytes = self._make_zip({"../evil.txt": "malicious"})
+        url = "http://example.com/test.zip"
+
+        def fake_urlretrieve(url: str, dest: str) -> None:
+            Path(dest).write_bytes(zip_bytes)
+
+        with patch("rfdetr.datasets._develop.urlretrieve", side_effect=fake_urlretrieve):
+            with pytest.raises(RuntimeError, match="Unsafe path detected"):
+                _develop._download_and_extract(url, tmp_path)

--- a/tests/benchmarks/test_develop_downloads.py
+++ b/tests/benchmarks/test_develop_downloads.py
@@ -46,27 +46,25 @@ class TestCocoValImagesComplete:
         assert _develop._coco_val_images_complete(images_root)
 
 
-class TestAnnotationFilePreconditions:
-    """Coverage for annotation file preconditions used by benchmark downloads."""
+class TestNonemptyFileExists:
+    """Regression coverage for annotation file integrity checks in benchmark downloads."""
 
     def test_missing_file_is_incomplete(self, tmp_path: Path) -> None:
-        """Missing files must trigger a download."""
+        """A missing annotation file must trigger a download."""
         annotations_path = tmp_path / "instances_val2017.json"
 
-        assert not annotations_path.exists()
+        assert not _develop._nonempty_file_exists(annotations_path)
 
     def test_empty_file_is_incomplete(self, tmp_path: Path) -> None:
-        """Empty files must trigger a download."""
+        """An empty annotation file must trigger a re-download."""
         annotations_path = tmp_path / "instances_val2017.json"
-        annotations_path.write_text("")
+        annotations_path.write_bytes(b"")
 
-        assert annotations_path.is_file()
-        assert annotations_path.stat().st_size == 0
+        assert not _develop._nonempty_file_exists(annotations_path)
 
     def test_nonempty_file_is_complete(self, tmp_path: Path) -> None:
-        """Non-empty files are accepted."""
+        """A non-empty annotation file is accepted without re-download."""
         annotations_path = tmp_path / "instances_val2017.json"
-        annotations_path.write_text("{}")
+        annotations_path.write_bytes(b"{}")
 
-        assert annotations_path.is_file()
-        assert annotations_path.stat().st_size > 0
+        assert _develop._nonempty_file_exists(annotations_path)


### PR DESCRIPTION
This pull request adds new regression and integrity tests for private developer download helpers related to COCO dataset image and annotation downloads. The tests ensure that incomplete or missing data triggers downloads, and that file integrity checks are properly enforced.

**New test coverage for download helpers:**

* Added `TestCocoValImagesComplete` class to verify that image directory completeness is correctly detected, ensuring downloads are triggered for missing, empty, or incomplete directories, and skipped only for complete directories.
* Added `TestNonemptyFileExists` class to test file integrity checks, confirming that missing or empty annotation files trigger downloads, while non-empty files are accepted.