### PR TITLE
refactor: standardize naming and imports of `Detections` across modules

### DIFF
--- a/src/rfdetr/datasets/save_grids.py
+++ b/src/rfdetr/datasets/save_grids.py
@@ -9,10 +9,10 @@ from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
-import supervision as sv
 import torch
 import torchvision.transforms as T  # noqa: N812
 from matplotlib.axes import Axes
+from supervision import BoxAnnotator, Color, Detections, LabelAnnotator
 from torch.utils.data import DataLoader
 
 from rfdetr.util.box_ops import box_cxcywh_to_xyxy
@@ -50,9 +50,9 @@ class DatasetGridSaver:
             mean=[-0.485 / 0.229, -0.456 / 0.224, -0.406 / 0.225],
             std=[1 / 0.229, 1 / 0.224, 1 / 0.225],
         )
-        box_annotator = sv.BoxAnnotator(thickness=2)
-        label_annotator = sv.LabelAnnotator(
-            text_color=sv.Color.BLACK,
+        box_annotator = BoxAnnotator(thickness=2)
+        label_annotator = LabelAnnotator(
+            text_color=Color.BLACK,
             text_scale=0.5,
             text_padding=3,
         )
@@ -88,8 +88,8 @@ class DatasetGridSaver:
         single_target: dict[str, Any],
         ax: Axes,
         inv_normalize: T.Normalize,
-        box_annotator: sv.BoxAnnotator,
-        label_annotator: sv.LabelAnnotator,
+        box_annotator: BoxAnnotator,
+        label_annotator: LabelAnnotator,
     ) -> None:
         """De-normalize a single image tensor, annotate it with boxes and labels, and plot it on ``ax``.
 
@@ -98,8 +98,8 @@ class DatasetGridSaver:
             single_target: Target dict with keys ``'size'``, ``'boxes'`` (cx,cy,wh normalized), and ``'labels'``.
             ax: Matplotlib axis to plot the annotated image on.
             inv_normalize: Inverse normalization transform to convert the tensor back to pixel values.
-            box_annotator: ``sv.BoxAnnotator`` instance for drawing bounding boxes.
-            label_annotator: ``sv.LabelAnnotator`` instance for drawing class labels.
+            box_annotator: ``BoxAnnotator`` instance for drawing bounding boxes.
+            label_annotator: ``LabelAnnotator`` instance for drawing class labels.
         """
         from PIL import Image as PILImage
 
@@ -130,7 +130,7 @@ class DatasetGridSaver:
                 [[b[0] * w, b[1] * h, b[2] * w, b[3] * h] for box in boxes_iter for b in [box_cxcywh_to_xyxy(box)]],
                 dtype=np.float32,
             )
-            detections = sv.Detections(xyxy=xyxy, class_id=class_ids)
+            detections = Detections(xyxy=xyxy, class_id=class_ids)
             labels = [str(c) for c in class_ids]
             scene = box_annotator.annotate(scene=scene, detections=detections)
             scene = label_annotator.annotate(scene=scene, detections=detections, labels=labels)

--- a/src/rfdetr/datasets/synthetic.py
+++ b/src/rfdetr/datasets/synthetic.py
@@ -15,8 +15,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Tuple, Union
 
-import cv2
 import numpy as np
+from PIL import Image
 from supervision import Color, Detections, box_iou_batch, draw_filled_polygon
 from tqdm.auto import tqdm
 from typing_extensions import Literal
@@ -498,7 +498,9 @@ def generate_coco_dataset(
 
             file_name = f"{i:06d}.jpg"
             file_path = str(split_dir / file_name)
-            cv2.imwrite(file_path, img)
+            # ``supervision.draw_filled_polygon`` paints colors in BGR order (via ``cv2.fillPoly``);
+            # flip the last axis so PIL writes a true RGB JPEG that downstream loaders read correctly.
+            Image.fromarray(img[..., ::-1]).save(file_path)
 
             file_paths_ordered.append(file_path)
             detections_ordered.append(detections)

--- a/src/rfdetr/datasets/synthetic.py
+++ b/src/rfdetr/datasets/synthetic.py
@@ -17,7 +17,7 @@ from typing import Dict, List, Tuple, Union
 
 import cv2
 import numpy as np
-import supervision as sv
+from supervision import Color, Detections, box_iou_batch, draw_filled_polygon
 from tqdm.auto import tqdm
 from typing_extensions import Literal
 
@@ -113,11 +113,11 @@ def _normalize_split_ratios(split_ratios: SplitRatiosType) -> Dict[str, float]:
 # Available shapes for synthetic dataset generation
 SYNTHETIC_SHAPES = ["square", "triangle", "circle"]
 # Available colors for synthetic dataset generation (RGB format)
-SYNTHETIC_COLORS = {"red": sv.Color.RED, "green": sv.Color.GREEN, "blue": sv.Color.BLUE}
+SYNTHETIC_COLORS = {"red": Color.RED, "green": Color.GREEN, "blue": Color.BLUE}
 
 
 def draw_synthetic_shape(
-    img: np.ndarray, shape: str, color: sv.Color, center: Tuple[int, int], size: int
+    img: np.ndarray, shape: str, color: Color, center: Tuple[int, int], size: int
 ) -> Tuple[np.ndarray, List[float]]:
     """Draw a geometric shape on an image and return its COCO polygon.
 
@@ -159,7 +159,7 @@ def draw_synthetic_shape(
     else:
         return img, []
 
-    img = sv.draw_filled_polygon(scene=img, polygon=np.array(pts, dtype=np.int32), color=color)
+    img = draw_filled_polygon(scene=img, polygon=np.array(pts, dtype=np.int32), color=color)
     polygon = [float(v) for pt in pts for v in pt]
     return img, polygon
 
@@ -199,7 +199,7 @@ def generate_synthetic_sample(
     min_size_ratio: float = 0.1,
     max_size_ratio: float = 0.3,
     overlap_threshold: float = 0.1,
-) -> Tuple[np.ndarray, sv.Detections]:
+) -> Tuple[np.ndarray, Detections]:
     """Generate a single synthetic image and its detections.
 
     Args:
@@ -215,7 +215,7 @@ def generate_synthetic_sample(
 
     Returns:
         Tuple of ``(image, detections)`` where ``image`` is an ``(img_size, img_size, 3)`` uint8 array and
-        ``detections`` is an :class:`sv.Detections` instance whose ``data["polygons"]`` field contains one flat ``[x1,
+        ``detections`` is an :class:`Detections` instance whose ``data["polygons"]`` field contains one flat ``[x1,
         y1, x2, y2, …]`` polygon list per detection, matching the geometry returned by :func:`draw_synthetic_shape`.
     """
     img = np.ones((img_size, img_size, 3), dtype=np.uint8) * 128
@@ -256,7 +256,7 @@ def generate_synthetic_sample(
                 continue
 
             if len(xyxys) > 0:
-                ious = sv.box_iou_batch(np.array([bbox]), np.array(xyxys))[0]
+                ious = box_iou_batch(np.array([bbox]), np.array(xyxys))[0]
                 if np.any(ious > overlap_threshold):
                     continue
 
@@ -286,7 +286,7 @@ def generate_synthetic_sample(
     for i, poly in enumerate(polygons):
         polygon_data[i] = poly
 
-    detections = sv.Detections(
+    detections = Detections(
         xyxy=np.array(xyxys) if xyxys else np.empty((0, 4)),
         class_id=np.array(class_ids) if class_ids else np.empty((0,), dtype=int),
         data={"polygons": polygon_data},
@@ -309,7 +309,7 @@ def _write_coco_json(
     annotations_path: Path,
     classes: List[str],
     file_paths: List[str],
-    detections_list: List[sv.Detections],
+    detections_list: List[Detections],
     img_size: int,
     with_segmentation: bool = False,
 ) -> None:
@@ -485,7 +485,7 @@ def generate_coco_dataset(
         annotations_path = split_dir / "_annotations.coco.json"
 
         file_paths_ordered: List[str] = []
-        detections_ordered: List[sv.Detections] = []
+        detections_ordered: List[Detections] = []
 
         logger.info(f"Generating {split} split with {len(split_indices)} images...")
         for i in tqdm(split_indices, desc=f"Generating {split} split"):

--- a/src/rfdetr/datasets/yolo.py
+++ b/src/rfdetr/datasets/yolo.py
@@ -190,13 +190,13 @@ class _LazyYoloDetectionDataset:
         return len(self._samples)
 
     def __getitem__(self, idx: int) -> tuple[str, np.ndarray, "Detections"]:
-        import cv2
-
         sample = self._samples[idx]
-        image = cv2.imread(sample.image_path)
-        if image is None:
-            raise ValueError(f"Could not read image from path: {sample.image_path}")
-        return sample.image_path, image, sample.to_detections()
+        try:
+            with Image.open(sample.image_path) as image:
+                rgb_image = np.array(image.convert("RGB"))
+        except (FileNotFoundError, OSError, Image.UnidentifiedImageError) as exc:
+            raise ValueError(f"Could not read image from path: {sample.image_path}") from exc
+        return sample.image_path, rgb_image, sample.to_detections()
 
     def get_image_info(self, idx: int) -> _LazyYoloSample:
         """Return lightweight metadata without loading pixels or dense masks."""
@@ -430,8 +430,8 @@ def _build_coco_api_from_samples(classes: list[str], dataset: Any) -> Any:
             class_id = sample.class_id
             has_masks = len(sample.polygons) > 0
         else:
-            image_path, cv2_image, detections = dataset[img_id]
-            height, width = cv2_image.shape[:2]
+            image_path, image_array, detections = dataset[img_id]
+            height, width = image_array.shape[:2]
             xyxy = detections.xyxy
             class_id = detections.class_id
             has_masks = detections.mask is not None
@@ -636,10 +636,8 @@ class YoloDetection(VisionDataset):
 
     def __getitem__(self, idx: int):
         image_id = self.ids[idx]
-        image_path, cv2_image, detections = self.sv_dataset[idx]
+        image_path, rgb_image, detections = self.sv_dataset[idx]
 
-        # Convert BGR (OpenCV) to RGB (PIL)
-        rgb_image = cv2_image[:, :, ::-1]
         img = Image.fromarray(rgb_image)
 
         target = {"image_id": image_id, "detections": detections}

--- a/src/rfdetr/datasets/yolo.py
+++ b/src/rfdetr/datasets/yolo.py
@@ -15,7 +15,7 @@ import numpy as np
 import torch
 
 if TYPE_CHECKING:
-    import supervision as sv
+    from supervision import Detections
 from PIL import Image, ImageDraw
 from torchvision.datasets import VisionDataset
 
@@ -159,24 +159,24 @@ class _LazyYoloSample:
     class_id: np.ndarray
     polygons: tuple[np.ndarray, ...]
 
-    def to_detections(self) -> "sv.Detections":
+    def to_detections(self) -> "Detections":
         """Materialize the current sample as a supervision ``Detections`` object."""
-        import supervision as sv
+        from supervision import Detections
 
         if len(self.class_id) == 0:
-            return sv.Detections.empty()
+            return Detections.empty()
         if len(self.polygons) == 0:
             # Detection-only path: no masks were computed, return bare boxes.
-            return sv.Detections(class_id=self.class_id, xyxy=self.xyxy)
+            return Detections(class_id=self.class_id, xyxy=self.xyxy)
         # TODO: once supervision v0.28 ships CompactMask, wrap the dense result:
         #   compact = sv.CompactMask.from_dense(mask, self.xyxy, (self.height, self.width))
-        #   return sv.Detections(..., mask=compact)
+        #   return Detections(..., mask=compact)
         # CompactMask stores crop-RLE instead of a full H×W bool array, reducing memory
         # at the detections level for large images with sparse objects.
         # Note: _polygon_to_mask / _polygons_to_masks remain required as the intermediate
         # rasterization step until supervision provides a direct from_polygon factory.
         mask = _polygons_to_masks(self.polygons, (self.width, self.height))
-        return sv.Detections(class_id=self.class_id, xyxy=self.xyxy, mask=mask)
+        return Detections(class_id=self.class_id, xyxy=self.xyxy, mask=mask)
 
 
 class _LazyYoloDetectionDataset:
@@ -189,7 +189,7 @@ class _LazyYoloDetectionDataset:
     def __len__(self) -> int:
         return len(self._samples)
 
-    def __getitem__(self, idx: int) -> tuple[str, np.ndarray, "sv.Detections"]:
+    def __getitem__(self, idx: int) -> tuple[str, np.ndarray, "Detections"]:
         import cv2
 
         sample = self._samples[idx]
@@ -500,11 +500,11 @@ class ConvertYolo:
 
     Examples:
         >>> import numpy as np
-        >>> import supervision as sv
+        >>> from supervision import Detections
         >>> from PIL import Image
         >>> # Create a sample image and target
         >>> image = Image.new("RGB", (100, 100))
-        >>> detections = sv.Detections(
+        >>> detections = Detections(
         ...     xyxy=np.array([[10, 20, 30, 40]]),
         ...     class_id=np.array([0])
         ... )
@@ -531,7 +531,7 @@ class ConvertYolo:
 
         Args:
             image: PIL Image
-            target: dict with 'image_id' and 'detections' (sv.Detections)
+            target: dict with 'image_id' and 'detections'
 
         Returns:
             tuple of (image, target_dict)

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -33,7 +33,7 @@ from PIL import Image
 
 from rfdetr.assets.coco_classes import COCO_CLASS_NAMES, COCO_CLASSES
 from rfdetr.assets.model_weights import download_pretrain_weights, get_model_cache_dir
-from rfdetr.config import ModelConfig, TrainConfig 
+from rfdetr.config import ModelConfig, TrainConfig
 from rfdetr.datasets._keypoint_schema import active_keypoint_counts, infer_coco_keypoint_schema
 from rfdetr.datasets.coco import is_valid_coco_dataset
 from rfdetr.datasets.yolo import is_valid_yolo_dataset
@@ -1437,7 +1437,7 @@ class RFDETR:
                 either dimension is zero or negative, if either dimension is not divisible by ``patch_size *
                 num_windows``, or if ``patch_size`` is not a positive integer.
         """
-        from supervision import Detections, KeyPoints
+        from supervision import Detections
 
         patch_size = _resolve_patch_size(patch_size, self.model_config, "predict")
         num_windows = getattr(self.model_config, "num_windows", 1)

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -1437,7 +1437,7 @@ class RFDETR:
                 either dimension is zero or negative, if either dimension is not divisible by ``patch_size *
                 num_windows``, or if ``patch_size`` is not a positive integer.
         """
-        from supervision import Detections
+        from supervision import Detections, KeyPoints
 
         patch_size = _resolve_patch_size(patch_size, self.model_config, "predict")
         num_windows = getattr(self.model_config, "num_windows", 1)
@@ -1580,7 +1580,7 @@ class RFDETR:
             }
         else:
             _class_id_to_name = dict(enumerate(model_class_names))
-        predictions_list: list[sv.Detections | sv.KeyPoints] = []
+        predictions_list: list[Detections | KeyPoints] = []
         for i, result in enumerate(results):
             scores = result["scores"]
             labels = result["labels"]
@@ -1659,7 +1659,7 @@ class RFDETR:
                         )
                 keypoints_array = keypoints_array.astype(np.float32, copy=False)
                 keypoint_confidence = keypoints_array[:, :, 2]
-                key_points = sv.KeyPoints(
+                key_points = KeyPoints(
                     xy=keypoints_array[:, :, :2],
                     keypoint_confidence=keypoint_confidence,
                     detection_confidence=detections.confidence.astype(np.float32)

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -23,10 +23,6 @@ from typing import TYPE_CHECKING, Any, Concatenate, Optional, ParamSpec, TypeVar
 import numpy as np
 import requests
 import torch
-
-if TYPE_CHECKING:
-    from supervision import Detections, KeyPoints
-
 import torchvision.transforms.functional as F  # noqa: N812
 import yaml
 from PIL import Image
@@ -42,6 +38,9 @@ from rfdetr.utilities.decorators import deprecated
 from rfdetr.utilities.distributed import is_main_process
 from rfdetr.utilities.keypoints import precision_cholesky_to_pixel_covariance
 from rfdetr.utilities.logger import get_logger
+
+if TYPE_CHECKING:
+    from supervision import Detections, KeyPoints
 
 try:
     torch.set_float32_matmul_precision("high")

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -23,7 +23,7 @@ import requests
 import torch
 
 if TYPE_CHECKING:
-    import supervision as sv
+    from supervision import Detections
 
 import torchvision.transforms.functional as F  # noqa: N812
 import yaml
@@ -1211,7 +1211,7 @@ class RFDETR:
         patch_size: int | None = None,
         include_source_image: bool = True,
         **kwargs: Any,
-    ) -> sv.Detections | list[sv.Detections]:
+    ) -> "Detections" | list["Detections"]:
         """Performs object detection on the input images and returns bounding box predictions.
 
         This method accepts a single image or a list of images in various formats (file path, image url, PIL Image,
@@ -1265,7 +1265,7 @@ class RFDETR:
                 either dimension is zero or negative, if either dimension is not divisible by ``patch_size *
                 num_windows``, or if ``patch_size`` is not a positive integer.
         """
-        import supervision as sv
+        from supervision import Detections
 
         _ensure_model_on_device(self.model)
 
@@ -1422,14 +1422,14 @@ class RFDETR:
                 masks = result["masks"]
                 masks = masks[keep]
 
-                detections = sv.Detections(
+                detections = Detections(
                     xyxy=boxes.float().cpu().numpy(),
                     confidence=scores.float().cpu().numpy(),
                     class_id=labels.cpu().numpy(),
                     mask=masks.squeeze(1).cpu().numpy(),
                 )
             else:
-                detections = sv.Detections(
+                detections = Detections(
                     xyxy=boxes.float().cpu().numpy(),
                     confidence=scores.float().cpu().numpy(),
                     class_id=labels.cpu().numpy(),

--- a/src/rfdetr/export/_onnx/inference.py
+++ b/src/rfdetr/export/_onnx/inference.py
@@ -16,8 +16,8 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-import supervision as sv
 from PIL import Image as PILImage
+from supervision import Detections
 
 from rfdetr.utilities.logger import get_logger
 
@@ -64,7 +64,7 @@ def _run_inference(
     session: Any,
     image_path: str | Path,
     threshold: float = 0.3,
-) -> tuple[sv.Detections, PILImage.Image]:
+) -> tuple[Detections, PILImage.Image]:
     """Preprocess one image, run ONNX Runtime inference, and decode detections.
 
     Reads input shape from the session (NCHW ``float32``), resizes and normalises the image with ImageNet statistics,
@@ -206,4 +206,4 @@ def _run_inference(
     xyxy = np.stack([cx - bw / 2, cy - bh / 2, cx + bw / 2, cy + bh / 2], axis=1)
     xyxy *= np.array([ow, oh, ow, oh], dtype=np.float32)
 
-    return sv.Detections(xyxy=xyxy, confidence=scores[keep], class_id=cls[keep].astype(int)), pil_img
+    return Detections(xyxy=xyxy, confidence=scores[keep], class_id=cls[keep].astype(int)), pil_img

--- a/src/rfdetr/export/_tflite/inference.py
+++ b/src/rfdetr/export/_tflite/inference.py
@@ -18,9 +18,9 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-import supervision as sv
 from numpy.typing import NDArray
 from PIL import Image as PILImage
+from supervision import Detections
 
 from rfdetr.utilities.logger import get_logger
 
@@ -106,7 +106,7 @@ def _run_inference(
     interp: Any,
     image_path: str | Path,
     threshold: float = 0.3,
-) -> tuple[sv.Detections, PILImage.Image]:
+) -> tuple[Detections, PILImage.Image]:
     """Preprocess one image, run TFLite inference, and decode detections.
 
     Reads input shape from the interpreter (NHWC ``float32``), resizes and normalises the image with ImageNet
@@ -249,5 +249,5 @@ def _run_inference(
         raw_masks = interp.get_tensor(out_det[mask_idx]["index"])[0]  # (Q, Hm, Wm)
         masks = _decode_masks(raw_masks[keep], (ow, oh))
 
-    detections = sv.Detections(xyxy=xyxy, confidence=scores[keep], class_id=cls[keep].astype(int), mask=masks)
+    detections = Detections(xyxy=xyxy, confidence=scores[keep], class_id=cls[keep].astype(int), mask=masks)
     return detections, pil_img

--- a/src/rfdetr/models/backbone/projector.py
+++ b/src/rfdetr/models/backbone/projector.py
@@ -127,13 +127,13 @@ class Bottleneck(nn.Module):
         """ch_in, ch_out, shortcut, groups, kernels, expand."""
         super().__init__()
         c_ = int(c2 * e)  # hidden channels
-        self.cv1 = ConvX(c1, c_, k[0], 1, act=act, layer_norm=layer_norm, rms_norm=rms_norm)
-        self.cv2 = ConvX(c_, c2, k[1], 1, groups=g, act=act, layer_norm=layer_norm, rms_norm=rms_norm)
+        self.conv1 = ConvX(c1, c_, k[0], 1, act=act, layer_norm=layer_norm, rms_norm=rms_norm)
+        self.conv2 = ConvX(c_, c2, k[1], 1, groups=g, act=act, layer_norm=layer_norm, rms_norm=rms_norm)
         self.add = shortcut and c1 == c2
 
     def forward(self, x):
         """'forward()' applies the YOLOv5 FPN to input data."""
-        return x + self.cv2(self.cv1(x)) if self.add else self.cv2(self.cv1(x))
+        return x + self.conv2(self.conv1(x)) if self.add else self.conv2(self.conv1(x))
 
 
 class C2f(nn.Module):
@@ -143,8 +143,8 @@ class C2f(nn.Module):
         """ch_in, ch_out, number, shortcut, groups, expansion."""
         super().__init__()
         self.c = int(c2 * e)  # hidden channels
-        self.cv1 = ConvX(c1, 2 * self.c, 1, 1, act=act, layer_norm=layer_norm, rms_norm=rms_norm)
-        self.cv2 = ConvX(
+        self.conv1 = ConvX(c1, 2 * self.c, 1, 1, act=act, layer_norm=layer_norm, rms_norm=rms_norm)
+        self.conv2 = ConvX(
             (2 + n) * self.c, c2, 1, act=act, layer_norm=layer_norm, rms_norm=rms_norm
         )  # optional act=FReLU(c2)
         self.m = nn.ModuleList(
@@ -154,9 +154,9 @@ class C2f(nn.Module):
 
     def forward(self, x):
         """Forward pass using split() instead of chunk()."""
-        y = list(self.cv1(x).split((self.c, self.c), 1))
+        y = list(self.conv1(x).split((self.c, self.c), 1))
         y.extend(m(y[-1]) for m in self.m)
-        return self.cv2(torch.cat(y, 1))
+        return self.conv2(torch.cat(y, 1))
 
 
 class MultiScaleProjector(nn.Module):

--- a/src/rfdetr/models/backbone/projector.py
+++ b/src/rfdetr/models/backbone/projector.py
@@ -127,13 +127,13 @@ class Bottleneck(nn.Module):
         """ch_in, ch_out, shortcut, groups, kernels, expand."""
         super().__init__()
         c_ = int(c2 * e)  # hidden channels
-        self.conv1 = ConvX(c1, c_, k[0], 1, act=act, layer_norm=layer_norm, rms_norm=rms_norm)
-        self.conv2 = ConvX(c_, c2, k[1], 1, groups=g, act=act, layer_norm=layer_norm, rms_norm=rms_norm)
+        self.cv1 = ConvX(c1, c_, k[0], 1, act=act, layer_norm=layer_norm, rms_norm=rms_norm)
+        self.cv2 = ConvX(c_, c2, k[1], 1, groups=g, act=act, layer_norm=layer_norm, rms_norm=rms_norm)
         self.add = shortcut and c1 == c2
 
     def forward(self, x):
         """'forward()' applies the YOLOv5 FPN to input data."""
-        return x + self.conv2(self.conv1(x)) if self.add else self.conv2(self.conv1(x))
+        return x + self.cv2(self.cv1(x)) if self.add else self.cv2(self.cv1(x))
 
 
 class C2f(nn.Module):
@@ -143,8 +143,8 @@ class C2f(nn.Module):
         """ch_in, ch_out, number, shortcut, groups, expansion."""
         super().__init__()
         self.c = int(c2 * e)  # hidden channels
-        self.conv1 = ConvX(c1, 2 * self.c, 1, 1, act=act, layer_norm=layer_norm, rms_norm=rms_norm)
-        self.conv2 = ConvX(
+        self.cv1 = ConvX(c1, 2 * self.c, 1, 1, act=act, layer_norm=layer_norm, rms_norm=rms_norm)
+        self.cv2 = ConvX(
             (2 + n) * self.c, c2, 1, act=act, layer_norm=layer_norm, rms_norm=rms_norm
         )  # optional act=FReLU(c2)
         self.m = nn.ModuleList(
@@ -154,9 +154,9 @@ class C2f(nn.Module):
 
     def forward(self, x):
         """Forward pass using split() instead of chunk()."""
-        y = list(self.conv1(x).split((self.c, self.c), 1))
+        y = list(self.cv1(x).split((self.c, self.c), 1))
         y.extend(m(y[-1]) for m in self.m)
-        return self.conv2(torch.cat(y, 1))
+        return self.cv2(torch.cat(y, 1))
 
 
 class MultiScaleProjector(nn.Module):

--- a/src/rfdetr/visualize/data.py
+++ b/src/rfdetr/visualize/data.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import numpy as np
 from PIL import Image
+from supervision import BoxAnnotator, Color, ColorLookup, ColorPalette, Detections, LabelAnnotator, Position
 
 from rfdetr.utilities.logger import get_logger
 
@@ -31,7 +32,7 @@ def save_gt_predictions_visualization(
     Boxes are labeled with class ID and confidence (for predictions). For predictions with known IoU, the IoU value is
     also shown.
     """
-    import supervision as sv
+    from supervision import xywh_to_xyxy
 
     save_dir.mkdir(exist_ok=True)
 
@@ -42,59 +43,59 @@ def save_gt_predictions_visualization(
     gt_boxes_offset = [[x, y + top_padding, w, h] for x, y, w, h in gt_boxes]
     pred_boxes_offset = [[x, y + top_padding, w, h] for x, y, w, h in pred_boxes]
 
-    gt_xyxy = sv.xywh_to_xyxy(np.array(gt_boxes_offset))
-    pred_xyxy = sv.xywh_to_xyxy(np.array(pred_boxes_offset))
+    gt_xyxy = xywh_to_xyxy(np.array(gt_boxes_offset))
+    pred_xyxy = xywh_to_xyxy(np.array(pred_boxes_offset))
 
     gt_detections = None
     pred_detections = None
 
     if len(gt_xyxy) > 0:
-        gt_detections = sv.Detections(
+        gt_detections = Detections(
             xyxy=gt_xyxy,
             class_id=np.array(gt_class_ids),
         )
 
     if len(pred_xyxy) > 0:
-        pred_detections = sv.Detections(
+        pred_detections = Detections(
             xyxy=pred_xyxy,
             class_id=np.array(pred_class_ids),
             confidence=np.array(pred_confidences),
         )
 
     # Index 0 is unused because class IDs start at 1
-    gt_colors = sv.ColorPalette(
+    gt_colors = ColorPalette(
         [
-            sv.Color(128, 128, 128),  # dummy color for index 0
-            sv.Color(0, 255, 100),
-            sv.Color(0, 200, 255),
+            Color(128, 128, 128),  # dummy color for index 0
+            Color(0, 255, 100),
+            Color(0, 200, 255),
         ]
     )
-    pred_colors = sv.ColorPalette(
+    pred_colors = ColorPalette(
         [
-            sv.Color(128, 128, 128),  # dummy color for index 0
-            sv.Color(255, 100, 50),
-            sv.Color(255, 50, 200),
+            Color(128, 128, 128),  # dummy color for index 0
+            Color(255, 100, 50),
+            Color(255, 50, 200),
         ]
     )
 
-    gt_box_annotator = sv.BoxAnnotator(color=gt_colors, thickness=3, color_lookup=sv.ColorLookup.CLASS)
-    pred_box_annotator = sv.BoxAnnotator(color=pred_colors, thickness=3, color_lookup=sv.ColorLookup.CLASS)
+    gt_box_annotator = BoxAnnotator(color=gt_colors, thickness=3, color_lookup=ColorLookup.CLASS)
+    pred_box_annotator = BoxAnnotator(color=pred_colors, thickness=3, color_lookup=ColorLookup.CLASS)
 
-    gt_label_annotator = sv.LabelAnnotator(
+    gt_label_annotator = LabelAnnotator(
         color=gt_colors,
-        text_color=sv.Color.BLACK,
+        text_color=Color.BLACK,
         text_scale=0.5,
         text_padding=3,
-        text_position=sv.Position.TOP_LEFT,
-        color_lookup=sv.ColorLookup.CLASS,
+        text_position=Position.TOP_LEFT,
+        color_lookup=ColorLookup.CLASS,
     )
-    pred_label_annotator = sv.LabelAnnotator(
+    pred_label_annotator = LabelAnnotator(
         color=pred_colors,
-        text_color=sv.Color.BLACK,
+        text_color=Color.BLACK,
         text_scale=0.5,
         text_padding=3,
-        text_position=sv.Position.TOP_RIGHT,
-        color_lookup=sv.ColorLookup.CLASS,
+        text_position=Position.TOP_RIGHT,
+        color_lookup=ColorLookup.CLASS,
     )
 
     gt_labels = [f"c{class_id}" for class_id in gt_class_ids]

--- a/tests/datasets/test_yolo.py
+++ b/tests/datasets/test_yolo.py
@@ -172,11 +172,18 @@ class TestIsValidYoloDataset:
 class TestYoloDetectionLazyMasks:
     """Segmentation masks should stay lightweight until a sample is fetched."""
 
-    def test_segmentation_init_builds_coco_metadata_without_cv2_loading(self, tmp_path: Path) -> None:
-        """Dataset construction should not call cv2.imread for every image."""
+    def test_segmentation_init_builds_coco_metadata_without_pixel_loading(self, tmp_path: Path) -> None:
+        """Dataset construction must not decode pixel data for every image (only metadata is needed at init)."""
         image_dir, label_dir, data_file = _write_yolo_segmentation_dataset(tmp_path)
 
-        with patch("cv2.imread", side_effect=AssertionError("cv2.imread should not run during init")):
+        # ``Image.open`` is allowed during init to read header metadata (``image.size``),
+        # but ``Image.Image.convert`` decodes the full pixel buffer and must not run until
+        # ``__getitem__`` is invoked on the lazy dataset.
+        with patch.object(
+            Image.Image,
+            "convert",
+            side_effect=AssertionError("Image.convert should not run during init"),
+        ):
             dataset = YoloDetection(
                 img_folder=str(image_dir),
                 lb_folder=str(label_dir),
@@ -493,8 +500,8 @@ class TestYoloDetectionLazyMasks:
         assert target["boxes"].shape == (2, 4), f"Expected (2, 4), got {target['boxes'].shape}"
         assert set(target["labels"].tolist()) == {0, 1}
 
-    def test_lazy_getitem_cv2_returns_none_raises_value_error(self, tmp_path: Path) -> None:
-        """Lazy mask loading should raise ValueError when cv2.imread cannot read the image."""
+    def test_lazy_getitem_unreadable_image_raises_value_error(self, tmp_path: Path) -> None:
+        """Lazy mask loading should raise ValueError when PIL cannot decode the image."""
         image_dir, label_dir, data_file = _write_yolo_segmentation_dataset(tmp_path)
         dataset = YoloDetection(
             img_folder=str(image_dir),
@@ -504,9 +511,12 @@ class TestYoloDetectionLazyMasks:
             include_masks=True,
         )
 
-        with patch("cv2.imread", return_value=None):
-            with pytest.raises(ValueError, match="Could not read image"):
-                dataset[0]
+        # Replace the on-disk image with non-decodable bytes after dataset init has
+        # already captured width/height from the original PNG header.
+        (image_dir / "sample.png").write_bytes(b"not a valid image file")
+
+        with pytest.raises(ValueError, match="Could not read image"):
+            dataset[0]
 
     def test_non_integer_class_id_in_label_raises_value_error(self, tmp_path: Path) -> None:
         """A label line with a non-integer class ID must raise ValueError during init."""


### PR DESCRIPTION
This pull request refactors the codebase to use direct imports of specific classes and functions from the `supervision` library instead of importing the entire module as `sv`. This change improves code clarity and reduces unnecessary namespace usage. Additionally, the code now consistently uses `PIL.Image` for image I/O instead of `cv2`, standardizing image handling across the project. Some docstrings and type annotations have also been updated to reflect these changes.

**Refactor: Use direct imports from `supervision` instead of module alias**

* Replaced all usages of `sv.Detections`, `sv.Color`, `sv.BoxAnnotator`, `sv.LabelAnnotator`, `sv.box_iou_batch`, and `sv.draw_filled_polygon` with direct imports and usage of `Detections`, `Color`, `BoxAnnotator`, `LabelAnnotator`, `box_iou_batch`, and `draw_filled_polygon` throughout the codebase. Updated type annotations and docstrings accordingly. [[1]](diffhunk://#diff-1733f36e4b11b8699bb4407b7be18aac471a064ec7d3ceec540ae4a18a3b7230L12-R15) [[2]](diffhunk://#diff-1733f36e4b11b8699bb4407b7be18aac471a064ec7d3ceec540ae4a18a3b7230L53-R55) [[3]](diffhunk://#diff-1733f36e4b11b8699bb4407b7be18aac471a064ec7d3ceec540ae4a18a3b7230L91-R92) [[4]](diffhunk://#diff-1733f36e4b11b8699bb4407b7be18aac471a064ec7d3ceec540ae4a18a3b7230L101-R102) [[5]](diffhunk://#diff-1733f36e4b11b8699bb4407b7be18aac471a064ec7d3ceec540ae4a18a3b7230L133-R133) [[6]](diffhunk://#diff-cb5070d0695c1310f5dfb9017d5539210ca19b7ee762a817f509e82a8014b2f2L18-R20) [[7]](diffhunk://#diff-cb5070d0695c1310f5dfb9017d5539210ca19b7ee762a817f509e82a8014b2f2L116-R120) [[8]](diffhunk://#diff-cb5070d0695c1310f5dfb9017d5539210ca19b7ee762a817f509e82a8014b2f2L162-R162) [[9]](diffhunk://#diff-cb5070d0695c1310f5dfb9017d5539210ca19b7ee762a817f509e82a8014b2f2L202-R202) [[10]](diffhunk://#diff-cb5070d0695c1310f5dfb9017d5539210ca19b7ee762a817f509e82a8014b2f2L218-R218) [[11]](diffhunk://#diff-cb5070d0695c1310f5dfb9017d5539210ca19b7ee762a817f509e82a8014b2f2L259-R259) [[12]](diffhunk://#diff-cb5070d0695c1310f5dfb9017d5539210ca19b7ee762a817f509e82a8014b2f2L289-R289) [[13]](diffhunk://#diff-cb5070d0695c1310f5dfb9017d5539210ca19b7ee762a817f509e82a8014b2f2L312-R312) [[14]](diffhunk://#diff-cb5070d0695c1310f5dfb9017d5539210ca19b7ee762a817f509e82a8014b2f2L488-R488) [[15]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86L26-R26) [[16]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86L1214-R1214) [[17]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86L1268-R1268) [[18]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86L1425-R1432) [[19]](diffhunk://#diff-f4618ee04efd69b96f9a1707de568b6f85b1af0f0bb3e71b1eb42fa0debb5796L19-R20) [[20]](diffhunk://#diff-f4618ee04efd69b96f9a1707de568b6f85b1af0f0bb3e71b1eb42fa0debb5796L67-R67) [[21]](diffhunk://#diff-f4618ee04efd69b96f9a1707de568b6f85b1af0f0bb3e71b1eb42fa0debb5796L209-R209) [[22]](diffhunk://#diff-b97d0660e2c271d5846f16dd227daa7803091b2df11a2bd71cfaace54bd4c820L21-R23) [[23]](diffhunk://#diff-d1e5ad158d1fc9bb75ca28e5f00118f0b7283ceb9bcaf6cbc8ff82b2216d8852L18-R18) [[24]](diffhunk://#diff-d1e5ad158d1fc9bb75ca28e5f00118f0b7283ceb9bcaf6cbc8ff82b2216d8852L162-R179) [[25]](diffhunk://#diff-d1e5ad158d1fc9bb75ca28e5f00118f0b7283ceb9bcaf6cbc8ff82b2216d8852L192-R199) [[26]](diffhunk://#diff-d1e5ad158d1fc9bb75ca28e5f00118f0b7283ceb9bcaf6cbc8ff82b2216d8852L503-R507) [[27]](diffhunk://#diff-d1e5ad158d1fc9bb75ca28e5f00118f0b7283ceb9bcaf6cbc8ff82b2216d8852L534-R534)

**Image handling standardization**

* Replaced all uses of `cv2.imread` and OpenCV BGR-to-RGB conversion with `PIL.Image.open` and direct RGB handling, ensuring consistency and correctness in image loading and saving. [[1]](diffhunk://#diff-cb5070d0695c1310f5dfb9017d5539210ca19b7ee762a817f509e82a8014b2f2L501-R503) [[2]](diffhunk://#diff-d1e5ad158d1fc9bb75ca28e5f00118f0b7283ceb9bcaf6cbc8ff82b2216d8852L192-R199) [[3]](diffhunk://#diff-d1e5ad158d1fc9bb75ca28e5f00118f0b7283ceb9bcaf6cbc8ff82b2216d8852L433-R434) [[4]](diffhunk://#diff-d1e5ad158d1fc9bb75ca28e5f00118f0b7283ceb9bcaf6cbc8ff82b2216d8852L639-L642)

**Documentation and type annotation updates**

* Updated docstrings and type annotations to refer to the correct classes and usage patterns after the refactor, improving code readability and maintainability. [[1]](diffhunk://#diff-1733f36e4b11b8699bb4407b7be18aac471a064ec7d3ceec540ae4a18a3b7230L101-R102) [[2]](diffhunk://#diff-cb5070d0695c1310f5dfb9017d5539210ca19b7ee762a817f509e82a8014b2f2L218-R218) [[3]](diffhunk://#diff-d1e5ad158d1fc9bb75ca28e5f00118f0b7283ceb9bcaf6cbc8ff82b2216d8852L534-R534)

These changes collectively improve code clarity, maintainability, and consistency across the project.