### PR TITLE
remove deprecated API scheduled for `1.8.0`

### DIFF
--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -18,7 +18,7 @@ from collections.abc import Callable
 from copy import copy, deepcopy
 from functools import wraps
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Concatenate, Optional, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Any, Concatenate, ParamSpec, TypeVar
 
 import numpy as np
 import requests
@@ -34,7 +34,6 @@ from rfdetr.datasets._keypoint_schema import active_keypoint_counts, infer_coco_
 from rfdetr.datasets.coco import is_valid_coco_dataset
 from rfdetr.datasets.yolo import is_valid_yolo_dataset
 from rfdetr.inference import ModelContext, _build_model_context
-from rfdetr.utilities.decorators import deprecated
 from rfdetr.utilities.distributed import is_main_process
 from rfdetr.utilities.keypoints import precision_cholesky_to_pixel_covariance
 from rfdetr.utilities.logger import get_logger
@@ -884,23 +883,13 @@ class RFDETR:
         self._optimized_resolution = None
         self._optimized_dtype = None
 
-    @deprecated(
-        target=True,
-        # `simplify` / `force` are retained for API compatibility and treated as no-op.
-        args_mapping={"simplify": None, "force": None},
-        deprecated_in="1.6.0",
-        remove_in="1.8.0",
-        num_warns=1,
-    )
     def export(
         self,
         output_dir: str = "output",
         infer_dir: str = None,
-        simplify: Optional[bool] = None,
         backbone_only: bool = False,
         opset_version: int = 17,
         verbose: bool = True,
-        force: Optional[bool] = None,
         shape: tuple[int, int] | None = None,
         batch_size: int = 1,
         dynamic_batch: bool = False,
@@ -919,11 +908,9 @@ class RFDETR:
         Args:
             output_dir: Directory to write the exported model to.
             infer_dir: Optional directory of sample images for dynamic-axes inference.
-            simplify: Deprecated and ignored. Simplification is no longer run.
             backbone_only: Export only the backbone (feature extractor).
             opset_version: ONNX opset version to target.
             verbose: Print export progress information.
-            force: Deprecated and ignored.
             shape: ``(height, width)`` tuple; defaults to square at model resolution.
                 Both dimensions must be divisible by ``patch_size * num_windows``.
             batch_size: Static batch size to bake into the ONNX graph.

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -886,7 +886,7 @@ class RFDETR:
     def export(
         self,
         output_dir: str = "output",
-        infer_dir: str = None,
+        infer_dir: str | None = None,
         backbone_only: bool = False,
         opset_version: int = 17,
         verbose: bool = True,

--- a/src/rfdetr/export/main.py
+++ b/src/rfdetr/export/main.py
@@ -181,11 +181,6 @@ def main(args):
         variant_name=getattr(args, "variant_name", None),
     )
 
-    if args.simplify:
-        logger.warning(
-            "The simplify flag is deprecated and ignored. RF-DETR no longer runs ONNX simplification automatically."
-        )
-
     onnx_path = output_file  # preserve ONNX path before any post-processing step overwrites it
 
     if args.tensorrt:

--- a/tests/models/test_export.py
+++ b/tests/models/test_export.py
@@ -111,7 +111,7 @@ def test_segmentation_model_export_no_crash(tmp_path: Path) -> None:
 
     # This should not crash with "AttributeError: 'dict' object has no attribute 'shape'"
     with ignore_tracer_warnings():
-        model.export(output_dir=str(tmp_path), simplify=False, verbose=False)
+        model.export(output_dir=str(tmp_path), verbose=False)
 
     # Verify export produced output files
     onnx_files = list(tmp_path.glob("*.onnx"))
@@ -138,44 +138,10 @@ def test_export_does_not_change_original_training_state(tmp_path: Path) -> None:
 
     # Call export() on the high-level model; this should not change the original model's mode
     with ignore_tracer_warnings():
-        model.export(output_dir=str(tmp_path), simplify=False)
+        model.export(output_dir=str(tmp_path))
 
     # After export, the original underlying model should still be in training mode
     assert torch_model.training is True, "export() should not change the original model's training state"
-
-
-@pytest.fixture
-def _detr_export_scaffold(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
-    """Shared scaffold for RFDETR.export() deprecated-argument tests."""
-
-    model = types.SimpleNamespace(
-        model=types.SimpleNamespace(
-            model=_DummyCoreModel(),
-            device="cpu",
-            resolution=14,
-        ),
-        model_config=types.SimpleNamespace(
-            segmentation_head=False,
-            use_grouppose_keypoints=False,
-            num_channels=3,
-        ),
-        size=None,
-    )
-
-    export_called: dict[str, bool] = {"value": False}
-
-    def _fake_make_infer_image(*_args, **_kwargs):
-        return torch.zeros(1, 3, 14, 14)
-
-    def _fake_export_onnx(*_args, **_kwargs):
-        export_called["value"] = True
-        return str(tmp_path / "inference_model.onnx")
-
-    monkeypatch.setattr("rfdetr.export.main.make_infer_image", _fake_make_infer_image)
-    monkeypatch.setattr("rfdetr.export.main.export_onnx", _fake_export_onnx)
-    monkeypatch.setattr("rfdetr.detr.deepcopy", lambda x: x)
-
-    return model, export_called
 
 
 @pytest.mark.parametrize(
@@ -235,22 +201,6 @@ def test_rfdetr_export_dynamic_batch_forwards_dynamic_axes(
     assert set(dynamic_axes.keys()) == expected_names, f"expected keys {expected_names}, got {set(dynamic_axes.keys())}"
 
 
-def test_export_simplify_flag_is_ignored_with_deprecation_warning(_detr_export_scaffold: tuple, tmp_path: Path) -> None:
-    """`simplify=True` should not run ONNX simplification and should emit a deprecation warning."""
-    model, export_called = _detr_export_scaffold
-    with pytest.deprecated_call(match=r".*`export`.*deprecated.*`simplify`.*"):
-        _detr_module.RFDETR.export(model, output_dir=str(tmp_path), simplify=True, verbose=False, shape=(14, 14))
-    assert export_called["value"] is True
-
-
-def test_export_force_flag_is_ignored_with_deprecation_warning(_detr_export_scaffold: tuple, tmp_path: Path) -> None:
-    """`force=True` should be a no-op and emit a deprecation warning."""
-    model, export_called = _detr_export_scaffold
-    with pytest.deprecated_call(match=r".*`export`.*deprecated.*`force`.*"):
-        _detr_module.RFDETR.export(model, output_dir=str(tmp_path), force=True, verbose=False, shape=(14, 14))
-    assert export_called["value"] is True
-
-
 @pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 @pytest.mark.parametrize("mode", ["train", "eval"], ids=["train_mode", "eval_mode"])
@@ -307,7 +257,6 @@ class TestCliExportMain:
         batch_size: int = 1,
         verbose: bool = False,
         opset_version: int = 17,
-        simplify: bool = False,
         tensorrt: bool = False,
         dynamic_batch: bool = False,
     ) -> types.SimpleNamespace:
@@ -324,7 +273,6 @@ class TestCliExportMain:
             batch_size=batch_size,
             verbose=verbose,
             opset_version=opset_version,
-            simplify=simplify,
             tensorrt=tensorrt,
             dynamic_batch=dynamic_batch,
         )
@@ -477,46 +425,6 @@ class TestCliExportMain:
             f"expected opset_version={args.opset_version!r}, got {kwargs.get('opset_version')!r}"
         )
         assert "backbone_only" in kwargs, "backbone_only kwarg missing from export_onnx call"
-
-    def test_simplify_flag_logs_warning_and_continues_export(self, output_dir: str) -> None:
-        """CLI --simplify=True must log a deprecation warning and still call export_onnx.
-
-        The flag is now a no-op: the logger emits a warning and export continues without running ONNX simplification.
-        """
-        args = self._make_args(output_dir=output_dir, simplify=True)
-        export_onnx_called: dict[str, bool] = {"value": False}
-
-        mock_model = MagicMock()
-        mock_model.parameters.return_value = []
-        mock_model.backbone.parameters.return_value = []
-        mock_model.backbone.__getitem__.return_value.projector.parameters.return_value = []
-        mock_model.backbone.__getitem__.return_value.encoder.parameters.return_value = []
-        mock_model.transformer.parameters.return_value = []
-        mock_model.to.return_value = mock_model
-        mock_model.cpu.return_value = mock_model
-        mock_model.eval.return_value = mock_model
-        mock_model.return_value = {"pred_boxes": torch.zeros(1, 300, 4), "pred_logits": torch.zeros(1, 300, 90)}
-
-        mock_tensor = MagicMock()
-        mock_tensor.to.return_value = mock_tensor
-        mock_tensor.cpu.return_value = mock_tensor
-
-        def fake_export_onnx(*_args, **_kwargs):
-            export_onnx_called["value"] = True
-            return str(output_dir) + "/inference_model.onnx"
-
-        with (
-            patch.object(_cli_export_module, "build_model", return_value=(mock_model, MagicMock(), MagicMock())),
-            patch.object(_cli_export_module, "make_infer_image", return_value=mock_tensor),
-            patch.object(_cli_export_module, "export_onnx", side_effect=fake_export_onnx),
-            patch.object(_cli_export_module, "get_rank", return_value=0),
-            patch.object(_cli_export_module, "logger") as mock_logger,
-        ):
-            _cli_export_module.main(args)
-
-        mock_logger.warning.assert_called_once()
-        assert "simplify" in mock_logger.warning.call_args[0][0].lower()
-        assert export_onnx_called["value"] is True, "export_onnx should still be called with simplify=True"
 
     @pytest.mark.parametrize(
         "dynamic_batch, segmentation_head, backbone_only",


### PR DESCRIPTION
Scheduled for removal in v1.8.0 (deprecated since v1.6.0). Both args were no-ops — dropped from RFDETR.export() signature, docstring, and @deprecated decorator; unused `deprecated` import removed from detr.py. Removed matching CLI warning block in export/main.py. Deleted three deprecated-arg tests, their fixture, and CLI simplify test.
