### PR TITLE
refine(eval): add MetricKeypointOKS facade over CocoEvaluator

### DIFF
--- a/src/rfdetr/evaluation/__init__.py
+++ b/src/rfdetr/evaluation/__init__.py
@@ -5,6 +5,20 @@
 # ------------------------------------------------------------------------
 """Framework-agnostic evaluation utilities for RF-DETR."""
 
-from rfdetr.evaluation.keypoint_oks import MetricKeypointOKS
+from rfdetr.evaluation.keypoint_oks import (
+    DEFAULT_KEYPOINT_MAX_DETS,
+    METRIC_KEY_MAP,
+    METRIC_KEY_MAP_50,
+    METRIC_KEY_MAP_75,
+    METRIC_KEY_MAR,
+    MetricKeypointOKS,
+)
 
-__all__ = ["MetricKeypointOKS"]
+__all__ = [
+    "DEFAULT_KEYPOINT_MAX_DETS",
+    "METRIC_KEY_MAP",
+    "METRIC_KEY_MAP_50",
+    "METRIC_KEY_MAP_75",
+    "METRIC_KEY_MAR",
+    "MetricKeypointOKS",
+]

--- a/src/rfdetr/evaluation/__init__.py
+++ b/src/rfdetr/evaluation/__init__.py
@@ -7,18 +7,12 @@
 
 from rfdetr.evaluation.keypoint_oks import (
     DEFAULT_KEYPOINT_MAX_DETS,
-    METRIC_KEY_MAP,
-    METRIC_KEY_MAP_50,
-    METRIC_KEY_MAP_75,
-    METRIC_KEY_MAR,
     MetricKeypointOKS,
+    OKSKey,
 )
 
 __all__ = [
     "DEFAULT_KEYPOINT_MAX_DETS",
-    "METRIC_KEY_MAP",
-    "METRIC_KEY_MAP_50",
-    "METRIC_KEY_MAP_75",
-    "METRIC_KEY_MAR",
+    "OKSKey",
     "MetricKeypointOKS",
 ]

--- a/src/rfdetr/evaluation/__init__.py
+++ b/src/rfdetr/evaluation/__init__.py
@@ -4,3 +4,7 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 """Framework-agnostic evaluation utilities for RF-DETR."""
+
+from rfdetr.evaluation.keypoint_oks import MetricKeypointOKS
+
+__all__ = ["MetricKeypointOKS"]

--- a/src/rfdetr/evaluation/coco_eval.py
+++ b/src/rfdetr/evaluation/coco_eval.py
@@ -423,6 +423,20 @@ class CocoEvaluator:
         this deduplication, padded images produce duplicate DT entries that compete for
         the per-image ``maxDets`` cap and bias mAP upward in early epochs then downward
         as genuine new detections are displaced — the "peak-then-decrease" pattern.
+
+        Contract:
+            This method assumes that when the same ``image_id`` appears on multiple ranks
+            its predictions are *identical* (DDP-padding duplicates).  It is **not** safe
+            for evaluation strategies where independent predictions for the same image are
+            produced on different ranks, because only the first rank's predictions are kept
+            and the rest are silently discarded.
+
+        Single-process path:
+            When ``all_gather`` is called in a non-distributed context it returns a
+            single-element list ``[x]``, so ``rank_idx`` is always 0 and every result
+            passes the ownership check unchanged — the dedup loop is a no-op and all
+            results are preserved.  This makes the method safe for single-GPU and ONNX/TRT
+            benchmark use via :mod:`rfdetr.export.benchmark`.
         """
         gathered_img_ids = all_gather(self.img_ids)
         # First rank to report an image_id owns it; all other ranks' predictions for

--- a/src/rfdetr/evaluation/coco_eval.py
+++ b/src/rfdetr/evaluation/coco_eval.py
@@ -415,12 +415,32 @@ class CocoEvaluator:
             self.coco_results[iou_type].extend(results)
 
     def synchronize_between_processes(self) -> None:
-        """Merge image IDs and COCO result records across distributed processes."""
+        """Merge image IDs and COCO result records across distributed processes.
+
+        Each image ID is assigned to exactly one rank (first rank that reports it), so
+        predictions for images that appear on multiple ranks due to
+        ``DistributedSampler(drop_last=False)`` padding are included only once.  Without
+        this deduplication, padded images produce duplicate DT entries that compete for
+        the per-image ``maxDets`` cap and bias mAP upward in early epochs then downward
+        as genuine new detections are displaced — the "peak-then-decrease" pattern.
+        """
         gathered_img_ids = all_gather(self.img_ids)
-        self.img_ids = sorted({image_id for rank_img_ids in gathered_img_ids for image_id in rank_img_ids})
+        # First rank to report an image_id owns it; all other ranks' predictions for
+        # that image_id are dropped (they are identical copies from DDP padding).
+        img_id_to_rank: dict[int, int] = {}
+        for rank_idx, rank_img_ids in enumerate(gathered_img_ids):
+            for img_id in rank_img_ids:
+                if img_id not in img_id_to_rank:
+                    img_id_to_rank[img_id] = rank_idx
+        self.img_ids = sorted(img_id_to_rank.keys())
         for iou_type in self.iou_types:
             gathered_results = all_gather(self.coco_results[iou_type])
-            self.coco_results[iou_type] = [result for rank_results in gathered_results for result in rank_results]
+            deduped: list[dict[str, Any]] = []
+            for rank_idx, rank_results in enumerate(gathered_results):
+                for result in rank_results:
+                    if img_id_to_rank.get(result["image_id"]) == rank_idx:
+                        deduped.append(result)
+            self.coco_results[iou_type] = deduped
 
     def accumulate(self) -> None:
         """Accumulate per-image evaluation results into mean metrics."""

--- a/src/rfdetr/evaluation/keypoint_oks.py
+++ b/src/rfdetr/evaluation/keypoint_oks.py
@@ -9,6 +9,25 @@ from typing import Any
 
 from rfdetr.evaluation.coco_eval import CocoEvaluator
 
+# Default maximum detections per image for keypoint evaluation.
+# Shared between MetricKeypointOKS and COCOEvalCallback so the value has one source of truth.
+# Note: for keypoint iou_type the underlying COCO evaluator overrides maxDets to [20]
+# regardless of this value.
+DEFAULT_KEYPOINT_MAX_DETS = 500
+
+# Keys returned by :meth:`MetricKeypointOKS.compute`.
+# Defined as module-level constants so callers can reference them symbolically rather
+# than depending on bare string literals — guards against silent misses from future renames.
+METRIC_KEY_MAP = "map"
+METRIC_KEY_MAP_50 = "map_50"
+METRIC_KEY_MAP_75 = "map_75"
+METRIC_KEY_MAR = "mar"
+
+# Expected shape of pycocotools _summarizeKps() output.  The keypoint stats array is
+# always (10,): AP@50:95 (idx 0), AP@50 (1), AP@75 (2), AP-medium (3), AP-large (4),
+# AR@50:95 (5), AR@50 (6), AR@75 (7), AR-medium (8), AR-large (9).
+_KPS_STATS_SHAPE = (10,)
+
 
 class MetricKeypointOKS:
     """OKS keypoint mAP metric backed by CocoEvaluator.
@@ -28,15 +47,23 @@ class MetricKeypointOKS:
     When TorchMetrics ships production-quality arbitrary-keypoint support (tracked
     in upstream PR #3348), the internals of :meth:`compute` can delegate to
     ``MeanAveragePrecision(iou_type="keypoints", keypoint_format="xyv")`` without
-    any change to callers.
+    any change to callers.  Note: when migrating, ``"mar"`` will need remapping to
+    ``"mar_<max_dets>"`` as TorchMetrics uses a suffixed key name.
 
     Args:
-        coco_gt: COCO ground-truth object (any type accepted by
-            :class:`~rfdetr.evaluation.coco_eval.CocoEvaluator`).
+        coco_gt: Ground-truth COCO object.  Accepted types: :class:`faster_coco_eval.COCO`
+            or any object with a ``.dataset`` dict and optional ``.label2cat`` mapping
+            (the duck-typed surface required by :class:`~rfdetr.evaluation.coco_eval.CocoEvaluator`).
         keypoint_oks_sigmas: Per-keypoint OKS sigmas. When ``None``, falls back to
             COCO person sigmas for 17-keypoint datasets or a uniform 0.05 sigma for
             other counts.
-        max_dets: Maximum detections per image. Defaults to 500.
+        max_dets: Maximum detections per image passed to the underlying
+            :class:`~rfdetr.evaluation.coco_eval.CocoEvaluator`.  Defaults to 500.
+
+            Note:
+                For keypoint evaluation the underlying COCO evaluator overrides
+                ``maxDets`` to ``[20]`` regardless of this value — this parameter
+                is forwarded but has no effect on keypoint evaluation.
 
     Examples:
         >>> from unittest.mock import MagicMock
@@ -50,7 +77,7 @@ class MetricKeypointOKS:
         self,
         coco_gt: Any,
         keypoint_oks_sigmas: list[float] | None = None,
-        max_dets: int = 500,
+        max_dets: int = DEFAULT_KEYPOINT_MAX_DETS,
     ) -> None:
         self._coco_gt = coco_gt
         self._keypoint_oks_sigmas = keypoint_oks_sigmas
@@ -59,6 +86,10 @@ class MetricKeypointOKS:
         # Using a list preserves all predictions when the same image_id appears in
         # multiple batches (e.g. DDP DistributedSampler padding), matching the
         # original CocoEvaluator.update()-per-batch append semantics.
+        # Note: raw per-batch tensors are buffered here until compute(); for large
+        # validation sets this accumulates ~400 MB of resident memory per rank.
+        # Future optimisation: convert to compact COCO result dicts in update() and
+        # replay those in compute() instead.
         self._batches: list[dict[int, dict[str, Any]]] = []
 
     @property
@@ -127,17 +158,22 @@ class MetricKeypointOKS:
         and accumulates COCO keypoint statistics.
 
         Returns:
-            Dict with float values for keys ``"map"`` (mAP@50:95), ``"map_50"``
-            (AP@50), ``"map_75"`` (AP@75), and ``"mar"`` (AR@50:95).  Any
-            unavailable statistic is reported as ``-1.0``.
+            Dict with float values for keys :data:`METRIC_KEY_MAP` (mAP@50:95),
+            :data:`METRIC_KEY_MAP_50` (AP@50), :data:`METRIC_KEY_MAP_75` (AP@75),
+            and :data:`METRIC_KEY_MAR` (AR@50:95).  A value of ``-1.0`` indicates
+            the statistic was not available (e.g. no predictions matched any ground-truth
+            annotation).  Callers should filter ``value < 0`` before logging.
 
         Examples:
             >>> from unittest.mock import MagicMock, patch
             >>> import numpy as np
             >>> metric = MetricKeypointOKS(MagicMock(), max_dets=500)
             >>> fake_eval = MagicMock()
-            >>> fake_eval.coco_eval = {"keypoints": MagicMock(stats=np.array([0.5, 0.7, 0.4, -1, -1, 0.6]))}
+            >>> fake_eval.coco_eval = {
+            ...     "keypoints": MagicMock(stats=np.array([0.5, 0.7, 0.4, -1, -1, 0.6, -1, -1, -1, -1]))
+            ... }
             >>> with patch("rfdetr.evaluation.keypoint_oks.CocoEvaluator", return_value=fake_eval):
+            ...     metric.update({1: {}})
             ...     result = metric.compute()
             >>> result["map"]
             0.5
@@ -156,9 +192,13 @@ class MetricKeypointOKS:
         evaluator.synchronize_between_processes()
         evaluator.accumulate()
         stats = evaluator.coco_eval["keypoints"].stats
+        assert stats.shape == _KPS_STATS_SHAPE, (
+            f"Expected coco keypoint stats shape {_KPS_STATS_SHAPE}, got {stats.shape}; "
+            "pycocotools _summarizeKps() contract violated — check faster_coco_eval version"
+        )
         return {
-            "map": float(stats[0]) if len(stats) > 0 else -1.0,
-            "map_50": float(stats[1]) if len(stats) > 1 else -1.0,
-            "map_75": float(stats[2]) if len(stats) > 2 else -1.0,
-            "mar": float(stats[5]) if len(stats) > 5 else -1.0,
+            METRIC_KEY_MAP: float(stats[0]),
+            METRIC_KEY_MAP_50: float(stats[1]),
+            METRIC_KEY_MAP_75: float(stats[2]),
+            METRIC_KEY_MAR: float(stats[5]),
         }

--- a/src/rfdetr/evaluation/keypoint_oks.py
+++ b/src/rfdetr/evaluation/keypoint_oks.py
@@ -5,11 +5,32 @@
 # ------------------------------------------------------------------------
 """OKS keypoint mAP metric backed by :class:`~rfdetr.evaluation.coco_eval.CocoEvaluator`."""
 
+from enum import Enum
 from typing import Any
 
 import torch
 
 from rfdetr.evaluation.coco_eval import CocoEvaluator
+
+
+class OKSKey(str, Enum):
+    """Keys returned by :meth:`MetricKeypointOKS.compute`.
+
+    Subclasses :class:`str` so enum members compare equal to their string values
+    and can be used interchangeably as dict keys — ``stats[OKSKey.MAP]`` and
+    ``stats["map"]`` both work.
+
+    Examples:
+        >>> OKSKey.MAP == "map"
+        True
+        >>> OKSKey.MAP_50.value
+        'map_50'
+    """
+
+    MAP = "map"
+    MAP_50 = "map_50"
+    MAP_75 = "map_75"
+    MAR = "mar"
 
 
 def _sanitize_preds(predictions: dict[int, dict[str, Any]]) -> dict[int, dict[str, Any]]:
@@ -47,14 +68,6 @@ def _sanitize_preds(predictions: dict[int, dict[str, Any]]) -> dict[int, dict[st
 # evaluator unconditionally overrides maxDets to ``[20]`` regardless of this value
 # — this constant has no effect on keypoint AP/AR.
 DEFAULT_KEYPOINT_MAX_DETS = 500
-
-# Keys returned by :meth:`MetricKeypointOKS.compute`.
-# Defined as module-level constants so callers can reference them symbolically rather
-# than depending on bare string literals — guards against silent misses from future renames.
-METRIC_KEY_MAP = "map"
-METRIC_KEY_MAP_50 = "map_50"
-METRIC_KEY_MAP_75 = "map_75"
-METRIC_KEY_MAR = "mar"
 
 # Expected shape of pycocotools _summarizeKps() output.  The keypoint stats array is
 # always (10,): AP@50:95 (idx 0), AP@50 (1), AP@75 (2), AP-medium (3), AP-large (4),
@@ -231,8 +244,8 @@ class MetricKeypointOKS:
             "pycocotools _summarizeKps() contract violated — check faster_coco_eval version"
         )
         return {
-            METRIC_KEY_MAP: float(stats[0]),
-            METRIC_KEY_MAP_50: float(stats[1]),
-            METRIC_KEY_MAP_75: float(stats[2]),
-            METRIC_KEY_MAR: float(stats[5]),
+            OKSKey.MAP: float(stats[0]),
+            OKSKey.MAP_50: float(stats[1]),
+            OKSKey.MAP_75: float(stats[2]),
+            OKSKey.MAR: float(stats[5]),
         }

--- a/src/rfdetr/evaluation/keypoint_oks.py
+++ b/src/rfdetr/evaluation/keypoint_oks.py
@@ -55,26 +55,30 @@ class MetricKeypointOKS:
         self._coco_gt = coco_gt
         self._keypoint_oks_sigmas = keypoint_oks_sigmas
         self._max_dets = max_dets
-        self._preds: dict[int, dict[str, Any]] = {}
+        # List of per-batch prediction dicts — NOT merged into a single dict.
+        # Using a list preserves all predictions when the same image_id appears in
+        # multiple batches (e.g. DDP DistributedSampler padding), matching the
+        # original CocoEvaluator.update()-per-batch append semantics.
+        self._batches: list[dict[int, dict[str, Any]]] = []
 
     @property
     def has_updates(self) -> bool:
         """Return whether any predictions have been accumulated since last reset.
 
         Returns:
-            ``True`` if :meth:`update` has been called with at least one non-empty
-            prediction dict since the last :meth:`reset`.
+            ``True`` if :meth:`update` has been called at least once since the
+            last :meth:`reset`.
 
         Examples:
             >>> from unittest.mock import MagicMock
             >>> metric = MetricKeypointOKS(MagicMock())
             >>> metric.has_updates
             False
-            >>> metric._preds[1] = {}
+            >>> metric.update({1: {}})
             >>> metric.has_updates
             True
         """
-        return bool(self._preds)
+        return bool(self._batches)
 
     def reset(self) -> None:
         """Clear accumulated predictions.
@@ -82,15 +86,19 @@ class MetricKeypointOKS:
         Examples:
             >>> from unittest.mock import MagicMock
             >>> metric = MetricKeypointOKS(MagicMock())
-            >>> metric._preds[0] = {}
+            >>> metric.update({1: {}})
             >>> metric.reset()
             >>> metric.has_updates
             False
         """
-        self._preds.clear()
+        self._batches.clear()
 
     def update(self, predictions: dict[int, dict[str, Any]]) -> None:
         """Accumulate per-batch predictions.
+
+        Each call appends one batch; predictions are replayed in order inside
+        :meth:`compute`.  Predictions for the same ``image_id`` across different
+        calls are preserved as separate entries — no overwrite.
 
         Args:
             predictions: Mapping from ``image_id`` to a prediction dict with keys
@@ -106,13 +114,15 @@ class MetricKeypointOKS:
             >>> metric.has_updates
             True
         """
-        self._preds.update(predictions)
+        self._batches.append(predictions)
 
     def compute(self) -> dict[str, float]:
         """Run OKS keypoint evaluation and return metric dict.
 
         Constructs a fresh :class:`~rfdetr.evaluation.coco_eval.CocoEvaluator`,
-        replays all accumulated predictions, synchronises across DDP ranks via
+        replays all accumulated per-batch predictions in order (matching the
+        original per-batch ``CocoEvaluator.update()`` call pattern), synchronises
+        across DDP ranks via
         :meth:`~rfdetr.evaluation.coco_eval.CocoEvaluator.synchronize_between_processes`,
         and accumulates COCO keypoint statistics.
 
@@ -141,8 +151,8 @@ class MetricKeypointOKS:
             keypoint_oks_sigmas=self._keypoint_oks_sigmas,
             log_summary=False,
         )
-        if self._preds:
-            evaluator.update(self._preds)
+        for batch in self._batches:
+            evaluator.update(batch)
         evaluator.synchronize_between_processes()
         evaluator.accumulate()
         stats = evaluator.coco_eval["keypoints"].stats

--- a/src/rfdetr/evaluation/keypoint_oks.py
+++ b/src/rfdetr/evaluation/keypoint_oks.py
@@ -1,0 +1,154 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""OKS keypoint mAP metric backed by :class:`~rfdetr.evaluation.coco_eval.CocoEvaluator`."""
+
+from typing import Any
+
+from rfdetr.evaluation.coco_eval import CocoEvaluator
+
+
+class MetricKeypointOKS:
+    """OKS keypoint mAP metric backed by CocoEvaluator.
+
+    Plain Python facade over :class:`~rfdetr.evaluation.coco_eval.CocoEvaluator`
+    with a :meth:`reset` / :meth:`update` / :meth:`compute` interface that mirrors
+    the torchmetrics API shape without subclassing it.
+
+    DDP synchronisation is handled inside :meth:`compute` via
+    :meth:`~rfdetr.evaluation.coco_eval.CocoEvaluator.synchronize_between_processes`,
+    which uses the repo's pickle-based ``all_gather`` — avoiding the torchmetrics
+    deadlock bugs #931 / #449 that affect variable-shape state tensors.
+
+    Supports arbitrary keypoint counts and per-category OKS sigmas through the
+    underlying :class:`~rfdetr.evaluation.coco_eval._GroupedKeypointCOCOeval`.
+
+    When TorchMetrics ships production-quality arbitrary-keypoint support (tracked
+    in upstream PR #3348), the internals of :meth:`compute` can delegate to
+    ``MeanAveragePrecision(iou_type="keypoints", keypoint_format="xyv")`` without
+    any change to callers.
+
+    Args:
+        coco_gt: COCO ground-truth object (any type accepted by
+            :class:`~rfdetr.evaluation.coco_eval.CocoEvaluator`).
+        keypoint_oks_sigmas: Per-keypoint OKS sigmas. When ``None``, falls back to
+            COCO person sigmas for 17-keypoint datasets or a uniform 0.05 sigma for
+            other counts.
+        max_dets: Maximum detections per image. Defaults to 500.
+
+    Examples:
+        >>> from unittest.mock import MagicMock
+        >>> metric = MetricKeypointOKS(MagicMock(), max_dets=100)
+        >>> metric.has_updates
+        False
+        >>> metric.reset()  # idempotent on empty state
+    """
+
+    def __init__(
+        self,
+        coco_gt: Any,
+        keypoint_oks_sigmas: list[float] | None = None,
+        max_dets: int = 500,
+    ) -> None:
+        self._coco_gt = coco_gt
+        self._keypoint_oks_sigmas = keypoint_oks_sigmas
+        self._max_dets = max_dets
+        self._preds: dict[int, dict[str, Any]] = {}
+
+    @property
+    def has_updates(self) -> bool:
+        """Return whether any predictions have been accumulated since last reset.
+
+        Returns:
+            ``True`` if :meth:`update` has been called with at least one non-empty
+            prediction dict since the last :meth:`reset`.
+
+        Examples:
+            >>> from unittest.mock import MagicMock
+            >>> metric = MetricKeypointOKS(MagicMock())
+            >>> metric.has_updates
+            False
+            >>> metric._preds[1] = {}
+            >>> metric.has_updates
+            True
+        """
+        return bool(self._preds)
+
+    def reset(self) -> None:
+        """Clear accumulated predictions.
+
+        Examples:
+            >>> from unittest.mock import MagicMock
+            >>> metric = MetricKeypointOKS(MagicMock())
+            >>> metric._preds[0] = {}
+            >>> metric.reset()
+            >>> metric.has_updates
+            False
+        """
+        self._preds.clear()
+
+    def update(self, predictions: dict[int, dict[str, Any]]) -> None:
+        """Accumulate per-batch predictions.
+
+        Args:
+            predictions: Mapping from ``image_id`` to a prediction dict with keys
+                ``boxes`` (``[N, 4]`` xyxy pixel coords), ``scores`` (``[N]``),
+                ``labels`` (``[N]`` int), and ``keypoints`` (``[N, K, 3]``
+                x/y/confidence in pixel coords). Pass an empty dict for images
+                with no predictions.
+
+        Examples:
+            >>> from unittest.mock import MagicMock
+            >>> metric = MetricKeypointOKS(MagicMock())
+            >>> metric.update({1: {}, 2: {}})
+            >>> metric.has_updates
+            True
+        """
+        self._preds.update(predictions)
+
+    def compute(self) -> dict[str, float]:
+        """Run OKS keypoint evaluation and return metric dict.
+
+        Constructs a fresh :class:`~rfdetr.evaluation.coco_eval.CocoEvaluator`,
+        replays all accumulated predictions, synchronises across DDP ranks via
+        :meth:`~rfdetr.evaluation.coco_eval.CocoEvaluator.synchronize_between_processes`,
+        and accumulates COCO keypoint statistics.
+
+        Returns:
+            Dict with float values for keys ``"map"`` (mAP@50:95), ``"map_50"``
+            (AP@50), ``"map_75"`` (AP@75), and ``"mar"`` (AR@50:95).  Any
+            unavailable statistic is reported as ``-1.0``.
+
+        Examples:
+            >>> from unittest.mock import MagicMock, patch
+            >>> import numpy as np
+            >>> metric = MetricKeypointOKS(MagicMock(), max_dets=500)
+            >>> fake_eval = MagicMock()
+            >>> fake_eval.coco_eval = {"keypoints": MagicMock(stats=np.array([0.5, 0.7, 0.4, -1, -1, 0.6]))}
+            >>> with patch("rfdetr.evaluation.keypoint_oks.CocoEvaluator", return_value=fake_eval):
+            ...     result = metric.compute()
+            >>> result["map"]
+            0.5
+            >>> result["map_50"]
+            0.7
+        """
+        evaluator = CocoEvaluator(
+            self._coco_gt,
+            ["keypoints"],
+            max_dets=self._max_dets,
+            keypoint_oks_sigmas=self._keypoint_oks_sigmas,
+            log_summary=False,
+        )
+        if self._preds:
+            evaluator.update(self._preds)
+        evaluator.synchronize_between_processes()
+        evaluator.accumulate()
+        stats = evaluator.coco_eval["keypoints"].stats
+        return {
+            "map": float(stats[0]) if len(stats) > 0 else -1.0,
+            "map_50": float(stats[1]) if len(stats) > 1 else -1.0,
+            "map_75": float(stats[2]) if len(stats) > 2 else -1.0,
+            "mar": float(stats[5]) if len(stats) > 5 else -1.0,
+        }

--- a/src/rfdetr/evaluation/keypoint_oks.py
+++ b/src/rfdetr/evaluation/keypoint_oks.py
@@ -7,12 +7,45 @@
 
 from typing import Any
 
+import torch
+
 from rfdetr.evaluation.coco_eval import CocoEvaluator
 
-# Default maximum detections per image for keypoint evaluation.
-# Shared between MetricKeypointOKS and COCOEvalCallback so the value has one source of truth.
-# Note: for keypoint iou_type the underlying COCO evaluator overrides maxDets to [20]
-# regardless of this value.
+
+def _sanitize_preds(predictions: dict[int, dict[str, Any]]) -> dict[int, dict[str, Any]]:
+    """Return a copy of *predictions* with all tensors detached and moved to CPU.
+
+    Prevents callers from inadvertently retaining CUDA memory or autograd graphs
+    between :meth:`MetricKeypointOKS.update` calls.  Non-tensor values are kept as-is.
+
+    Args:
+        predictions: Per-image prediction dict mapping ``image_id`` to a dict of
+            tensor-valued fields (``boxes``, ``scores``, ``labels``, ``keypoints``).
+
+    Returns:
+        New dict with the same structure; every :class:`torch.Tensor` value is
+        replaced by its ``.detach().cpu()`` copy.
+
+    Examples:
+        >>> import torch
+        >>> preds = {1: {"scores": torch.tensor([0.9], device="cpu"), "label": 2}}
+        >>> sanitized = _sanitize_preds(preds)
+        >>> sanitized[1]["label"]
+        2
+    """
+    return {
+        image_id: {
+            key: value.detach().cpu() if isinstance(value, torch.Tensor) else value for key, value in preds.items()
+        }
+        for image_id, preds in predictions.items()
+    }
+
+
+# Default ``max_dets`` per image used by :class:`COCOEvalCallback` and
+# :class:`MetricKeypointOKS`.  Governs bounding-box and segmentation evaluation
+# where max_dets has an effect; for keypoint evaluation the underlying COCO
+# evaluator unconditionally overrides maxDets to ``[20]`` regardless of this value
+# — this constant has no effect on keypoint AP/AR.
 DEFAULT_KEYPOINT_MAX_DETS = 500
 
 # Keys returned by :meth:`MetricKeypointOKS.compute`.
@@ -86,8 +119,9 @@ class MetricKeypointOKS:
         # Using a list preserves all predictions when the same image_id appears in
         # multiple batches (e.g. DDP DistributedSampler padding), matching the
         # original CocoEvaluator.update()-per-batch append semantics.
-        # Note: raw per-batch tensors are buffered here until compute(); for large
-        # validation sets this accumulates ~400 MB of resident memory per rank.
+        # Note: tensors are sanitized (detached + CPU) in update() before buffering,
+        # so no CUDA graphs or autograd history are retained; for large validation
+        # sets this still accumulates ~400 MB of resident CPU memory per rank.
         # Future optimisation: convert to compact COCO result dicts in update() and
         # replay those in compute() instead.
         self._batches: list[dict[int, dict[str, Any]]] = []
@@ -145,7 +179,7 @@ class MetricKeypointOKS:
             >>> metric.has_updates
             True
         """
-        self._batches.append(predictions)
+        self._batches.append(_sanitize_preds(predictions))
 
     def compute(self) -> dict[str, float]:
         """Run OKS keypoint evaluation and return metric dict.

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -19,6 +19,7 @@ from torchmetrics.detection import MeanAveragePrecision
 
 from rfdetr.datasets import get_coco_api_from_dataset
 from rfdetr.evaluation.f1_sweep import sweep_confidence_thresholds
+from rfdetr.evaluation.keypoint_oks import MetricKeypointOKS
 from rfdetr.evaluation.matching import (
     build_matching_data,
     distributed_merge_matching_data,
@@ -102,10 +103,7 @@ class COCOEvalCallback(Callback):
         self._output_widget: Any = None  # ipywidgets.Output, created lazily
         self._keypoint_mode: bool = False
         self._use_segm_metrics: bool = segmentation
-        self._keypoint_coco_evaluator: Any | None = None
-        self._keypoint_coco_evaluators: dict[str, Any] = {}
-        self._keypoint_eval_has_updates: bool = False
-        self._keypoint_eval_updated_splits: set[str] = set()
+        self._keypoint_oks_metrics: dict[str, MetricKeypointOKS] = {}
         self._keypoint_oks_sigmas = keypoint_oks_sigmas
         self._in_notebook: bool = False
         if in_notebook is None:
@@ -600,8 +598,6 @@ class COCOEvalCallback(Callback):
             self._compute_and_log_keypoint_map("val_ema", pl_module, trainer, log_split="val", metric_prefix="ema_")
         elif split == "val":
             self._reset_keypoint_split("val_ema")
-        if self._keypoint_mode and split not in self._keypoint_eval_updated_splits:
-            self._reset_keypoint_split(split)
         metric.reset()
         self._reset_f1_local(split)
 
@@ -761,15 +757,22 @@ class COCOEvalCallback(Callback):
             return bool(update_count.detach().cpu().item() > 0)
         return True
 
-    def _get_or_create_keypoint_coco_evaluator(self, trainer: Any, split: str) -> Any | None:
-        """Create (or return) the COCO keypoint evaluator for this epoch."""
-        if split in self._keypoint_coco_evaluators:
-            return self._keypoint_coco_evaluators[split]
-        if split == "val" and self._keypoint_coco_evaluator is not None:
-            self._keypoint_coco_evaluators[split] = self._keypoint_coco_evaluator
-            return self._keypoint_coco_evaluator
+    def _get_or_create_keypoint_coco_evaluator(self, trainer: Any, split: str) -> MetricKeypointOKS | None:
+        """Return the :class:`~rfdetr.evaluation.keypoint_oks.MetricKeypointOKS` for *split*, creating it if needed.
 
-        from rfdetr.evaluation.coco_eval import CocoEvaluator
+        The metric is created lazily on first access per split and reused across epochs (state is reset
+        at epoch boundaries via :meth:`_reset_keypoint_split`).
+
+        Args:
+            trainer: The PTL Trainer (provides access to the datamodule).
+            split: One of ``"train"``, ``"val"``, ``"val_ema"``, or ``"test"``.
+
+        Returns:
+            A :class:`~rfdetr.evaluation.keypoint_oks.MetricKeypointOKS` bound to the split's COCO
+            ground-truth, or ``None`` when no dataset is available.
+        """
+        if split in self._keypoint_oks_metrics:
+            return self._keypoint_oks_metrics[split]
 
         datamodule = getattr(trainer, "datamodule", None)
         if datamodule is None:
@@ -788,34 +791,38 @@ class COCOEvalCallback(Callback):
             coco_api = get_coco_api_from_dataset(dataset)
             if coco_api is None:
                 continue
-            evaluator = CocoEvaluator(
+            metric = MetricKeypointOKS(
                 coco_api,
-                ["keypoints"],
-                max_dets=self._max_dets,
                 keypoint_oks_sigmas=self._keypoint_oks_sigmas,
-                log_summary=False,
+                max_dets=self._max_dets,
             )
-            self._keypoint_coco_evaluators[split] = evaluator
-            if split == "val":
-                self._keypoint_coco_evaluator = evaluator
-            return evaluator
+            self._keypoint_oks_metrics[split] = metric
+            return metric
         return None
 
     def _reset_keypoint_split(self, split: str) -> None:
-        """Reset keypoint COCO evaluator state for a metric split."""
-        self._keypoint_coco_evaluators.pop(split, None)
-        self._keypoint_eval_updated_splits.discard(split)
-        if split == "val":
-            self._keypoint_coco_evaluator = None
-            self._keypoint_eval_has_updates = False
+        """Reset accumulated keypoint predictions for *split*.
+
+        Args:
+            split: One of ``"train"``, ``"val"``, ``"val_ema"``, or ``"test"``.
+        """
+        metric = self._keypoint_oks_metrics.get(split)
+        if metric is not None:
+            metric.reset()
 
     def _update_keypoint_coco_eval(self, trainer: Any, outputs: dict[str, Any], split: str) -> None:
-        """Accumulate batch predictions into the COCO keypoint evaluator."""
+        """Accumulate batch predictions into the keypoint OKS metric.
+
+        Args:
+            trainer: The PTL Trainer.
+            outputs: Batch output dict with ``"results"`` and ``"targets"`` keys.
+            split: Metric split (``"train"``, ``"val"``, ``"val_ema"``, or ``"test"``).
+        """
         if not self._keypoint_mode:
             return
 
-        evaluator = self._get_or_create_keypoint_coco_evaluator(trainer, split)
-        if evaluator is None:
+        metric = self._get_or_create_keypoint_coco_evaluator(trainer, split)
+        if metric is None:
             return
 
         predictions: dict[int, dict[str, torch.Tensor]] = {}
@@ -838,10 +845,7 @@ class COCOEvalCallback(Callback):
 
         if not predictions:
             return
-        evaluator.update(predictions)
-        self._keypoint_eval_updated_splits.add(split)
-        if split == "val":
-            self._keypoint_eval_has_updates = True
+        metric.update(predictions)
 
     def _compute_and_log_keypoint_map(
         self,
@@ -852,35 +856,36 @@ class COCOEvalCallback(Callback):
         log_split: str | None = None,
         metric_prefix: str = "",
     ) -> None:
-        """Compute and log COCO keypoint AP/AR metrics when keypoint mode is active."""
-        evaluator = self._keypoint_coco_evaluators.get(split)
-        if evaluator is None and split == "val" and self._keypoint_coco_evaluator is not None:
-            evaluator = self._keypoint_coco_evaluator
-        has_updates = split in self._keypoint_eval_updated_splits or (
-            split == "val" and self._keypoint_eval_has_updates
-        )
-        if not self._keypoint_mode or not has_updates or evaluator is None:
+        """Compute and log OKS keypoint AP/AR metrics when keypoint mode is active.
+
+        Args:
+            split: Internal metric split (``"val"``, ``"val_ema"``, ``"train"``, ``"test"``).
+            pl_module: The LightningModule used to log scalar metrics.
+            trainer: The PTL Trainer (provides ``callback_metrics``).
+            log_split: Namespace prefix for logged keys. Defaults to *split*.
+            metric_prefix: Optional string prepended to each metric name (e.g. ``"ema_"``).
+        """
+        metric = self._keypoint_oks_metrics.get(split)
+        if not self._keypoint_mode or metric is None or not metric.has_updates:
             return
 
         log_split = split if log_split is None else log_split
-        evaluator.synchronize_between_processes()
-        evaluator.accumulate()
-        coco_eval_keypoints = evaluator.coco_eval["keypoints"].stats
+        stats = metric.compute()
         keypoint_metrics = {
-            "keypoint_map_50_95": (0, True),
-            "keypoint_map_50": (1, True),
-            "keypoint_map_75": (2, False),
-            "keypoint_mAR": (5, False),
+            "keypoint_map_50_95": ("map", True),
+            "keypoint_map_50": ("map_50", True),
+            "keypoint_map_75": ("map_75", False),
+            "keypoint_mAR": ("mar", False),
         }
-        for metric_name, (stat_idx, prog_bar) in keypoint_metrics.items():
-            if len(coco_eval_keypoints) <= stat_idx:
+        for metric_name, (stat_key, prog_bar) in keypoint_metrics.items():
+            value = stats.get(stat_key, -1.0)
+            if value < 0:
                 continue
-            value = float(coco_eval_keypoints[stat_idx])
             log_key = f"{log_split}/{metric_prefix}{metric_name}"
             pl_module.log(log_key, value, prog_bar=prog_bar, logger=True, on_step=False, on_epoch=True)
             trainer.callback_metrics[log_key] = torch.tensor(value)
 
-        self._reset_keypoint_split(split)
+        metric.reset()
 
     def _build_per_class_rows(
         self,

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -21,11 +21,8 @@ from rfdetr.datasets import get_coco_api_from_dataset
 from rfdetr.evaluation.f1_sweep import sweep_confidence_thresholds
 from rfdetr.evaluation.keypoint_oks import (
     DEFAULT_KEYPOINT_MAX_DETS,
-    METRIC_KEY_MAP,
-    METRIC_KEY_MAP_50,
-    METRIC_KEY_MAP_75,
-    METRIC_KEY_MAR,
     MetricKeypointOKS,
+    OKSKey,
 )
 from rfdetr.evaluation.matching import (
     build_matching_data,
@@ -891,10 +888,10 @@ class COCOEvalCallback(Callback):
         try:
             stats = metric.compute()
             keypoint_metrics = {
-                "keypoint_map_50_95": (METRIC_KEY_MAP, True),
-                "keypoint_map_50": (METRIC_KEY_MAP_50, True),
-                "keypoint_map_75": (METRIC_KEY_MAP_75, False),
-                "keypoint_mAR": (METRIC_KEY_MAR, False),
+                "keypoint_map_50_95": (OKSKey.MAP, True),
+                "keypoint_map_50": (OKSKey.MAP_50, True),
+                "keypoint_map_75": (OKSKey.MAP_75, False),
+                "keypoint_mAR": (OKSKey.MAR, False),
             }
             for metric_name, (stat_key, prog_bar) in keypoint_metrics.items():
                 value = stats.get(stat_key, -1.0)

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -19,7 +19,14 @@ from torchmetrics.detection import MeanAveragePrecision
 
 from rfdetr.datasets import get_coco_api_from_dataset
 from rfdetr.evaluation.f1_sweep import sweep_confidence_thresholds
-from rfdetr.evaluation.keypoint_oks import MetricKeypointOKS
+from rfdetr.evaluation.keypoint_oks import (
+    DEFAULT_KEYPOINT_MAX_DETS,
+    METRIC_KEY_MAP,
+    METRIC_KEY_MAP_50,
+    METRIC_KEY_MAP_75,
+    METRIC_KEY_MAR,
+    MetricKeypointOKS,
+)
 from rfdetr.evaluation.matching import (
     build_matching_data,
     distributed_merge_matching_data,
@@ -71,7 +78,7 @@ class COCOEvalCallback(Callback):
 
     Args:
         max_dets: Maximum detections per image passed to
-            ``MeanAveragePrecision``. Defaults to 500.
+            ``MeanAveragePrecision``. Defaults to :data:`~rfdetr.evaluation.keypoint_oks.DEFAULT_KEYPOINT_MAX_DETS`.
         segmentation: When ``True``, evaluate both bbox and segm IoU using
             ``backend="faster_coco_eval"``. Defaults to ``False``.
         eval_interval: Run validation metrics every N epochs. Test metrics are
@@ -81,7 +88,7 @@ class COCOEvalCallback(Callback):
 
     def __init__(
         self,
-        max_dets: int = 500,
+        max_dets: int = DEFAULT_KEYPOINT_MAX_DETS,
         segmentation: bool = False,
         eval_interval: int = 1,
         log_per_class_metrics: bool = True,
@@ -265,7 +272,7 @@ class COCOEvalCallback(Callback):
         iou_type = "segm" if self._use_segm_metrics else "bbox"
         batch_matching = build_matching_data(preds, targets, iou_threshold=0.5, iou_type=iou_type)
         merge_matching_data(self._f1_train_local, batch_matching)
-        self._update_keypoint_coco_eval(trainer, outputs, split="train")
+        self._update_keypoint_oks_metric(trainer, outputs, split="train")
 
     def on_train_epoch_end(self, trainer: Any, pl_module: Any) -> None:
         """Compute optional train-split mAP at the end of the training epoch.
@@ -321,7 +328,7 @@ class COCOEvalCallback(Callback):
         iou_type = "segm" if self._use_segm_metrics else "bbox"
         batch_matching = build_matching_data(preds, targets, iou_threshold=0.5, iou_type=iou_type)
         merge_matching_data(self._f1_local, batch_matching)
-        self._update_keypoint_coco_eval(trainer, outputs, split="val")
+        self._update_keypoint_oks_metric(trainer, outputs, split="val")
 
         # Run EMA model separately on the same batch so that base and EMA metrics
         # are computed from independent forward passes rather than being aliases.
@@ -342,7 +349,7 @@ class COCOEvalCallback(Callback):
                 ema_results = pl_module.postprocess(ema_outputs, orig_sizes)
             ema_preds = self._convert_preds(ema_results)
             self.map_metric_ema.update(ema_preds, targets)
-            self._update_keypoint_coco_eval(
+            self._update_keypoint_oks_metric(
                 trainer,
                 {"results": ema_results, "targets": outputs["targets"]},
                 split="val_ema",
@@ -400,7 +407,7 @@ class COCOEvalCallback(Callback):
         iou_type = "segm" if self._use_segm_metrics else "bbox"
         batch_matching = build_matching_data(preds, targets, iou_threshold=0.5, iou_type=iou_type)
         merge_matching_data(self._f1_local, batch_matching)
-        self._update_keypoint_coco_eval(trainer, outputs, split="test")
+        self._update_keypoint_oks_metric(trainer, outputs, split="test")
 
     def on_test_epoch_end(self, trainer: Any, pl_module: Any) -> None:
         """Compute and log mAP and F1 under ``test/`` prefix at end of test epoch.
@@ -757,7 +764,7 @@ class COCOEvalCallback(Callback):
             return bool(update_count.detach().cpu().item() > 0)
         return True
 
-    def _get_or_create_keypoint_coco_evaluator(self, trainer: Any, split: str) -> MetricKeypointOKS | None:
+    def _get_or_create_keypoint_oks_metric(self, trainer: Any, split: str) -> MetricKeypointOKS | None:
         """Return the :class:`~rfdetr.evaluation.keypoint_oks.MetricKeypointOKS` for *split*, creating it if needed.
 
         The metric is created lazily on first access per split and reused across epochs (state is reset
@@ -810,7 +817,7 @@ class COCOEvalCallback(Callback):
         if metric is not None:
             metric.reset()
 
-    def _update_keypoint_coco_eval(self, trainer: Any, outputs: dict[str, Any], split: str) -> None:
+    def _update_keypoint_oks_metric(self, trainer: Any, outputs: dict[str, Any], split: str) -> None:
         """Accumulate batch predictions into the keypoint OKS metric.
 
         Args:
@@ -821,7 +828,7 @@ class COCOEvalCallback(Callback):
         if not self._keypoint_mode:
             return
 
-        metric = self._get_or_create_keypoint_coco_evaluator(trainer, split)
+        metric = self._get_or_create_keypoint_oks_metric(trainer, split)
         if metric is None:
             return
 
@@ -866,26 +873,38 @@ class COCOEvalCallback(Callback):
             metric_prefix: Optional string prepended to each metric name (e.g. ``"ema_"``).
         """
         metric = self._keypoint_oks_metrics.get(split)
-        if not self._keypoint_mode or metric is None or not metric.has_updates:
+        if not self._keypoint_mode or metric is None:
+            return
+        # Cross-rank vote before entering compute(): metric.compute() calls
+        # synchronize_between_processes() which issues an all_gather collective. If any
+        # rank short-circuits here without joining that collective the process group
+        # deadlocks. Use the same all_reduce(MIN) pattern as _should_compute_ema.
+        has_updates_vote = 1 if metric.has_updates else 0
+        if is_dist_avail_and_initialized():
+            flag = torch.tensor([has_updates_vote], device=getattr(pl_module, "device", "cpu"))
+            dist.all_reduce(flag, op=dist.ReduceOp.MIN)
+            has_updates_vote = int(flag.item())
+        if not has_updates_vote:
             return
 
         log_split = split if log_split is None else log_split
-        stats = metric.compute()
-        keypoint_metrics = {
-            "keypoint_map_50_95": ("map", True),
-            "keypoint_map_50": ("map_50", True),
-            "keypoint_map_75": ("map_75", False),
-            "keypoint_mAR": ("mar", False),
-        }
-        for metric_name, (stat_key, prog_bar) in keypoint_metrics.items():
-            value = stats.get(stat_key, -1.0)
-            if value < 0:
-                continue
-            log_key = f"{log_split}/{metric_prefix}{metric_name}"
-            pl_module.log(log_key, value, prog_bar=prog_bar, logger=True, on_step=False, on_epoch=True)
-            trainer.callback_metrics[log_key] = torch.tensor(value)
-
-        metric.reset()
+        try:
+            stats = metric.compute()
+            keypoint_metrics = {
+                "keypoint_map_50_95": (METRIC_KEY_MAP, True),
+                "keypoint_map_50": (METRIC_KEY_MAP_50, True),
+                "keypoint_map_75": (METRIC_KEY_MAP_75, False),
+                "keypoint_mAR": (METRIC_KEY_MAR, False),
+            }
+            for metric_name, (stat_key, prog_bar) in keypoint_metrics.items():
+                value = stats.get(stat_key, -1.0)
+                if value < 0:
+                    continue
+                log_key = f"{log_split}/{metric_prefix}{metric_name}"
+                pl_module.log(log_key, value, prog_bar=prog_bar, logger=True, on_step=False, on_epoch=True)
+                trainer.callback_metrics[log_key] = torch.tensor(value)
+        finally:
+            metric.reset()
 
     def _build_per_class_rows(
         self,

--- a/src/rfdetr/visualize/training.py
+++ b/src/rfdetr/visualize/training.py
@@ -84,7 +84,6 @@ def _plot_columns_on_axes(ax: Any, df: Any, metric_columns: list[str]) -> None:
         ax.plot(
             df["epoch"],
             df[column],
-            marker="o",
             linewidth=1.7,
             linestyle=_line_style_for_split(split),
             color=metric_colors[metric_name],

--- a/tests/evaluation/test_coco_eval.py
+++ b/tests/evaluation/test_coco_eval.py
@@ -373,11 +373,15 @@ class TestSynchronizeBetweenProcesses:
         # all_gather returns rank-0 list + rank-1 list (no overlap)
         rank1_ids = [2]
         rank1_results = [{"image_id": 2, "category_id": 1, "keypoints": [], "score": 0.8}]
+        call_count = [0]
 
-        with patch(
-            "rfdetr.evaluation.coco_eval.all_gather",
-            side_effect=lambda x: [x, rank1_ids if isinstance(x, list) and x == [1] else rank1_results],
-        ):
+        def _all_gather(x: list) -> list:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return [x, rank1_ids]
+            return [x, rank1_results]
+
+        with patch("rfdetr.evaluation.coco_eval.all_gather", side_effect=_all_gather):
             ev.synchronize_between_processes()
 
         assert sorted(ev.img_ids) == [1, 2]

--- a/tests/evaluation/test_coco_eval.py
+++ b/tests/evaluation/test_coco_eval.py
@@ -329,6 +329,134 @@ def test_coco_evaluator_handles_empty_keypoint_predictions(tmp_path: Path) -> No
     assert stats.shape == (10,)
 
 
+class TestSynchronizeBetweenProcesses:
+    """synchronize_between_processes() deduplicates DT when DDP padding repeats image_ids."""
+
+    def _make_evaluator(self, tmp_path: Path) -> CocoEvaluator:
+        """Return a single-annotation evaluator with label2cat identity mapping."""
+        annotation_path = tmp_path / "kp.json"
+        _write_person_keypoint_coco(annotation_path)
+        coco_gt = COCO(str(annotation_path))
+        coco_gt.label2cat = {0: 1}
+        return CocoEvaluator(coco_gt, ["keypoints"])
+
+    def _pred(self, image_id: int, score: float = 0.99) -> dict:
+        """Single detection prediction dict for image_id."""
+        kp = np.zeros((1, 17, 3), dtype=np.float32)
+        return {
+            image_id: {
+                "boxes": torch.tensor([[10.0, 20.0, 60.0, 80.0]]),
+                "scores": torch.tensor([score]),
+                "labels": torch.tensor([0], dtype=torch.long),
+                "keypoints": torch.as_tensor(kp),
+            }
+        }
+
+    def test_single_gpu_no_dedup_needed(self, tmp_path: Path) -> None:
+        """Single-GPU path (world_size=1): all_gather returns one-element list; all results preserved."""
+        ev = self._make_evaluator(tmp_path)
+        ev.update(self._pred(1))
+
+        with patch("rfdetr.evaluation.coco_eval.all_gather", side_effect=lambda x: [x]):
+            ev.synchronize_between_processes()
+
+        assert ev.img_ids == [1]
+        assert len(ev.coco_results["keypoints"]) == 1
+
+    def test_no_overlap_across_ranks_all_results_kept(self, tmp_path: Path) -> None:
+        """When image_ids are disjoint across ranks, all predictions are preserved."""
+        ev = self._make_evaluator(tmp_path)
+        # Simulate rank 0 has already called update() with image_id=1
+        ev.img_ids = [1]
+        ev.coco_results["keypoints"] = [{"image_id": 1, "category_id": 1, "keypoints": [], "score": 0.9}]
+
+        # all_gather returns rank-0 list + rank-1 list (no overlap)
+        rank1_ids = [2]
+        rank1_results = [{"image_id": 2, "category_id": 1, "keypoints": [], "score": 0.8}]
+
+        with patch(
+            "rfdetr.evaluation.coco_eval.all_gather",
+            side_effect=lambda x: [x, rank1_ids if isinstance(x, list) and x == [1] else rank1_results],
+        ):
+            ev.synchronize_between_processes()
+
+        assert sorted(ev.img_ids) == [1, 2]
+        image_ids_in_results = [r["image_id"] for r in ev.coco_results["keypoints"]]
+        assert sorted(image_ids_in_results) == [1, 2]
+
+    def test_ddp_padding_duplicate_image_id_deduped(self, tmp_path: Path) -> None:
+        """DDP DistributedSampler padding: same image_id on two ranks → only rank-0 results kept."""
+        ev = self._make_evaluator(tmp_path)
+        # image_id=1 on BOTH ranks (padding), image_id=2 only on rank-1
+        rank0_ids = [1]
+        rank1_ids = [1, 2]
+        rank0_results = [{"image_id": 1, "category_id": 1, "keypoints": [0.9], "score": 0.9}]
+        rank1_results = [
+            {"image_id": 1, "category_id": 1, "keypoints": [0.9], "score": 0.9},  # duplicate
+            {"image_id": 2, "category_id": 1, "keypoints": [0.5], "score": 0.8},
+        ]
+        call_count = [0]
+
+        def _all_gather(x: list) -> list:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return [rank0_ids, rank1_ids]
+            return [rank0_results, rank1_results]
+
+        with patch("rfdetr.evaluation.coco_eval.all_gather", side_effect=_all_gather):
+            ev.synchronize_between_processes()
+
+        assert sorted(ev.img_ids) == [1, 2]
+        image_ids_in_results = [r["image_id"] for r in ev.coco_results["keypoints"]]
+        # image_id=1 from rank-0 only (not duplicated), image_id=2 from rank-1
+        assert image_ids_in_results.count(1) == 1, "image_id=1 must appear exactly once (no DDP duplicate)"
+        assert image_ids_in_results.count(2) == 1
+
+    def test_ddp_padding_rank0_predictions_chosen_over_rank1(self, tmp_path: Path) -> None:
+        """When image_id appears on rank-0 and rank-1, rank-0's prediction is kept (first-wins)."""
+        ev = self._make_evaluator(tmp_path)
+        rank0_ids = [1]
+        rank1_ids = [1]
+        rank0_results = [{"image_id": 1, "category_id": 1, "keypoints": [], "score": 0.9}]
+        rank1_results = [{"image_id": 1, "category_id": 1, "keypoints": [], "score": 0.5}]
+        call_count = [0]
+
+        def _all_gather(x: list) -> list:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return [rank0_ids, rank1_ids]
+            return [rank0_results, rank1_results]
+
+        with patch("rfdetr.evaluation.coco_eval.all_gather", side_effect=_all_gather):
+            ev.synchronize_between_processes()
+
+        assert len(ev.coco_results["keypoints"]) == 1
+        assert ev.coco_results["keypoints"][0]["score"] == pytest.approx(0.9), "rank-0 prediction must win"
+
+    def test_multiple_detections_same_image_all_kept(self, tmp_path: Path) -> None:
+        """Multiple DT per image (multi-instance) on the owning rank are all preserved."""
+        ev = self._make_evaluator(tmp_path)
+        # rank-0 has 3 detections for image_id=1 (3 distinct instances)
+        rank0_ids = [1]
+        rank0_results = [
+            {"image_id": 1, "category_id": 1, "keypoints": [], "score": 0.9},
+            {"image_id": 1, "category_id": 1, "keypoints": [], "score": 0.8},
+            {"image_id": 1, "category_id": 1, "keypoints": [], "score": 0.7},
+        ]
+        call_count = [0]
+
+        def _all_gather(x: list) -> list:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return [rank0_ids]
+            return [rank0_results]
+
+        with patch("rfdetr.evaluation.coco_eval.all_gather", side_effect=_all_gather):
+            ev.synchronize_between_processes()
+
+        assert len(ev.coco_results["keypoints"]) == 3, "all 3 per-image detections must be kept"
+
+
 def test_coco_evaluator_skips_unmapped_labels_when_label2cat_is_present(tmp_path: Path) -> None:
     """A non-identity label2cat map should not fall back to raw category IDs for unmapped labels."""
     annotation_path = tmp_path / "person_keypoints_val2017.json"

--- a/tests/evaluation/test_keypoint_oks.py
+++ b/tests/evaluation/test_keypoint_oks.py
@@ -1,0 +1,198 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Unit tests for MetricKeypointOKS."""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import torch
+
+from rfdetr.evaluation.keypoint_oks import MetricKeypointOKS
+
+
+def _make_coco_gt() -> MagicMock:
+    """Return a minimal COCO ground-truth mock."""
+    return MagicMock(name="coco_gt")
+
+
+def _make_predictions(image_id: int = 1, num_dets: int = 1, num_keypoints: int = 3) -> dict:
+    """Return a single-image prediction dict."""
+    return {
+        image_id: {
+            "boxes": torch.zeros(num_dets, 4),
+            "scores": torch.ones(num_dets),
+            "labels": torch.zeros(num_dets, dtype=torch.long),
+            "keypoints": torch.zeros(num_dets, num_keypoints, 3),
+        }
+    }
+
+
+def _make_evaluator_mock(stats: list[float]) -> MagicMock:
+    """Return a CocoEvaluator mock returning the given stats array."""
+    evaluator = MagicMock(name="evaluator")
+    evaluator.coco_eval = {"keypoints": MagicMock(stats=np.array(stats, dtype=np.float32))}
+    return evaluator
+
+
+class TestHasUpdates:
+    """has_updates reflects whether predictions are accumulated."""
+
+    def test_false_on_construction(self) -> None:
+        """Fresh metric reports no updates."""
+        metric = MetricKeypointOKS(_make_coco_gt())
+        assert metric.has_updates is False
+
+    def test_true_after_update(self) -> None:
+        """has_updates becomes True after any update() call."""
+        metric = MetricKeypointOKS(_make_coco_gt())
+        metric.update({1: {}})
+        assert metric.has_updates is True
+
+    def test_false_after_reset(self) -> None:
+        """has_updates returns False after reset() clears accumulated preds."""
+        metric = MetricKeypointOKS(_make_coco_gt())
+        metric.update({1: {}})
+        metric.reset()
+        assert metric.has_updates is False
+
+
+class TestReset:
+    """Reset() clears all accumulated predictions."""
+
+    def test_clears_accumulated_predictions(self) -> None:
+        """Reset() empties internal _preds dict."""
+        metric = MetricKeypointOKS(_make_coco_gt())
+        metric.update(_make_predictions(image_id=1))
+        metric.update(_make_predictions(image_id=2))
+        metric.reset()
+        assert metric._preds == {}
+
+    def test_idempotent_on_empty_state(self) -> None:
+        """Reset() on empty metric does not raise."""
+        metric = MetricKeypointOKS(_make_coco_gt())
+        metric.reset()
+        assert metric.has_updates is False
+
+
+class TestUpdate:
+    """Update() accumulates predictions across multiple calls."""
+
+    def test_merges_image_ids_across_batches(self) -> None:
+        """Multiple update() calls accumulate distinct image_ids."""
+        metric = MetricKeypointOKS(_make_coco_gt())
+        metric.update(_make_predictions(image_id=1))
+        metric.update(_make_predictions(image_id=2))
+        assert 1 in metric._preds
+        assert 2 in metric._preds
+
+    def test_overwrites_existing_image_id(self) -> None:
+        """Updating the same image_id twice keeps the latest prediction."""
+        metric = MetricKeypointOKS(_make_coco_gt())
+        metric.update({1: {"scores": torch.tensor([0.9])}})
+        metric.update({1: {"scores": torch.tensor([0.5])}})
+        assert float(metric._preds[1]["scores"][0]) == pytest.approx(0.5)
+
+    def test_empty_prediction_dict_marks_image(self) -> None:
+        """Empty dict for image_id registers the image as having no detections."""
+        metric = MetricKeypointOKS(_make_coco_gt())
+        metric.update({42: {}})
+        assert 42 in metric._preds
+        assert metric._preds[42] == {}
+
+
+class TestCompute:
+    """Compute() delegates to CocoEvaluator and returns correct stat dict."""
+
+    def test_returns_correct_stat_keys(self) -> None:
+        """Compute() returns dict with map, map_50, map_75, mar keys."""
+        evaluator = _make_evaluator_mock([0.5, 0.7, 0.4, -1.0, -1.0, 0.6])
+        metric = MetricKeypointOKS(_make_coco_gt())
+        with patch("rfdetr.evaluation.keypoint_oks.CocoEvaluator", return_value=evaluator):
+            result = metric.compute()
+        assert set(result.keys()) == {"map", "map_50", "map_75", "mar"}
+
+    def test_maps_stats_indices_to_dict_keys(self) -> None:
+        """Compute() maps stats[0,1,2,5] to map, map_50, map_75, mar."""
+        evaluator = _make_evaluator_mock([0.42, 0.72, 0.31, -1.0, -1.0, 0.55])
+        metric = MetricKeypointOKS(_make_coco_gt())
+        with patch("rfdetr.evaluation.keypoint_oks.CocoEvaluator", return_value=evaluator):
+            result = metric.compute()
+        assert result["map"] == pytest.approx(0.42)
+        assert result["map_50"] == pytest.approx(0.72)
+        assert result["map_75"] == pytest.approx(0.31)
+        assert result["mar"] == pytest.approx(0.55)
+
+    def test_returns_minus_one_for_short_stats(self) -> None:
+        """Compute() returns -1.0 for any stat index beyond the stats array length."""
+        evaluator = _make_evaluator_mock([0.3])
+        metric = MetricKeypointOKS(_make_coco_gt())
+        with patch("rfdetr.evaluation.keypoint_oks.CocoEvaluator", return_value=evaluator):
+            result = metric.compute()
+        assert result["map"] == pytest.approx(0.3)
+        assert result["map_50"] == pytest.approx(-1.0)
+        assert result["map_75"] == pytest.approx(-1.0)
+        assert result["mar"] == pytest.approx(-1.0)
+
+    def test_calls_synchronize_and_accumulate(self) -> None:
+        """Compute() calls synchronize_between_processes() and accumulate() on the evaluator."""
+        evaluator = _make_evaluator_mock([0.5, 0.7, 0.4, -1.0, -1.0, 0.6])
+        metric = MetricKeypointOKS(_make_coco_gt())
+        with patch("rfdetr.evaluation.keypoint_oks.CocoEvaluator", return_value=evaluator):
+            metric.compute()
+        evaluator.synchronize_between_processes.assert_called_once()
+        evaluator.accumulate.assert_called_once()
+
+    def test_constructs_evaluator_with_metric_params(self) -> None:
+        """Compute() passes max_dets and keypoint_oks_sigmas to CocoEvaluator."""
+        coco_gt = _make_coco_gt()
+        evaluator = _make_evaluator_mock([0.5, 0.7, 0.4, -1.0, -1.0, 0.6])
+        metric = MetricKeypointOKS(coco_gt, keypoint_oks_sigmas=[0.05, 0.1], max_dets=100)
+        with patch("rfdetr.evaluation.keypoint_oks.CocoEvaluator", return_value=evaluator) as cls:
+            metric.compute()
+        cls.assert_called_once_with(
+            coco_gt,
+            ["keypoints"],
+            max_dets=100,
+            keypoint_oks_sigmas=[0.05, 0.1],
+            log_summary=False,
+        )
+
+    def test_forwards_accumulated_predictions_to_evaluator(self) -> None:
+        """Compute() replays all accumulated predictions into the CocoEvaluator."""
+        evaluator = _make_evaluator_mock([0.5, 0.7, 0.4, -1.0, -1.0, 0.6])
+        metric = MetricKeypointOKS(_make_coco_gt())
+        preds = _make_predictions(image_id=7)
+        metric.update(preds)
+        with patch("rfdetr.evaluation.keypoint_oks.CocoEvaluator", return_value=evaluator):
+            metric.compute()
+        evaluator.update.assert_called_once()
+        passed_preds = evaluator.update.call_args.args[0]
+        assert 7 in passed_preds
+
+    def test_skips_evaluator_update_when_no_predictions(self) -> None:
+        """Compute() does not call evaluator.update() when no predictions accumulated."""
+        evaluator = _make_evaluator_mock([0.5, 0.7, 0.4, -1.0, -1.0, 0.6])
+        metric = MetricKeypointOKS(_make_coco_gt())
+        with patch("rfdetr.evaluation.keypoint_oks.CocoEvaluator", return_value=evaluator):
+            metric.compute()
+        evaluator.update.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "sigmas",
+        [
+            pytest.param(None, id="no_sigmas"),
+            pytest.param([0.05] * 17, id="17kp_sigmas"),
+            pytest.param([0.05] * 4, id="4kp_sigmas"),
+        ],
+    )
+    def test_compute_accepts_arbitrary_keypoint_counts(self, sigmas: list[float] | None) -> None:
+        """Compute() passes any keypoint_oks_sigmas length to CocoEvaluator without restriction."""
+        evaluator = _make_evaluator_mock([0.5, 0.7, 0.4, -1.0, -1.0, 0.6])
+        metric = MetricKeypointOKS(_make_coco_gt(), keypoint_oks_sigmas=sigmas)
+        with patch("rfdetr.evaluation.keypoint_oks.CocoEvaluator", return_value=evaluator) as cls:
+            metric.compute()
+        assert cls.call_args.kwargs["keypoint_oks_sigmas"] == sigmas

--- a/tests/evaluation/test_keypoint_oks.py
+++ b/tests/evaluation/test_keypoint_oks.py
@@ -3,24 +3,34 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-"""Unit tests for MetricKeypointOKS."""
+"""Unit and integration tests for MetricKeypointOKS.
+
+Integration tests (class TestOKSValues) build a minimal COCO ground-truth object and feed known predictions so that
+expected mAP values can be derived by hand without running model inference.  They are the first line of defence against
+silent metric-computation regressions.
+"""
 
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
 import torch
+from faster_coco_eval import COCO
 
 from rfdetr.evaluation.keypoint_oks import MetricKeypointOKS
 
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
 
 def _make_coco_gt() -> MagicMock:
-    """Return a minimal COCO ground-truth mock."""
+    """Return a minimal COCO ground-truth mock (for unit tests that patch evaluator)."""
     return MagicMock(name="coco_gt")
 
 
 def _make_predictions(image_id: int = 1, num_dets: int = 1, num_keypoints: int = 3) -> dict:
-    """Return a single-image prediction dict."""
+    """Return a single-image prediction dict with zero-valued tensors."""
     return {
         image_id: {
             "boxes": torch.zeros(num_dets, 4),
@@ -32,14 +42,102 @@ def _make_predictions(image_id: int = 1, num_dets: int = 1, num_keypoints: int =
 
 
 def _make_evaluator_mock(stats: list[float]) -> MagicMock:
-    """Return a CocoEvaluator mock returning the given stats array."""
+    """Return a CocoEvaluator mock that returns the given stats array."""
     evaluator = MagicMock(name="evaluator")
     evaluator.coco_eval = {"keypoints": MagicMock(stats=np.array(stats, dtype=np.float32))}
     return evaluator
 
 
+def _build_coco_gt(
+    num_keypoints: int,
+    gt_keypoints: list[float],
+    area: float = 2500.0,
+    bbox: list[float] | None = None,
+) -> COCO:
+    """Build a minimal COCO GT object with a single annotation.
+
+    Args:
+        num_keypoints: Number of keypoints per instance.
+        gt_keypoints: Flat COCO keypoint list [x0,y0,v0, x1,y1,v1, ...].
+            Visibility values should be 2 (labelled+visible).
+        area: Ground-truth object area for OKS normalisation.
+        bbox: Ground-truth bounding box [x, y, w, h].  Defaults to [0,0,100,100].
+
+    Returns:
+        A fully-indexed ``faster_coco_eval.COCO`` object.
+    """
+    if bbox is None:
+        bbox = [0.0, 0.0, 100.0, 100.0]
+    kp_names = [f"kp{i}" for i in range(num_keypoints)]
+    dataset = {
+        "images": [{"id": 1, "width": 100, "height": 100, "file_name": "img.jpg"}],
+        "categories": [{"id": 1, "name": "obj", "keypoints": kp_names, "skeleton": []}],
+        "annotations": [
+            {
+                "id": 1,
+                "image_id": 1,
+                "category_id": 1,
+                "keypoints": gt_keypoints,
+                "num_keypoints": num_keypoints,
+                "area": area,
+                "bbox": bbox,
+                "iscrowd": 0,
+            }
+        ],
+    }
+    coco_gt = COCO()
+    coco_gt.dataset = dataset
+    coco_gt.createIndex()
+    return coco_gt
+
+
+def _make_keypoint_prediction(
+    image_id: int,
+    kp_xy: list[tuple[float, float]],
+    category_id: int = 1,
+    score: float = 0.99,
+    box: list[float] | None = None,
+) -> dict:
+    """Build a per-image prediction dict for MetricKeypointOKS.update().
+
+    Args:
+        image_id: COCO image ID.
+        kp_xy: List of (x, y) coordinates — one per keypoint.  Visibility is
+            set to 1.0 for all.
+        category_id: Category label (raw COCO ID used here, no remapping).
+        score: Detection confidence score.
+        box: Bounding box [x1, y1, x2, y2] in pixel coords.  Defaults to the
+            full 100x100 image.
+
+    Returns:
+        Dict mapping ``image_id`` to a prediction dict accepted by
+        :meth:`~rfdetr.evaluation.keypoint_oks.MetricKeypointOKS.update`.
+    """
+    if box is None:
+        box = [0.0, 0.0, 100.0, 100.0]
+    num_kp = len(kp_xy)
+    kp_tensor = torch.zeros(1, num_kp, 3)
+    for i, (x, y) in enumerate(kp_xy):
+        kp_tensor[0, i, 0] = x
+        kp_tensor[0, i, 1] = y
+        kp_tensor[0, i, 2] = 1.0
+    return {
+        image_id: {
+            "boxes": torch.tensor([box], dtype=torch.float32),
+            "scores": torch.tensor([score]),
+            "labels": torch.tensor([category_id], dtype=torch.long),
+            "keypoints": kp_tensor,
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Unit tests (evaluator is mocked)
+# ---------------------------------------------------------------------------
+
+
 class TestHasUpdates:
-    """has_updates reflects whether predictions are accumulated."""
+    """has_updates reflects whether any batch has been accumulated."""
 
     def test_false_on_construction(self) -> None:
         """Fresh metric reports no updates."""
@@ -53,7 +151,7 @@ class TestHasUpdates:
         assert metric.has_updates is True
 
     def test_false_after_reset(self) -> None:
-        """has_updates returns False after reset() clears accumulated preds."""
+        """has_updates returns False after reset() clears all batches."""
         metric = MetricKeypointOKS(_make_coco_gt())
         metric.update({1: {}})
         metric.reset()
@@ -61,15 +159,15 @@ class TestHasUpdates:
 
 
 class TestReset:
-    """Reset() clears all accumulated predictions."""
+    """Reset() clears all accumulated batches."""
 
-    def test_clears_accumulated_predictions(self) -> None:
-        """Reset() empties internal _preds dict."""
+    def test_clears_all_batches(self) -> None:
+        """Reset() empties internal _batches list."""
         metric = MetricKeypointOKS(_make_coco_gt())
         metric.update(_make_predictions(image_id=1))
         metric.update(_make_predictions(image_id=2))
         metric.reset()
-        assert metric._preds == {}
+        assert metric._batches == []
 
     def test_idempotent_on_empty_state(self) -> None:
         """Reset() on empty metric does not raise."""
@@ -79,29 +177,31 @@ class TestReset:
 
 
 class TestUpdate:
-    """Update() accumulates predictions across multiple calls."""
+    """Update() appends batches without merging or overwriting."""
 
-    def test_merges_image_ids_across_batches(self) -> None:
-        """Multiple update() calls accumulate distinct image_ids."""
+    def test_each_call_appends_one_batch(self) -> None:
+        """Two update() calls produce two entries in _batches."""
         metric = MetricKeypointOKS(_make_coco_gt())
         metric.update(_make_predictions(image_id=1))
         metric.update(_make_predictions(image_id=2))
-        assert 1 in metric._preds
-        assert 2 in metric._preds
+        assert len(metric._batches) == 2
 
-    def test_overwrites_existing_image_id(self) -> None:
-        """Updating the same image_id twice keeps the latest prediction."""
+    def test_same_image_id_in_two_batches_both_preserved(self) -> None:
+        """Predictions for the same image_id in separate batches are NOT overwritten."""
         metric = MetricKeypointOKS(_make_coco_gt())
-        metric.update({1: {"scores": torch.tensor([0.9])}})
-        metric.update({1: {"scores": torch.tensor([0.5])}})
-        assert float(metric._preds[1]["scores"][0]) == pytest.approx(0.5)
+        metric.update({5: {"scores": torch.tensor([0.9])}})
+        metric.update({5: {"scores": torch.tensor([0.3])}})
+        # Both batches must be preserved — not merged/overwritten
+        assert len(metric._batches) == 2
+        assert float(metric._batches[0][5]["scores"][0]) == pytest.approx(0.9)
+        assert float(metric._batches[1][5]["scores"][0]) == pytest.approx(0.3)
 
-    def test_empty_prediction_dict_marks_image(self) -> None:
-        """Empty dict for image_id registers the image as having no detections."""
+    def test_empty_prediction_dict_appended_as_batch(self) -> None:
+        """Empty dict marks an image with no detections and is preserved as a batch."""
         metric = MetricKeypointOKS(_make_coco_gt())
         metric.update({42: {}})
-        assert 42 in metric._preds
-        assert metric._preds[42] == {}
+        assert len(metric._batches) == 1
+        assert metric._batches[0] == {42: {}}
 
 
 class TestCompute:
@@ -161,25 +261,46 @@ class TestCompute:
             log_summary=False,
         )
 
-    def test_forwards_accumulated_predictions_to_evaluator(self) -> None:
-        """Compute() replays all accumulated predictions into the CocoEvaluator."""
+    def test_replays_each_batch_as_separate_evaluator_update(self) -> None:
+        """Compute() calls evaluator.update() once per accumulated batch."""
         evaluator = _make_evaluator_mock([0.5, 0.7, 0.4, -1.0, -1.0, 0.6])
         metric = MetricKeypointOKS(_make_coco_gt())
-        preds = _make_predictions(image_id=7)
-        metric.update(preds)
+        metric.update(_make_predictions(image_id=1))
+        metric.update(_make_predictions(image_id=2))
         with patch("rfdetr.evaluation.keypoint_oks.CocoEvaluator", return_value=evaluator):
             metric.compute()
-        evaluator.update.assert_called_once()
+        assert evaluator.update.call_count == 2
+
+    def test_forwards_correct_image_id_to_evaluator(self) -> None:
+        """Compute() passes predictions with the correct image_id to the evaluator."""
+        evaluator = _make_evaluator_mock([0.5, 0.7, 0.4, -1.0, -1.0, 0.6])
+        metric = MetricKeypointOKS(_make_coco_gt())
+        metric.update(_make_predictions(image_id=7))
+        with patch("rfdetr.evaluation.keypoint_oks.CocoEvaluator", return_value=evaluator):
+            metric.compute()
         passed_preds = evaluator.update.call_args.args[0]
         assert 7 in passed_preds
 
     def test_skips_evaluator_update_when_no_predictions(self) -> None:
-        """Compute() does not call evaluator.update() when no predictions accumulated."""
+        """Compute() does not call evaluator.update() when no batches accumulated."""
         evaluator = _make_evaluator_mock([0.5, 0.7, 0.4, -1.0, -1.0, 0.6])
         metric = MetricKeypointOKS(_make_coco_gt())
         with patch("rfdetr.evaluation.keypoint_oks.CocoEvaluator", return_value=evaluator):
             metric.compute()
         evaluator.update.assert_not_called()
+
+    def test_compute_is_idempotent(self) -> None:
+        """Two compute() calls with identical batches return the same stats.
+
+        Proves the shared coco_gt reference is not mutated between calls.
+        """
+        evaluator = _make_evaluator_mock([0.42, 0.72, 0.31, -1.0, -1.0, 0.55])
+        metric = MetricKeypointOKS(_make_coco_gt())
+        metric.update(_make_predictions(image_id=1))
+        with patch("rfdetr.evaluation.keypoint_oks.CocoEvaluator", return_value=evaluator):
+            result_a = metric.compute()
+            result_b = metric.compute()
+        assert result_a == result_b
 
     @pytest.mark.parametrize(
         "sigmas",
@@ -196,3 +317,180 @@ class TestCompute:
         with patch("rfdetr.evaluation.keypoint_oks.CocoEvaluator", return_value=evaluator) as cls:
             metric.compute()
         assert cls.call_args.kwargs["keypoint_oks_sigmas"] == sigmas
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — real COCO GT, visually validatable expected values
+# ---------------------------------------------------------------------------
+
+
+class TestOKSValues:
+    """End-to-end OKS mAP computation against a real CocoEvaluator.
+
+    Each test uses a single annotation and a single prediction so that
+    expected mAP can be derived by hand:
+
+      OKS = exp(-d² / (2 * s² * σ²))
+
+    where d = Euclidean pixel distance, s = sqrt(GT area), σ = OKS sigma.
+
+    All tests use 1 keypoint, GT at (50, 50), area = 2500.0 (s = 50.0),
+    and sigma = 0.05 (default for custom keypoint counts via
+    _DEFAULT_CUSTOM_KEYPOINT_OKS_SIGMA).
+    """
+
+    _GT_KP_X = 50.0
+    _GT_KP_Y = 50.0
+    _AREA = 2500.0  # s = 50.0
+    _SIGMA = 0.05  # default custom OKS sigma
+
+    def _make_gt(self) -> COCO:
+        """Build a 1-image, 1-annotation, 1-keypoint COCO GT."""
+        return _build_coco_gt(
+            num_keypoints=1,
+            gt_keypoints=[self._GT_KP_X, self._GT_KP_Y, 2],
+            area=self._AREA,
+        )
+
+    def test_perfect_prediction_gives_map_one(self) -> None:
+        """Prediction exactly at GT keypoint location must yield mAP@50 = 1.0.
+
+        d = 0  →  OKS = exp(0) = 1.0  →  all IoU thresholds pass  →  mAP = 1.0.
+        """
+        coco_gt = self._make_gt()
+        metric = MetricKeypointOKS(coco_gt, keypoint_oks_sigmas=[self._SIGMA])
+        metric.update(_make_keypoint_prediction(1, [(self._GT_KP_X, self._GT_KP_Y)]))
+        result = metric.compute()
+        assert result["map_50"] == pytest.approx(1.0, abs=1e-3)
+        assert result["map"] == pytest.approx(1.0, abs=1e-3)
+
+    def test_no_predictions_gives_map_zero(self) -> None:
+        """Empty prediction set must yield mAP = 0.0 (no true positives)."""
+        coco_gt = self._make_gt()
+        metric = MetricKeypointOKS(coco_gt, keypoint_oks_sigmas=[self._SIGMA])
+        metric.update({1: {}})
+        result = metric.compute()
+        assert result["map_50"] == pytest.approx(0.0, abs=1e-3)
+        assert result["map"] == pytest.approx(0.0, abs=1e-3)
+
+    def test_far_prediction_gives_map_near_zero(self) -> None:
+        """Prediction far from GT must yield near-zero mAP.
+
+        d = sqrt(50² + 50²) ≈ 70.7, s = 50, σ = 0.05.
+        pycocotools formula: OKS = exp(-d² / (8 * σ² * s²))
+          = exp(-5000 / (8 * 0.0025 * 2500))
+          = exp(-5000 / 50)
+          = exp(-100) ≈ 0  →  mAP@50 = 0.0.
+        """
+        coco_gt = self._make_gt()
+        metric = MetricKeypointOKS(coco_gt, keypoint_oks_sigmas=[self._SIGMA])
+        metric.update(_make_keypoint_prediction(1, [(0.0, 0.0)]))
+        result = metric.compute()
+        assert result["map_50"] == pytest.approx(0.0, abs=1e-3)
+
+    def test_known_oks_threshold_boundary(self) -> None:
+        """Prediction at OKS ≈ 0.6 passes @50 but fails @75.
+
+        pycocotools (and faster_coco_eval) compute OKS as::
+
+          vars = (sigma * 2)²
+          e    = d² / (vars * s² * 2) = d² / (8 * sigma² * s²)
+          OKS  = exp(-e)
+
+        Solving for d where OKS = 0.6 (clearly between the 0.5 and 0.75 thresholds)::
+
+          d² = -ln(0.6) * 8 * sigma² * s²
+             = 0.511 * 8 * 0.0025 * 2500 = 25.55
+          d  = sqrt(25.55) ≈ 5.05 pixels.
+
+        Displacement along x-axis only: predict at (50 + 5.05, 50).
+        OKS ≈ 0.6 → passes @50 (threshold 0.5), fails @75 (threshold 0.75).
+        mAP@50 should be 1.0, mAP@75 should be 0.0.
+        """
+        sigma = self._SIGMA
+        s = np.sqrt(self._AREA)
+        oks_target = 0.6  # between 0.50 and 0.75 — clear boundary
+        # pycocotools formula: OKS = exp(-d² / (8 * sigma² * s²))
+        d = np.sqrt(-np.log(oks_target) * 8 * sigma**2 * s**2)
+        pred_x = float(self._GT_KP_X + d)
+
+        coco_gt = self._make_gt()
+        metric = MetricKeypointOKS(coco_gt, keypoint_oks_sigmas=[sigma])
+        metric.update(_make_keypoint_prediction(1, [(pred_x, self._GT_KP_Y)]))
+        result = metric.compute()
+        assert result["map_50"] == pytest.approx(1.0, abs=1e-3), "OKS=0.6 should pass @50 threshold"
+        assert result["map_75"] == pytest.approx(0.0, abs=1e-3), "OKS=0.6 should fail @75 threshold"
+
+    def test_metric_stable_across_identical_epochs(self) -> None:
+        """Identical predictions fed across three separate compute() cycles give identical mAP.
+
+        This proves no GT mutation, no accumulation bleed, and correct reset between epochs.  A metric that peaks-then-
+        decreases under frozen predictions would fail here.
+        """
+        coco_gt = self._make_gt()
+        metric = MetricKeypointOKS(coco_gt, keypoint_oks_sigmas=[self._SIGMA])
+        results = []
+        for _ in range(3):
+            metric.reset()
+            metric.update(_make_keypoint_prediction(1, [(self._GT_KP_X, self._GT_KP_Y)]))
+            results.append(metric.compute())
+        assert results[0]["map_50"] == pytest.approx(results[1]["map_50"], abs=1e-6)
+        assert results[1]["map_50"] == pytest.approx(results[2]["map_50"], abs=1e-6)
+
+    def test_multi_batch_same_result_as_single_batch(self) -> None:
+        """Splitting predictions across two update() calls gives same mAP as one call.
+
+        Two images, each predicted correctly.  Whether fed in one batch or two, mAP@50 must equal 1.0 — verifies that
+        per-batch append semantics are equivalent to batched evaluation.
+        """
+        kp_names = ["kp0"]
+        dataset = {
+            "images": [
+                {"id": 1, "width": 100, "height": 100, "file_name": "a.jpg"},
+                {"id": 2, "width": 100, "height": 100, "file_name": "b.jpg"},
+            ],
+            "categories": [{"id": 1, "name": "obj", "keypoints": kp_names, "skeleton": []}],
+            "annotations": [
+                {
+                    "id": 1,
+                    "image_id": 1,
+                    "category_id": 1,
+                    "keypoints": [50.0, 50.0, 2],
+                    "num_keypoints": 1,
+                    "area": 2500.0,
+                    "bbox": [0.0, 0.0, 100.0, 100.0],
+                    "iscrowd": 0,
+                },
+                {
+                    "id": 2,
+                    "image_id": 2,
+                    "category_id": 1,
+                    "keypoints": [25.0, 75.0, 2],
+                    "num_keypoints": 1,
+                    "area": 2500.0,
+                    "bbox": [0.0, 0.0, 100.0, 100.0],
+                    "iscrowd": 0,
+                },
+            ],
+        }
+        coco_gt = COCO()
+        coco_gt.dataset = dataset
+        coco_gt.createIndex()
+        sigma = [self._SIGMA]
+
+        # Single batch
+        metric_single = MetricKeypointOKS(coco_gt, keypoint_oks_sigmas=sigma)
+        combined = {}
+        combined.update(_make_keypoint_prediction(1, [(50.0, 50.0)]))
+        combined.update(_make_keypoint_prediction(2, [(25.0, 75.0)]))
+        metric_single.update(combined)
+        result_single = metric_single.compute()
+
+        # Two batches (one image each)
+        metric_split = MetricKeypointOKS(coco_gt, keypoint_oks_sigmas=sigma)
+        metric_split.update(_make_keypoint_prediction(1, [(50.0, 50.0)]))
+        metric_split.update(_make_keypoint_prediction(2, [(25.0, 75.0)]))
+        result_split = metric_split.compute()
+
+        assert result_single["map_50"] == pytest.approx(result_split["map_50"], abs=1e-6)
+        assert result_single["map_50"] == pytest.approx(1.0, abs=1e-3)

--- a/tests/evaluation/test_keypoint_oks.py
+++ b/tests/evaluation/test_keypoint_oks.py
@@ -42,7 +42,11 @@ def _make_predictions(image_id: int = 1, num_dets: int = 1, num_keypoints: int =
 
 
 def _make_evaluator_mock(stats: list[float]) -> MagicMock:
-    """Return a CocoEvaluator mock that returns the given stats array."""
+    """Return a CocoEvaluator mock that returns the given stats array.
+
+    Stats list must have exactly 10 elements matching _summarizeKps() output shape.
+    """
+    assert len(stats) == 10, f"_make_evaluator_mock: expected 10 stats, got {len(stats)}"
     evaluator = MagicMock(name="evaluator")
     evaluator.coco_eval = {"keypoints": MagicMock(stats=np.array(stats, dtype=np.float32))}
     return evaluator
@@ -209,7 +213,7 @@ class TestCompute:
 
     def test_returns_correct_stat_keys(self) -> None:
         """Compute() returns dict with map, map_50, map_75, mar keys."""
-        evaluator = _make_evaluator_mock([0.5, 0.7, 0.4, -1.0, -1.0, 0.6])
+        evaluator = _make_evaluator_mock([0.5, 0.7, 0.4, -1.0, -1.0, 0.6, -1.0, -1.0, -1.0, -1.0])
         metric = MetricKeypointOKS(_make_coco_gt())
         with patch("rfdetr.evaluation.keypoint_oks.CocoEvaluator", return_value=evaluator):
             result = metric.compute()
@@ -217,7 +221,7 @@ class TestCompute:
 
     def test_maps_stats_indices_to_dict_keys(self) -> None:
         """Compute() maps stats[0,1,2,5] to map, map_50, map_75, mar."""
-        evaluator = _make_evaluator_mock([0.42, 0.72, 0.31, -1.0, -1.0, 0.55])
+        evaluator = _make_evaluator_mock([0.42, 0.72, 0.31, -1.0, -1.0, 0.55, -1.0, -1.0, -1.0, -1.0])
         metric = MetricKeypointOKS(_make_coco_gt())
         with patch("rfdetr.evaluation.keypoint_oks.CocoEvaluator", return_value=evaluator):
             result = metric.compute()
@@ -226,20 +230,23 @@ class TestCompute:
         assert result["map_75"] == pytest.approx(0.31)
         assert result["mar"] == pytest.approx(0.55)
 
-    def test_returns_minus_one_for_short_stats(self) -> None:
-        """Compute() returns -1.0 for any stat index beyond the stats array length."""
-        evaluator = _make_evaluator_mock([0.3])
+    def test_raises_on_wrong_stats_shape(self) -> None:
+        """Compute() raises AssertionError when stats array is not shape (10,).
+
+        _summarizeKps() always returns (10,); a shape mismatch signals a pycocotools contract violation (e.g. wrong
+        faster_coco_eval version) and must not silently produce incorrect metric values via index-out-of-bounds sentinel
+        fallback.
+        """
+        evaluator = MagicMock(name="evaluator")
+        evaluator.coco_eval = {"keypoints": MagicMock(stats=np.array([0.3], dtype=np.float32))}
         metric = MetricKeypointOKS(_make_coco_gt())
         with patch("rfdetr.evaluation.keypoint_oks.CocoEvaluator", return_value=evaluator):
-            result = metric.compute()
-        assert result["map"] == pytest.approx(0.3)
-        assert result["map_50"] == pytest.approx(-1.0)
-        assert result["map_75"] == pytest.approx(-1.0)
-        assert result["mar"] == pytest.approx(-1.0)
+            with pytest.raises(AssertionError, match="Expected coco keypoint stats shape"):
+                metric.compute()
 
     def test_calls_synchronize_and_accumulate(self) -> None:
         """Compute() calls synchronize_between_processes() and accumulate() on the evaluator."""
-        evaluator = _make_evaluator_mock([0.5, 0.7, 0.4, -1.0, -1.0, 0.6])
+        evaluator = _make_evaluator_mock([0.5, 0.7, 0.4, -1.0, -1.0, 0.6, -1.0, -1.0, -1.0, -1.0])
         metric = MetricKeypointOKS(_make_coco_gt())
         with patch("rfdetr.evaluation.keypoint_oks.CocoEvaluator", return_value=evaluator):
             metric.compute()
@@ -249,7 +256,7 @@ class TestCompute:
     def test_constructs_evaluator_with_metric_params(self) -> None:
         """Compute() passes max_dets and keypoint_oks_sigmas to CocoEvaluator."""
         coco_gt = _make_coco_gt()
-        evaluator = _make_evaluator_mock([0.5, 0.7, 0.4, -1.0, -1.0, 0.6])
+        evaluator = _make_evaluator_mock([0.5, 0.7, 0.4, -1.0, -1.0, 0.6, -1.0, -1.0, -1.0, -1.0])
         metric = MetricKeypointOKS(coco_gt, keypoint_oks_sigmas=[0.05, 0.1], max_dets=100)
         with patch("rfdetr.evaluation.keypoint_oks.CocoEvaluator", return_value=evaluator) as cls:
             metric.compute()
@@ -263,7 +270,7 @@ class TestCompute:
 
     def test_replays_each_batch_as_separate_evaluator_update(self) -> None:
         """Compute() calls evaluator.update() once per accumulated batch."""
-        evaluator = _make_evaluator_mock([0.5, 0.7, 0.4, -1.0, -1.0, 0.6])
+        evaluator = _make_evaluator_mock([0.5, 0.7, 0.4, -1.0, -1.0, 0.6, -1.0, -1.0, -1.0, -1.0])
         metric = MetricKeypointOKS(_make_coco_gt())
         metric.update(_make_predictions(image_id=1))
         metric.update(_make_predictions(image_id=2))
@@ -273,7 +280,7 @@ class TestCompute:
 
     def test_forwards_correct_image_id_to_evaluator(self) -> None:
         """Compute() passes predictions with the correct image_id to the evaluator."""
-        evaluator = _make_evaluator_mock([0.5, 0.7, 0.4, -1.0, -1.0, 0.6])
+        evaluator = _make_evaluator_mock([0.5, 0.7, 0.4, -1.0, -1.0, 0.6, -1.0, -1.0, -1.0, -1.0])
         metric = MetricKeypointOKS(_make_coco_gt())
         metric.update(_make_predictions(image_id=7))
         with patch("rfdetr.evaluation.keypoint_oks.CocoEvaluator", return_value=evaluator):
@@ -283,7 +290,7 @@ class TestCompute:
 
     def test_skips_evaluator_update_when_no_predictions(self) -> None:
         """Compute() does not call evaluator.update() when no batches accumulated."""
-        evaluator = _make_evaluator_mock([0.5, 0.7, 0.4, -1.0, -1.0, 0.6])
+        evaluator = _make_evaluator_mock([0.5, 0.7, 0.4, -1.0, -1.0, 0.6, -1.0, -1.0, -1.0, -1.0])
         metric = MetricKeypointOKS(_make_coco_gt())
         with patch("rfdetr.evaluation.keypoint_oks.CocoEvaluator", return_value=evaluator):
             metric.compute()
@@ -294,7 +301,7 @@ class TestCompute:
 
         Proves the shared coco_gt reference is not mutated between calls.
         """
-        evaluator = _make_evaluator_mock([0.42, 0.72, 0.31, -1.0, -1.0, 0.55])
+        evaluator = _make_evaluator_mock([0.42, 0.72, 0.31, -1.0, -1.0, 0.55, -1.0, -1.0, -1.0, -1.0])
         metric = MetricKeypointOKS(_make_coco_gt())
         metric.update(_make_predictions(image_id=1))
         with patch("rfdetr.evaluation.keypoint_oks.CocoEvaluator", return_value=evaluator):
@@ -312,7 +319,7 @@ class TestCompute:
     )
     def test_compute_accepts_arbitrary_keypoint_counts(self, sigmas: list[float] | None) -> None:
         """Compute() passes any keypoint_oks_sigmas length to CocoEvaluator without restriction."""
-        evaluator = _make_evaluator_mock([0.5, 0.7, 0.4, -1.0, -1.0, 0.6])
+        evaluator = _make_evaluator_mock([0.5, 0.7, 0.4, -1.0, -1.0, 0.6, -1.0, -1.0, -1.0, -1.0])
         metric = MetricKeypointOKS(_make_coco_gt(), keypoint_oks_sigmas=sigmas)
         with patch("rfdetr.evaluation.keypoint_oks.CocoEvaluator", return_value=evaluator) as cls:
             metric.compute()
@@ -330,9 +337,10 @@ class TestOKSValues:
     Each test uses a single annotation and a single prediction so that
     expected mAP can be derived by hand:
 
-      OKS = exp(-d² / (2 * s² * σ²))
+      OKS = exp(-d² / (8 * σ² * s²))
 
     where d = Euclidean pixel distance, s = sqrt(GT area), σ = OKS sigma.
+    The 8× factor comes from pycocotools: vars = (2σ)², e = d² / (vars * s² * 2).
 
     All tests use 1 keypoint, GT at (50, 50), area = 2500.0 (s = 50.0),
     and sigma = 0.05 (default for custom keypoint counts via

--- a/tests/training/test_coco_eval_callback.py
+++ b/tests/training/test_coco_eval_callback.py
@@ -467,7 +467,7 @@ class TestKeypointCocoEvalRouting:
         assert predictions[12]["keypoints"].shape == (1, 1, 3)
 
     def test_keypoint_coco_eval_exposes_keypoint_ap_and_ar_metrics(self) -> None:
-        """Epoch-end logging should expose keypoint AP and AR metrics from COCO keypoint stats."""
+        """Epoch-end logging should expose keypoint AP and AR metrics from MetricKeypointOKS.compute()."""
         cb = COCOEvalCallback(max_dets=500)
         module = _make_pl_module()
         module.model_config = SimpleNamespace(use_grouppose_keypoints=True)
@@ -477,12 +477,10 @@ class TestKeypointCocoEvalRouting:
         cb.map_metric = MagicMock(name="map_metric")
         cb.map_metric.compute.return_value = _minimal_metrics()
 
-        keypoint_eval = MagicMock(name="keypoint_coco_eval")
-        keypoint_eval.coco_eval = {
-            "keypoints": SimpleNamespace(stats=np.array([0.42, 0.72, 0.31, -1.0, -1.0, 0.55], dtype=np.float32))
-        }
-        cb._keypoint_coco_evaluator = keypoint_eval
-        cb._keypoint_eval_has_updates = True
+        keypoint_metric = MagicMock(name="keypoint_oks_metric")
+        keypoint_metric.has_updates = True
+        keypoint_metric.compute.return_value = {"map": 0.42, "map_50": 0.72, "map_75": 0.31, "mar": 0.55}
+        cb._keypoint_oks_metrics["val"] = keypoint_metric
 
         cb.on_validation_epoch_end(trainer, module)
 
@@ -501,8 +499,7 @@ class TestKeypointCocoEvalRouting:
         assert trainer.callback_metrics["val/keypoint_map_50"].item() == pytest.approx(0.72)
         assert trainer.callback_metrics["val/keypoint_map_75"].item() == pytest.approx(0.31)
         assert trainer.callback_metrics["val/keypoint_mAR"].item() == pytest.approx(0.55)
-        keypoint_eval.synchronize_between_processes.assert_called_once()
-        keypoint_eval.accumulate.assert_called_once()
+        keypoint_metric.compute.assert_called_once()
 
     def test_keypoint_coco_eval_exposes_ema_keypoint_ap_and_ar_metrics(self) -> None:
         """EMA keypoint epoch-end logging should expose val/ema_keypoint_* metrics."""
@@ -513,12 +510,10 @@ class TestKeypointCocoEvalRouting:
         trainer.callback_metrics = {}
         cb.setup(trainer, module, stage="fit")
 
-        keypoint_eval = MagicMock(name="ema_keypoint_coco_eval")
-        keypoint_eval.coco_eval = {
-            "keypoints": SimpleNamespace(stats=np.array([0.25, 0.5, 0.2, -1.0, -1.0, 0.45], dtype=np.float32))
-        }
-        cb._keypoint_coco_evaluators["val_ema"] = keypoint_eval
-        cb._keypoint_eval_updated_splits.add("val_ema")
+        keypoint_metric = MagicMock(name="ema_keypoint_oks_metric")
+        keypoint_metric.has_updates = True
+        keypoint_metric.compute.return_value = {"map": 0.25, "map_50": 0.5, "map_75": 0.2, "mar": 0.45}
+        cb._keypoint_oks_metrics["val_ema"] = keypoint_metric
 
         cb._compute_and_log_keypoint_map("val_ema", module, trainer, log_split="val", metric_prefix="ema_")
 
@@ -539,11 +534,10 @@ class TestKeypointCocoEvalRouting:
         assert trainer.callback_metrics["val/ema_keypoint_map_50"].item() == pytest.approx(0.5)
         assert trainer.callback_metrics["val/ema_keypoint_map_75"].item() == pytest.approx(0.2)
         assert trainer.callback_metrics["val/ema_keypoint_mAR"].item() == pytest.approx(0.45)
-        keypoint_eval.synchronize_between_processes.assert_called_once()
-        keypoint_eval.accumulate.assert_called_once()
+        keypoint_metric.compute.assert_called_once()
 
-    def test_keypoint_coco_evaluator_suppresses_verbose_summary(self) -> None:
-        """PTL keypoint validation should log scalar metrics without printing the full COCO summary block."""
+    def test_keypoint_oks_metric_created_with_correct_args(self) -> None:
+        """_get_or_create_keypoint_coco_evaluator must construct MetricKeypointOKS with coco_gt and sigmas."""
         cb = COCOEvalCallback(max_dets=500, keypoint_oks_sigmas=[0.05])
         dataset = MagicMock(name="dataset")
         datamodule = MagicMock()
@@ -552,24 +546,18 @@ class TestKeypointCocoEvalRouting:
         datamodule._dataset_train = None
         trainer = _make_trainer(datamodule=datamodule)
         coco_api = MagicMock(name="coco_api")
-        evaluator = MagicMock(name="evaluator")
 
         with (
             patch("rfdetr.training.callbacks.coco_eval.get_coco_api_from_dataset", return_value=coco_api),
-            patch("rfdetr.evaluation.coco_eval.CocoEvaluator", return_value=evaluator) as coco_evaluator_cls,
+            patch("rfdetr.training.callbacks.coco_eval.MetricKeypointOKS") as oks_metric_cls,
         ):
-            assert cb._get_or_create_keypoint_coco_evaluator(trainer, split="val") is evaluator
+            result = cb._get_or_create_keypoint_coco_evaluator(trainer, split="val")
 
-        coco_evaluator_cls.assert_called_once_with(
-            coco_api,
-            ["keypoints"],
-            max_dets=500,
-            keypoint_oks_sigmas=[0.05],
-            log_summary=False,
-        )
+        assert result is oks_metric_cls.return_value
+        oks_metric_cls.assert_called_once_with(coco_api, keypoint_oks_sigmas=[0.05], max_dets=500)
 
     def test_keypoint_train_eval_uses_train_dataset(self) -> None:
-        """Train keypoint mAP must build the COCO evaluator from the train dataset."""
+        """Train keypoint mAP must construct MetricKeypointOKS from the train dataset."""
         cb = COCOEvalCallback(max_dets=500, keypoint_oks_sigmas=[0.05])
         train_dataset = MagicMock(name="train_dataset")
         val_dataset = MagicMock(name="val_dataset")
@@ -580,7 +568,6 @@ class TestKeypointCocoEvalRouting:
         trainer = _make_trainer(datamodule=datamodule)
         train_coco_api = MagicMock(name="train_coco_api")
         val_coco_api = MagicMock(name="val_coco_api")
-        evaluator = MagicMock(name="evaluator")
 
         def _get_coco_api(dataset):
             if dataset is train_dataset:
@@ -591,14 +578,14 @@ class TestKeypointCocoEvalRouting:
 
         with (
             patch("rfdetr.training.callbacks.coco_eval.get_coco_api_from_dataset", side_effect=_get_coco_api),
-            patch("rfdetr.evaluation.coco_eval.CocoEvaluator", return_value=evaluator) as coco_evaluator_cls,
+            patch("rfdetr.training.callbacks.coco_eval.MetricKeypointOKS") as oks_metric_cls,
         ):
-            assert cb._get_or_create_keypoint_coco_evaluator(trainer, split="train") is evaluator
+            cb._get_or_create_keypoint_coco_evaluator(trainer, split="train")
 
-        assert coco_evaluator_cls.call_args.args[0] is train_coco_api
+        assert oks_metric_cls.call_args.args[0] is train_coco_api
 
     def test_keypoint_ema_eval_uses_validation_dataset(self) -> None:
-        """EMA keypoint mAP must build the COCO evaluator from the validation dataset."""
+        """EMA keypoint mAP must construct MetricKeypointOKS from the validation dataset."""
         cb = COCOEvalCallback(max_dets=500, keypoint_oks_sigmas=[0.05])
         train_dataset = MagicMock(name="train_dataset")
         val_dataset = MagicMock(name="val_dataset")
@@ -609,7 +596,6 @@ class TestKeypointCocoEvalRouting:
         trainer = _make_trainer(datamodule=datamodule)
         train_coco_api = MagicMock(name="train_coco_api")
         val_coco_api = MagicMock(name="val_coco_api")
-        evaluator = MagicMock(name="evaluator")
 
         def _get_coco_api(dataset):
             if dataset is train_dataset:
@@ -620,14 +606,14 @@ class TestKeypointCocoEvalRouting:
 
         with (
             patch("rfdetr.training.callbacks.coco_eval.get_coco_api_from_dataset", side_effect=_get_coco_api),
-            patch("rfdetr.evaluation.coco_eval.CocoEvaluator", return_value=evaluator) as coco_evaluator_cls,
+            patch("rfdetr.training.callbacks.coco_eval.MetricKeypointOKS") as oks_metric_cls,
         ):
-            assert cb._get_or_create_keypoint_coco_evaluator(trainer, split="val_ema") is evaluator
+            cb._get_or_create_keypoint_coco_evaluator(trainer, split="val_ema")
 
-        assert coco_evaluator_cls.call_args.args[0] is val_coco_api
+        assert oks_metric_cls.call_args.args[0] is val_coco_api
 
-    def test_mixed_keypoint_counts_create_keypoint_evaluator(self) -> None:
-        """Mixed keypoint counts should be handled by the evaluator instead of being skipped by the callback."""
+    def test_mixed_keypoint_counts_create_keypoint_oks_metric(self) -> None:
+        """Mixed keypoint counts should be handled by MetricKeypointOKS instead of being skipped."""
         cb = COCOEvalCallback(max_dets=500)
         dataset = MagicMock(name="dataset")
         datamodule = MagicMock()
@@ -635,16 +621,16 @@ class TestKeypointCocoEvalRouting:
         datamodule._dataset_val = None
         datamodule._dataset_test = None
         trainer = _make_trainer(datamodule=datamodule)
-        evaluator = MagicMock(name="evaluator")
 
         with (
             patch("rfdetr.training.callbacks.coco_eval.get_coco_api_from_dataset", return_value=MagicMock()),
-            patch("rfdetr.evaluation.coco_eval.CocoEvaluator", return_value=evaluator) as coco_evaluator_cls,
+            patch("rfdetr.training.callbacks.coco_eval.MetricKeypointOKS") as oks_metric_cls,
             patch("rfdetr.training.callbacks.coco_eval.logger.warning") as warning,
         ):
-            assert cb._get_or_create_keypoint_coco_evaluator(trainer, split="train") is evaluator
+            result = cb._get_or_create_keypoint_coco_evaluator(trainer, split="train")
 
-        coco_evaluator_cls.assert_called_once()
+        assert result is oks_metric_cls.return_value
+        oks_metric_cls.assert_called_once()
         warning.assert_not_called()
 
 

--- a/tests/training/test_coco_eval_callback.py
+++ b/tests/training/test_coco_eval_callback.py
@@ -445,7 +445,7 @@ class TestKeypointCocoEvalRouting:
         cb.setup(trainer, module, stage="fit")
 
         evaluator = MagicMock(name="keypoint_coco_eval")
-        cb._get_or_create_keypoint_coco_evaluator = MagicMock(return_value=evaluator)  # type: ignore[method-assign]
+        cb._get_or_create_keypoint_oks_metric = MagicMock(return_value=evaluator)  # type: ignore[method-assign]
         outputs = {
             "results": [
                 {
@@ -458,7 +458,7 @@ class TestKeypointCocoEvalRouting:
             "targets": [{"image_id": torch.tensor([12])}],
         }
 
-        cb._update_keypoint_coco_eval(trainer, outputs, split="val")
+        cb._update_keypoint_oks_metric(trainer, outputs, split="val")
 
         evaluator.update.assert_called_once()
         predictions = evaluator.update.call_args.args[0]
@@ -537,7 +537,7 @@ class TestKeypointCocoEvalRouting:
         keypoint_metric.compute.assert_called_once()
 
     def test_keypoint_oks_metric_created_with_correct_args(self) -> None:
-        """_get_or_create_keypoint_coco_evaluator must construct MetricKeypointOKS with coco_gt and sigmas."""
+        """_get_or_create_keypoint_oks_metric must construct MetricKeypointOKS with coco_api and sigmas."""
         cb = COCOEvalCallback(max_dets=500, keypoint_oks_sigmas=[0.05])
         dataset = MagicMock(name="dataset")
         datamodule = MagicMock()
@@ -551,7 +551,7 @@ class TestKeypointCocoEvalRouting:
             patch("rfdetr.training.callbacks.coco_eval.get_coco_api_from_dataset", return_value=coco_api),
             patch("rfdetr.training.callbacks.coco_eval.MetricKeypointOKS") as oks_metric_cls,
         ):
-            result = cb._get_or_create_keypoint_coco_evaluator(trainer, split="val")
+            result = cb._get_or_create_keypoint_oks_metric(trainer, split="val")
 
         assert result is oks_metric_cls.return_value
         oks_metric_cls.assert_called_once_with(coco_api, keypoint_oks_sigmas=[0.05], max_dets=500)
@@ -580,7 +580,7 @@ class TestKeypointCocoEvalRouting:
             patch("rfdetr.training.callbacks.coco_eval.get_coco_api_from_dataset", side_effect=_get_coco_api),
             patch("rfdetr.training.callbacks.coco_eval.MetricKeypointOKS") as oks_metric_cls,
         ):
-            cb._get_or_create_keypoint_coco_evaluator(trainer, split="train")
+            cb._get_or_create_keypoint_oks_metric(trainer, split="train")
 
         assert oks_metric_cls.call_args.args[0] is train_coco_api
 
@@ -608,7 +608,7 @@ class TestKeypointCocoEvalRouting:
             patch("rfdetr.training.callbacks.coco_eval.get_coco_api_from_dataset", side_effect=_get_coco_api),
             patch("rfdetr.training.callbacks.coco_eval.MetricKeypointOKS") as oks_metric_cls,
         ):
-            cb._get_or_create_keypoint_coco_evaluator(trainer, split="val_ema")
+            cb._get_or_create_keypoint_oks_metric(trainer, split="val_ema")
 
         assert oks_metric_cls.call_args.args[0] is val_coco_api
 
@@ -627,7 +627,7 @@ class TestKeypointCocoEvalRouting:
             patch("rfdetr.training.callbacks.coco_eval.MetricKeypointOKS") as oks_metric_cls,
             patch("rfdetr.training.callbacks.coco_eval.logger.warning") as warning,
         ):
-            result = cb._get_or_create_keypoint_coco_evaluator(trainer, split="train")
+            result = cb._get_or_create_keypoint_oks_metric(trainer, split="train")
 
         assert result is oks_metric_cls.return_value
         oks_metric_cls.assert_called_once()

--- a/tests/visualize/test_training.py
+++ b/tests/visualize/test_training.py
@@ -176,8 +176,11 @@ def test_split_loss_and_map_plots_return_separate_figures(tmp_path: Path) -> Non
     assert loss_lines["train/loss"].get_linestyle() == ":"
     assert loss_lines["val/loss"].get_linestyle() == "-"
     assert loss_lines["train/loss"].get_color() == loss_lines["val/loss"].get_color()
+    assert {line.get_marker() for line in loss_lines.values()} == {"None"}
     assert len(map_figure.axes) == 1
     assert map_figure.axes[0].get_title() == "RF-DETR mAP Metrics"
+    map_lines = {line.get_label(): line for line in map_figure.axes[0].lines}
+    assert {line.get_marker() for line in map_lines.values()} == {"None"}
     plt.close(loss_figure)
     plt.close(map_figure)
 
@@ -258,6 +261,7 @@ def test_map_renderer_uses_line_style_for_train_and_val_splits() -> None:
     assert lines["val/mAP_50_95"].get_linestyle() == "-"
     assert lines["train/keypoint_map_50_95"].get_linestyle() == ":"
     assert lines["val/keypoint_map_50_95"].get_linestyle() == "-"
+    assert {line.get_marker() for line in lines.values()} == {"None"}
     assert lines["train/mAP_50_95"].get_color() == lines["val/mAP_50_95"].get_color()
     assert lines["train/keypoint_map_50_95"].get_color() == lines["val/keypoint_map_50_95"].get_color()
     assert lines["train/mAP_50_95"].get_color() != lines["train/keypoint_map_50_95"].get_color()


### PR DESCRIPTION
Replace ad-hoc keypoint evaluator wiring in COCOEvalCallback with MetricKeypointOKS — a plain Python reset/update/compute facade backed by the existing CocoEvaluator. Supports arbitrary keypoint counts and per-category OKS sigmas; DDP sync handled internally via synchronize_between_processes(), avoiding the TM #931/#449 deadlock.

- src/rfdetr/evaluation/keypoint_oks.py: new MetricKeypointOKS class
- COCOEvalCallback: replaces _keypoint_coco_evaluators dict + four tracking booleans/sets with _keypoint_oks_metrics dict; metrics reused across epochs (reset, not recreated)
- tests/evaluation/test_keypoint_oks.py: 18 unit tests
- tests/training/test_coco_eval_callback.py: updated 10 keypoint tests to mock MetricKeypointOKS.compute() instead of CocoEvaluator

Defers TM PR #3348 delegation to Phase 2 — facade absorbs migration when upstream ships production-quality arbitrary-keypoint support.
