### PR TITLE
fix(config): verify accelerator runtime availability in device detection

### DIFF
--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -30,12 +30,23 @@ def _detect_device() -> str:
 
     We defer to :func:`torch.accelerator.current_accelerator` (PyTorch ≥ 2.4) when available — it queries the driver
     through NVML without creating a primary context.  On older builds we fall back to ``torch.cuda.is_available()``.
+
+    ``check_available=True`` is required: without it ``current_accelerator()`` only reports the *compile-time*
+    accelerator, so the default CUDA wheel on a machine without an NVIDIA driver yields ``"cuda"`` and every model
+    build crashes with "Found no NVIDIA driver".  The runtime check is NVML-backed and still avoids creating a
+    CUDA context.  Builds whose ``current_accelerator`` predates the ``check_available`` kwarg get the same runtime
+    verification via :func:`torch.accelerator.is_available`.
     """
     accelerator = getattr(torch, "accelerator", None)
     current_accelerator = getattr(accelerator, "current_accelerator", None)
     if current_accelerator is not None:
         try:
-            accel = current_accelerator()
+            try:
+                accel = current_accelerator(check_available=True)
+            except TypeError:
+                accel = current_accelerator()
+                if accel is not None and not accelerator.is_available():
+                    accel = None
             if accel is not None:
                 return str(accel)
             return "cpu"

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -499,6 +499,53 @@ class TestDetectDevice:
         mock_torch.backends.mps.is_available.return_value = False
         assert _detect_device() == "cpu"
 
+    @patch("rfdetr.config.torch")
+    def test_returns_cpu_when_accelerator_compiled_in_but_unavailable(self, mock_torch: MagicMock) -> None:
+        """Returns 'cpu' when torch was compiled with CUDA but no driver is present at runtime.
+
+        Without ``check_available=True``, ``current_accelerator()`` reports the compile-time accelerator,
+        so the default CUDA wheel on a driverless machine yields ``device("cuda")`` and every model
+        build crashes with "Found no NVIDIA driver". The runtime availability check must win.
+        """
+
+        def fake_current_accelerator(check_available: bool = False) -> "torch.device | None":
+            return None if check_available else torch.device("cuda")
+
+        mock_torch.accelerator.current_accelerator = fake_current_accelerator
+        assert _detect_device() == "cpu"
+
+    @patch("rfdetr.config.torch")
+    def test_returns_accelerator_when_runtime_available(self, mock_torch: MagicMock) -> None:
+        """Returns the accelerator when it passes the runtime availability check."""
+
+        def fake_current_accelerator(check_available: bool = False) -> "torch.device":
+            return torch.device("cuda")
+
+        mock_torch.accelerator.current_accelerator = fake_current_accelerator
+        assert _detect_device() == "cuda"
+
+    @patch("rfdetr.config.torch")
+    def test_legacy_signature_unavailable_accelerator_returns_cpu(self, mock_torch: MagicMock) -> None:
+        """Falls back to ``is_available()`` when ``current_accelerator`` lacks ``check_available`` (PyTorch < 2.7)."""
+
+        def legacy_current_accelerator() -> "torch.device":
+            return torch.device("cuda")
+
+        mock_torch.accelerator.current_accelerator = legacy_current_accelerator
+        mock_torch.accelerator.is_available.return_value = False
+        assert _detect_device() == "cpu"
+
+    @patch("rfdetr.config.torch")
+    def test_legacy_signature_available_accelerator_is_kept(self, mock_torch: MagicMock) -> None:
+        """Keeps the accelerator on pre-``check_available`` builds when ``is_available()`` confirms it."""
+
+        def legacy_current_accelerator() -> "torch.device":
+            return torch.device("cuda")
+
+        mock_torch.accelerator.current_accelerator = legacy_current_accelerator
+        mock_torch.accelerator.is_available.return_value = True
+        assert _detect_device() == "cuda"
+
 
 class TestPretrainWeightsCompatibilityWarning:
     """Config-time warning for overrides that prevent pretrained weights from loading.


### PR DESCRIPTION
## What does this PR do?

_detect_device() called torch.accelerator.current_accelerator() without check_available=True, which only reports the compile-time accelerator. On the default CUDA wheel with no NVIDIA driver present (common on CPU-only Linux/Windows), it returned "cuda", so every model build and predict() crashed with "Found no NVIDIA driver".

Pass check_available=True so the NVML-backed runtime check decides; on torch builds whose current_accelerator predates the kwarg, fall back to torch.accelerator.is_available(). The NVML path still avoids creating a CUDA primary context, preserving fork-based DDP compatibility.

**Related Issue(s):** N/A

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

Added 4 mock-based regression tests to the existing `TestDetectDevice`
suite in `tests/models/test_config.py` (they patch `rfdetr.config.torch`,
so they need no GPU and run in the CPU suite):

- **`test_returns_cpu_when_accelerator_compiled_in_but_unavailable`** —
  the core regression: a CUDA-compiled-but-driverless accelerator
  (`current_accelerator(check_available=True)` → `None`,
  no-arg → `cuda`) must resolve to `"cpu"`. Fails before the fix (returned `"cuda"`).
- **`test_returns_accelerator_when_runtime_available`** — an accelerator
  that passes the runtime availability check is kept.
- **`test_legacy_signature_unavailable_accelerator_returns_cpu`** — on
  torch builds whose `current_accelerator` predates the `check_available`
  kwarg, a `TypeError` triggers the fallback to
  `torch.accelerator.is_available()`; an unavailable accelerator → `"cpu"`.
  Fails before the fix.
- **`test_legacy_signature_available_accelerator_is_kept`** — same legacy
  path, but `is_available()` confirms the accelerator, so it is kept.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context
