### PR TITLE
releasing `1.8.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,27 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [1.8.0] — 2026-06-13
+
 ### Added
 
-- `RFDETR.export_for_roboflow(output_dir)` — writes a Roboflow upload bundle (`weights.pt` + `class_names.txt`) without a network call; extracted from `deploy_to_roboflow`, which now uses it ([#1086](https://github.com/roboflow/rf-detr/pull/1086))
-- `RFDETRKeypointPreview` — keypoint detection model variant with GroupPose-style head, covariance-based uncertainty (precision-Cholesky parameterization), and COCO keypoint AP evaluation. Also adds `KeypointTrainConfig`, `infer_coco_keypoint_schema`, `CocoKeypointSchema`, and `active_keypoint_counts` to the public API ([#1099](https://github.com/roboflow/rf-detr/pull/1099))
+- `RFDETRKeypointPreview` — keypoint detection model variant with GroupPose-style head, covariance-based uncertainty (precision-Cholesky parameterization), and COCO keypoint AP evaluation. Public config classes: `KeypointTrainConfig`, `RFDETRKeypointPreviewConfig` (from `rfdetr.config`). Utility: `precision_cholesky_to_pixel_covariance` (from `rfdetr.utilities`). Schema helpers `infer_coco_keypoint_schema`, `CocoKeypointSchema`, `active_keypoint_counts` accessible via `rfdetr.datasets._keypoint_schema`. ([#1099](https://github.com/roboflow/rf-detr/pull/1099))
+- `RFDETR.export_for_roboflow(output_dir)` — writes a Roboflow upload bundle (`weights.pt` + `class_names.txt`) without a network call; extracted from `deploy_to_roboflow`, which now delegates to it. ([#1086](https://github.com/roboflow/rf-detr/pull/1086))
+- Keypoint fine-tuning cookbook (`docs/cookbooks/fine-tune_keypoints.ipynb`) — end-to-end walkthrough: dataset download, schema inference, `KeypointTrainConfig`, training metrics, and inference with covariance uncertainty. ([#1104](https://github.com/roboflow/rf-detr/pull/1104))
+- `MetricKeypointOKS` — reusable OKS metric facade over `CocoEvaluator`, exported from `rfdetr.evaluation`. Supports arbitrary keypoint counts, per-category OKS sigma values, DDP-safe evaluation with first-rank-wins deduplication, and an `OKSKey` enum (`mAP`, `mAP@50`, `mAP@75`, `mAR`) for standardised metric keys. ([#1107](https://github.com/roboflow/rf-detr/pull/1107))
 
 ### Changed
 
--
+- DDP strategy now enables `find_unused_parameters=True` for all detection, keypoint, and segmentation models when running under `strategy='ddp'` or `strategy='auto'` with a distributed launcher. Previously only enabled for segmentation. Opt out via `trainer_kwargs={"strategy": DDPStrategy(find_unused_parameters=False)}`. ([#1094](https://github.com/roboflow/rf-detr/pull/1094))
+- `rfdetr.datasets.aug_config` module renamed to `rfdetr.datasets.aug_configs` (plural). Direct imports from `rfdetr.datasets.aug_config` must be updated to `rfdetr.datasets.aug_configs`; the augmentation preset constants (`AUG_AGGRESSIVE`, etc.) are unchanged. ([#1103](https://github.com/roboflow/rf-detr/pull/1103))
 
-### Deprecated
+### Removed
 
--
+- `RFDETR.export(simplify=..., force=...)` — both kwargs removed from the signature. Deprecated since v1.6.0 with `remove_in="1.8.0"`; both were no-ops during the deprecation window. Callers passing these args must remove them before upgrading. ([#1102](https://github.com/roboflow/rf-detr/pull/1102))
 
 ### Fixed
 
-- Fixed `import rfdetr` failing on NumPy 2.x when a transitive dependency references the removed `np.complex_` alias ([#1064](https://github.com/roboflow/rf-detr/pull/1064))
+- `RFDETR.from_checkpoint()` no longer treats `num_classes` loaded from the checkpoint as a user-supplied override. Previously, fine-tuning a checkpoint model on a dataset with a different class count was silently refused — the head refused to re-initialise and trained against the stale class count. An explicit `num_classes` kwarg from the caller still wins over both the checkpoint value and the dataset. ([#1106](https://github.com/roboflow/rf-detr/pull/1106))
+- Scale jitter restored in non-square training crop. `RandomCrop` in the `option_b` branch replaced with `RandomSizedCrop`, restoring the scale-augmentation behaviour lost during the Albumentations migration. ([#1088](https://github.com/roboflow/rf-detr/pull/1088))
+- Multi-GPU validation deadlock in COCO mAP synchronization prevented. `_merge_metric_state_across_ranks` now safe across zero-batch ranks. ([#1085](https://github.com/roboflow/rf-detr/pull/1085))
+- `import rfdetr` no longer fails on NumPy 2.x when a transitive dependency references the removed `np.complex_` alias. ([#1064](https://github.com/roboflow/rf-detr/pull/1064))
+- `rfdetr_plus` module availability check corrected; false-positive hit when the package was partially installed. ([#1083](https://github.com/roboflow/rf-detr/pull/1083))
 - Fixed spurious "Keypoint class-logit boost has N classes but detection head has M" warning on custom (non-Roboflow) keypoint datasets: `_align_num_classes_from_dataset` now zero-pads `num_keypoints_per_class` when auto-adjusting `num_classes` beyond the schema length ([#1113](https://github.com/roboflow/rf-detr/pull/1113))
-
-### Security
-
--
+- Loss scaling corrected for keypoint training under gradient accumulation (`accumulate_grad_batches > 1`). Keypoint models now use manual optimization to normalize losses by the accumulated box count across the effective batch; detection and segmentation remain on Lightning's automatic-optimization path. Optimizer-step scheduling, LR warmup/decay, and epoch-boundary flushing are correctly handled in both paths. ([#1117](https://github.com/roboflow/rf-detr/pull/1117))
+- Device auto-detection now verifies accelerator runtime availability before selecting a device (PyTorch ≥ 2.4: `torch.accelerator.current_accelerator`; older builds: `torch.cuda.is_available()`). Previously, a machine with CUDA headers but no GPU driver could be assigned a CUDA device that fails at first use. ([#1111](https://github.com/roboflow/rf-detr/pull/1111))
+- `RFDETR.from_checkpoint()` and related APIs now honor an explicit `num_classes` argument even when its value equals the model default. Previously, passing `num_classes=N` where `N` is the default (e.g. 80 for COCO) was silently treated as unset, causing fine-tuning on a different class count to be refused. ([#1109](https://github.com/roboflow/rf-detr/pull/1109))
+- `RFDETR.from_checkpoint()` correctly infers the model variant from the checkpoint filename when `pretrain_weights` is absent or unset-like (empty string, `None`, whitespace). Previously, starter-like checkpoints without an explicit `pretrain_weights` entry raised an error or silently loaded the wrong model class. ([#1065](https://github.com/roboflow/rf-detr/pull/1065))
 
 ---
 

--- a/docs/cookbooks/fine-tune_keypoints.ipynb
+++ b/docs/cookbooks/fine-tune_keypoints.ipynb
@@ -23,7 +23,7 @@
    "cell_type": "code",
    "outputs": [],
    "execution_count": null,
-   "source": "%pip install -q \"rfdetr[train,visual]==1.8.0rc2\" roboflow pandas seaborn",
+   "source": "%pip install -q \"rfdetr[train,visual]==1.8.0\" roboflow pandas seaborn",
    "id": "f7ea56d7a98aea36"
   },
   {

--- a/docs/getting-started/migration.md
+++ b/docs/getting-started/migration.md
@@ -8,13 +8,63 @@ Read each section between your current version and your target — every section
 only the delta between two adjacent releases.
 
 ```
-1.4.x  →  1.5 →  1.6  →  1.7
+1.4.x  →  1.5 →  1.6  →  1.7  →  1.8
 ```
 
 You can apply all changes in one go; working through sections one release at a time
 and verifying between each step is optional but makes failures easier to isolate.
 Deprecated APIs emit a `DeprecationWarning` until the version marked for removal.
 See the [Changelog](../changelog.md) for the full list of changes in each release.
+
+---
+
+## Upgrade 1.7 → 1.8
+
+### Removed
+
+!!! warning "Deprecated in v1.6 → Removed in v1.8: `simplify` and `force` arguments in `RFDETR.export()`"
+
+    **`RFDETR.export(..., simplify=..., force=...)`** — deprecated since v1.6.0, removed in v1.8.0.
+    Both were no-ops. Delete the kwargs from any `model.export(...)` call.
+
+    ```python
+    # Before (raises TypeError in v1.8.0)
+    model.export(output_dir="out/", simplify=True, force=True)
+
+    # After
+    model.export(output_dir="out/")
+    ```
+
+### Breaking changes
+
+!!! warning "Breaking: `rfdetr.datasets.aug_config` renamed to `rfdetr.datasets.aug_configs`"
+
+    The augmentation config module was renamed (singular → plural). If you import from it directly:
+
+    ```python
+    # Before
+    from rfdetr.datasets.aug_config import AUG_AGGRESSIVE
+
+    # After
+    from rfdetr.datasets.aug_configs import AUG_AGGRESSIVE
+    ```
+
+    All preset constants (`AUG_AGGRESSIVE`, `AUG_MOSAIC`, etc.) are unchanged.
+
+### Dependency updates
+
+!!! note "New minimum: `supervision>=0.29.0`"
+
+    Required for `sv.KeyPoints` support. `pip install rfdetr==1.8.0` pulls this automatically.
+    If another dependency pins `supervision<0.29.0`, resolve the conflict manually.
+
+!!! note "`pyDeprecate` constraint narrowed to `>=0.9,<0.10`"
+
+    Was `>=0.6,<0.8`. If another package pins an older version, resolve with:
+
+    ```bash
+    pip install "rfdetr==1.8.0" "pyDeprecate>=0.9,<0.10"
+    ```
 
 ---
 
@@ -242,7 +292,7 @@ See the [Changelog](../changelog.md) for the full list of changes in each releas
 
 ### Deprecated (removal in v1.8.0)
 
-!!! note "Deprecated: `simplify` and `force` arguments removed from `RFDETR.export()`"
+!!! note "Deprecated in v1.6 → Removed in v1.8: `simplify` and `force` arguments in `RFDETR.export()`"
 
     **`RFDETR.export(..., simplify=..., force=...)`** — both arguments are no-ops.
     Remove them from your calls.

--- a/docs/getting-started/migration.md
+++ b/docs/getting-started/migration.md
@@ -20,21 +20,6 @@ See the [Changelog](../changelog.md) for the full list of changes in each releas
 
 ## Upgrade 1.7 → 1.8
 
-### Removed
-
-!!! warning "Deprecated in v1.6 → Removed in v1.8: `simplify` and `force` arguments in `RFDETR.export()`"
-
-    **`RFDETR.export(..., simplify=..., force=...)`** — deprecated since v1.6.0, removed in v1.8.0.
-    Both were no-ops. Delete the kwargs from any `model.export(...)` call.
-
-    ```python
-    # Before (raises TypeError in v1.8.0)
-    model.export(output_dir="out/", simplify=True, force=True)
-
-    # After
-    model.export(output_dir="out/")
-    ```
-
 ### Breaking changes
 
 !!! warning "Breaking: `rfdetr.datasets.aug_config` renamed to `rfdetr.datasets.aug_configs`"
@@ -97,7 +82,7 @@ See the [Changelog](../changelog.md) for the full list of changes in each releas
     source = detections.metadata["source_image"]
     ```
 
-### Deprecated (removal in v1.9.0)
+### Deprecated in v1.7 → Remove in v1.9
 
 !!! note "Deprecated: `rfdetr.util.*` and `rfdetr.deploy.*` import paths"
 
@@ -200,7 +185,7 @@ See the [Changelog](../changelog.md) for the full list of changes in each releas
     train_config = TrainConfig(cls_loss_coef=2.0)
     ```
 
-### Deprecated (removal in v2.0.0)
+### Deprecated in v1.7 → Remove in v2.0
 
 !!! note "Deprecated: `RFDETRBase` replaced by size-specific classes"
 
@@ -222,21 +207,23 @@ See the [Changelog](../changelog.md) for the full list of changes in each releas
 
 !!! note "Deprecated: `RFDETRSegPreview` replaced by size-specific segmentation classes"
 
-    **`RFDETRSegPreview`** defaulted to the small variant and is replaced by size-specific
-    segmentation classes. If you used `RFDETRSegPreview()` without arguments, switch to
-    `RFDETRSegSmall()`.
+````
+**`RFDETRSegPreview`** defaulted to the small variant and is replaced by size-specific
+segmentation classes. If you used `RFDETRSegPreview()` without arguments, switch to
+`RFDETRSegSmall()`.
 
-    ```python
-    # Before (deprecated)
-    from rfdetr import RFDETRSegPreview
+```python
+# Before (deprecated)
+from rfdetr import RFDETRSegPreview
 
-    model = RFDETRSegPreview()
+model = RFDETRSegPreview()
 
-    # After — pick one
-    from rfdetr import RFDETRSegNano, RFDETRSegSmall, RFDETRSegMedium, RFDETRSegLarge
+# After — pick one
+from rfdetr import RFDETRSegNano, RFDETRSegSmall, RFDETRSegMedium, RFDETRSegLarge
 
-    model = RFDETRSegSmall()
-    ```
+model = RFDETRSegSmall()
+```
+````
 
 ---
 
@@ -290,22 +277,7 @@ See the [Changelog](../changelog.md) for the full list of changes in each releas
     img, polygon = draw_synthetic_shape(...)
     ```
 
-### Deprecated (removal in v1.8.0)
-
-!!! note "Deprecated in v1.6 → Removed in v1.8: `simplify` and `force` arguments in `RFDETR.export()`"
-
-    **`RFDETR.export(..., simplify=..., force=...)`** — both arguments are no-ops.
-    Remove them from your calls.
-
-    ```python
-    # Before (deprecated)
-    model.export("model.onnx", simplify=True, force=True)
-
-    # After
-    model.export("model.onnx")
-    ```
-
-### Deprecated (removal in v1.9.0, extended from v1.7.0)
+### Deprecated in v1.6 → Remove in v1.9
 
 !!! note "Deprecated: `rfdetr.deploy.*` moved to `rfdetr.export.*`"
 
@@ -352,7 +324,7 @@ See the [Changelog](../changelog.md) for the full list of changes in each releas
     config = ModelConfig()
     ```
 
-### Deprecated (removal in v1.7.0)
+### Deprecated in v1.5 → Remove in v1.7
 
 !!! note "Deprecated: `OPEN_SOURCE_MODELS` replaced by `ModelWeights` enum"
 

--- a/docs/getting-started/migration.md
+++ b/docs/getting-started/migration.md
@@ -34,16 +34,14 @@ See the [Changelog](../changelog.md) for the full list of changes in each releas
     from rfdetr.datasets.aug_configs import AUG_AGGRESSIVE
     ```
 
-    All preset constants (`AUG_AGGRESSIVE`, `AUG_MOSAIC`, etc.) are unchanged.
+    All preset constants (`AUG_AGGRESSIVE`, `AUG_CONSERVATIVE`, etc.) are unchanged.
 
-### Dependency updates
-
-!!! note "New minimum: `supervision>=0.29.0`"
+!!! warning "Breaking: `supervision>=0.29.0` now required"
 
     Required for `sv.KeyPoints` support. `pip install rfdetr==1.8.0` pulls this automatically.
     If another dependency pins `supervision<0.29.0`, resolve the conflict manually.
 
-!!! note "`pyDeprecate` constraint narrowed to `>=0.9,<0.10`"
+!!! warning "Breaking: `pyDeprecate` constraint narrowed to `>=0.9,<0.10`"
 
     Was `>=0.6,<0.8`. If another package pins an older version, resolve with:
 
@@ -82,52 +80,15 @@ See the [Changelog](../changelog.md) for the full list of changes in each releas
     source = detections.metadata["source_image"]
     ```
 
-### Deprecated in v1.7 → Remove in v1.9
+!!! warning "Breaking: `pyDeprecate` constraint changed to `>=0.6,<0.8`"
 
-!!! note "Deprecated: `rfdetr.util.*` and `rfdetr.deploy.*` import paths"
+    Was `>=0.3,<0.6`. If another package pins an older version, resolve with:
 
-    Backward-compatibility shims are still active but emit `DeprecationWarning` on import.
-    Replace with the canonical paths listed in the table below.
-
-    | Deprecated module                 | Canonical replacement              |
-    | --------------------------------- | ---------------------------------- |
-    | `rfdetr.util.coco_classes`        | `rfdetr.assets.coco_classes`       |
-    | `rfdetr.util.misc`                | `rfdetr.utilities`                 |
-    | `rfdetr.util.logger`              | `rfdetr.utilities.logger`          |
-    | `rfdetr.util.box_ops`             | `rfdetr.utilities.box_ops`         |
-    | `rfdetr.util.files`               | `rfdetr.utilities.files`           |
-    | `rfdetr.util.package`             | `rfdetr.utilities.package`         |
-    | `rfdetr.util.get_param_dicts`     | `rfdetr.training.param_groups`     |
-    | `rfdetr.util.drop_scheduler`      | `rfdetr.training.drop_schedule`    |
-    | `rfdetr.util.visualize`           | `rfdetr.visualize.data`            |
-    | `rfdetr.deploy`                   | `rfdetr.export`                    |
-    | `rfdetr.models.segmentation_head` | `rfdetr.models.heads.segmentation` |
-
-    **Examples:**
-
-    ```python
-    # Before (deprecated)
-    from rfdetr.util.coco_classes import COCO_CLASSES
-    from rfdetr.util.misc import get_rank, get_world_size, is_main_process, save_on_master
-    from rfdetr.util.logger import get_logger
-    from rfdetr.util.box_ops import box_cxcywh_to_xyxy, generalized_box_iou
-    from rfdetr.util.get_param_dicts import get_param_dict
-    from rfdetr.util.drop_scheduler import drop_scheduler
-    from rfdetr.util.visualize import save_gt_predictions_visualization
-    from rfdetr.deploy import export_onnx
-    from rfdetr.models.segmentation_head import SegmentationHead
-
-    # After
-    from rfdetr.assets.coco_classes import COCO_CLASSES
-    from rfdetr.utilities.distributed import get_rank, get_world_size, is_main_process, save_on_master
-    from rfdetr.utilities.logger import get_logger
-    from rfdetr.utilities.box_ops import box_cxcywh_to_xyxy, generalized_box_iou
-    from rfdetr.training.param_groups import get_param_dict
-    from rfdetr.training.drop_schedule import drop_scheduler
-    from rfdetr.visualize.data import save_gt_predictions_visualization
-    from rfdetr.export.main import export_onnx
-    from rfdetr.models.heads.segmentation import SegmentationHead
+    ```bash
+    pip install "rfdetr==1.7.0" "pyDeprecate>=0.6,<0.8"
     ```
+
+### Deprecated in v1.7 → Remove in v1.9
 
 !!! note "Deprecated: `build_namespace()` split into two functions"
 
@@ -277,30 +238,66 @@ model = RFDETRSegSmall()
     img, polygon = draw_synthetic_shape(...)
     ```
 
-### Deprecated in v1.6 → Remove in v1.9
+### Deprecated in v1.6 → Removed in v1.8
 
-!!! note "Deprecated: `rfdetr.deploy.*` moved to `rfdetr.export.*`"
+!!! note "Deprecated: `simplify` and `force` arguments in `RFDETR.export()`"
 
-    **`rfdetr.deploy.*`** — use `rfdetr.export.*`.
+    **`RFDETR.export(..., simplify=..., force=...)`** — both arguments are no-ops.
+    Remove them from your calls.
 
     ```python
     # Before (deprecated)
-    from rfdetr.deploy import export_onnx
+    model.export("model.onnx", simplify=True, force=True)
 
     # After
-    from rfdetr.export.main import export_onnx
+    model.export("model.onnx")
     ```
 
-!!! note "Deprecated: `rfdetr.util.*` moved to `rfdetr.utilities.*`"
+### Deprecated in v1.6 → Remove in v1.9
 
-    **`rfdetr.util.*`** — use `rfdetr.utilities.*`.
+!!! note "Deprecated: `rfdetr.util.*` and `rfdetr.deploy.*` import paths"
+
+    Backward-compatibility shims are still active but emit `DeprecationWarning` on import.
+    Replace with the canonical paths listed in the table below.
+
+    | Deprecated module                 | Canonical replacement              |
+    | --------------------------------- | ---------------------------------- |
+    | `rfdetr.util.coco_classes`        | `rfdetr.assets.coco_classes`       |
+    | `rfdetr.util.misc`                | `rfdetr.utilities`                 |
+    | `rfdetr.util.logger`              | `rfdetr.utilities.logger`          |
+    | `rfdetr.util.box_ops`             | `rfdetr.utilities.box_ops`         |
+    | `rfdetr.util.files`               | `rfdetr.utilities.files`           |
+    | `rfdetr.util.package`             | `rfdetr.utilities.package`         |
+    | `rfdetr.util.get_param_dicts`     | `rfdetr.training.param_groups`     |
+    | `rfdetr.util.drop_scheduler`      | `rfdetr.training.drop_schedule`    |
+    | `rfdetr.util.visualize`           | `rfdetr.visualize.data`            |
+    | `rfdetr.deploy`                   | `rfdetr.export`                    |
+    | `rfdetr.models.segmentation_head` | `rfdetr.models.heads.segmentation` |
+
+    **Examples:**
 
     ```python
     # Before (deprecated)
-    from rfdetr.util.misc import get_rank
+    from rfdetr.util.coco_classes import COCO_CLASSES
+    from rfdetr.util.misc import get_rank, get_world_size, is_main_process, save_on_master
+    from rfdetr.util.logger import get_logger
+    from rfdetr.util.box_ops import box_cxcywh_to_xyxy, generalized_box_iou
+    from rfdetr.util.get_param_dicts import get_param_dict
+    from rfdetr.util.drop_scheduler import drop_scheduler
+    from rfdetr.util.visualize import save_gt_predictions_visualization
+    from rfdetr.deploy import export_onnx
+    from rfdetr.models.segmentation_head import SegmentationHead
 
     # After
-    from rfdetr.utilities.distributed import get_rank
+    from rfdetr.assets.coco_classes import COCO_CLASSES
+    from rfdetr.utilities.distributed import get_rank, get_world_size, is_main_process, save_on_master
+    from rfdetr.utilities.logger import get_logger
+    from rfdetr.utilities.box_ops import box_cxcywh_to_xyxy, generalized_box_iou
+    from rfdetr.training.param_groups import get_param_dict
+    from rfdetr.training.drop_schedule import drop_scheduler
+    from rfdetr.visualize.data import save_gt_predictions_visualization
+    from rfdetr.export.main import export_onnx
+    from rfdetr.models.heads.segmentation import SegmentationHead
     ```
 
 ---
@@ -324,7 +321,7 @@ model = RFDETRSegSmall()
     config = ModelConfig()
     ```
 
-### Deprecated in v1.5 → Remove in v1.7
+### Deprecated in v1.5 → Removed in v1.7
 
 !!! note "Deprecated: `OPEN_SOURCE_MODELS` replaced by `ModelWeights` enum"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rfdetr"
-version = "1.8.0.rc2"
+version = "1.8.0"
 description = "RF-DETR"
 readme = "README.md"
 authors = [
@@ -42,7 +42,7 @@ dependencies = [
     "tqdm",                            # progress bars during weight download
     "transformers>=5.1.0,<6.0.0",     # DINOv2 backbone loading
     "pydantic>=2.0,<3",               # ModelConfig / TrainConfig validation
-    "supervision==0.29.0rc0",       # inference output (Detections, Masks)
+    "supervision>=0.29.0",       # inference output (Detections, Masks)
     "pyDeprecate>=0.9,<0.10",             # deprecation warnings for legacy APIs; >=0.6 for deprecated_class
 ]
 


### PR DESCRIPTION
# 🦅 RF-DETR 1.8.0: Keypoint Detection

## 📋 Summary

RF-DETR 1.8.0 introduces `RFDETRKeypointPreview` — a keypoint detection model that fits naturally into the same `.train()` / `.predict()` workflow you already know. It ships with COCO keypoint AP evaluation out of the box, and its predictions include per-keypoint uncertainty estimates alongside coordinates and visibility scores. This release also fixes loss scaling for gradient accumulation in keypoint training, adds `export_for_roboflow` for creating offline upload bundles, and ships five checkpoint and device-detection reliability fixes. The long-deprecated `simplify` and `force` kwargs are removed from `RFDETR.export`.

## ✨ Spotlights

### 🎯 Keypoint detection — `RFDETRKeypointPreview`

`RFDETRKeypointPreview` brings keypoint detection to RF-DETR with the same interface you use for object detection and segmentation. It produces `sv.KeyPoints` predictions carrying per-detection keypoint coordinates, visibility scores, and covariance matrices you can use to reason about prediction uncertainty.

The `Preview` in the name signals this is an early-access capability — the API and model behavior are stable enough for experimentation and real projects, but expect continued iteration based on community feedback before it graduates to a non-preview release.

```python
from rfdetr import RFDETRKeypointPreview
from rfdetr.config import KeypointTrainConfig
from rfdetr.datasets._keypoint_schema import infer_coco_keypoint_schema

schema = infer_coco_keypoint_schema("dataset/train/_annotations.coco.json")

model = RFDETRKeypointPreview()
model.train(
    dataset_dir="dataset/",
    config=KeypointTrainConfig(epochs=50, batch_size=8, keypoint_schema=schema),
)

results = model.predict("image.jpg")
print(results.xy)  # (N, K, 2) keypoint coordinates
print(results.keypoint_confidence)  # (N, K) per-keypoint visibility
```

To visualize prediction uncertainty as pixel-space ellipses, convert the stored covariance matrices:

```python
from rfdetr.utilities.keypoints import precision_cholesky_to_pixel_covariance

cov = precision_cholesky_to_pixel_covariance(
    results.data["covariance"],
    source_shape=image.shape[:2],
)  # (N, K, 2, 2)
```

New public APIs: `KeypointTrainConfig`, `RFDETRKeypointPreviewConfig` from `rfdetr.config`; `precision_cholesky_to_pixel_covariance` from `rfdetr.utilities`; schema helpers `infer_coco_keypoint_schema`, `CocoKeypointSchema`, `active_keypoint_counts` from `rfdetr.datasets._keypoint_schema`. There's also a fine-tuning cookbook (`docs/cookbooks/fine-tune_keypoints.ipynb`) with an end-to-end walkthrough covering dataset setup, schema inference, training, and inference with uncertainty.

### 🔧 Gradient accumulation fix for keypoint training

If you train keypoint models with `accumulate_grad_batches > 1`, losses were previously normalized per mini-batch instead of across the full effective batch. This is now fixed automatically — no code changes needed.

```python
# Losses now correctly normalized over the full effective batch
# (batch_size × accumulate_grad_batches)
model.train(
    dataset_dir="dataset/",
    config=KeypointTrainConfig(batch_size=4, accumulate_grad_batches=4),
)
```

Object detection and segmentation models are not affected.

### 📦 Local Roboflow bundle export — `RFDETR.export_for_roboflow`

Creates a self-contained Roboflow upload bundle (`weights.pt` + `class_names.txt`) on disk without making any network calls. Useful for air-gapped environments or reviewing the bundle before uploading.

```python
model.export_for_roboflow("roboflow_upload/")
# → roboflow_upload/weights.pt
# → roboflow_upload/class_names.txt
```

Existing `deploy_to_roboflow()` calls work unchanged — they now delegate to this method internally.

## ⚠️ Migration guide

Full guide: [rfdetr.roboflow.com/latest/getting-started/migration/](https://rfdetr.roboflow.com/latest/getting-started/migration/)

### ❌ Remove deperacted `simplify` and `force` from `RFDETR.export` calls

Both kwargs were deprecated in v1.6.0 and are removed in v1.8.0. They were no-ops throughout their deprecation period.

```python
# Before (DeprecationWarning since v1.6.0):
model.export(output_dir="out/", simplify=True, force=True)

# After:
model.export(output_dir="out/")
```

### 📝 `rfdetr.datasets.aug_config` → `rfdetr.datasets.aug_configs`

The module name changed from singular to plural. If you import from it directly:

```python
# Before:
from rfdetr.datasets.aug_config import AUG_AGGRESSIVE

# After:
from rfdetr.datasets.aug_configs import AUG_AGGRESSIVE
```

All preset constants (`AUG_AGGRESSIVE`, `AUG_MOSAIC`, etc.) are unchanged.

### 🔗 Dependency updates

- `supervision>=0.29.0` is now required (for `sv.KeyPoints` support).
- `pyDeprecate` constraint narrowed to `>=0.9,<0.10` (was `>=0.6,<0.8`). Update your environment if you're pinned to the older range.

## 📝 Notable changes

### 🚀 Added

- **`RFDETRKeypointPreview`** — keypoint detection with covariance-based uncertainty and COCO keypoint AP evaluation. ([#1099](https://github.com/roboflow/rf-detr/pull/1099))
- **`MetricKeypointOKS`** — reusable OKS metric exported from `rfdetr.evaluation`. Supports arbitrary keypoint counts, per-category sigmas, and multi-GPU evaluation. ([#1107](https://github.com/roboflow/rf-detr/pull/1107))
- **`RFDETR.export_for_roboflow(output_dir)`** — local Roboflow bundle without a network call; `deploy_to_roboflow` delegates to this. ([#1086](https://github.com/roboflow/rf-detr/pull/1086))
- **Keypoint fine-tuning cookbook** (`docs/cookbooks/fine-tune_keypoints.ipynb`) — end-to-end walkthrough: dataset download, schema inference, training, and inference with uncertainty. ([#1104](https://github.com/roboflow/rf-detr/pull/1104))

### 🌱 Changed

- **DDP strategy** — `find_unused_parameters=True` is now set unconditionally for all model variants under `strategy='ddp'` or `'auto'`. Previously only segmentation set this flag. To opt out: `trainer_kwargs={"strategy": DDPStrategy(find_unused_parameters=False)}`. ([#1094](https://github.com/roboflow/rf-detr/pull/1094))
- **`rfdetr.datasets.aug_config` renamed to `rfdetr.datasets.aug_configs`** — update any direct imports; all constants are unchanged. ([#1103](https://github.com/roboflow/rf-detr/pull/1103))

### 🗑️ Removed

- **`RFDETR.export(simplify=..., force=...)`** — removed after deprecation since v1.6.0; both were no-ops. ([#1102](https://github.com/roboflow/rf-detr/pull/1102))

### 🔧 Fixed

- **Gradient accumulation for keypoint training** — loss scaling now correct across the accumulated effective batch. ([#1117](https://github.com/roboflow/rf-detr/pull/1117))
- **`from_checkpoint()` fine-tuning on a different class count** — checkpoint-derived class count no longer overrides user intent; fine-tuning on a different class count now adapts the head correctly. ([#1106](https://github.com/roboflow/rf-detr/pull/1106))
- **Explicit `num_classes` honored when it equals the default** — passing `num_classes=N` where `N` matches the model default was previously ignored; the explicit value is now always respected. ([#1109](https://github.com/roboflow/rf-detr/pull/1109))
- **`from_checkpoint()` with starter checkpoints** — model variant is now inferred from the checkpoint filename when `pretrain_weights` is absent or unset. ([#1065](https://github.com/roboflow/rf-detr/pull/1065))
- **Device auto-detection** — accelerator availability is now verified before selecting a device; prevents assigning CUDA on machines that have the CUDA headers installed but no driver. ([#1111](https://github.com/roboflow/rf-detr/pull/1111))
- **Spurious warning on keypoint datasets** — a false mismatch warning triggered on custom datasets when auto-adjusting `num_classes` beyond the schema length is now suppressed. ([#1113](https://github.com/roboflow/rf-detr/pull/1113))
- Scale jitter restored in non-square training crop. ([#1088](https://github.com/roboflow/rf-detr/pull/1088))
- Multi-GPU validation deadlock in COCO mAP sync across zero-batch ranks. ([#1085](https://github.com/roboflow/rf-detr/pull/1085))
- `import rfdetr` no longer fails on NumPy 2.x alongside dependencies that reference `np.complex_`. ([#1064](https://github.com/roboflow/rf-detr/pull/1064))
- `rfdetr_plus` availability check corrected — false-positive when the package is partially installed. ([#1083](https://github.com/roboflow/rf-detr/pull/1083))

---

## 🏆 Contributors

- **Jirka Borovec** (@Borda, [LinkedIn](https://linkedin.com/in/jirka-borovec)) — keypoint detection pipeline, gradient accumulation fix, OKS metric, release
- **Anatoly Ryabchenko** (@anatoly-ryabchenko) — checkpoint reliability improvements (class count handling, device detection)
- **Aaryan Kangte** (@Aaryan562, [LinkedIn](https://www.linkedin.com/in/aaryan-kangte-096686225/)) — multi-GPU validation deadlock fix
- **Dohyeon Yoon** (@dohyeonYoon, [LinkedIn](https://www.linkedin.com/in/dh-yoon/)) — DDP `find_unused_parameters` fix
- **Lee Clement** (@leeclemnet, [LinkedIn](https://www.linkedin.com/in/leeclemnet)) — `export_for_roboflow` extraction

---

**Full changelog**: https://github.com/roboflow/rf-detr/compare/1.7.0...1.8.0
