### PR TITLE
fix(segm): keep grad_input fp32 in bf16-mixed AMP backward

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,10 +88,10 @@ See `pyproject.toml` for complete dependency specifications:
 
 ```bash
 # CPU tests (default for local development; mirrors CI)
-uv run --no-sync pytest src/ tests/ -n 2 -m "not gpu" --ignore=tests/try_instantiate_all_models.py --cov=rfdetr --cov-report=xml --timeout=240 --durations=50
+uv run --no-sync pytest src/ tests/ -n 1 -m "not gpu" --ignore=tests/try_instantiate_all_models.py --cov=rfdetr --cov-report=xml --timeout=240 --durations=50
 
 # GPU tests (requires GPU; mirrors CI)
-uv run --no-sync pytest tests/ -m gpu -n 3 --reruns 1 --only-rerun "OutOfMemoryError" --cov=rfdetr --cov-report=xml --timeout=600 --durations=20
+uv run --no-sync pytest tests/ -m gpu -n 2 --reruns 1 --only-rerun "OutOfMemoryError" --cov=rfdetr --cov-report=xml --timeout=600 --durations=20
 
 # Pre-commit checks (ALWAYS run before committing)
 pre-commit run --all-files

--- a/src/rfdetr/models/heads/segmentation.py
+++ b/src/rfdetr/models/heads/segmentation.py
@@ -83,13 +83,15 @@ class _DepthwiseConvWithoutCuDNN(torch.autograd.Function):
             ``False``) get ``None``. Non-tensor inputs always get ``None``.
 
         Note:
-            Under AMP (``"16-mixed"``), ``grad_output`` arrives as ``fp16`` while the saved ``weight`` stays ``fp32``.
-            Both tensors are upcast to ``weight.dtype`` before calling ``conv2d_input`` / ``conv2d_weight``.
-            ``grad_input`` is then cast back to the original input dtype so downstream gradient accumulation uses the
-            expected dtype.
+            Under AMP (``"bf16-mixed"`` or ``"16-mixed"``), ``grad_output`` may arrive in a reduced dtype while the
+            saved ``weight`` stays ``fp32``.  Both tensors are upcast to ``weight.dtype`` before calling
+            ``conv2d_input`` / ``conv2d_weight``.  ``grad_input`` is kept in ``weight.dtype`` (fp32) so that upstream
+            gradient accumulation into fp32 leaf parameters stays in fp32 — matching standard ``F.conv2d`` backward
+            behaviour.  Casting back to the activation dtype (``x.dtype``) would propagate a reduced-precision gradient
+            to fp32 backbone parameters, causing a ``params, grads, exp_avgs, and exp_avg_sqs must have same dtype``
+            crash in fused AdamW (see issue #959).
         """
         x, weight = ctx.saved_tensors
-        input_dtype = x.dtype
 
         needs_x_grad = ctx.needs_input_grad[0]
         needs_w_grad = ctx.needs_input_grad[1]
@@ -100,9 +102,10 @@ class _DepthwiseConvWithoutCuDNN(torch.autograd.Function):
         grad_bias = None
 
         if needs_x_grad or needs_w_grad:
-            # Under AMP ("16-mixed" on T4/P100), grad_output arrives as fp16 while
+            # Under AMP, grad_output may arrive in a reduced dtype (fp16/bf16) while
             # weight stays fp32.  conv2d_input/conv2d_weight require matching dtypes,
-            # so upcast to weight.dtype (fp32); cast grad_input back afterward.
+            # so upcast to weight.dtype (fp32).  grad_input is kept in weight.dtype —
+            # casting back to x.dtype would inject a bf16 gradient into fp32 params.
             grad_output_cast = grad_output.to(dtype=weight.dtype)
             # Same process-global caveat as forward: safe under DDP, not under DataParallel.
             with torch.backends.cudnn.flags(enabled=False):
@@ -115,7 +118,7 @@ class _DepthwiseConvWithoutCuDNN(torch.autograd.Function):
                         padding=ctx.padding,
                         dilation=ctx.dilation,
                         groups=ctx.groups,
-                    ).to(dtype=input_dtype)
+                    )  # kept in weight.dtype (fp32) — do NOT cast back to x.dtype
                 if needs_w_grad:
                     grad_weight = torch.nn.grad.conv2d_weight(
                         x.to(dtype=weight.dtype),

--- a/tests/models/test_segmentation_head.py
+++ b/tests/models/test_segmentation_head.py
@@ -176,6 +176,49 @@ def test_depthwise_conv_backward_fp16_grad_output() -> None:
     assert torch.isfinite(x.grad).all()
 
 
+def test_depthwise_conv_backward_bf16_activation_keeps_grads_fp32() -> None:
+    """grad_input and weight.grad must be fp32 when saved activation x is bf16 (issue #959).
+
+    Under bf16-mixed AMP, the activation x entering _DepthwiseConvWithoutCuDNN is bf16 while weight stays fp32.  The old
+    code cast grad_input back to x.dtype (bf16), propagating bf16 gradients to fp32 backbone parameters so that
+    param.grad.dtype became bf16.  Fused AdamW then crashed with 'params, grads, exp_avgs, and exp_avg_sqs must have
+    same dtype, device, and layout' (see issue #959).  The fix keeps grad_input in weight.dtype (fp32).
+
+    This test drives the backward directly with a bf16 saved activation to reproduce the dtype that is present at
+    training time without requiring a GPU.
+    """
+    import types
+
+    from rfdetr.models.heads.segmentation import _DepthwiseConvWithoutCuDNN
+
+    dim = 8
+    weight = torch.randn(dim, 1, 3, 3, requires_grad=True)  # fp32 parameter (never cast by AMP)
+    x_bf16 = torch.randn(1, dim, 4, 4, dtype=torch.bfloat16)  # bf16 activation (cast by AMP forward)
+    grad_output = torch.ones(1, dim, 4, 4, dtype=torch.bfloat16)  # bf16 grad (from bf16 backward)
+
+    # Build a minimal context mirroring what ctx would contain after the AMP forward pass.
+    ctx = types.SimpleNamespace()
+    ctx.saved_tensors = (x_bf16, weight)
+    ctx.has_bias = False
+    ctx.stride = (1, 1)
+    ctx.padding = (1, 1)
+    ctx.dilation = (1, 1)
+    ctx.groups = dim
+    ctx.needs_input_grad = [True, True, False, False, False, False, False]
+
+    grad_input, grad_weight, *_ = _DepthwiseConvWithoutCuDNN.backward(ctx, grad_output)
+
+    assert grad_input is not None, "grad_input should not be None when needs_input_grad[0] is True"
+    assert grad_input.dtype == torch.float32, (
+        f"grad_input is {grad_input.dtype} — bf16 grad_input propagates to fp32 backbone params "
+        "and crashes fused AdamW (issue #959)"
+    )
+    assert grad_weight is not None, "grad_weight should not be None when needs_input_grad[1] is True"
+    assert grad_weight.dtype == torch.float32, (
+        f"grad_weight is {grad_weight.dtype} — weight grad must stay fp32 to match param dtype"
+    )
+
+
 def test_depthwise_conv_no_cudnn_bias_none() -> None:
     """_DepthwiseConvWithoutCuDNN forward and backward work correctly with bias=None.
 


### PR DESCRIPTION
_DepthwiseConvWithoutCuDNN.backward cast grad_input back to x.dtype (bfloat16 under bf16-mixed AMP) via .to(dtype=input_dtype).  This injected bf16 gradients into fp32 backbone parameters so param.grad became bf16 while param remained fp32.  Fused AdamW then crashed:
  RuntimeError: params, grads, exp_avgs, and exp_avg_sqs must have
  same dtype, device, and layout
Detection models were unaffected — their backward runs outside autocast and naturally returns fp32 grad_input.

Fix: remove the .to(dtype=input_dtype) cast; grad_input stays in weight.dtype (fp32), matching standard F.conv2d backward behaviour.

- Add regression test driving backward with bf16 saved activation to pin the dtype contract on CPU without a GPU
- Update AGENTS.md CPU/GPU worker counts

Fixes #959