### PR TITLE
fix(training): prevent multi-GPU validation deadlock in COCO mAP sync

### DIFF
--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -105,6 +105,22 @@ class COCOEvalCallback(Callback):
         )
         kwargs["backend"] = "faster_coco_eval"
         self.map_metric = MeanAveragePrecision(iou_type=iou_type, **kwargs)
+        # Verify _MAP_STATE_ATTRS is complete for the installed torchmetrics version.  A missing
+        # attr is silently skipped in _merge_metric_state_across_ranks, producing wrong mAP with
+        # no error — an upgrade that adds a list-type state would hit this silently without the check.
+        installed = {k for k, v in self.map_metric._defaults.items() if isinstance(v, list)}
+        declared = set(self._MAP_STATE_ATTRS)
+        if installed != declared:
+            raise RuntimeError(
+                f"COCOEvalCallback._MAP_STATE_ATTRS is out of sync with the installed torchmetrics "
+                f"(version {self.map_metric.__class__.__module__}). "
+                f"Missing from _MAP_STATE_ATTRS: {sorted(installed - declared)}. "
+                f"Stale in _MAP_STATE_ATTRS: {sorted(declared - installed)}. "
+                f'Re-run: python -c "from torchmetrics.detection import MeanAveragePrecision; '
+                f"m = MeanAveragePrecision(); "
+                f'print(sorted(k for k, v in m._defaults.items() if isinstance(v, list)))" '
+                f"and update COCOEvalCallback._MAP_STATE_ATTRS to match."
+            )
         # Separate metric for the EMA model.  Created deterministically on EVERY rank in
         # on_validation_epoch_start / on_test_epoch_start (see _prepare_ema_metric) so its
         # cross-rank compute() sync is issued symmetrically and cannot deadlock DDP val.
@@ -490,7 +506,14 @@ class COCOEvalCallback(Callback):
             vote = int(flag.item())
         return bool(vote)
 
-    # torchmetrics MeanAveragePrecision accumulates predictions/targets in these list states.
+    # torchmetrics MeanAveragePrecision list-type state attributes — verified against torchmetrics >=1.2,<2
+    # (pyproject.toml pin).  List states are identified by an empty-list default in metric._defaults.
+    # On any torchmetrics upgrade, re-verify and update:
+    #   python -c "from torchmetrics.detection import MeanAveragePrecision; \
+    #              m = MeanAveragePrecision(); \
+    #              print(sorted(k for k, v in m._defaults.items() if isinstance(v, list)))"
+    # setup() asserts this tuple matches installed torchmetrics on every run.
+    # TODO: remove this tuple (and the merge workaround) when Lightning-AI/torchmetrics#3199 is resolved.
     _MAP_STATE_ATTRS = (
         "detection_box",
         "detection_scores",

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import numpy as np
 import torch
+import torch.distributed as dist
 import torch.nn.functional as F  # noqa: N812
 from pytorch_lightning import Callback
 from torchmetrics.detection import MeanAveragePrecision
@@ -22,6 +23,7 @@ from rfdetr.evaluation.matching import (
     merge_matching_data,
 )
 from rfdetr.utilities.box_ops import box_cxcywh_to_xyxy
+from rfdetr.utilities.distributed import all_gather, get_world_size, is_dist_avail_and_initialized
 
 
 class COCOEvalCallback(Callback):
@@ -64,6 +66,9 @@ class COCOEvalCallback(Callback):
         self._class_names: list[str] = []
         self._cat_id_to_name: dict[int, str] = {}
         self._f1_local: dict[int, dict[str, Any]] = init_matching_accumulator()
+        # Whether the EMA metric received ≥1 update this epoch.  Gates the EMA cross-rank
+        # sync so it is issued symmetrically on all DDP ranks (see _should_compute_ema).
+        self._ema_has_updates: bool = False
         self._output_widget: Any = None  # ipywidgets.Output, created lazily
         self._in_notebook: bool = False
         if in_notebook is None:
@@ -90,10 +95,19 @@ class COCOEvalCallback(Callback):
         kwargs: dict[str, Any] = dict(
             class_metrics=True,
             max_detection_thresholds=[1, 10, self._max_dets],
+            # Disable torchmetrics' built-in cross-rank sync: its `gather_all_tensors` requires every
+            # state tensor to have the same ndim on all ranks, but DDP seg validation produces
+            # per-rank states that are scalar on some ranks and vectors on others, so the internal
+            # sync issues a different number of collectives per rank and deadlocks (known torchmetrics
+            # bug, #931/#449). We merge state across ranks ourselves in `_merge_metric_state_across_ranks`
+            # using the repo's fixed-shape `all_gather`, then compute() runs locally on the full set.
+            sync_on_compute=False,
         )
         kwargs["backend"] = "faster_coco_eval"
         self.map_metric = MeanAveragePrecision(iou_type=iou_type, **kwargs)
-        # Separate metric for the EMA model; created lazily in on_validation_batch_end.
+        # Separate metric for the EMA model.  Created deterministically on EVERY rank in
+        # on_validation_epoch_start / on_test_epoch_start (see _prepare_ema_metric) so its
+        # cross-rank compute() sync is issued symmetrically and cannot deadlock DDP val.
         self.map_metric_ema: Any = None
 
     def on_fit_start(self, trainer: Any, pl_module: Any) -> None:
@@ -132,6 +146,24 @@ class COCOEvalCallback(Callback):
         # Fallback: treat class_names as 0-based sequential labels.
         self._cat_id_to_name = {i: name for i, name in enumerate(self._class_names)}
 
+    def on_validation_epoch_start(self, trainer: Any, pl_module: Any) -> None:
+        """Prepare the EMA metric on every rank before validation (keeps DDP collectives symmetric).
+
+        Args:
+            trainer: The PTL Trainer.
+            pl_module: The LightningModule.
+        """
+        self._prepare_ema_metric(trainer, pl_module)
+
+    def on_test_epoch_start(self, trainer: Any, pl_module: Any) -> None:
+        """Prepare the EMA metric on every rank before test (keeps DDP collectives symmetric).
+
+        Args:
+            trainer: The PTL Trainer.
+            pl_module: The LightningModule.
+        """
+        self._prepare_ema_metric(trainer, pl_module)
+
     def on_validation_batch_end(
         self,
         trainer: Any,
@@ -166,16 +198,13 @@ class COCOEvalCallback(Callback):
 
         # Run EMA model separately on the same batch so that base and EMA metrics
         # are computed from independent forward passes rather than being aliases.
+        # The EMA metric object itself is created on every rank in
+        # on_validation_epoch_start (_prepare_ema_metric); here we only run the EMA
+        # forward pass + update when the averaged model is available.  ema_cb._average_model
+        # availability is rank-invariant (EMA updates fire on the same global step on every
+        # rank), so per-rank EMA update counts stay consistent.
         ema_cb = self._get_ema_callback(trainer)
-        if ema_cb is not None and ema_cb._average_model is not None:
-            if self.map_metric_ema is None:
-                ema_iou_type: Any = ["bbox", "segm"] if self._segmentation else "bbox"
-                self.map_metric_ema = MeanAveragePrecision(
-                    iou_type=ema_iou_type,
-                    class_metrics=True,
-                    max_detection_thresholds=[1, 10, self._max_dets],
-                    backend="faster_coco_eval",
-                ).to(pl_module.device)
+        if ema_cb is not None and ema_cb._average_model is not None and self.map_metric_ema is not None:
             samples, _ = batch
             orig_sizes = torch.stack([t["orig_size"] for t in outputs["targets"]]).to(pl_module.device)
             ema_underlying = ema_cb._average_model.module.model
@@ -185,6 +214,7 @@ class COCOEvalCallback(Callback):
                 ema_results = pl_module.postprocess(ema_outputs, orig_sizes)
             ema_preds = self._convert_preds(ema_results)
             self.map_metric_ema.update(ema_preds, targets)
+            self._ema_has_updates = True
 
     def on_validation_epoch_end(self, trainer: Any, pl_module: Any) -> None:
         """Compute and log mAP and F1 metrics at the end of the validation epoch.
@@ -264,6 +294,10 @@ class COCOEvalCallback(Callback):
             pl_module: The LightningModule.
             split: Metric namespace — ``"val"`` or ``"test"``.
         """
+        # Merge per-rank state across ranks ourselves (DDP-safe, fixed-shape gather) before the
+        # metric computes locally — replaces torchmetrics' deadlock-prone internal sync. No-op when
+        # not distributed. Called unconditionally on every rank, so the collectives stay symmetric.
+        self._merge_metric_state_across_ranks(self.map_metric)
         metrics = self.map_metric.compute()
 
         # torchmetrics prefixes all keys when iou_type is a list (e.g. "bbox_map")
@@ -291,9 +325,14 @@ class COCOEvalCallback(Callback):
         trainer.callback_metrics[f"{split}/mAP_75"] = metrics[f"{pfx}map_75"].detach().cpu()
         trainer.callback_metrics[f"{split}/mAR"] = metrics[mar_key].detach().cpu()
 
-        # EMA metrics — computed from a separate EMA forward pass accumulated
-        # in on_validation_batch_end, so base and EMA values are independent.
-        if self.map_metric_ema is not None:
+        # EMA metrics — computed from a separate EMA forward pass accumulated in
+        # on_validation_batch_end, so base and EMA values are independent.  The EMA
+        # compute() triggers a cross-rank metric sync, so it must be issued by EVERY rank
+        # or none: a rank whose EMA metric is empty/absent would otherwise skip this
+        # collective and desync the DDP collective sequence, deadlocking validation
+        # (#931 / #449).  _should_compute_ema makes the decision unanimous across ranks.
+        if self._should_compute_ema(pl_module):
+            self._merge_metric_state_across_ranks(self.map_metric_ema)
             ema_metrics = self.map_metric_ema.compute()
             pl_module.log(f"{split}/ema_mAP_50_95", ema_metrics[f"{pfx}map"], prog_bar=True)
             pl_module.log(f"{split}/ema_mAP_50", ema_metrics[f"{pfx}map_50"])
@@ -306,6 +345,10 @@ class COCOEvalCallback(Callback):
                 pl_module.log(f"{split}/ema_segm_mAP_50", ema_metrics["segm_map_50"])
                 trainer.callback_metrics[f"{split}/ema_segm_mAP_50_95"] = ema_metrics["segm_map"].detach().cpu()
                 trainer.callback_metrics[f"{split}/ema_segm_mAP_50"] = ema_metrics["segm_map_50"].detach().cpu()
+            self.map_metric_ema.reset()
+        elif self.map_metric_ema is not None:
+            # Not all ranks have EMA data this epoch (e.g. EMA not yet warmed up) → skip the
+            # sync uniformly on every rank, but clear local state so the next epoch is clean.
             self.map_metric_ema.reset()
 
         if self._segmentation:
@@ -387,6 +430,96 @@ class COCOEvalCallback(Callback):
             if callable(getattr(callback, "get_ema_model_state_dict", None)):
                 return callback
         return None
+
+    def _prepare_ema_metric(self, trainer: Any, pl_module: Any) -> None:
+        """Ensure ``map_metric_ema`` exists (and is reset) on EVERY rank when EMA is active.
+
+        Driven by the rank-invariant presence of the EMA callback rather than by per-batch state, so the EMA
+        ``compute()`` collective is issued symmetrically across DDP ranks.  Previously the metric was created lazily
+        in :meth:`on_validation_batch_end`, so a rank with an empty/uneven shard could finish without it, skip the
+        collective, and deadlock validation (#931 / #449).
+
+        Args:
+            trainer: The PTL Trainer.
+            pl_module: The LightningModule (provides the device for metric placement).
+        """
+        self._ema_has_updates = False
+        if self._get_ema_callback(trainer) is None:
+            self.map_metric_ema = None
+            return
+        if self.map_metric_ema is None:
+            ema_iou_type: Any = ["bbox", "segm"] if self._segmentation else "bbox"
+            self.map_metric_ema = MeanAveragePrecision(
+                iou_type=ema_iou_type,
+                class_metrics=True,
+                max_detection_thresholds=[1, 10, self._max_dets],
+                backend="faster_coco_eval",
+                sync_on_compute=False,  # we merge state across ranks ourselves (see map_metric in setup)
+            ).to(pl_module.device)
+        else:
+            self.map_metric_ema.reset()
+
+    def _should_compute_ema(self, pl_module: Any) -> bool:
+        """Decide — identically on every rank — whether to run the EMA metric ``compute()``.
+
+        The EMA ``compute()`` triggers a cross-rank metric sync.  Under DDP every rank must issue that collective
+        or none may, otherwise the collective sequence diverges and NCCL deadlocks (#931 / #449).  Each rank votes
+        ``1`` only when its EMA metric exists and has at least one update (so all synced state tensors are non-empty
+        and identically shaped across ranks); a cross-rank ``all_reduce(MIN)`` then makes the decision unanimous.
+
+        Args:
+            pl_module: The LightningModule (provides the device for the reduction).
+
+        Returns:
+            ``True`` iff every rank has a populated EMA metric, i.e. the EMA ``compute()`` is safe to run everywhere.
+        """
+        has_ema = self.map_metric_ema is not None and self._ema_has_updates
+        vote = 1 if has_ema else 0
+        if is_dist_avail_and_initialized():
+            flag = torch.tensor([vote], device=getattr(pl_module, "device", "cpu"))
+            dist.all_reduce(flag, op=dist.ReduceOp.MIN)
+            vote = int(flag.item())
+        return bool(vote)
+
+    # torchmetrics MeanAveragePrecision accumulates predictions/targets in these list states.
+    _MAP_STATE_ATTRS = (
+        "detection_box",
+        "detection_scores",
+        "detection_labels",
+        "detection_mask",
+        "groundtruth_box",
+        "groundtruth_labels",
+        "groundtruth_mask",
+        "groundtruth_crowds",
+        "groundtruth_area",
+    )
+
+    def _merge_metric_state_across_ranks(self, metric: Any) -> None:
+        """Merge a metric's accumulated per-rank state onto every rank, replacing torchmetrics' sync.
+
+        torchmetrics' built-in sync (``gather_all_tensors``) varies the number of collectives by each state
+        tensor's *local* ndim (scalar → 1 all_gather, vector → 2), so when DDP seg validation leaves a state
+        scalar on some ranks and a vector on others the ranks issue different collective counts and deadlock
+        (#931 / #449).  Instead we gather each state list once with the repo's pickle-based ``all_gather`` — a
+        fixed collective pattern issued identically on every rank regardless of tensor shape — and concatenate.
+        With ``sync_on_compute=False`` the metric's own ``compute()`` then runs locally over the merged full-set
+        state, yielding the identical global mAP without any shape-dependent collective.
+
+        Args:
+            metric: The ``MeanAveragePrecision`` instance whose state should be merged in place.
+        """
+        if metric is None or not is_dist_avail_and_initialized() or get_world_size() == 1:
+            return
+        for attr in self._MAP_STATE_ATTRS:
+            local = getattr(metric, attr, None)
+            if local is None:
+                continue
+            # Move tensors to CPU so cross-device pickling during the gather is safe; RLE mask
+            # entries are already CPU tuples and pass through unchanged.
+            local_cpu = [v.detach().cpu() if torch.is_tensor(v) else v for v in local]
+            gathered = all_gather(local_cpu)  # list of per-rank lists (identical on every rank)
+            merged = [item for rank_list in gathered for item in rank_list]
+            setattr(metric, attr, merged)
 
     def _build_per_class_rows(
         self,

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -112,14 +112,14 @@ class COCOEvalCallback(Callback):
         declared = set(self._MAP_STATE_ATTRS)
         if installed != declared:
             raise RuntimeError(
-                f"COCOEvalCallback._MAP_STATE_ATTRS is out of sync with the installed torchmetrics "
+                "COCOEvalCallback._MAP_STATE_ATTRS is out of sync with the installed torchmetrics "
                 f"(version {self.map_metric.__class__.__module__}). "
                 f"Missing from _MAP_STATE_ATTRS: {sorted(installed - declared)}. "
                 f"Stale in _MAP_STATE_ATTRS: {sorted(declared - installed)}. "
-                f'Re-run: python -c "from torchmetrics.detection import MeanAveragePrecision; '
-                f"m = MeanAveragePrecision(); "
-                f'print(sorted(k for k, v in m._defaults.items() if isinstance(v, list)))" '
-                f"and update COCOEvalCallback._MAP_STATE_ATTRS to match."
+                'Re-run: python -c "from torchmetrics.detection import MeanAveragePrecision; '
+                "m = MeanAveragePrecision(); "
+                'print(sorted(k for k, v in m._defaults.items() if isinstance(v, list)))" '
+                "and update COCOEvalCallback._MAP_STATE_ATTRS to match."
             )
         # Separate metric for the EMA model.  Created deterministically on EVERY rank in
         # on_validation_epoch_start / on_test_epoch_start (see _prepare_ema_metric) so its

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -462,16 +462,19 @@ class COCOEvalCallback(Callback):
     def _should_compute_ema(self, pl_module: Any) -> bool:
         """Decide — identically on every rank — whether to run the EMA metric ``compute()``.
 
-        The EMA ``compute()`` triggers a cross-rank metric sync.  Under DDP every rank must issue that collective
-        or none may, otherwise the collective sequence diverges and NCCL deadlocks (#931 / #449).  Each rank votes
-        ``1`` only when its EMA metric exists and has at least one update (so all synced state tensors are non-empty
-        and identically shaped across ranks); a cross-rank ``all_reduce(MIN)`` then makes the decision unanimous.
+        Under DDP, ``_merge_metric_state_across_ranks`` issues cross-rank collectives that every rank must
+        participate in, or none may — a rank that skips desynchronises the NCCL collective sequence and deadlocks
+        validation (#931 / #449).  Each rank votes ``1`` only when its EMA metric exists and received at least
+        one batch update this epoch; a cross-rank ``all_reduce(MIN)`` makes the decision unanimous — a single
+        rank voting 0 suppresses EMA compute on all ranks.
 
         Args:
             pl_module: The LightningModule (provides the device for the reduction).
 
         Returns:
-            ``True`` iff every rank has a populated EMA metric, i.e. the EMA ``compute()`` is safe to run everywhere.
+            ``True`` iff every rank both holds an EMA metric object and received at least one batch update this
+            epoch, making ``compute()`` safe to run identically on all ranks; ``False`` otherwise (EMA compute
+            skipped uniformly on all ranks).
         """
         has_ema = self.map_metric_ema is not None and self._ema_has_updates
         vote = 1 if has_ema else 0

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -434,10 +434,10 @@ class COCOEvalCallback(Callback):
     def _prepare_ema_metric(self, trainer: Any, pl_module: Any) -> None:
         """Ensure ``map_metric_ema`` exists (and is reset) on EVERY rank when EMA is active.
 
-        Driven by the rank-invariant presence of the EMA callback rather than by per-batch state, so the EMA
-        ``compute()`` collective is issued symmetrically across DDP ranks.  Previously the metric was created lazily
-        in :meth:`on_validation_batch_end`, so a rank with an empty/uneven shard could finish without it, skip the
-        collective, and deadlock validation (#931 / #449).
+        Driven by the rank-invariant presence of the EMA callback rather than by per-batch state, so any cross-rank
+        state merge (via :meth:`_merge_metric_state_across_ranks`) is issued symmetrically across DDP ranks. Previously
+        the metric was created lazily in :meth:`on_validation_batch_end`, so a rank with an empty/uneven shard could
+        finish without it, skip the merge/compute path, and deadlock validation (#931 / #449).
 
         Args:
             trainer: The PTL Trainer.

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -156,7 +156,13 @@ class COCOEvalCallback(Callback):
         self._prepare_ema_metric(trainer, pl_module)
 
     def on_test_epoch_start(self, trainer: Any, pl_module: Any) -> None:
-        """Prepare the EMA metric on every rank before test (keeps DDP collectives symmetric).
+        """Reset ``_ema_has_updates`` before test to prevent stale validation state from triggering EMA compute.
+
+        ``on_test_batch_end`` never sets ``_ema_has_updates = True``, so EMA compute is always skipped during
+        test (test metrics already reflect the EMA model via checkpoint loading in
+        :class:`~rfdetr.lit.callbacks.best_model.BestModelCallback`).  Without this hook a stale ``True`` value
+        left by a preceding validation epoch would make ``_should_compute_ema`` return ``True``, causing an
+        empty-state EMA compute pass that logs sentinel ``-1`` values.
 
         Args:
             trainer: The PTL Trainer.

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -510,6 +510,11 @@ class COCOEvalCallback(Callback):
 
         Args:
             metric: The ``MeanAveragePrecision`` instance whose state should be merged in place.
+
+        Note:
+            No-op when ``metric`` is ``None``, when the distributed process group is not
+            initialised, or when world size is 1 (single GPU / CPU training).  In these
+            cases the metric state is unchanged.
         """
         if metric is None or not is_dist_avail_and_initialized() or get_world_size() == 1:
             return

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -557,6 +557,10 @@ class COCOEvalCallback(Callback):
             gathered = all_gather(local_cpu)  # list of per-rank lists (identical on every rank)
             merged = [item for rank_list in gathered for item in rank_list]
             setattr(metric, attr, merged)
+        # After merging, _update_count may still be 0 on ranks that received no local updates.
+        # torchmetrics 1.x compute() works correctly regardless, but emits a UserWarning
+        # ("compute called before update") that spams DDP logs on those ranks.
+        metric._update_count = max(getattr(metric, "_update_count", 0), 1)
 
     def _build_per_class_rows(
         self,

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -176,7 +176,7 @@ class COCOEvalCallback(Callback):
 
         ``on_test_batch_end`` never sets ``_ema_has_updates = True``, so EMA compute is always skipped during
         test (test metrics already reflect the EMA model via checkpoint loading in
-        :class:`~rfdetr.lit.callbacks.best_model.BestModelCallback`).  Without this hook a stale ``True`` value
+        :class:`~rfdetr.training.callbacks.best_model.BestModelCallback`).  Without this hook a stale ``True`` value
         left by a preceding validation epoch would make ``_should_compute_ema`` return ``True``, causing an
         empty-state EMA compute pass that logs sentinel ``-1`` values.
 

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -112,14 +112,14 @@ class COCOEvalCallback(Callback):
         declared = set(self._MAP_STATE_ATTRS)
         if installed != declared:
             raise RuntimeError(
-                "COCOEvalCallback._MAP_STATE_ATTRS is out of sync with the installed torchmetrics "
-                f"(version {self.map_metric.__class__.__module__}). "
-                f"Missing from _MAP_STATE_ATTRS: {sorted(installed - declared)}. "
-                f"Stale in _MAP_STATE_ATTRS: {sorted(declared - installed)}. "
-                'Re-run: python -c "from torchmetrics.detection import MeanAveragePrecision; '
-                "m = MeanAveragePrecision(); "
-                'print(sorted(k for k, v in m._defaults.items() if isinstance(v, list)))" '
-                "and update COCOEvalCallback._MAP_STATE_ATTRS to match."
+                "COCOEvalCallback._MAP_STATE_ATTRS is out of sync with the installed torchmetrics"
+                f" (version {self.map_metric.__class__.__module__})."
+                f" Missing from _MAP_STATE_ATTRS: {sorted(installed - declared)}."
+                f" Stale in _MAP_STATE_ATTRS: {sorted(declared - installed)}."
+                ' Re-run: python -c "from torchmetrics.detection import MeanAveragePrecision;'
+                " m = MeanAveragePrecision();"
+                ' print(sorted(k for k, v in m._defaults.items() if isinstance(v, list)))"'
+                " and update COCOEvalCallback._MAP_STATE_ATTRS to match."
             )
         # Separate metric for the EMA model.  Created deterministically on EVERY rank in
         # on_validation_epoch_start / on_test_epoch_start (see _prepare_ema_metric) so its

--- a/tests/training/test_coco_eval_callback.py
+++ b/tests/training/test_coco_eval_callback.py
@@ -885,3 +885,94 @@ class TestMergeMetricStateAcrossRanks:
         assert len(metric.detection_scores) == 2
         assert len(metric.detection_mask) == 2
         assert len(metric.groundtruth_area) == 2
+
+    @patch("rfdetr.training.callbacks.coco_eval.get_world_size", return_value=1)
+    @patch("rfdetr.training.callbacks.coco_eval.is_dist_avail_and_initialized", return_value=True)
+    def test_no_op_when_world_size_is_one_in_initialized_group(self, _init, _ws) -> None:
+        """world_size==1 in an initialised group: state untouched, no gather issued."""
+        cb = COCOEvalCallback()
+        metric = _metric_with_state(n=1)
+        with patch("rfdetr.training.callbacks.coco_eval.all_gather") as mock_gather:
+            cb._merge_metric_state_across_ranks(metric)
+        mock_gather.assert_not_called()
+        assert len(metric.detection_box) == 1  # unchanged
+
+
+class TestOnTestEpochStart:
+    """on_test_epoch_start resets _ema_has_updates before test to prevent stale val state."""
+
+    def test_ema_metric_not_created_without_ema_callback_on_test_start(self) -> None:
+        """No EMA callback → map_metric_ema stays None after test hook fires."""
+        cb = COCOEvalCallback()
+        trainer = _make_trainer(callbacks=[])
+        module = _cpu_module()
+        cb.setup(trainer, module, stage="fit")
+
+        cb.on_test_epoch_start(trainer, module)
+
+        assert cb.map_metric_ema is None
+
+    def test_ema_has_updates_reset_on_test_epoch_start(self) -> None:
+        """on_test_epoch_start resets _ema_has_updates to False even when stale True from validation."""
+        cb = COCOEvalCallback()
+        trainer = _make_trainer(callbacks=[_ema_callback()])
+        module = _cpu_module()
+        cb.setup(trainer, module, stage="fit")
+        cb._ema_has_updates = True  # simulate stale value from a preceding validation epoch
+
+        cb.on_test_epoch_start(trainer, module)
+
+        assert cb._ema_has_updates is False
+
+
+class TestPrepareEmaMetricSecondEpoch:
+    """_prepare_ema_metric resets (not re-creates) the metric on subsequent epochs."""
+
+    def test_second_epoch_resets_existing_metric_not_recreates(self) -> None:
+        """Calling on_validation_epoch_start twice resets the metric rather than replacing it."""
+        cb = COCOEvalCallback()
+        trainer = _make_trainer(callbacks=[_ema_callback()])
+        module = _cpu_module()
+        cb.setup(trainer, module, stage="fit")
+
+        cb.on_validation_epoch_start(trainer, module)
+        assert cb.map_metric_ema is not None
+
+        # Replace with a spy mock so reset() calls are trackable on the second epoch
+        spy_metric = MagicMock(name="map_metric_ema")
+        cb.map_metric_ema = spy_metric
+
+        cb.on_validation_epoch_start(trainer, module)
+
+        assert cb.map_metric_ema is spy_metric  # same object, not replaced
+        spy_metric.reset.assert_called_once()
+
+
+class TestComputeAndLogEmaResetPath:
+    """elif branch in _compute_and_log: gate False + metric not None → reset() fires."""
+
+    def test_ema_metric_reset_when_gate_false_but_metric_not_none(self) -> None:
+        """EMA not computed this epoch but metric exists → reset() clears state for the next epoch."""
+        cb = COCOEvalCallback()
+        trainer = _make_trainer()
+        module = _cpu_module()
+        cb.setup(trainer, module, stage="fit")
+        trainer.callback_metrics = {}
+
+        # EMA metric exists but no batch updated it this epoch → gate returns False → elif fires
+        mock_ema = MagicMock(name="map_metric_ema")
+        cb.map_metric_ema = mock_ema
+        cb._ema_has_updates = False
+
+        cb.map_metric = MagicMock(name="map_metric")
+        cb.map_metric.compute.return_value = _minimal_metrics()
+
+        with (
+            patch.object(cb, "_merge_metric_state_across_ranks"),
+            patch.object(cb, "_build_per_class_rows", return_value=[]),
+            patch.object(cb, "_print_metrics_tables"),
+            patch("rfdetr.training.callbacks.coco_eval.distributed_merge_matching_data", return_value={}),
+        ):
+            cb._compute_and_log(trainer, module, "val")
+
+        mock_ema.reset.assert_called_once()

--- a/tests/training/test_coco_eval_callback.py
+++ b/tests/training/test_coco_eval_callback.py
@@ -411,6 +411,7 @@ class TestOnValidationEpochEnd:
         # Simulate map_metric_ema being populated by on_validation_batch_end.
         cb.map_metric_ema = MagicMock(name="map_metric_ema")
         cb.map_metric_ema.compute.return_value = _minimal_metrics()
+        cb._ema_has_updates = True
         module = _make_pl_module()
 
         cb.on_validation_epoch_end(_make_trainer(), module)
@@ -505,6 +506,7 @@ class TestOnValidationEpochEnd:
         cb.map_metric.compute.return_value = _minimal_metrics()
         cb.map_metric_ema = MagicMock(name="map_metric_ema")
         cb.map_metric_ema.compute.return_value = _minimal_metrics()
+        cb._ema_has_updates = True
 
         cb.on_validation_epoch_end(trainer, _make_pl_module())
 
@@ -535,6 +537,7 @@ class TestOnValidationEpochEnd:
         ema_metrics["segm_map_50"] = torch.tensor(0.65)
         cb.map_metric_ema = MagicMock(name="map_metric_ema")
         cb.map_metric_ema.compute.return_value = ema_metrics
+        cb._ema_has_updates = True
         module = _make_pl_module()
 
         cb.on_validation_epoch_end(trainer, module)
@@ -748,3 +751,136 @@ class TestConvertTargets:
         ]
         out = cb._convert_targets(targets)
         assert set(out[0].keys()) == {"boxes", "labels"}
+
+
+def _ema_callback() -> MagicMock:
+    """Return a mock that ``_get_ema_callback`` recognises (has ``get_ema_model_state_dict``)."""
+    cb = MagicMock(name="ema_callback")
+    cb.get_ema_model_state_dict = MagicMock(name="get_ema_model_state_dict")
+    return cb
+
+
+def _cpu_module() -> MagicMock:
+    """Mock LightningModule whose ``device`` is a real string so ``metric.to(device)`` works."""
+    module = MagicMock(name="pl_module")
+    module.device = "cpu"
+    return module
+
+
+class TestEmaCollectiveSymmetry:
+    """DDP-deadlock fix: the EMA metric's cross-rank sync must be issued symmetrically (#931/#449)."""
+
+    def test_ema_metric_created_on_val_epoch_start_when_ema_active(self) -> None:
+        """map_metric_ema is created on validation start whenever the EMA callback is present.
+
+        This makes the EMA ``compute()`` collective rank-invariant — created on every rank regardless of how many
+        (or zero) val batches that rank later processes — rather than lazily per-batch.
+        """
+        cb = COCOEvalCallback(max_dets=500)
+        trainer = _make_trainer(callbacks=[_ema_callback()])
+        module = _cpu_module()
+        cb.setup(trainer, module, stage="fit")
+        assert cb.map_metric_ema is None  # not created yet at setup
+
+        cb.on_validation_epoch_start(trainer, module)
+
+        assert cb.map_metric_ema is not None
+
+    def test_ema_metric_not_created_without_ema_callback(self) -> None:
+        """No EMA callback → map_metric_ema stays None (no EMA collective is ever issued)."""
+        cb = COCOEvalCallback()
+        trainer = _make_trainer(callbacks=[])
+        module = _cpu_module()
+        cb.setup(trainer, module, stage="fit")
+
+        cb.on_validation_epoch_start(trainer, module)
+
+        assert cb.map_metric_ema is None
+
+    def test_should_compute_ema_false_when_metric_has_no_updates(self) -> None:
+        """A rank whose EMA metric saw no updates votes against computing (avoids empty-state divergence)."""
+        cb = COCOEvalCallback()
+        cb.map_metric_ema = MagicMock(name="map_metric_ema")
+        cb._ema_has_updates = False
+
+        assert cb._should_compute_ema(_cpu_module()) is False
+
+    def test_should_compute_ema_true_when_metric_has_updates_single_process(self) -> None:
+        """With updates and no distributed group, the EMA compute proceeds."""
+        cb = COCOEvalCallback()
+        cb.map_metric_ema = MagicMock(name="map_metric_ema")
+        cb._ema_has_updates = True
+
+        assert cb._should_compute_ema(_cpu_module()) is True
+
+    @patch("rfdetr.training.callbacks.coco_eval.is_dist_avail_and_initialized", return_value=True)
+    @patch("rfdetr.training.callbacks.coco_eval.dist.all_reduce")
+    def test_unanimous_gate_skips_when_a_peer_lacks_ema(self, mock_all_reduce, _mock_init) -> None:
+        """Even with local updates, the gate returns False if any peer voted 0 (all_reduce MIN → 0)."""
+
+        def _peer_voted_zero(flag, op=None):  # simulate a rank with no EMA data
+            flag.zero_()
+
+        mock_all_reduce.side_effect = _peer_voted_zero
+        cb = COCOEvalCallback()
+        cb.map_metric_ema = MagicMock(name="map_metric_ema")
+        cb._ema_has_updates = True
+
+        assert cb._should_compute_ema(_cpu_module()) is False
+        mock_all_reduce.assert_called_once()
+
+    @patch("rfdetr.training.callbacks.coco_eval.is_dist_avail_and_initialized", return_value=True)
+    @patch("rfdetr.training.callbacks.coco_eval.dist.all_reduce")
+    def test_unanimous_gate_runs_when_all_ranks_have_ema(self, mock_all_reduce, _mock_init) -> None:
+        """When every rank has EMA updates (all_reduce MIN leaves the vote at 1), the gate returns True."""
+        mock_all_reduce.side_effect = lambda flag, op=None: None  # vote tensor stays [1]
+        cb = COCOEvalCallback()
+        cb.map_metric_ema = MagicMock(name="map_metric_ema")
+        cb._ema_has_updates = True
+
+        assert cb._should_compute_ema(_cpu_module()) is True
+        mock_all_reduce.assert_called_once()
+
+
+def _metric_with_state(n: int = 1) -> MagicMock:
+    """Mock MeanAveragePrecision carrying minimal per-image state lists (one entry each)."""
+    metric = MagicMock(name="map_metric")
+    metric.detection_box = [torch.zeros(2, 4) for _ in range(n)]
+    metric.detection_scores = [torch.zeros(2) for _ in range(n)]
+    metric.detection_labels = [torch.zeros(2, dtype=torch.long) for _ in range(n)]
+    metric.detection_mask = [((10, 10), b"rle") for _ in range(n)]
+    metric.groundtruth_box = [torch.zeros(1, 4) for _ in range(n)]
+    metric.groundtruth_labels = [torch.zeros(1, dtype=torch.long) for _ in range(n)]
+    metric.groundtruth_mask = [((10, 10), b"rle") for _ in range(n)]
+    metric.groundtruth_crowds = [torch.zeros(1) for _ in range(n)]
+    metric.groundtruth_area = [torch.zeros(1) for _ in range(n)]
+    return metric
+
+
+class TestMergeMetricStateAcrossRanks:
+    """The DDP-safe replacement for torchmetrics' internal sync (#931/#449)."""
+
+    def test_no_op_when_not_distributed(self) -> None:
+        """Single-process / non-distributed: state is left untouched and no gather happens."""
+        cb = COCOEvalCallback()
+        metric = _metric_with_state(n=1)
+        with patch("rfdetr.training.callbacks.coco_eval.all_gather") as mock_gather:
+            cb._merge_metric_state_across_ranks(metric)
+        mock_gather.assert_not_called()
+        assert len(metric.detection_box) == 1  # unchanged
+
+    @patch("rfdetr.training.callbacks.coco_eval.get_world_size", return_value=2)
+    @patch("rfdetr.training.callbacks.coco_eval.is_dist_avail_and_initialized", return_value=True)
+    def test_concatenates_each_state_across_ranks(self, _init, _ws) -> None:
+        """Distributed: every state list is gathered once and concatenated across ranks."""
+        cb = COCOEvalCallback()
+        metric = _metric_with_state(n=1)
+        # Simulate a 2-rank gather: this rank's list plus an identical "other rank" list.
+        with patch("rfdetr.training.callbacks.coco_eval.all_gather", side_effect=lambda local: [local, local]) as mg:
+            cb._merge_metric_state_across_ranks(metric)
+        # One gather per state tensor (9 states), each now holding both ranks' entries.
+        assert mg.call_count == 9
+        assert len(metric.detection_box) == 2
+        assert len(metric.detection_scores) == 2
+        assert len(metric.detection_mask) == 2
+        assert len(metric.groundtruth_area) == 2

--- a/tests/training/test_coco_eval_callback.py
+++ b/tests/training/test_coco_eval_callback.py
@@ -888,7 +888,7 @@ class TestMergeMetricStateAcrossRanks:
 
     @patch("rfdetr.training.callbacks.coco_eval.get_world_size", return_value=1)
     @patch("rfdetr.training.callbacks.coco_eval.is_dist_avail_and_initialized", return_value=True)
-    def test_no_op_when_world_size_is_one_in_initialized_group(self, _init, _ws) -> None:
+    def test_no_op_when_world_size_one(self, _init, _ws) -> None:
         """world_size==1 in an initialised group: state untouched, no gather issued."""
         cb = COCOEvalCallback()
         metric = _metric_with_state(n=1)
@@ -901,7 +901,7 @@ class TestMergeMetricStateAcrossRanks:
 class TestOnTestEpochStart:
     """on_test_epoch_start resets _ema_has_updates before test to prevent stale val state."""
 
-    def test_ema_metric_not_created_without_ema_callback_on_test_start(self) -> None:
+    def test_map_metric_ema_stays_none_without_ema_callback(self) -> None:
         """No EMA callback → map_metric_ema stays None after test hook fires."""
         cb = COCOEvalCallback()
         trainer = _make_trainer(callbacks=[])
@@ -912,7 +912,7 @@ class TestOnTestEpochStart:
 
         assert cb.map_metric_ema is None
 
-    def test_ema_has_updates_reset_on_test_epoch_start(self) -> None:
+    def test_resets_ema_has_updates_to_false(self) -> None:
         """on_test_epoch_start resets _ema_has_updates to False even when stale True from validation."""
         cb = COCOEvalCallback()
         trainer = _make_trainer(callbacks=[_ema_callback()])
@@ -928,7 +928,7 @@ class TestOnTestEpochStart:
 class TestPrepareEmaMetricSecondEpoch:
     """_prepare_ema_metric resets (not re-creates) the metric on subsequent epochs."""
 
-    def test_second_epoch_resets_existing_metric_not_recreates(self) -> None:
+    def test_resets_not_recreates_metric(self) -> None:
         """Calling on_validation_epoch_start twice resets the metric rather than replacing it."""
         cb = COCOEvalCallback()
         trainer = _make_trainer(callbacks=[_ema_callback()])
@@ -951,7 +951,7 @@ class TestPrepareEmaMetricSecondEpoch:
 class TestComputeAndLogEmaResetPath:
     """elif branch in _compute_and_log: gate False + metric not None → reset() fires."""
 
-    def test_ema_metric_reset_when_gate_false_but_metric_not_none(self) -> None:
+    def test_resets_ema_metric(self) -> None:
         """EMA not computed this epoch but metric exists → reset() clears state for the next epoch."""
         cb = COCOEvalCallback()
         trainer = _make_trainer()

--- a/tests/training/test_coco_eval_callback.py
+++ b/tests/training/test_coco_eval_callback.py
@@ -854,6 +854,7 @@ def _metric_with_state(n: int = 1) -> MagicMock:
     metric.groundtruth_mask = [((10, 10), b"rle") for _ in range(n)]
     metric.groundtruth_crowds = [torch.zeros(1) for _ in range(n)]
     metric.groundtruth_area = [torch.zeros(1) for _ in range(n)]
+    metric._update_count = 0
     return metric
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes a **deadlock** in multi-GPU (DDP) **segmentation** validation. After an epoch, validation
hangs at the metric-sync step and is eventually killed by the NCCL watchdog:

[rankN] Watchdog caught collective operation timeout:
WorkNCCL(SeqNum=..., OpType=ALLGATHER, ...) ran for 1800000 milliseconds before timing out



It only reproduces **at scale** — a small/smoke validation set passes, the full set deadlocks —
which is what made it hard to catch.

### Background: how validation metrics are combined across GPUs

Under DDP, each GPU runs validation on its **own shard** of images. To produce one global mAP, the
per-GPU metric states must be **combined**, which `torchmetrics` does with a series of NCCL
collectives at `compute()` time. The hard rule of NCCL is that **every rank must issue the exact
same sequence of collectives, in the same order** — if one rank issues even one fewer/extra
collective, the ranks fall out of step and block on each other forever.

### Root cause: a divergent collective *count*, not a slow collective

This is a **circular-wait deadlock**, not a "slow" collective (so a longer NCCL timeout does not
help — it just delays the failure). The divergence is inside torchmetrics' own sync. Its
`gather_all_tensors` helper decides **how many collectives to run for each state tensor based on
that tensor's *local* `ndim`**:

- **scalar** (`ndim == 0`) → **1** collective (`all_gather` of the value)
- **vector** (`ndim ≥ 1`) → **2** collectives (`all_gather` of the *size*, then of the *data*)

`torchmetrics` only supports gathering tensors that have the **same number of dimensions on every
rank** — but DDP seg validation violates that, because different shards produce
differently-shaped state.

#### Worked example (4 GPUs)

Take one of MAP's per-class state tensors (e.g. scores for a given class). Suppose rank 3's shard
happened to contain no instances of that class this epoch, so its state collapses to a **0-dim
scalar**, while ranks 0/1/2 hold a normal **1-D vector**:

| | ranks 0, 1, 2 (vector) | rank 3 (scalar) |
|---|---|---|
| collectives issued for this state | `all_gather(size)` + `all_gather(data)` = **2** | `all_gather(value)` = **1** |

Rank 3 has now issued **one fewer** collective. NCCL matches collectives purely by issue order, so
from here on rank 3 is **off by one** — its next gather lines up with the others' current gather.
A few state tensors later, rank 3 is gathering its `labels` (int64) while ranks 0/1/2 are gathering
`scores` (float) **at the same sequence number** → the ops don't match → all ranks block → watchdog
fires after 30 min.

Captured live with `TORCH_DISTRIBUTED_DEBUG=DETAIL` (which turns the silent hang into an explicit
error):

Detected mismatch between collectives on ranks.
Rank 3:     CollectiveFingerPrint(SequenceNumber=40104, OpType=ALLGATHER, TensorShape=[1], TensorDtypes=Long)
Rank 0/1/2: CollectiveFingerPrint(SequenceNumber=40104, OpType=ALLGATHER, TensorShape=[1], TensorDtypes=Float)



This is a known, open `torchmetrics` limitation: Lightning-AI/torchmetrics#3199.

### Fix

Stop relying on torchmetrics' internal sync and **combine the per-rank state ourselves with a
single, fixed, shape-independent collective** — the exact pattern RF-DETR already uses for its F1
metric (`distributed_merge_matching_data`). torchmetrics still computes the mAP; we only replace
its one fragile merge step.

- Both mAP metrics are created with `sync_on_compute=False` (disables the internal sync).
- `_merge_metric_state_across_ranks()` gathers each metric's accumulated state with the repo's
  `all_gather` (a pickle-based object gather whose collective pattern is **identical on every rank
  regardless of tensor shape**), concatenates it, then `compute()` runs **locally** on the merged
  full-set state — producing the identical global mAP with no shape-dependent collective.
- The EMA metric is created **deterministically on every rank** (`on_validation_epoch_start`) so its
  gather is issued symmetrically too (a second, independent source of the same divergence).

**Why not the usual workaround?** The common suggestion (`sync_on_compute=False` +
`self.log(..., sync_dist=True)`) is mathematically wrong for mAP: `sync_dist` *averages* per-rank
values, but the mAP of the union of predictions ≠ the mean of per-shard mAPs.

**Related Issue(s):** Closes #931

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**
- New CPU unit tests in `tests/training/test_coco_eval_callback.py`:
  - `_merge_metric_state_across_ranks` — no-op in single-process; concatenates each state list across ranks under a mocked 2-rank gather.
  - EMA-metric symmetry — created on `on_validation_epoch_start` for every rank regardless of batch count; the unanimous `all_reduce(MIN)` gate decides EMA compute identically on all ranks.
- Full CPU suite (`pytest -m "not gpu"`) and `pre-commit run --all-files` pass.
- **4× L4, full dataset, end-to-end:** DDP validation now completes with no collective
  mismatch/deadlock and produces correct merged mAP/segm/F1 (the previous code reproducibly crashed
  at this exact step, as captured above).