### PR TITLE
fix(platform): correct `rfdetr_plus` module availability check

### DIFF
--- a/src/rfdetr/platform/__init__.py
+++ b/src/rfdetr/platform/__init__.py
@@ -12,7 +12,7 @@ _INSTALL_MSG = (
 )
 
 try:
-    _IS_RFDETR_PLUS_AVAILABLE = importlib.util.find_spec("rfdetr_plus.models") is not None
+    _IS_RFDETR_PLUS_AVAILABLE = importlib.util.find_spec("rfdetr_plus") is not None
 except ImportError:
     _IS_RFDETR_PLUS_AVAILABLE = False
 if not _IS_RFDETR_PLUS_AVAILABLE:


### PR DESCRIPTION
This pull request makes a minor update to the way the code checks for the availability of the `rfdetr_plus` package. Instead of checking for the `rfdetr_plus.models` module, it now checks for the base `rfdetr_plus` package, which is a more reliable approach.

* Changed the import check to look for the `rfdetr_plus` package instead of the `rfdetr_plus.models` module in `src/rfdetr/platform/__init__.py`

unblock https://github.com/roboflow/rf-detr_plus/pull/34