### PR TITLE
fix(training): make `_use_fused_optimizer` doctest HW-deterministic

### DIFF
--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -223,12 +223,11 @@ class RFDETRModelModule(LightningModule):
             ``True`` when fused AdamW is both requested and safe to use.
 
         Examples:
-            >>> # Fused is disabled when trainer precision is 32-true
+            >>> from unittest.mock import patch
             >>> module = RFDETRModelModule.__new__(RFDETRModelModule)
             >>> module.model_config = type("Cfg", (), {"fused_optimizer": True})()
-            >>> module._trainer = type("Trainer", (), {"precision": "32-true"})()
-            >>> module._trainer.precision = "32-true"
-            >>> module._use_fused_optimizer
+            >>> with patch("torch.cuda.is_available", return_value=False):
+            ...     module._use_fused_optimizer
             False
         """
         return (

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -1003,6 +1003,14 @@ class TestConfigureOptimizers:
 
         assert optimizer.defaults.get("fused") is True
 
+    @patch("rfdetr.training.module_model.torch.cuda.is_available", return_value=False)
+    def test_fused_optimizer_disabled_when_cuda_unavailable(self, mock_cuda_available, tmp_path):
+        """_use_fused_optimizer must return False when CUDA is not available, regardless of precision."""
+        module, _ = self._setup_module(tmp_path)
+        module._trainer.precision = "bf16-mixed"
+
+        assert not module._use_fused_optimizer
+
 
 class TestClipGradients:
     """Tests for clip_gradients() — verifies precision gating mirrors configure_optimizers()."""


### PR DESCRIPTION
- Replace trainer-stub doctest with patch("torch.cuda.is_available", return_value=False); stub was bypassed on CPU (is_available short-circuits) but hit Lightning trainer property validation on GPU, re-surfacing as AttributeError: 'RFDETRModelModule' object has no attribute '_use_fused_optimizer'
- Add test_fused_optimizer_disabled_when_cuda_unavailable to TestConfigureOptimizers, covering the CUDA-unavailable path that was only validated by the broken doctest

Closes #1079