### PR TITLE
releasing `1.7.1` [rebase & merge]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,10 +88,10 @@ See `pyproject.toml` for complete dependency specifications:
 
 ```bash
 # CPU tests (default for local development; mirrors CI)
-uv run --no-sync pytest src/ tests/ -n 2 -m "not gpu" --ignore=tests/try_instantiate_all_models.py --cov=rfdetr --cov-report=xml --timeout=240 --durations=50
+uv run --no-sync pytest src/ tests/ -n 1 -m "not gpu" --ignore=tests/try_instantiate_all_models.py --cov=rfdetr --cov-report=xml --timeout=240 --durations=50
 
 # GPU tests (requires GPU; mirrors CI)
-uv run --no-sync pytest tests/ -m gpu -n 3 --reruns 1 --only-rerun "OutOfMemoryError" --cov=rfdetr --cov-report=xml --timeout=600 --durations=20
+uv run --no-sync pytest tests/ -m gpu -n 2 --reruns 1 --only-rerun "OutOfMemoryError" --cov=rfdetr --cov-report=xml --timeout=600 --durations=20
 
 # Pre-commit checks (ALWAYS run before committing)
 pre-commit run --all-files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fixed `import rfdetr` failing on NumPy 2.x when a transitive dependency references the removed `np.complex_` alias ([#1064](https://github.com/roboflow/rf-detr/pull/1064))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-
+
+### Changed
+
+-
+
+### Deprecated
+
+-
+
+### Fixed
+
+-
+
+### Security
+
+-
+
+---
+
 ## [1.7.0] — 2026-04-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,25 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+---
 
--
-
-### Changed
-
--
-
-### Deprecated
-
--
+## [1.7.1] — 2026-05-28
 
 ### Fixed
 
-- Fixed `import rfdetr` failing on NumPy 2.x when a transitive dependency references the removed `np.complex_` alias ([#1064](https://github.com/roboflow/rf-detr/pull/1064))
-
-### Security
-
--
+- Fixed `RFDETR.from_checkpoint` failing when loading a starter-style checkpoint with `pretrain_weights` unset or set to a sentinel value: the model variant is now inferred from the checkpoint filename as a fallback. ([#1065](https://github.com/roboflow/rf-detr/pull/1065))
+- Fixed segmentation backward pass in BF16 mixed-precision (`bf16-mixed` AMP): `grad_input` now stays in `fp32` (matching standard `F.conv2d` backward behaviour) instead of being cast to the activation dtype, preventing a `params, grads, exp_avgs, and exp_avg_sqs must have same dtype` crash in fused AdamW during mixed-precision training. ([#1076](https://github.com/roboflow/rf-detr/pull/1076))
+- Fixed `import rfdetr` failing on NumPy 2.x when a transitive dependency references the removed `np.complex_` alias. ([#1064](https://github.com/roboflow/rf-detr/pull/1064))
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rfdetr"
-version = "1.7.0"
+version = "1.8.0.dev"
 description = "RF-DETR"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rfdetr"
-version = "1.8.0.dev"
+version = "1.7.1"
 description = "RF-DETR"
 readme = "README.md"
 authors = [

--- a/src/rfdetr/__init__.py
+++ b/src/rfdetr/__init__.py
@@ -31,6 +31,22 @@ import os
 import sys
 from typing import Any
 
+# np.complex_ was removed in NumPy 2.0 (June 2024). Some transitive dependencies (e.g. older
+# tensorflow, chumpy) still reference it, causing AttributeError on import rfdetr. See issue #1061.
+# TODO: Remove once all transitive deps support NumPy 2.x natively.
+try:
+    import numpy
+
+    _IS_NUMPY_INSTALLED = True
+except ImportError:
+    _IS_NUMPY_INSTALLED = False
+
+if _IS_NUMPY_INSTALLED and not hasattr(numpy, "complex_"):
+    _complex128 = getattr(numpy, "complex128", None)
+    if _complex128 is not None:
+        numpy.complex_ = _complex128
+
+
 from rfdetr.detr import RFDETR
 from rfdetr.inference import ModelContext
 from rfdetr.variants import (

--- a/src/rfdetr/datasets/_develop.py
+++ b/src/rfdetr/datasets/_develop.py
@@ -36,6 +36,65 @@ _COCO_URLS = {
     "annotations": "http://images.cocodataset.org/annotations/annotations_trainval2017.zip",
 }
 
+_COCO_VAL_IMAGE_COUNT: int = 5000
+
+
+def _coco_val_images_complete(images_dir: Path) -> bool:
+    """Check whether the COCO val2017 image directory contains the expected number of JPEG files.
+
+    Returns ``False`` for a missing or empty directory so callers can trigger a
+    re-download without inspecting the directory manually.
+
+    Args:
+        images_dir: Path to the directory that should contain the val2017 images.
+
+    Returns:
+        ``True`` if *images_dir* exists and contains at least ``_COCO_VAL_IMAGE_COUNT``
+        ``.jpg`` files, ``False`` otherwise.
+
+    Raises:
+        OSError: If *images_dir* exists but cannot be read (e.g. ``PermissionError``
+            when the directory is not accessible, or ``FileNotFoundError`` on a
+            TOCTOU race between the ``is_dir()`` check and ``iterdir()``).
+
+    Examples:
+        >>> import tempfile
+        >>> with tempfile.TemporaryDirectory() as tmpdir:
+        ...     _coco_val_images_complete(Path(tmpdir) / "val2017")
+        False
+    """
+    if not images_dir.is_dir():
+        return False
+    return (
+        sum(1 for entry in images_dir.iterdir() if entry.is_file() and entry.suffix.lower() == ".jpg")
+        >= _COCO_VAL_IMAGE_COUNT
+    )
+
+
+def _nonempty_file_exists(path: Path) -> bool:
+    """Check whether a file exists and contains at least one byte.
+
+    Returns ``False`` for a missing or empty file so callers can trigger a
+    re-download without inspecting the file manually.
+
+    Args:
+        path: Path to the file to check.
+
+    Returns:
+        ``True`` if *path* refers to an existing file with ``size > 0``,
+        ``False`` otherwise.
+
+    Examples:
+        >>> import tempfile
+        >>> with tempfile.TemporaryDirectory() as tmpdir:
+        ...     _nonempty_file_exists(Path(tmpdir) / "missing.json")
+        False
+    """
+    try:
+        return path.is_file() and path.stat().st_size > 0
+    except OSError:
+        return False
+
 
 class _SimpleDataset:
     """Simple synthetic dataset for testing augmentations and training loops.

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -267,7 +267,14 @@ class RFDETR:
         1. ``model_name`` key in the checkpoint (written by the PTL training
            stack since v1.7.0).
         2. ``pretrain_weights`` field in the checkpoint's ``args`` entry
-           (legacy fallback).
+           (legacy fallback for older checkpoints).
+        3. The **filename** of *path* itself, used as a last resort when
+           ``pretrain_weights`` is absent or an unset-like sentinel value
+           (empty string, ``"none"``, or ``"null"``).  Starter weights
+           published by Roboflow store ``pretrain_weights="none"`` in their
+           ``args``; passing the canonical filename (e.g.
+           ``rf-detr-small.pth``) lets ``from_checkpoint`` infer the class
+           automatically.
 
         Both legacy ``argparse.Namespace`` checkpoints (produced by ``engine.py``) and dict-style checkpoints (produced
         by the PTL training stack) are supported.
@@ -288,7 +295,8 @@ class RFDETR:
             FileNotFoundError: If *path* does not exist.
             OSError: If *path* exists but cannot be read.
             KeyError: If the checkpoint does not contain an ``"args"`` key.
-            ValueError: If the model class cannot be inferred from ``model_name`` or ``pretrain_weights``.
+            ValueError: If the model class cannot be inferred from ``model_name``,
+                ``pretrain_weights``, or the checkpoint filename.
 
         Examples:
             >>> model = RFDETR.from_checkpoint("checkpoint_best_total.pth")  # doctest: +SKIP
@@ -360,11 +368,24 @@ class RFDETR:
         else:
             normalized_name = ""
 
-        # Fall back to pretrain_weights filename parsing for older checkpoints.
+        # Fall back to pretrain_weights (legacy) or, when unset-like, the checkpoint filename.
         if isinstance(args, dict):
-            weights_name = str(args.get("pretrain_weights", "")).lower()
+            weights_name = str(args.get("pretrain_weights", "")).strip().lower()
         else:
-            weights_name = str(getattr(args, "pretrain_weights", "")).lower()
+            weights_name = str(getattr(args, "pretrain_weights", "")).strip().lower()
+        # The sentinel set {"", "none", "null"} covers unset-like checkpoint values:
+        #   ""     — pretrain_weights key absent entirely
+        #   "none" — checkpoint value was None or the literal string "none";
+        #            after str(...).strip().lower() both normalize to the same sentinel.
+        #            This is NOT an intentional "no pretraining" flag (see
+        #            test_pretrain_weights_none_warns, which operates at the config
+        #            level, not the checkpoint level)
+        #   "null" — checkpoint stored the literal string "null" (for example from a
+        #            YAML-originated value), which is also treated as unset-like here
+        _filename_fallback = False
+        if weights_name in {"", "none", "null"}:
+            weights_name = os.path.basename(os.fspath(path)).lower()
+            _filename_fallback = True
 
         if model_cls is None:
             # Guard: plus-only checkpoints should raise an actionable install error
@@ -384,6 +405,14 @@ class RFDETR:
                 if name in weights_name:
                     model_cls = klass
                     break
+
+            if _filename_fallback and model_cls is not None:
+                logger.info(
+                    "pretrain_weights unset in checkpoint %r; inferred model class %s from filename %r",
+                    path,
+                    getattr(model_cls, "__name__", repr(model_cls)),
+                    weights_name,
+                )
 
         if model_cls is None:
             raise ValueError(

--- a/src/rfdetr/models/heads/segmentation.py
+++ b/src/rfdetr/models/heads/segmentation.py
@@ -83,13 +83,15 @@ class _DepthwiseConvWithoutCuDNN(torch.autograd.Function):
             ``False``) get ``None``. Non-tensor inputs always get ``None``.
 
         Note:
-            Under AMP (``"16-mixed"``), ``grad_output`` arrives as ``fp16`` while the saved ``weight`` stays ``fp32``.
-            Both tensors are upcast to ``weight.dtype`` before calling ``conv2d_input`` / ``conv2d_weight``.
-            ``grad_input`` is then cast back to the original input dtype so downstream gradient accumulation uses the
-            expected dtype.
+            Under AMP (``"bf16-mixed"`` or ``"16-mixed"``), ``grad_output`` may arrive in a reduced dtype while the
+            saved ``weight`` stays ``fp32``.  Both tensors are upcast to ``weight.dtype`` before calling
+            ``conv2d_input`` / ``conv2d_weight``.  ``grad_input`` is kept in ``weight.dtype`` (fp32) so that upstream
+            gradient accumulation into fp32 leaf parameters stays in fp32 — matching standard ``F.conv2d`` backward
+            behaviour.  Casting back to the activation dtype (``x.dtype``) would propagate a reduced-precision gradient
+            to fp32 backbone parameters, causing a ``params, grads, exp_avgs, and exp_avg_sqs must have same dtype``
+            crash in fused AdamW (see issue #959).
         """
         x, weight = ctx.saved_tensors
-        input_dtype = x.dtype
 
         needs_x_grad = ctx.needs_input_grad[0]
         needs_w_grad = ctx.needs_input_grad[1]
@@ -100,9 +102,10 @@ class _DepthwiseConvWithoutCuDNN(torch.autograd.Function):
         grad_bias = None
 
         if needs_x_grad or needs_w_grad:
-            # Under AMP ("16-mixed" on T4/P100), grad_output arrives as fp16 while
+            # Under AMP, grad_output may arrive in a reduced dtype (fp16/bf16) while
             # weight stays fp32.  conv2d_input/conv2d_weight require matching dtypes,
-            # so upcast to weight.dtype (fp32); cast grad_input back afterward.
+            # so upcast to weight.dtype (fp32).  grad_input is kept in weight.dtype —
+            # casting back to x.dtype would inject a bf16 gradient into fp32 params.
             grad_output_cast = grad_output.to(dtype=weight.dtype)
             # Same process-global caveat as forward: safe under DDP, not under DataParallel.
             with torch.backends.cudnn.flags(enabled=False):
@@ -115,7 +118,7 @@ class _DepthwiseConvWithoutCuDNN(torch.autograd.Function):
                         padding=ctx.padding,
                         dilation=ctx.dilation,
                         groups=ctx.groups,
-                    ).to(dtype=input_dtype)
+                    )  # kept in weight.dtype (fp32) — do NOT cast back to x.dtype
                 if needs_w_grad:
                     grad_weight = torch.nn.grad.conv2d_weight(
                         x.to(dtype=weight.dtype),

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -223,12 +223,11 @@ class RFDETRModelModule(LightningModule):
             ``True`` when fused AdamW is both requested and safe to use.
 
         Examples:
-            >>> # Fused is disabled when trainer precision is 32-true
+            >>> from unittest.mock import patch
             >>> module = RFDETRModelModule.__new__(RFDETRModelModule)
             >>> module.model_config = type("Cfg", (), {"fused_optimizer": True})()
-            >>> module._trainer = type("Trainer", (), {"precision": "32-true"})()
-            >>> module._trainer.precision = "32-true"
-            >>> module._use_fused_optimizer
+            >>> with patch("torch.cuda.is_available", return_value=False):
+            ...     module._use_fused_optimizer
             False
         """
         return (

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -9,8 +9,10 @@ import pytest
 
 from rfdetr.datasets._develop import (
     _COCO_URLS,
+    _coco_val_images_complete,
     _download_and_extract,
     _download_lock,
+    _nonempty_file_exists,
 )
 from rfdetr.utilities.reproducibility import seed_all
 
@@ -30,9 +32,9 @@ def download_coco_val() -> tuple[Path, Path]:
 
     lock_path = _DATA_DIR / ".coco_download.lock"
     with _download_lock(lock_path):
-        if not images_root.exists():
+        if not _coco_val_images_complete(images_root):
             _download_and_extract(_COCO_URLS["val2017"], _DATA_DIR)
-        if not annotations_path.exists():
+        if not _nonempty_file_exists(annotations_path):
             _download_and_extract(_COCO_URLS["annotations"], _DATA_DIR)
 
     return images_root, annotations_path

--- a/tests/benchmarks/test_develop_downloads.py
+++ b/tests/benchmarks/test_develop_downloads.py
@@ -1,0 +1,118 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Tests for private developer download helpers."""
+
+import io
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from rfdetr.datasets._develop import (
+    _coco_val_images_complete,
+    _download_and_extract,
+    _download_lock,
+    _nonempty_file_exists,
+)
+
+
+class TestCocoValImagesComplete:
+    """Regression coverage for interrupted COCO val2017 image downloads."""
+
+    def test_missing_directory_is_incomplete(self, tmp_path: Path) -> None:
+        """A missing image directory must trigger a download."""
+        assert not _coco_val_images_complete(tmp_path / "val2017")
+
+    def test_empty_existing_directory_is_incomplete(self, tmp_path: Path) -> None:
+        """An empty ``val2017`` directory must not skip the image download."""
+        images_root = tmp_path / "val2017"
+        images_root.mkdir()
+
+        assert not _coco_val_images_complete(images_root)
+
+    @pytest.mark.parametrize(
+        "file_count,expected",
+        [
+            pytest.param(1, False, id="below_threshold_is_incomplete"),
+            pytest.param(2, True, id="at_threshold_is_complete"),
+            pytest.param(3, True, id="above_threshold_is_complete"),
+        ],
+    )
+    def test_file_count_threshold(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, file_count: int, expected: bool
+    ) -> None:
+        """Directory completeness reflects the >= threshold semantics."""
+        import rfdetr.datasets._develop as _develop_mod
+
+        monkeypatch.setattr(_develop_mod, "_COCO_VAL_IMAGE_COUNT", 2)
+        images_root = tmp_path / "val2017"
+        images_root.mkdir()
+        for i in range(file_count):
+            (images_root / f"{i:012d}.jpg").write_bytes(b"jpeg")
+
+        assert _coco_val_images_complete(images_root) is expected
+
+
+class TestNonemptyFileExists:
+    """Regression coverage for annotation file integrity checks in benchmark downloads."""
+
+    def test_missing_file_is_incomplete(self, tmp_path: Path) -> None:
+        """A missing annotation file must trigger a download."""
+        annotations_path = tmp_path / "instances_val2017.json"
+
+        assert not _nonempty_file_exists(annotations_path)
+
+    def test_empty_file_is_incomplete(self, tmp_path: Path) -> None:
+        """An empty annotation file must trigger a re-download."""
+        annotations_path = tmp_path / "instances_val2017.json"
+        annotations_path.write_bytes(b"")
+
+        assert not _nonempty_file_exists(annotations_path)
+
+    def test_nonempty_file_is_complete(self, tmp_path: Path) -> None:
+        """A non-empty annotation file is accepted without re-download."""
+        annotations_path = tmp_path / "instances_val2017.json"
+        annotations_path.write_bytes(b"{}")
+
+        assert _nonempty_file_exists(annotations_path)
+
+
+class TestDownloadLock:
+    """Coverage for the cross-process file-lock context manager."""
+
+    def test_timeout_raises_when_lock_held(self, tmp_path: Path) -> None:
+        """TimeoutError is raised immediately when the lock file already exists and timeout_s=0."""
+        lock_path = tmp_path / "test.lock"
+        lock_path.touch()
+
+        with pytest.raises(TimeoutError):
+            with _download_lock(lock_path, timeout_s=0, poll_s=0):
+                pass
+
+
+class TestDownloadAndExtract:
+    """Coverage for the ZIP download-and-extract helper."""
+
+    def _make_zip(self, members: dict) -> bytes:
+        """Build an in-memory ZIP archive from a mapping of filename→content."""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            for name, content in members.items():
+                zf.writestr(name, content)
+        return buf.getvalue()
+
+    def test_path_traversal_raises_runtime_error(self, tmp_path: Path) -> None:
+        """A ZIP entry escaping dest_dir must raise RuntimeError (path-traversal guard)."""
+        zip_bytes = self._make_zip({"../evil.txt": "malicious"})
+        url = "http://example.com/test.zip"
+
+        def fake_urlretrieve(url: str, dest: str) -> None:
+            Path(dest).write_bytes(zip_bytes)
+
+        with patch("rfdetr.datasets._develop.urlretrieve", side_effect=fake_urlretrieve):
+            with pytest.raises(RuntimeError, match="Unsafe path detected"):
+                _download_and_extract(url, tmp_path)

--- a/tests/datasets/test_augmentations.py
+++ b/tests/datasets/test_augmentations.py
@@ -1507,6 +1507,86 @@ class TestMakeCocoTransformsAugConfig:
         assert len(wrappers) == expected_resize_wrappers
 
 
+class TestMakeCocoTransformsOutputSize:
+    """Regression tests for #979: transforms must resize high-resolution images to the target resolution.
+
+    These tests verify that ``make_coco_transforms`` and ``make_coco_transforms_square_div_64``
+    actually produce output images at the requested ``resolution``, not at the original image size.
+    Existing tests only check pipeline *structure*; these check actual output *dimensions*.
+    """
+
+    # 1920x1080 (landscape) — larger than any typical training resolution.
+    # PIL size is (width, height), so Image.new("RGB", (1920, 1080)) gives a 1920-wide, 1080-tall image.
+    _INPUT_W = 1920
+    _INPUT_H = 1080
+    _RESOLUTION = 640
+
+    def _make_image(self) -> Image.Image:
+        return Image.new("RGB", (self._INPUT_W, self._INPUT_H))
+
+    def test_square_val_resizes_large_image(self) -> None:
+        """Square val transform resizes 1920x1080 to exactly 640x640."""
+        transform = make_coco_transforms_square_div_64("val", self._RESOLUTION)
+        tensor, _ = transform(self._make_image(), None)
+        assert tensor.shape[-2:] == (self._RESOLUTION, self._RESOLUTION)
+
+    def test_square_train_resizes_large_image(self) -> None:
+        """Square train transform resizes 1920x1080 to 640x640 regardless of OneOf branch."""
+        transform = make_coco_transforms_square_div_64("train", self._RESOLUTION, aug_config={})
+        tensor, _ = transform(self._make_image(), None)
+        assert tensor.shape[-2:] == (self._RESOLUTION, self._RESOLUTION)
+
+    def test_nonsquare_val_resizes_and_caps_longest_side(self) -> None:
+        """Non-square val transform resizes the image and keeps the longest side within 1333 px.
+
+        Avoid asserting an exact output dimension here because Albumentations resize behavior can vary across supported
+        versions. The stable contract is that the image is resized and the longest side does not exceed the configured
+        maximum.
+        """
+        transform = make_coco_transforms("val", self._RESOLUTION)
+        tensor, _ = transform(self._make_image(), None)
+        height, width = tensor.shape[-2], tensor.shape[-1]
+        assert (height, width) != (self._INPUT_H, self._INPUT_W)
+        assert max(height, width) <= 1333
+
+    def test_nonsquare_val_longest_side_at_most_1333(self) -> None:
+        """Non-square val transform caps the longest side at 1333 px.
+
+        Use an input that still exceeds 1333 px on its longest side after SmallestMaxSize(640), so this assertion
+        specifically validates that LongestMaxSize(1333) is applied.
+        """
+        transform = make_coco_transforms("val", self._RESOLUTION)
+        image = Image.new("RGB", (4000, 1000))
+        tensor, _ = transform(image, None)
+        height, width = tensor.shape[-2], tensor.shape[-1]
+        assert max(height, width) <= 1333
+
+    def test_nonsquare_val_does_not_pass_original_dimensions(self) -> None:
+        """Non-square val transform must not emit the original 1920x1080 dimensions — the core regression."""
+        transform = make_coco_transforms("val", self._RESOLUTION)
+        tensor, _ = transform(self._make_image(), None)
+        height, width = tensor.shape[-2], tensor.shape[-1]
+        assert (height, width) != (self._INPUT_H, self._INPUT_W), (
+            f"Transform emitted original {self._INPUT_H}x{self._INPUT_W} — resize was not applied"
+        )
+
+    def test_square_val_does_not_pass_original_dimensions(self) -> None:
+        """Square val transform must not emit the original 1920x1080 dimensions — the core regression."""
+        transform = make_coco_transforms_square_div_64("val", self._RESOLUTION)
+        tensor, _ = transform(self._make_image(), None)
+        height, width = tensor.shape[-2], tensor.shape[-1]
+        assert (height, width) != (self._INPUT_H, self._INPUT_W), (
+            f"Transform emitted original {self._INPUT_H}x{self._INPUT_W} — resize was not applied"
+        )
+
+    def test_output_is_float_tensor(self) -> None:
+        """Transform pipeline produces a float32 tensor, not a PIL Image."""
+        transform = make_coco_transforms_square_div_64("val", self._RESOLUTION)
+        tensor, _ = transform(self._make_image(), None)
+        assert isinstance(tensor, torch.Tensor)
+        assert tensor.dtype == torch.float32
+
+
 class TestAugPresets:
     """Regression tests for built-in augmentation presets."""
 

--- a/tests/export/test_tflite_inference.py
+++ b/tests/export/test_tflite_inference.py
@@ -93,17 +93,30 @@ def _save_grayscale_image(path: Path, size: tuple[int, int] = (64, 64)) -> None:
 # TestCreateInterpreter
 # ---------------------------------------------------------------------------
 
+# Shared masking entries for mock.patch.dict(sys.modules, ...) that force
+# ``_create_interpreter`` to skip the ai_edge_litert backend probe.
+_AI_EDGE_LITERT_MASK: dict[str, None] = {
+    "ai_edge_litert": None,
+    "ai_edge_litert.interpreter": None,
+}
+
 
 class TestCreateInterpreter:
     """Tests for ``_create_interpreter()``."""
 
     @pytest.fixture()
     def _mock_tflite_runtime(self):
-        """Inject a fake tflite_runtime.interpreter into sys.modules.
+        """Inject a fake tflite_runtime.interpreter into sys.modules and mask ai_edge_litert.
+
+        ``_create_interpreter`` probes backends in priority order: ``ai_edge_litert`` first, then
+        ``tflite_runtime``, then ``tensorflow``. Masking ``ai_edge_litert`` and
+        ``ai_edge_litert.interpreter`` to ``None`` forces the import loop to fall through to the
+        ``tflite_runtime`` path so tests exercise that branch regardless of what is installed.
 
         Python's import machinery resolves ``import tflite_runtime.interpreter`` by looking up
-        ``sys.modules["tflite_runtime.interpreter"]`` directly. We also set the ``interpreter`` attribute on the parent
-        package mock so attribute-path resolution is consistent regardless of Python version.
+        ``sys.modules["tflite_runtime.interpreter"]`` directly. We also set the ``interpreter``
+        attribute on the parent package mock so attribute-path resolution is consistent regardless
+        of Python version.
         """
         interp_instance = mock.MagicMock()
         interp_instance.get_input_details.return_value = [{"shape": [1, 640, 640, 3], "dtype": np.float32}]
@@ -123,11 +136,18 @@ class TestCreateInterpreter:
         parent_mod = types.ModuleType("tflite_runtime")
         parent_mod.interpreter = mod  # type: ignore[attr-defined]
 
-        with mock.patch.dict(sys.modules, {"tflite_runtime": parent_mod, "tflite_runtime.interpreter": mod}):
+        with mock.patch.dict(
+            sys.modules,
+            {
+                **_AI_EDGE_LITERT_MASK,
+                "tflite_runtime": parent_mod,
+                "tflite_runtime.interpreter": mod,
+            },
+        ):
             yield interp_cls, interp_instance
 
-    def test_uses_tflite_runtime_when_available(self, _mock_tflite_runtime) -> None:
-        """Interpreter is constructed from tflite_runtime when it is importable."""
+    def test_uses_tflite_runtime_when_ai_edge_litert_absent(self, _mock_tflite_runtime) -> None:
+        """tflite_runtime is used as backend when ai_edge_litert is masked from the environment."""
         interp_cls, interp_instance = _mock_tflite_runtime
         _create_interpreter("model.tflite")
         interp_cls.assert_called_once_with(model_path="model.tflite")
@@ -153,8 +173,7 @@ class TestCreateInterpreter:
         with mock.patch.dict(
             sys.modules,
             {
-                "ai_edge_litert": None,
-                "ai_edge_litert.interpreter": None,
+                **_AI_EDGE_LITERT_MASK,
                 "tflite_runtime": None,
                 "tflite_runtime.interpreter": None,
                 "tensorflow": tf_mod,
@@ -164,6 +183,7 @@ class TestCreateInterpreter:
             _create_interpreter("model.tflite")
 
         tf_interp_cls.assert_called_once_with(model_path="model.tflite")
+        interp_instance.allocate_tensors.assert_called_once()
 
     def test_returns_interpreter(self, _mock_tflite_runtime) -> None:
         """Return value is the interpreter instance (not the class)."""
@@ -186,6 +206,74 @@ class TestCreateInterpreter:
         call_kwargs = interp_cls.call_args[1]
         assert call_kwargs["model_path"] == "model.tflite"
         assert isinstance(call_kwargs["model_path"], str)
+
+    @pytest.fixture()
+    def _mock_ai_edge_litert(self):
+        """Inject a fake ai_edge_litert.interpreter into sys.modules and mask lower-priority backends.
+
+        Mirrors ``_mock_tflite_runtime`` for the first-priority backend so the
+        ``ai_edge_litert.interpreter`` branch of ``_create_interpreter`` can be exercised
+        independently of whether the real package is installed.
+        """
+        interp_instance = mock.MagicMock()
+        interp_instance.get_input_details.return_value = [{"shape": [1, 640, 640, 3], "dtype": np.float32}]
+        interp_instance.get_output_details.return_value = [
+            {"shape": [1, 300, 4], "name": "dets"},
+            {"shape": [1, 300, 81], "name": "labels"},
+        ]
+        interp_cls = mock.MagicMock(return_value=interp_instance)
+
+        import types
+
+        mod = types.ModuleType("ai_edge_litert.interpreter")
+        mod.Interpreter = interp_cls  # type: ignore[attr-defined]
+
+        parent_mod = types.ModuleType("ai_edge_litert")
+        parent_mod.interpreter = mod  # type: ignore[attr-defined]
+
+        with mock.patch.dict(
+            sys.modules,
+            {
+                "ai_edge_litert": parent_mod,
+                "ai_edge_litert.interpreter": mod,
+                "tflite_runtime": None,
+                "tflite_runtime.interpreter": None,
+            },
+        ):
+            yield interp_cls, interp_instance
+
+    def test_uses_ai_edge_litert_when_available(self, _mock_ai_edge_litert) -> None:
+        """ai_edge_litert is used as the first-priority backend when it is importable."""
+        interp_cls, _ = _mock_ai_edge_litert
+        _create_interpreter("model.tflite")
+        interp_cls.assert_called_once_with(model_path="model.tflite")
+
+    def test_ai_edge_litert_allocate_tensors_called(self, _mock_ai_edge_litert) -> None:
+        """allocate_tensors() is called after construction via the ai_edge_litert backend."""
+        _, interp_instance = _mock_ai_edge_litert
+        _create_interpreter("model.tflite")
+        interp_instance.allocate_tensors.assert_called_once()
+
+    def test_ai_edge_litert_returns_interpreter(self, _mock_ai_edge_litert) -> None:
+        """Return value is the ai_edge_litert interpreter instance."""
+        _, interp_instance = _mock_ai_edge_litert
+        result = _create_interpreter("model.tflite")
+        assert result is interp_instance
+
+    def test_raises_when_no_backend_available(self) -> None:
+        """ImportError with a helpful install message is raised when all backends are absent."""
+        with mock.patch.dict(
+            sys.modules,
+            {
+                **_AI_EDGE_LITERT_MASK,
+                "tflite_runtime": None,
+                "tflite_runtime.interpreter": None,
+                "tensorflow": None,
+                "tensorflow.lite": None,
+            },
+        ):
+            with pytest.raises(ImportError, match="TFLite inference requires"):
+                _create_interpreter("model.tflite")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/models/test_from_checkpoint.py
+++ b/tests/models/test_from_checkpoint.py
@@ -96,6 +96,27 @@ class TestFromCheckpointNamespaceArgs:
         assert call_kwargs.get("pretrain_weights") == str(tmp_path / "ckpt.pth")
         assert result is mock_cls.return_value
 
+    @pytest.mark.parametrize(
+        "missing_value",
+        [
+            pytest.param("none", id="bare-none"),
+            pytest.param("null", id="bare-null"),
+            pytest.param("", id="empty"),
+            pytest.param("  None  ", id="whitespace-None"),
+            pytest.param("  ", id="whitespace-only"),
+            pytest.param(" null ", id="whitespace-null"),
+            pytest.param(None, id="python-None"),
+        ],
+    )
+    def test_namespace_args_falls_back_to_checkpoint_filename_when_pretrain_weights_missing(
+        self, tmp_path: Path, missing_value: str | None
+    ) -> None:
+        """Namespace args: filename fallback fires when pretrain_weights is unset-like."""
+        ckpt = _ns(missing_value)  # type: ignore[arg-type]
+        _, mock_cls = _call_from_checkpoint(ckpt, tmp_path / "rf-detr-small.pth", "rfdetr.variants.RFDETRSmall")
+        mock_cls.assert_called_once()
+        assert mock_cls.call_args.kwargs["num_classes"] == 80
+
 
 # ---------------------------------------------------------------------------
 # Dict args (PTL / converted checkpoints)
@@ -150,6 +171,21 @@ class TestFromCheckpointEdgeCases:
         with patch("rfdetr.detr.torch.load", return_value=ckpt):
             with pytest.raises(ValueError, match="Could not infer model class"):
                 RFDETR.from_checkpoint(tmp_path / "ckpt.pth")
+
+    def test_filename_fallback_unrecognized_name_raises_value_error(self, tmp_path: Path) -> None:
+        """ValueError fires via filename-fallback path when filename has no known model token."""
+        ckpt = {"args": {"pretrain_weights": "none", "num_classes": 80}}
+        with patch("rfdetr.detr.torch.load", return_value=ckpt):
+            with pytest.raises(ValueError, match="Could not infer model class"):
+                RFDETR.from_checkpoint(tmp_path / "finetuned.pth")
+
+    @pytest.mark.skipif(_IS_RFDETR_PLUS_AVAILABLE, reason="rfdetr_plus is installed — guard not active")
+    def test_filename_fallback_xlarge_without_plus_raises_import_error(self, tmp_path: Path) -> None:
+        """ImportError fires via filename-fallback path when rfdetr_plus is absent."""
+        ckpt = {"args": {"pretrain_weights": "none", "num_classes": 80}}
+        with patch("rfdetr.detr.torch.load", return_value=ckpt):
+            with pytest.raises(ImportError):
+                RFDETR.from_checkpoint(tmp_path / "rf-detr-xlarge-starter.pth")
 
     def test_characterization_missing_args_key_raises_key_error(self, tmp_path: Path) -> None:
         """Checkpoint without 'args' key raises KeyError."""
@@ -313,6 +349,27 @@ class TestFromCheckpointModelName:
         assert "model_name" not in ckpt
         _, mock_cls = _call_from_checkpoint(ckpt, tmp_path / "ckpt.pth", "rfdetr.variants.RFDETRSmall")
         mock_cls.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "missing_value",
+        [
+            pytest.param("none", id="bare-none"),
+            pytest.param("null", id="bare-null"),
+            pytest.param("", id="empty"),
+            pytest.param("  None  ", id="whitespace-None"),
+            pytest.param("  ", id="whitespace-only"),
+            pytest.param(" null ", id="whitespace-null"),
+            pytest.param(None, id="python-None"),
+        ],
+    )
+    def test_falls_back_to_checkpoint_filename_when_pretrain_weights_missing(
+        self, tmp_path: Path, missing_value: str | None
+    ) -> None:
+        """When pretrain_weights is missing-like, from_checkpoint infers class from checkpoint filename."""
+        ckpt = {"args": {"pretrain_weights": missing_value, "num_classes": 80}}
+        _, mock_cls = _call_from_checkpoint(ckpt, tmp_path / "rf-detr-small.pth", "rfdetr.variants.RFDETRSmall")
+        mock_cls.assert_called_once()
+        assert mock_cls.call_args.kwargs["num_classes"] == 80
 
     def test_unknown_model_name_falls_back_to_pretrain_weights(self, tmp_path: Path) -> None:
         """Unrecognised model_name falls back to pretrain_weights parsing."""

--- a/tests/models/test_segmentation_head.py
+++ b/tests/models/test_segmentation_head.py
@@ -176,6 +176,49 @@ def test_depthwise_conv_backward_fp16_grad_output() -> None:
     assert torch.isfinite(x.grad).all()
 
 
+def test_depthwise_conv_backward_bf16_activation_keeps_grads_fp32() -> None:
+    """grad_input and weight.grad must be fp32 when saved activation x is bf16 (issue #959).
+
+    Under bf16-mixed AMP, the activation x entering _DepthwiseConvWithoutCuDNN is bf16 while weight stays fp32.  The old
+    code cast grad_input back to x.dtype (bf16), propagating bf16 gradients to fp32 backbone parameters so that
+    param.grad.dtype became bf16.  Fused AdamW then crashed with 'params, grads, exp_avgs, and exp_avg_sqs must have
+    same dtype, device, and layout' (see issue #959).  The fix keeps grad_input in weight.dtype (fp32).
+
+    This test drives the backward directly with a bf16 saved activation to reproduce the dtype that is present at
+    training time without requiring a GPU.
+    """
+    import types
+
+    from rfdetr.models.heads.segmentation import _DepthwiseConvWithoutCuDNN
+
+    dim = 8
+    weight = torch.randn(dim, 1, 3, 3, requires_grad=True)  # fp32 parameter (never cast by AMP)
+    x_bf16 = torch.randn(1, dim, 4, 4, dtype=torch.bfloat16)  # bf16 activation (cast by AMP forward)
+    grad_output = torch.ones(1, dim, 4, 4, dtype=torch.bfloat16)  # bf16 grad (from bf16 backward)
+
+    # Build a minimal context mirroring what ctx would contain after the AMP forward pass.
+    ctx = types.SimpleNamespace()
+    ctx.saved_tensors = (x_bf16, weight)
+    ctx.has_bias = False
+    ctx.stride = (1, 1)
+    ctx.padding = (1, 1)
+    ctx.dilation = (1, 1)
+    ctx.groups = dim
+    ctx.needs_input_grad = [True, True, False, False, False, False, False]
+
+    grad_input, grad_weight, *_ = _DepthwiseConvWithoutCuDNN.backward(ctx, grad_output)
+
+    assert grad_input is not None, "grad_input should not be None when needs_input_grad[0] is True"
+    assert grad_input.dtype == torch.float32, (
+        f"grad_input is {grad_input.dtype} — bf16 grad_input propagates to fp32 backbone params "
+        "and crashes fused AdamW (issue #959)"
+    )
+    assert grad_weight is not None, "grad_weight should not be None when needs_input_grad[1] is True"
+    assert grad_weight.dtype == torch.float32, (
+        f"grad_weight is {grad_weight.dtype} — weight grad must stay fp32 to match param dtype"
+    )
+
+
 def test_depthwise_conv_no_cudnn_bias_none() -> None:
     """_DepthwiseConvWithoutCuDNN forward and backward work correctly with bias=None.
 

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -1003,6 +1003,14 @@ class TestConfigureOptimizers:
 
         assert optimizer.defaults.get("fused") is True
 
+    @patch("rfdetr.training.module_model.torch.cuda.is_available", return_value=False)
+    def test_fused_optimizer_disabled_when_cuda_unavailable(self, mock_cuda_available, tmp_path):
+        """_use_fused_optimizer must return False when CUDA is not available, regardless of precision."""
+        module, _ = self._setup_module(tmp_path)
+        module._trainer.precision = "bf16-mixed"
+
+        assert not module._use_fused_optimizer
+
 
 class TestClipGradients:
     """Tests for clip_gradients() — verifies precision gating mirrors configure_optimizers()."""

--- a/tests/try_instantiate_all_models.py
+++ b/tests/try_instantiate_all_models.py
@@ -92,7 +92,9 @@ _HEAVY_MODEL_NAMES = {
 }
 
 
-def _test_from_checkpoint(model_instance: object, actual_cls: type, extra_kwargs: dict) -> None:
+def _test_from_checkpoint(
+    model_instance: object, actual_cls: type, extra_kwargs: dict, *, test_starter: bool = True
+) -> None:
     """Round-trip a model through from_checkpoint using a temp training checkpoint.
 
     Saves the instantiated model's weights into a minimal training-style checkpoint (``{"args": ..., "model":
@@ -104,6 +106,9 @@ def _test_from_checkpoint(model_instance: object, actual_cls: type, extra_kwargs
         actual_cls: The expected model class (e.g. ``RFDETRSmall``).
         extra_kwargs: Extra kwargs to pass to ``from_checkpoint`` (e.g.
             ``{"accept_platform_model_license": True}`` for plus models).
+        test_starter: When ``True`` (default) also run the starter-like
+            checkpoint round-trip.  Pass ``False`` for non-default resolutions
+            to avoid running the same resolution-independent test multiple times.
 
     Raises:
         AssertionError: If the recovered model is not an instance of *actual_cls*.
@@ -121,6 +126,13 @@ def _test_from_checkpoint(model_instance: object, actual_cls: type, extra_kwargs
         ),
         "model": model_instance.model.model.state_dict(),
     }
+    starter_like_ckpt = {
+        "args": argparse.Namespace(
+            pretrain_weights="none",
+            num_classes=num_classes,
+        ),
+        "model": model_instance.model.model.state_dict(),
+    }
 
     tmp_fd, tmp_path = tempfile.mkstemp(suffix=".pth")
     os.close(tmp_fd)
@@ -134,6 +146,21 @@ def _test_from_checkpoint(model_instance: object, actual_cls: type, extra_kwargs
         )
     finally:
         os.unlink(tmp_path)
+
+    if test_starter:
+        starter_tmp_fd, starter_path = tempfile.mkstemp(prefix=f"{actual_cls.size}-starter-", suffix=".pth")
+        os.close(starter_tmp_fd)
+        try:
+            torch.save(starter_like_ckpt, starter_path)
+            starter_recovered = _rfdetr.from_checkpoint(starter_path, **extra_kwargs)
+            assert starter_recovered is not None, "from_checkpoint returned None for starter-like checkpoint"
+            assert hasattr(starter_recovered, "model"), "starter-like from_checkpoint result missing 'model' attribute"
+            got = type(starter_recovered).__name__
+            assert isinstance(starter_recovered, actual_cls), (
+                f"starter-like from_checkpoint returned {got}, expected {actual_cls.__name__}"
+            )
+        finally:
+            os.unlink(starter_path)
 
 
 def _test_coco_class_name_mapping(model_instance: object) -> None:
@@ -232,7 +259,7 @@ def main() -> None:
                 # from_checkpoint round-trip: save a training-style checkpoint and reload it.
                 # Pass the real class (not a partial) so `_test_from_checkpoint` can read
                 # `.size` and `.__name__` and run `isinstance(recovered, actual_cls)`.
-                _test_from_checkpoint(model_instance, actual_cls, instantiate_kwargs)
+                _test_from_checkpoint(model_instance, actual_cls, instantiate_kwargs, test_starter=(res is None))
 
                 # Inference class-name regression for issue #988 — run on all
                 # nano-sized pretrained COCO models at default resolution only.

--- a/tests/utilities/test_package.py
+++ b/tests/utilities/test_package.py
@@ -168,6 +168,36 @@ class TestImportPaths:
 
         assert ModelContext is not None
 
+    def test_top_level_import_sets_numpy_complex_alias(self) -> None:
+        """Verify rfdetr shim sets np.complex_ in a fresh interpreter with complex_ absent.
+
+        Runs in a subprocess so the shim code path is actually executed — importing rfdetr inside pytest is a no-op
+        because rfdetr is already cached in sys.modules.
+        """
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import numpy\n"
+                    "if hasattr(numpy, 'complex_'):\n"
+                    "    del numpy.complex_\n"
+                    "import rfdetr\n"
+                    "assert hasattr(numpy, 'complex_'), 'shim did not set numpy.complex_'\n"
+                    "assert numpy.complex_ is numpy.complex128, 'complex_ must alias complex128'\n"
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            "Subprocess for NumPy complex_ shim failed:\n"
+            f"return code: {result.returncode}\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+
     def test_identity_across_import_paths(self) -> None:
         """The same class object must be returned regardless of import path.
 


### PR DESCRIPTION
# RF-DETR 1.7.1: Stability fixes (BF16 train & ckpt loading)

## Summary

RF-DETR 1.7.1 is a focused patch release that fixes three bugs affecting common workflows. If you train segmentation models with BF16 mixed-precision, load official starter checkpoints with `from_checkpoint`, or run RF-DETR alongside NumPy 2.x, this release resolves crashes you may have hit.

## What's fixed

- **BF16 mixed-precision segmentation training crash.** Training a segmentation model with BF16 mixed-precision (e.g. `amp_dtype="bfloat16"`) could fail with a dtype mismatch error in fused AdamW. The root cause was a low-level convolution backward pass converting a gradient to reduced precision before it reached the optimizer. Gradients now stay in the correct dtype throughout, matching standard PyTorch behaviour. (#1076)

- **`RFDETR.from_checkpoint` failing on official starter checkpoints.** Loading official Roboflow starter weights with `RFDETR.from_checkpoint(...)` raised `ValueError: Could not infer model class`. The checkpoint metadata stores `pretrain_weights="none"` as a sentinel value, which the loader didn't handle. It now falls back to inferring the model variant from the checkpoint filename and logs which variant it detected. (#1065)

- **NumPy 2.x import crash.** `import rfdetr` raised `AttributeError: module 'numpy' has no attribute 'complex_'` when NumPy 2.0 or later was installed alongside an older transitive dependency (such as chumpy or older TensorFlow builds) that still references the removed `np.complex_` alias. A compatibility shim at import time resolves this without requiring any changes to your environment. (#1064)

---

## Contributors

New contributor to this release — welcome!

- **Omkar Kabde** (@omkar-334) — TFLite test reliability improvements
- **Jirka Borovec** (@Borda) — BF16 segmentation fix, release

---

**Full changelog**: https://github.com/roboflow/rf-detr/compare/1.7.0...1.7.1
