### PR TITLE
fix: honor explicit `num_classes` even when it equals the default

### DIFF
--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -1202,10 +1202,10 @@ class RFDETR:
         Must be called before ``RFDETRModelModule`` is constructed so that weight loading inside the module uses the
         correct (dataset-derived) class count.
 
-        When the user did **not** explicitly override ``num_classes`` (or passed the class-config default),
-        ``model_config.num_classes`` and ``self.model.args.num_classes`` are updated to match the dataset.  When the
-        user *did* set a non-default value that differs from the dataset, the configured value is preserved and a
-        warning is emitted.
+        When the user did **not** explicitly set ``num_classes`` (it is left unset, e.g. inferred from a
+        checkpoint), ``model_config.num_classes`` and ``self.model.args.num_classes`` are updated to match the dataset.
+        When the user *did* set ``num_classes`` explicitly — to any value, including the class default — and it differs
+        from the dataset, the configured value is preserved and a warning is emitted.
 
         Failures from ``_detect_num_classes_for_training`` are caught and logged at DEBUG level so that training is
         never blocked by detection errors.
@@ -1234,13 +1234,13 @@ class RFDETR:
         if dataset_num_classes == model_num_classes:
             return
 
-        # Determine whether the user explicitly overrode num_classes to a non-default value.
-        # "num_classes" in model_fields_set is True when the field was explicitly set at
-        # construction time; comparing against the class default filters out cases where the
-        # user passed the default value explicitly (treat those like "not set").
-        user_set = "num_classes" in getattr(self.model_config, "model_fields_set", set())
-        default_nc = type(self.model_config).model_fields["num_classes"].default
-        user_overrode = user_set and model_num_classes != default_nc
+        # Determine whether the user explicitly set num_classes.  "num_classes" in
+        # model_fields_set is True only when the field was explicitly provided at construction
+        # (or assigned afterwards); an explicit value is honored regardless of whether it equals
+        # the class default, so an intentional num_classes is never silently overridden by the
+        # dataset count.  A checkpoint-derived num_classes is cleared from model_fields_set by
+        # ``from_checkpoint`` (see issue #1092), so it correctly counts as "not set" here.
+        user_overrode = "num_classes" in getattr(self.model_config, "model_fields_set", set())
 
         if not user_overrode:
             logger.debug(

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -307,7 +307,8 @@ class RFDETR:
                 used when present; otherwise the constructor default applies.  In either case the
                 field is not recorded as a user-set override, so :meth:`train` can still adapt the
                 detection head to the training dataset's class count.  Pass an explicit
-                ``num_classes=N`` to pin it and prevent head adaptation.
+                ``num_classes=N`` to pin the head and prevent adaptation, even when ``N`` equals
+                the class default (e.g. ``num_classes=90`` on a COCO-pretrained checkpoint).
 
         Returns:
             An instance of the appropriate :class:`RFDETR` subclass loaded from the checkpoint.
@@ -1239,7 +1240,7 @@ class RFDETR:
         # (or assigned afterwards); an explicit value is honored regardless of whether it equals
         # the class default, so an intentional num_classes is never silently overridden by the
         # dataset count.  A checkpoint-derived num_classes is cleared from model_fields_set by
-        # ``from_checkpoint`` (see issue #1092), so it correctly counts as "not set" here.
+        # ``from_checkpoint`` (see PR #1106 / issue #1092), so it correctly counts as "not set" here.
         user_overrode = "num_classes" in getattr(self.model_config, "model_fields_set", set())
 
         if not user_overrode:

--- a/src/rfdetr/models/weights.py
+++ b/src/rfdetr/models/weights.py
@@ -373,9 +373,9 @@ def load_pretrain_weights(
     # (or assigned afterwards, e.g. by dataset alignment); an explicit value is honored
     # regardless of whether it equals the class default, so an intentional num_classes always
     # wins over the checkpoint's class count.
-    user_set_num_classes = False
-    if hasattr(mc, "model_fields_set"):
-        user_set_num_classes = "num_classes" in getattr(mc, "model_fields_set", set())
+    # Capture BEFORE any mc.num_classes assignment below — those re-add "num_classes" to
+    # model_fields_set, which would falsely appear as user-set to the second guard (~line 524).
+    user_overrode = "num_classes" in getattr(mc, "model_fields_set", set())
     num_classes = mc.num_classes
 
     checkpoint_num_classes = checkpoint["model"]["class_embed.bias"].shape[0]
@@ -384,7 +384,7 @@ def load_pretrain_weights(
         # Align model head size before loading checkpoint weights.
         if checkpoint_num_classes < configured_num_classes_plus_bg:
             # Checkpoint has FEWER classes than configured.
-            if not user_set_num_classes:
+            if not user_overrode:
                 # Auto-align to the checkpoint when the user did NOT explicitly set
                 # num_classes (i.e., left it unset): treat the checkpoint as authoritative.
                 num_classes = checkpoint_num_classes - 1
@@ -521,7 +521,7 @@ def load_pretrain_weights(
 
     # If the user explicitly set a class count larger than the checkpoint,
     # expand/reinitialize the head back to the configured size after load.
-    if checkpoint_num_classes < configured_num_classes_plus_bg and user_set_num_classes:
+    if checkpoint_num_classes < configured_num_classes_plus_bg and user_overrode:
         nn_model.reinitialize_detection_head(configured_num_classes_plus_bg)
 
     # Only trim back down when loading a larger pretrain checkpoint into a

--- a/src/rfdetr/models/weights.py
+++ b/src/rfdetr/models/weights.py
@@ -268,12 +268,11 @@ def load_pretrain_weights(
 
     Uses the Pydantic-aware logic from ``module_model.py``:
 
-    - When the user did **not** explicitly override ``num_classes`` (left at the
-      ModelConfig default), the checkpoint class count is treated as authoritative and the model head is auto-aligned to
-      it.
-    - When the user **did** explicitly override ``num_classes`` to a value larger
-      than the checkpoint provides, the head is temporarily aligned to the checkpoint for loading, then expanded back to
-      the configured size.
+    - When the user did **not** explicitly set ``num_classes`` (it is left unset),
+      the checkpoint class count is treated as authoritative and the model head is auto-aligned to it.
+    - When the user **did** explicitly set ``num_classes`` (to any value, including the
+      class default) larger than the checkpoint provides, the head is temporarily aligned to the checkpoint for
+      loading, then expanded back to the configured size.
     - When the checkpoint has more classes than configured (backbone-pretrain
       scenario), both reinitializations are applied: expand to checkpoint size for loading, then trim to configured
       size.
@@ -369,15 +368,15 @@ def load_pretrain_weights(
 
     validate_checkpoint_compatibility(checkpoint, mc)
 
-    # Determine whether the user explicitly set num_classes on the ModelConfig,
-    # and whether that explicit value differs from the model default.
+    # Determine whether the user explicitly set num_classes on the ModelConfig.
+    # "num_classes" in model_fields_set is True only when the field was explicitly provided
+    # (or assigned afterwards, e.g. by dataset alignment); an explicit value is honored
+    # regardless of whether it equals the class default, so an intentional num_classes always
+    # wins over the checkpoint's class count.
     user_set_num_classes = False
     if hasattr(mc, "model_fields_set"):
         user_set_num_classes = "num_classes" in getattr(mc, "model_fields_set", set())
-    default_num_classes = type(mc).model_fields["num_classes"].default
     num_classes = mc.num_classes
-    # True only when the user explicitly set num_classes to a non-default value.
-    user_overrode_default_num_classes = user_set_num_classes and num_classes != default_num_classes
 
     checkpoint_num_classes = checkpoint["model"]["class_embed.bias"].shape[0]
     configured_num_classes_plus_bg = num_classes + 1
@@ -385,10 +384,9 @@ def load_pretrain_weights(
         # Align model head size before loading checkpoint weights.
         if checkpoint_num_classes < configured_num_classes_plus_bg:
             # Checkpoint has FEWER classes than configured.
-            if not user_overrode_default_num_classes:
-                # Auto-align to the checkpoint when the user did NOT provide a
-                # non-default override for num_classes (i.e., left it at the
-                # ModelConfig default): treat the checkpoint as authoritative.
+            if not user_set_num_classes:
+                # Auto-align to the checkpoint when the user did NOT explicitly set
+                # num_classes (i.e., left it unset): treat the checkpoint as authoritative.
                 num_classes = checkpoint_num_classes - 1
                 configured_num_classes_plus_bg = checkpoint_num_classes
                 mc.num_classes = num_classes
@@ -523,7 +521,7 @@ def load_pretrain_weights(
 
     # If the user explicitly set a class count larger than the checkpoint,
     # expand/reinitialize the head back to the configured size after load.
-    if checkpoint_num_classes < configured_num_classes_plus_bg and user_overrode_default_num_classes:
+    if checkpoint_num_classes < configured_num_classes_plus_bg and user_set_num_classes:
         nn_model.reinitialize_detection_head(configured_num_classes_plus_bg)
 
     # Only trim back down when loading a larger pretrain checkpoint into a

--- a/tests/models/test_from_checkpoint.py
+++ b/tests/models/test_from_checkpoint.py
@@ -613,6 +613,39 @@ class TestFromCheckpointNumClassesProvenance:
         )
         assert any("Using the model's configured value" in record.message for record in caplog.records)
 
+    def test_explicit_default_num_classes_via_from_checkpoint_integrated(
+        self,
+        two_class_checkpoint: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """from_checkpoint(path, num_classes=<default>) pins head via the integrated code path.
+
+        Unlike test_explicit_default_num_classes_pins_head which simulates the explicit-default scenario via post-
+        construction assignment, this test calls from_checkpoint directly with num_classes=default_nc.  A regression in
+        how from_checkpoint passes num_classes into the constructor would be caught here but not by the proxy-based
+        test.
+        """
+        default_nc = RFDETRSmall._model_config_class.model_fields["num_classes"].default
+        model = RFDETR.from_checkpoint(two_class_checkpoint, num_classes=default_nc)
+
+        assert model.model_config.num_classes == default_nc
+        assert "num_classes" in model.model_config.model_fields_set, (
+            "from_checkpoint with explicit num_classes must keep it in model_fields_set; "
+            "only checkpoint-derived num_classes should be cleared."
+        )
+
+        monkeypatch.setattr(RFDETR, "_detect_num_classes_for_training", staticmethod(lambda *a, **k: 5))
+        monkeypatch.setattr(detr_logger, "propagate", True)
+        with caplog.at_level(logging.WARNING, logger="rf-detr"):
+            model._align_num_classes_from_dataset("<five-class-dataset>")
+
+        assert model.model_config.num_classes == default_nc, (
+            "Head must remain pinned at default_nc after alignment; "
+            "from_checkpoint-supplied num_classes must not be silently overridden."
+        )
+        assert any("Using the model's configured value" in record.message for record in caplog.records)
+
     def test_equal_class_count_does_not_rebuild_head(
         self, two_class_checkpoint: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/models/test_from_checkpoint.py
+++ b/tests/models/test_from_checkpoint.py
@@ -581,15 +581,19 @@ class TestFromCheckpointNumClassesProvenance:
             "otherwise train() refuses to adapt the head to a new dataset's class count."
         )
 
-    def test_explicit_default_num_classes_does_not_block_alignment(
-        self, two_class_checkpoint: Path, monkeypatch: pytest.MonkeyPatch
+    def test_explicit_default_num_classes_pins_head(
+        self,
+        two_class_checkpoint: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """Passing num_classes equal to the ModelConfig default does not pin the detection head.
+        """Passing num_classes equal to the ModelConfig default still pins the detection head.
 
-        _align_num_classes_from_dataset checks user_overrode = user_set AND value != default;
-        when the caller passes the class default explicitly, user_overrode is False and
-        adaptation still proceeds.  This documents the intended semantics and guards against
-        accidental removal of the ``value != default`` guard.
+        An explicit num_classes is honored regardless of whether it equals the class default:
+        ``_align_num_classes_from_dataset`` keys off whether the field was set, not whether the
+        value differs from the default, so the dataset count cannot silently override it.  This
+        guards against re-introducing the ``value != default`` clause, whose asymmetric behavior
+        (default silently aligned, non-default preserved) was the bug this test now pins.
         """
         model = RFDETR.from_checkpoint(two_class_checkpoint)
         default_nc = type(model.model_config).model_fields["num_classes"].default
@@ -599,12 +603,15 @@ class TestFromCheckpointNumClassesProvenance:
 
         assert "num_classes" in model.model_config.model_fields_set
         monkeypatch.setattr(RFDETR, "_detect_num_classes_for_training", staticmethod(lambda *a, **k: 5))
-        model._align_num_classes_from_dataset("<five-class-dataset>")
+        monkeypatch.setattr(detr_logger, "propagate", True)
+        with caplog.at_level(logging.WARNING, logger="rf-detr"):
+            model._align_num_classes_from_dataset("<five-class-dataset>")
 
-        assert model.model_config.num_classes == 5, (
-            "Passing the ModelConfig default for num_classes explicitly must not pin the head; "
-            "_align_num_classes_from_dataset must still adapt to the dataset class count."
+        assert model.model_config.num_classes == default_nc, (
+            "Explicitly passing the ModelConfig default for num_classes must pin the head; "
+            "the dataset class count must not silently override an explicit user setting."
         )
+        assert any("Using the model's configured value" in record.message for record in caplog.records)
 
     def test_equal_class_count_does_not_rebuild_head(
         self, two_class_checkpoint: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/models/test_weights.py
+++ b/tests/models/test_weights.py
@@ -181,6 +181,33 @@ class TestLoadPretrainWeightsReinitScenarios:
         assert calls == [call(3), call(6)], f"Expected reinit to [3, 6] (load then expand), got {calls}"
         assert mc.num_classes == 5, "Dataset-aligned num_classes must not be clobbered by the checkpoint."
 
+    def test_explicit_default_num_classes_treated_as_explicit(self, monkeypatch, tmp_path):
+        """num_classes set explicitly to the class default is honored like any explicit value.
+
+        Scenario: config constructed with ``num_classes`` equal to the ModelConfig default (so it is
+        recorded in ``model_fields_set``), loading a smaller checkpoint.  The configured value must be
+        preserved — the head aligns to the checkpoint for loading, then expands back to the configured
+        size — it must NOT auto-align down to the checkpoint's class count.  Guards against
+        re-introducing the ``num_classes != default`` clause, which made an explicit default behave
+        like "unset" and so silently adopted the checkpoint's class count.
+        """
+        from rfdetr.models.weights import load_pretrain_weights
+
+        default_nc = RFDETRBaseConfig.model_fields["num_classes"].default
+        mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu", num_classes=default_nc)
+        assert "num_classes" in mc.model_fields_set
+        checkpoint = _make_checkpoint(num_classes=3)
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
+
+        nn_model = _fake_nn_model()
+        load_pretrain_weights(nn_model, mc)
+
+        calls = nn_model.reinitialize_detection_head.call_args_list
+        assert calls == [call(3), call(default_nc + 1)], (
+            f"Expected reinit to [3, {default_nc + 1}] (load at checkpoint, expand back to configured), got {calls}"
+        )
+        assert mc.num_classes == default_nc, "Explicit default num_classes must be preserved, not auto-aligned."
+
     def test_characterization_no_mismatch_no_reinit(self, monkeypatch, tmp_path):
         """Checkpoint class count matches config → no reinit.
 

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -1869,6 +1869,7 @@ class TestRFDETRTrainNumClassesAutoDetect:
         self,
         caplog,
         mock_self,
+        monkeypatch,
         patch_lit,
     ):
         """An explicitly-passed num_classes is preserved even when it equals the default.
@@ -1887,28 +1888,23 @@ class TestRFDETRTrainNumClassesAutoDetect:
 
         p_mod, p_dm, p_bt, *_ = patch_lit
         load_classes_patch = patch.object(RFDETR, "_load_classes", return_value=self._FOUR_CLASS_NAMES)
+        monkeypatch.setattr(detr_logger, "propagate", True)
         with p_mod, p_dm, p_bt, load_classes_patch:
-            previous_propagate = detr_logger.propagate
-            detr_logger.propagate = True
-            try:
-                with caplog.at_level("WARNING", logger="rf-detr"):
-                    RFDETR.train(mock_self)
-            finally:
-                detr_logger.propagate = previous_propagate
+            with caplog.at_level("WARNING", logger="rf-detr"):
+                RFDETR.train(mock_self)
 
         assert mock_self.model_config.num_classes == default_nc
-        assert any(
-            record.levelname == "WARNING"
-            and f"Dataset '{dataset_dir}' has 4 classes" in record.message
-            and f"num_classes={default_nc}" in record.message
-            for record in caplog.records
+        expected_fragment = (
+            f"Dataset '{dataset_dir}' has 4 classes but model was initialized with num_classes={default_nc}"
         )
+        assert any(record.levelname == "WARNING" and expected_fragment in record.message for record in caplog.records)
 
     def test_preserves_explicit_non_default_num_classes_when_dataset_differs(
         self,
         tmp_path,
         caplog,
         mock_self,
+        monkeypatch,
         patch_lit,
     ):
         """When user explicitly set a non-default num_classes, it is preserved.
@@ -1922,22 +1918,14 @@ class TestRFDETRTrainNumClassesAutoDetect:
 
         p_mod, p_dm, p_bt, *_ = patch_lit
         load_classes_patch = patch.object(RFDETR, "_load_classes", return_value=self._FOUR_CLASS_NAMES)
+        monkeypatch.setattr(detr_logger, "propagate", True)
         with p_mod, p_dm, p_bt, load_classes_patch:
-            previous_propagate = detr_logger.propagate
-            detr_logger.propagate = True
-            try:
-                with caplog.at_level("WARNING", logger="rf-detr"):
-                    RFDETR.train(mock_self)
-            finally:
-                detr_logger.propagate = previous_propagate
+            with caplog.at_level("WARNING", logger="rf-detr"):
+                RFDETR.train(mock_self)
 
         assert mock_self.model_config.num_classes == 10
-        assert any(
-            record.levelname == "WARNING"
-            and f"Dataset '{dataset_dir}' has 4 classes" in record.message
-            and "num_classes=10" in record.message
-            for record in caplog.records
-        )
+        expected_fragment = f"Dataset '{dataset_dir}' has 4 classes but model was initialized with num_classes=10"
+        assert any(record.levelname == "WARNING" and expected_fragment in record.message for record in caplog.records)
 
     def test_auto_adjust_syncs_model_args_num_classes(self, mock_self, patch_lit):
         """When auto-adjusting, keep ModelContext args.num_classes in sync."""

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -1865,23 +1865,44 @@ class TestRFDETRTrainNumClassesAutoDetect:
         assert mock_self.model_config.num_classes == 2
         assert mock_self.model.args.num_classes == 2
 
-    def test_auto_adjusts_when_default_explicitly_passed(self, mock_self, patch_lit):
-        """Passing num_classes=<default> is treated the same as not setting it.
+    def test_preserves_explicit_default_num_classes_when_dataset_differs(
+        self,
+        caplog,
+        mock_self,
+        patch_lit,
+    ):
+        """An explicitly-passed num_classes is preserved even when it equals the default.
 
-        Scenario: user passes num_classes=90 (the ModelConfig default) explicitly.
-        Dataset has 4 classes.  Expected: model_config.num_classes becomes 4.
+        Scenario: user passes num_classes=90 (the ModelConfig default) explicitly.  Dataset has
+        4 classes.  Expected: model_config.num_classes stays at 90 and a warning is logged —
+        identical to the non-default case below, so an explicit setting always wins regardless of
+        whether it happens to equal the class default.
         """
-        mc = RFDETRBaseConfig(pretrain_weights=None, device="cpu", num_classes=90)
+        default_nc = RFDETRBaseConfig.model_fields["num_classes"].default
+        mc = RFDETRBaseConfig(pretrain_weights=None, device="cpu", num_classes=default_nc)
         mock_self.model_config = mc
-        # num_classes is in model_fields_set, but equals the class default (90).
+        # num_classes equals the class default but was set explicitly.
         assert "num_classes" in mock_self.model_config.model_fields_set
+        dataset_dir = mock_self.get_train_config.return_value.dataset_dir
 
         p_mod, p_dm, p_bt, *_ = patch_lit
         load_classes_patch = patch.object(RFDETR, "_load_classes", return_value=self._FOUR_CLASS_NAMES)
         with p_mod, p_dm, p_bt, load_classes_patch:
-            RFDETR.train(mock_self)
+            previous_propagate = detr_logger.propagate
+            detr_logger.propagate = True
+            try:
+                with caplog.at_level("WARNING", logger="rf-detr"):
+                    RFDETR.train(mock_self)
+            finally:
+                detr_logger.propagate = previous_propagate
 
-        assert mock_self.model_config.num_classes == 4
+        assert mock_self.model_config.num_classes == default_nc
+        assert any(
+            record.levelname == "WARNING"
+            and f"Dataset '{dataset_dir}' has 4 classes" in record.message
+            and f"num_classes={default_nc}" in record.message
+            for record in caplog.records
+        )
 
     def test_preserves_explicit_non_default_num_classes_when_dataset_differs(
         self,


### PR DESCRIPTION
## What does this PR do?

Both train-time guards that decide whether the user overrode num_classes keyed off `("num_classes" in model_fields_set) and (num_classes != default)`. The `!= default` clause made the default value inconsistent: an explicit num_classes=90 (the class default) was silently realigned to the dataset's class count with no warning, while any non-default value was preserved and warned about.

Drop the clause at both guard sites (detr._align_num_classes_from_dataset and weights.load_pretrain_weights) so an explicit num_classes is always honored regardless of whether it equals the default; the unset case still auto-aligns to the dataset.

Follow-up to #1106 (approved as a separate PR in review). With #1106 merged, from_checkpoint no longer records checkpoint-derived num_classes in model_fields_set, so the `!= default` heuristic is no longer needed.

**Related Issue(s):** #1106

## Type of Change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**
- `tests/training/test_detr_shim.py::TestRFDETRTrainNumClassesAutoDetect::test_preserves_explicit_default_num_classes_when_dataset_differs`
  — *replaces* `test_auto_adjusts_when_default_explicitly_passed`. Covers the `train()`-time
  guard (`_align_num_classes_from_dataset`): passing `num_classes=90` (the class default)
  explicitly on a 4-class dataset now **preserves 90 and logs a warning** — identical to the
  non-default case, instead of silently realigning to 4.

- `tests/models/test_from_checkpoint.py::TestFromCheckpointNumClassesProvenance::test_explicit_default_num_classes_pins_head`
  — *replaces* `test_explicit_default_num_classes_does_not_block_alignment`. Covers a
  `from_checkpoint` model with an explicit default `num_classes`: the head is **pinned** (not
  silently realigned to the dataset) and a warning is logged. Explicitly guards against
  re-introducing the `!= default` clause.

- `tests/models/test_weights.py::TestLoadPretrainWeightsReinitScenarios::test_explicit_default_num_classes_treated_as_explicit`
  — *new*. Covers the second guard site (`load_pretrain_weights`): an explicit default
  `num_classes` + a smaller checkpoint reinitializes the head `[3, 91]` (load at the checkpoint
  size, then expand back to the configured size) rather than auto-aligning down to the
  checkpoint's class count.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

I flagged it as breaking change, since previously this edge case (`num_classes explicitly` set but equal to default) was handled differently - it was described both in docstrings and tests.
