### PR TITLE
Update DDP strategy to handle unused parameters consistently

### DIFF
--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -163,13 +163,21 @@ def build_trainer(
             "%s → spawn-based DDP to avoid OpenMP thread pool corruption after fork.",
             tc.strategy,
         )
-    elif strategy == "ddp" and model_config.segmentation_head:
+    elif strategy == "ddp":
         # The segmentation head's sparse_forward() returns dict intermediates and
         # leaves some parameters unused on certain forward steps, causing DDP to
         # raise "It looks like your LightningModule has parameters that were not
         # used in producing the loss" with plain ddp.  Enabling
         # find_unused_parameters lets DDP traverse the autograd graph after each
         # backward pass to detect which parameters contributed to the loss.
+        #
+        # Previously this was only enabled when a segmentation head was present.
+        # However, unused-parameter errors can also occur in detection models
+        # depending on the active branches and loss computation path. Therefore,
+        # the segmentation_head condition was removed so that the same DDP
+        # configuration is applied consistently across both detection and
+        # segmentation models.
+        
         strategy = _DDPStrategy(find_unused_parameters=True)
         _logger.info(
             "segmentation_head=True with strategy='ddp' → DDPStrategy(find_unused_parameters=True).",

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -131,7 +131,9 @@ def build_trainer(
 
     Args:
         train_config: Training hyperparameter configuration.
-        model_config: Architecture configuration (used for precision and segmentation).
+        model_config: Architecture configuration. Used for precision resolution
+            (``model_config.amp``) and to guard against unsupported distributed
+            configurations for keypoint models.
         accelerator: PTL accelerator string (e.g. ``"auto"``, ``"cpu"``, ``"gpu"``).
             Defaults to ``None`` which reads from ``train_config.accelerator`` (itself defaulting to ``"auto"``). Pass
             ``"cpu"`` to override auto-detection (e.g. when the caller explicitly requests CPU training via
@@ -210,19 +212,18 @@ def build_trainer(
             tc.strategy,
         )
     elif strategy == "ddp":
-        # The segmentation head's sparse_forward() returns dict intermediates and
-        # leaves some parameters unused on certain forward steps, causing DDP to
-        # raise "It looks like your LightningModule has parameters that were not
-        # used in producing the loss" with plain ddp.  Enabling
-        # find_unused_parameters lets DDP traverse the autograd graph after each
-        # backward pass to detect which parameters contributed to the loss.
-        #
-        # Previously this was only enabled when a segmentation head was present.
-        # However, unused-parameter errors can also occur in detection models
-        # depending on the active branches and loss computation path. Therefore,
-        # the segmentation_head condition was removed so that the same DDP
-        # configuration is applied consistently across both detection and
-        # segmentation models.
+        # DETR-family architectures can leave parameters unused on certain forward
+        # steps under DDP, causing "It looks like your LightningModule has parameters
+        # that were not used in producing the loss".  Sources include:
+        #   - segmentation_head.sparse_forward() returning dict intermediates;
+        #   - two-stage encoder query groups (group_detr ModuleLists) where per-group
+        #     matcher assignment can leave groups without targets on low-annotation
+        #     batches (issue #1093);
+        #   - conditional aux_loss / keypoint branches.
+        # Enabling find_unused_parameters lets DDP traverse the autograd graph after
+        # each backward pass to identify which parameters contributed to the loss.
+        # To opt out (e.g. configs with two_stage=False that never hit unused params),
+        # pass strategy=DDPStrategy(find_unused_parameters=False) via trainer_kwargs.
         strategy = _DDPStrategy(find_unused_parameters=True)
         _logger.info(
             "strategy='ddp' → DDPStrategy(find_unused_parameters=True).",

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -179,7 +179,7 @@ def build_trainer(
         # segmentation models.
         strategy = _DDPStrategy(find_unused_parameters=True)
         _logger.info(
-            "segmentation_head=True with strategy='ddp' → DDPStrategy(find_unused_parameters=True).",
+            "strategy='ddp' → DDPStrategy(find_unused_parameters=True).",
         )
     sharded = any(s in str(strategy).lower() for s in ("fsdp", "deepspeed"))
     enable_ema = bool(tc.use_ema) and not sharded

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -177,7 +177,6 @@ def build_trainer(
         # the segmentation_head condition was removed so that the same DDP
         # configuration is applied consistently across both detection and
         # segmentation models.
-
         strategy = _DDPStrategy(find_unused_parameters=True)
         _logger.info(
             "segmentation_head=True with strategy='ddp' → DDPStrategy(find_unused_parameters=True).",

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -177,7 +177,7 @@ def build_trainer(
         # the segmentation_head condition was removed so that the same DDP
         # configuration is applied consistently across both detection and
         # segmentation models.
-        
+
         strategy = _DDPStrategy(find_unused_parameters=True)
         _logger.info(
             "segmentation_head=True with strategy='ddp' → DDPStrategy(find_unused_parameters=True).",

--- a/tests/training/test_build_trainer.py
+++ b/tests/training/test_build_trainer.py
@@ -678,11 +678,11 @@ class TestBuildTrainerDDPFields:
             captured.update(kwargs)
             return mock.MagicMock()
 
-        tc = _tc(tmp_path, use_ema=False, strategy="ddp")
+        tc = _tc(tmp_path, use_ema=False, strategy="auto")
         with mock.patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer):
             build_trainer(tc, _mc())
 
-        assert captured["strategy"] == "ddp"
+        assert captured["strategy"] == "auto"
 
     def test_default_devices_is_1(self, tmp_path):
         """Default TrainConfig.devices must produce devices=1 (single-GPU default)."""
@@ -746,9 +746,11 @@ class TestBuildTrainerKeypointDistributedGuard:
         ):
             build_trainer(tc, mc)
 
-    def test_non_keypoint_ddp_strategy_is_unchanged(self, tmp_path):
-        """Non-keypoint mode keeps the existing ddp strategy behavior unchanged."""
+    def test_non_keypoint_ddp_strategy_wrapped_with_find_unused_parameters(self, tmp_path):
+        """Non-keypoint mode with strategy='ddp' produces DDPStrategy(find_unused_parameters=True)."""
         import unittest.mock as mock
+
+        from pytorch_lightning.strategies import DDPStrategy
 
         captured: dict = {}
 
@@ -761,17 +763,20 @@ class TestBuildTrainerKeypointDistributedGuard:
         with mock.patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer):
             build_trainer(tc, mc)
 
-        assert captured["strategy"] == "ddp"
+        strategy_obj = captured["strategy"]
+        assert isinstance(strategy_obj, DDPStrategy)
+        assert strategy_obj._ddp_kwargs.get("find_unused_parameters") is True
 
 
-class TestBuildTrainerSegmentationDDP:
-    """build_trainer() must enable find_unused_parameters when segmentation_head=True + strategy='ddp'."""
+class TestBuildTrainerDDPFindUnusedParameters:
+    """build_trainer() must enable find_unused_parameters for strategy='ddp' on both detection and segmentation."""
 
     def test_ddp_segmentation_enables_find_unused_parameters(self, tmp_path):
         """Strategy='ddp' + segmentation_head=True must produce DDPStrategy(find_unused_parameters=True).
 
-        The segmentation head's sparse_forward() leaves parameters unused on some forward steps.  Plain DDP raises
-        RuntimeError unless find_unused_parameters is enabled.
+        One case of the broader unconditional rule: find_unused_parameters is enabled for all strategy='ddp'
+        requests.  The segmentation head's sparse_forward() is one source of conditionally-unused parameters under
+        DDP.
         """
         import unittest.mock as mock
 
@@ -792,13 +797,17 @@ class TestBuildTrainerSegmentationDDP:
         assert isinstance(strategy_obj, DDPStrategy)
         assert strategy_obj._ddp_kwargs.get("find_unused_parameters") is True
 
-    def test_ddp_no_segmentation_strategy_unchanged(self, tmp_path):
-        """Strategy='ddp' without segmentation_head must pass the string through unchanged.
+    def test_ddp_no_segmentation_enables_find_unused_parameters(self, tmp_path):
+        """Strategy='ddp' for detection-only must produce DDPStrategy(find_unused_parameters=True).
 
-        Only the segmentation path needs find_unused_parameters; standard detection DDP must not be wrapped
-        unnecessarily to avoid the autograd-graph traversal overhead on every backward pass.
+        Detection models can leave parameters unused under DDP (two-stage group_detr ModuleLists, conditional aux_loss
+        branches), so find_unused_parameters is enabled unconditionally for strategy='ddp' regardless of
+        segmentation_head. Regression test for
+        https://github.com/roboflow/rf-detr/issues/1093.
         """
         import unittest.mock as mock
+
+        from pytorch_lightning.strategies import DDPStrategy
 
         captured: dict = {}
 
@@ -811,7 +820,9 @@ class TestBuildTrainerSegmentationDDP:
         with mock.patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer):
             build_trainer(tc, mc)
 
-        assert captured["strategy"] == "ddp"
+        strategy_obj = captured["strategy"]
+        assert isinstance(strategy_obj, DDPStrategy)
+        assert strategy_obj._ddp_kwargs.get("find_unused_parameters") is True
 
     def test_ddp_spawn_segmentation_preserves_find_unused_parameters(self, tmp_path):
         """strategy='ddp_spawn' + segmentation_head=True must keep find_unused_parameters=True.


### PR DESCRIPTION
Removed segmentation head condition for DDP strategy to consistently apply unused parameters detection across detection and segmentation models.

## What does this PR do?

<!-- Provide a clear and concise description of the changes -->

**Related Issue(s): closes #1093  <!-- Link to related issues, e.g., Fixes #123 or Related to #456 -->

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->
I used the code below, and the error is gone.
```
import os
from rfdetr import RFDETRMedium

model = RFDETRMedium()

model.train(
    dataset_dir="/home/dohyeon/Datasets/dataset_rfdetr_576",
    epochs=1,
    batch_size=4,
    grad_accum_steps=2,  # 2GPU × grad_accum_steps=2 × batch_size=4 = effective 16
    output_dir="output/strategy1",
    progress_bar="tqdm",
    devices=2,
    # strategy="ddp_find_unused_parameters_true",  # NOT set → triggers error
    num_workers=16,
    pin_memory=True,
    resolution=576,
    resume=None,
    checkpoint_interval=1,
    use_ema=True,
    tensorboard=True,
    seed=42,
)
```
## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
This bug only occurs when training with multiple GPUs, for example using:
```
torchrun --nproc_per_node=2 train.py
```
The error occurs only when using two or more GPUs. It does not occur when running on a single GPU:
```
python train.py
```