### PR TITLE
feat: extract `export_for_roboflow` from `deploy_to_roboflow`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--
+- `RFDETR.export_for_roboflow(output_dir)` — writes a Roboflow upload bundle (`weights.pt` + `class_names.txt`) without a network call; extracted from `deploy_to_roboflow`, which now uses it ([#1086](https://github.com/roboflow/rf-detr/pull/1086))
 
 ### Changed
 

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -1509,26 +1509,40 @@ class RFDETR:
 
         size = self.size or size
         with tempfile.TemporaryDirectory(prefix="roboflow_upload_") as tmp_out_dir:
-            # Write class_names.txt so the Roboflow upload pipeline can discover
-            # the class labels without relying on args.class_names in the checkpoint.
-            class_names_path = os.path.join(tmp_out_dir, "class_names.txt")
-            with open(class_names_path, "w", encoding="utf-8", newline="\n") as f:
-                f.write("\n".join(self.class_names))
-
-            # Also embed class_names in the args namespace so that any code path
-            # that loads the checkpoint directly (e.g. roboflow-python's second
-            # fallback) can find them.  Mutating the shared SimpleNamespace is
-            # intentional here: this mirrors reinitialize_detection_head(), which
-            # already mutates args.num_classes in-place.
-            args = self.model.args
-            if not hasattr(args, "class_names") or args.class_names is None:
-                args.class_names = self.class_names
-
-            outpath = os.path.join(tmp_out_dir, "weights.pt")
-            torch.save({"model": self.model.model.state_dict(), "args": args}, outpath)
+            self.export_for_roboflow(tmp_out_dir)
             project = workspace.project(project_id)
             project_version = project.version(version)
             project_version.deploy(model_type=size, model_path=tmp_out_dir, filename="weights.pt")
+
+    def export_for_roboflow(self, output_dir: str) -> None:
+        """Write a Roboflow upload bundle (``weights.pt`` + ``class_names.txt``) into *output_dir*.
+
+        This is the network-free core of :meth:`deploy_to_roboflow`: it serialises the model state and training args
+        into ``weights.pt`` and writes the class labels to ``class_names.txt``.  The Roboflow SDK uses this format to
+        adapt raw PyTorch-Lightning checkpoints into a deploy-ready bundle.
+
+        Args:
+            output_dir: Directory into which ``weights.pt`` and ``class_names.txt`` are written.  Created if it does
+                not exist.
+        """
+        os.makedirs(output_dir, exist_ok=True)
+        # Write class_names.txt so the Roboflow upload pipeline can discover
+        # the class labels without relying on args.class_names in the checkpoint.
+        class_names_path = os.path.join(output_dir, "class_names.txt")
+        with open(class_names_path, "w", encoding="utf-8", newline="\n") as f:
+            f.write("\n".join(self.class_names))
+
+        # Also embed class_names in the args namespace so that any code path
+        # that loads the checkpoint directly (e.g. roboflow-python's second
+        # fallback) can find them.  Mutating the shared SimpleNamespace is
+        # intentional here: this mirrors reinitialize_detection_head(), which
+        # already mutates args.num_classes in-place.
+        args = self.model.args
+        if not hasattr(args, "class_names") or args.class_names is None:
+            args.class_names = self.class_names
+
+        outpath = os.path.join(output_dir, "weights.pt")
+        torch.save({"model": self.model.model.state_dict(), "args": args}, outpath)
 
 
 def __getattr__(name: str):

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -14,7 +14,7 @@ import os
 import tempfile
 import warnings
 from collections import defaultdict
-from copy import deepcopy
+from copy import copy, deepcopy
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -1532,12 +1532,11 @@ class RFDETR:
         with open(class_names_path, "w", encoding="utf-8", newline="\n") as f:
             f.write("\n".join(self.class_names))
 
-        # Also embed class_names in the args namespace so that any code path
-        # that loads the checkpoint directly (e.g. roboflow-python's second
-        # fallback) can find them.  Mutating the shared SimpleNamespace is
-        # intentional here: this mirrors reinitialize_detection_head(), which
-        # already mutates args.num_classes in-place.
-        args = self.model.args
+        # Embed class_names in a shallow copy of args so the saved bundle is
+        # self-contained (roboflow-python's second fallback reads args.class_names
+        # directly from the checkpoint).  Using a copy leaves self.model.args
+        # unmodified — each export call is independent regardless of call order.
+        args = copy(self.model.args)
         if not hasattr(args, "class_names") or args.class_names is None:
             args.class_names = self.class_names
 

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -1514,7 +1514,7 @@ class RFDETR:
             project_version = project.version(version)
             project_version.deploy(model_type=size, model_path=tmp_out_dir, filename="weights.pt")
 
-    def export_for_roboflow(self, output_dir: str) -> None:
+    def export_for_roboflow(self, output_dir: str | os.PathLike[str]) -> None:
         """Write a Roboflow upload bundle (``weights.pt`` + ``class_names.txt``) into *output_dir*.
 
         This is the network-free core of :meth:`deploy_to_roboflow`: it serialises the model state and training args

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -1493,6 +1493,10 @@ class RFDETR:
         Raises:
             ValueError: If the `api_key` is not provided and not found in the
                 environment variable `ROBOFLOW_API_KEY`, or if the `size` is not set for custom architectures.
+
+        Note:
+            Bundle creation is delegated to :meth:`export_for_roboflow`, which can be called independently
+            to write ``weights.pt`` and ``class_names.txt`` without a network round-trip.
         """
         from roboflow import Roboflow
 
@@ -1517,13 +1521,19 @@ class RFDETR:
     def export_for_roboflow(self, output_dir: str | os.PathLike[str]) -> None:
         """Write a Roboflow upload bundle (``weights.pt`` + ``class_names.txt``) into *output_dir*.
 
-        This is the network-free core of :meth:`deploy_to_roboflow`: it serialises the model state and training args
-        into ``weights.pt`` and writes the class labels to ``class_names.txt``.  The Roboflow SDK uses this format to
-        adapt raw PyTorch-Lightning checkpoints into a deploy-ready bundle.
+        This is the network-free core of :meth:`deploy_to_roboflow`: it serialises the model state and
+        training args into ``weights.pt``, always embedding ``class_names`` into a copy of the args so
+        the bundle is self-contained, and writes the class labels to ``class_names.txt``.  The Roboflow
+        SDK uses this format to adapt raw PyTorch-Lightning checkpoints into a deploy-ready bundle.
 
         Args:
-            output_dir: Directory into which ``weights.pt`` and ``class_names.txt`` are written.  Created if it does
-                not exist.
+            output_dir: Directory into which ``weights.pt`` and ``class_names.txt`` are written.  Created
+                if it does not exist.  Existing files are silently overwritten.
+
+        Raises:
+            PermissionError: If the process lacks write access to *output_dir* or its parent directory.
+            OSError: On disk-full, invalid path, or other filesystem failure during directory creation,
+                file write, or ``torch.save``.
         """
         os.makedirs(output_dir, exist_ok=True)
         # Write class_names.txt so the Roboflow upload pipeline can discover

--- a/tests/models/test_export_for_roboflow.py
+++ b/tests/models/test_export_for_roboflow.py
@@ -63,6 +63,16 @@ class TestExportForRoboflow:
         bundle = torch.load(tmp_path / "weights.pt", map_location="cpu", weights_only=False)
         assert bundle["args"].class_names == ["cat", "dog"]
 
+    def test_does_not_overwrite_existing_args_class_names(self, tmp_path: Path) -> None:
+        """args.class_names already set on the model is preserved in the saved bundle."""
+        model = _make_stub_model(["cat", "dog"])
+        model.model.args.class_names = ["pre_existing"]
+
+        model.export_for_roboflow(str(tmp_path))
+
+        bundle = torch.load(tmp_path / "weights.pt", map_location="cpu", weights_only=False)
+        assert bundle["args"].class_names == ["pre_existing"]
+
     def test_creates_output_dir_when_missing(self, tmp_path: Path) -> None:
         """output_dir is created if it does not already exist."""
         model = _make_stub_model(["cat", "dog"])

--- a/tests/models/test_export_for_roboflow.py
+++ b/tests/models/test_export_for_roboflow.py
@@ -73,6 +73,14 @@ class TestExportForRoboflow:
         bundle = torch.load(tmp_path / "weights.pt", map_location="cpu", weights_only=False)
         assert bundle["args"].class_names == ["pre_existing"]
 
+    def test_empty_class_names_writes_empty_file(self, tmp_path: Path) -> None:
+        """Empty class_names list produces an empty class_names.txt (no trailing newline)."""
+        model = _make_stub_model([])
+
+        model.export_for_roboflow(str(tmp_path))
+
+        assert (tmp_path / "class_names.txt").read_text(encoding="utf-8") == ""
+
     def test_creates_output_dir_when_missing(self, tmp_path: Path) -> None:
         """output_dir is created if it does not already exist."""
         model = _make_stub_model(["cat", "dog"])

--- a/tests/models/test_export_for_roboflow.py
+++ b/tests/models/test_export_for_roboflow.py
@@ -52,8 +52,7 @@ class TestExportForRoboflow:
 
         model.export_for_roboflow(str(tmp_path))
 
-        class_names_path = tmp_path / "class_names.txt"
-        assert class_names_path.read_text(encoding="utf-8").splitlines() == ["cat", "dog"]
+        assert (tmp_path / "class_names.txt").read_text(encoding="utf-8") == "cat\ndog"
 
     def test_embeds_class_names_in_args(self, tmp_path: Path) -> None:
         """class_names are embedded in the saved args namespace when absent."""

--- a/tests/models/test_export_for_roboflow.py
+++ b/tests/models/test_export_for_roboflow.py
@@ -1,0 +1,75 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Tests for ``RFDETR.export_for_roboflow``.
+
+``export_for_roboflow`` is the extracted, network-free core of ``deploy_to_roboflow``: it writes ``weights.pt`` (a dict
+with ``"model"`` and ``"args"`` keys) and ``class_names.txt`` into a target directory.  A lightweight stub stands in for
+``self.model`` so the file-writing contract is exercised without building a real model or downloading weights.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+
+from rfdetr.detr import RFDETR
+
+
+def _make_stub_model(class_names: list[str]) -> RFDETR:
+    """Build an RFDETR instance whose model/state are stubbed for export_for_roboflow.
+
+    ``RFDETR.__init__`` is bypassed; only the attributes ``export_for_roboflow`` reads are populated.
+    """
+    instance = RFDETR.__new__(RFDETR)
+    args = SimpleNamespace(resolution=560)
+    inner_module = SimpleNamespace(state_dict=lambda: {"weight": torch.zeros(2, 2)})
+    instance.model = SimpleNamespace(model=inner_module, args=args, class_names=class_names)
+    return instance
+
+
+class TestExportForRoboflow:
+    """export_for_roboflow writes a deploy-ready bundle into a directory."""
+
+    def test_writes_weights_pt_with_model_and_args(self, tmp_path: Path) -> None:
+        """weights.pt is a dict with 'model' and 'args', and args carries resolution."""
+        model = _make_stub_model(["cat", "dog"])
+
+        model.export_for_roboflow(str(tmp_path))
+
+        bundle = torch.load(tmp_path / "weights.pt", map_location="cpu", weights_only=False)
+        assert set(bundle) == {"model", "args"}
+        assert "weight" in bundle["model"]
+        assert bundle["args"].resolution == 560
+
+    def test_writes_class_names_txt(self, tmp_path: Path) -> None:
+        """class_names.txt lists one class name per line."""
+        model = _make_stub_model(["cat", "dog"])
+
+        model.export_for_roboflow(str(tmp_path))
+
+        class_names_path = tmp_path / "class_names.txt"
+        assert class_names_path.read_text(encoding="utf-8").splitlines() == ["cat", "dog"]
+
+    def test_embeds_class_names_in_args(self, tmp_path: Path) -> None:
+        """class_names are embedded in the saved args namespace when absent."""
+        model = _make_stub_model(["cat", "dog"])
+
+        model.export_for_roboflow(str(tmp_path))
+
+        bundle = torch.load(tmp_path / "weights.pt", map_location="cpu", weights_only=False)
+        assert bundle["args"].class_names == ["cat", "dog"]
+
+    def test_creates_output_dir_when_missing(self, tmp_path: Path) -> None:
+        """output_dir is created if it does not already exist."""
+        model = _make_stub_model(["cat", "dog"])
+        target = tmp_path / "nested" / "bundle"
+
+        model.export_for_roboflow(str(target))
+
+        assert (target / "weights.pt").exists()
+        assert (target / "class_names.txt").exists()

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -1488,6 +1488,10 @@ class TestDeployToRoboflow:
         mock_self.model = MagicMock()
         mock_self.model.model.state_dict.return_value = {}
         mock_self.model.args = SimpleNamespace(num_classes=len(class_names))
+        # deploy_to_roboflow now delegates bundle-writing to export_for_roboflow; bind the
+        # real method so these end-to-end tests exercise it (a bare MagicMock attribute
+        # would no-op the class_names.txt / torch.save side effects).
+        mock_self.export_for_roboflow = lambda output_dir: RFDETR.export_for_roboflow(mock_self, output_dir)
         return mock_self
 
     @staticmethod


### PR DESCRIPTION
## What does this PR do?

Extracts the Roboflow upload-bundle building logic out of `RFDETR.deploy_to_roboflow` into a reusable public method:

- **`RFDETR.export_for_roboflow(self, output_dir: str) -> None`** — writes `weights.pt` (`{"model": state_dict, "args": args}`, where `args` carries `resolution` + embeds `class_names`) and `class_names.txt` into `output_dir` (created if missing). The network-free core of `deploy_to_roboflow`.
- `deploy_to_roboflow` now calls `self.export_for_roboflow(tmp_out_dir)` then does its existing networked deploy. **Net behavior unchanged.**

Naming mirrors `deploy_to_roboflow`: `export_for_roboflow` writes the bundle locally; `deploy_to_roboflow` builds it **and** uploads.

## Why

The Roboflow Python SDK needs to adapt raw PyTorch-Lightning rf-detr checkpoints (e.g. `checkpoint_best_ema.pth`) into the deploy-bundle format on upload. Those raw checkpoints store `args = TrainConfig.model_dump()`, which omits `resolution` (a `ModelConfig` field), so the backend conversion fails. `export_for_roboflow` gives the SDK a single, drift-free way to produce the same bundle `deploy_to_roboflow` produces.

Companion SDK PR: roboflow/roboflow-python#488.

## Type of Change

- Refactoring (no functional changes) + new public method

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**
- New `tests/models/test_export_for_roboflow.py` — asserts the bundle is written (`weights.pt` with `model`/`args`/`resolution`, embedded `class_names`, `class_names.txt`) and that `output_dir` is created when missing.
- Updated `tests/training/test_detr_shim.py::TestDeployToRoboflow` — the fixture's `MagicMock(spec=RFDETR)` was no-op'ing the now-delegated method; bound the real method so these end-to-end regression tests still exercise it.
- `pytest tests/models/test_export_for_roboflow.py tests/training/test_detr_shim.py tests/models/test_from_checkpoint.py` → all pass; `pre-commit run` clean.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

Scoped to `export_for_roboflow` only — `from_checkpoint` is untouched. CHANGELOG updated under `[Unreleased] → Added`.