### PR TITLE
chore: suppress spurious keypoint class-logit boost warning for correct schema

### DIFF
--- a/src/rfdetr/models/lwdetr.py
+++ b/src/rfdetr/models/lwdetr.py
@@ -412,18 +412,24 @@ class LWDETR(nn.Module):
         class_boost = class_contrib.sum(dim=-1)
 
         detection_num_classes = self.class_embed.out_features
+        foreground_num_classes = detection_num_classes - 1
         if class_boost.shape[-1] < detection_num_classes:
-            if not self._kp_zero_pad_warned:
-                logger.warning(
-                    "Keypoint class-logit boost has %d classes but detection head has %d; "
-                    "zero-padding boost for classes %d..%d. Detection classes with no keypoint schema "
-                    "will receive zero boost. This warning is emitted once per model instance.",
-                    class_boost.shape[-1],
-                    detection_num_classes,
-                    class_boost.shape[-1],
-                    detection_num_classes - 1,
-                )
-                self._kp_zero_pad_warned = True
+            if class_boost.shape[-1] < foreground_num_classes:
+                # Only warn when the schema doesn't cover all foreground detection classes.
+                # The background slot (index detection_num_classes-1) always receives zero boost,
+                # so a schema that covers exactly num_classes foreground classes is correct and
+                # does not warrant a warning.
+                if not self._kp_zero_pad_warned:
+                    logger.warning(
+                        "Keypoint class-logit boost has %d classes but detection head has %d foreground classes; "
+                        "zero-padding boost for classes %d..%d. Detection classes with no keypoint schema "
+                        "will receive zero boost. This warning is emitted once per model instance.",
+                        class_boost.shape[-1],
+                        foreground_num_classes,
+                        class_boost.shape[-1],
+                        foreground_num_classes - 1,
+                    )
+                    self._kp_zero_pad_warned = True
             class_boost = torch.cat(
                 [
                     class_boost,

--- a/tests/models/test_detection_head.py
+++ b/tests/models/test_detection_head.py
@@ -3,14 +3,19 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-"""Regression tests for _resize_linear() and LWDETR.reinitialize_detection_head().
+"""Regression tests for _resize_linear(), LWDETR.reinitialize_detection_head(), and _aggregate_keypoint_class_logits().
 
 These tests guard against the out_features staleness bug where in-place .data mutation did not update
 nn.Linear.out_features, causing ONNX export to emit stale (pre-fine-tuning) class counts.
+
+Also covers the spurious "Keypoint class-logit boost has N classes but detection head has M" warning that fired when
+num_keypoints_per_class exactly covered all foreground classes (correct configuration) but the comparison was against
+class_embed.out_features which includes the background slot (+1).
 """
 
 from unittest.mock import MagicMock
 
+import pytest
 import torch
 from torch import nn
 
@@ -50,6 +55,73 @@ def _make_minimal_lwdetr(num_classes: int = 91, two_stage: bool = False) -> LWDE
         group_detr=1,
         two_stage=two_stage,
     )
+
+
+def _make_keypoint_lwdetr(num_classes: int, num_keypoints_per_class: list[int]) -> LWDETR:
+    """Construct a minimal keypoint-capable LWDETR with detection head resized to num_classes+1.
+
+    Mirrors what happens after loading a pretrained checkpoint and fine-tuning to num_classes
+    foreground categories: reinitialize_detection_head is called with num_classes+1 (includes
+    background), so class_embed.out_features == num_classes+1 in the returned model.
+
+    Args:
+        num_classes: Number of foreground detection classes.
+        num_keypoints_per_class: Keypoint count per foreground class.
+
+    Returns:
+        An LWDETR with use_grouppose_keypoints=True and class_embed.out_features==num_classes+1.
+
+    Examples:
+        >>> model = _make_keypoint_lwdetr(num_classes=2, num_keypoints_per_class=[17, 4])
+        >>> model.class_embed.out_features
+        3
+    """
+    hidden_dim = 4
+    backbone = MagicMock()
+    transformer = MagicMock()
+    transformer.d_model = hidden_dim
+    transformer.decoder = MagicMock()
+    transformer.decoder.bbox_embed = None
+    transformer.decoder.num_keypoints_per_class = num_keypoints_per_class
+    transformer.decoder.keypoint_class_mask = torch.zeros(1, 1, dtype=torch.bool)
+    transformer.num_keypoints_per_class = num_keypoints_per_class
+    model = LWDETR(
+        backbone=backbone,
+        transformer=transformer,
+        segmentation_head=None,
+        num_classes=num_classes,
+        num_queries=2,
+        group_detr=1,
+        use_grouppose_keypoints=True,
+        num_keypoints_per_class=num_keypoints_per_class,
+    )
+    # Simulate post-checkpoint-load state: detection head includes background slot.
+    model.reinitialize_detection_head(num_classes + 1)
+    return model
+
+
+def _keypoint_tensor(num_keypoints_per_class: list[int], batch: int = 1, seq: int = 1) -> torch.Tensor:
+    """Build a zero keypoint prediction tensor with the shape expected by _aggregate_keypoint_class_logits.
+
+    The second-to-last dimension must equal num_kp_classes * max_kp (padded layout).
+
+    Args:
+        num_keypoints_per_class: Keypoint schema for the model.
+        batch: Batch size dimension.
+        seq: Sequence (query) dimension.
+
+    Returns:
+        Zero tensor of shape (batch, seq, num_kp_classes * max_kp, 8).
+
+    Examples:
+        >>> t = _keypoint_tensor([17, 4])
+        >>> t.shape
+        torch.Size([1, 1, 34, 8])
+    """
+    num_kp_classes = len(num_keypoints_per_class)
+    max_kp = max(num_keypoints_per_class) if any(num_keypoints_per_class) else 1
+    total_padded = num_kp_classes * max_kp
+    return torch.zeros(batch, seq, total_padded, 8)
 
 
 class TestResizeLinear:
@@ -134,3 +206,69 @@ class TestReinitializeDetectionHead:
                 f"enc_out_class_embed[{i}].weight.shape={embed.weight.shape}, "
                 f"expected ({num_outputs_including_background}, 4)"
             )
+
+
+class TestAggregateKeypointClassLogits:
+    """Regression tests for LWDETR._aggregate_keypoint_class_logits().
+
+    Guards against a spurious warning that fired when num_keypoints_per_class exactly covered all
+    foreground classes: class_embed.out_features includes background (+1), so len(schema)==num_classes
+    always satisfied schema_len < detection_num_classes, triggering the warning incorrectly.
+
+    Uses _kp_zero_pad_warned as a proxy for whether the warning fired — the rf-detr logger uses
+    propagate=False which prevents standard caplog capture.
+    """
+
+    @pytest.mark.parametrize(
+        "num_classes,num_keypoints_per_class",
+        [
+            pytest.param(1, [17], id="coco-person-1class"),
+            pytest.param(2, [17, 4], id="basketball-2class"),
+            pytest.param(3, [17, 4, 0], id="3class-schema-covers-all"),
+        ],
+    )
+    def test_no_warning_when_schema_covers_all_foreground_classes(
+        self,
+        num_classes: int,
+        num_keypoints_per_class: list[int],
+    ) -> None:
+        """No warning when num_keypoints_per_class covers exactly all foreground detection classes.
+
+        Regression: the comparison used class_embed.out_features (num_classes+1) instead of
+        num_classes, so a fully correct schema always triggered the spurious mismatch warning.
+        """
+        model = _make_keypoint_lwdetr(num_classes=num_classes, num_keypoints_per_class=num_keypoints_per_class)
+        fake_kp = _keypoint_tensor(num_keypoints_per_class)
+
+        model._aggregate_keypoint_class_logits(fake_kp)
+
+        assert not model._kp_zero_pad_warned, (
+            f"Spurious warning fired for schema={num_keypoints_per_class} with num_classes={num_classes}"
+        )
+
+    def test_warning_fires_when_schema_shorter_than_foreground_classes(self) -> None:
+        """Warning fires when schema covers fewer classes than foreground detection classes.
+
+        Scenario: 3 foreground classes but schema only covers 1 (e.g. only person has keypoints).
+        The two uncovered foreground classes receive zero boost — a real mismatch worth warning about.
+        """
+        model = _make_keypoint_lwdetr(num_classes=3, num_keypoints_per_class=[17])
+        fake_kp = _keypoint_tensor([17])
+
+        model._aggregate_keypoint_class_logits(fake_kp)
+
+        assert model._kp_zero_pad_warned, "Expected warning flag set for schema shorter than foreground class count"
+
+    def test_output_shape_matches_detection_head(self) -> None:
+        """Output shape is (batch, seq, detection_num_classes) regardless of schema length."""
+        num_classes = 2
+        schema = [17, 4]
+        model = _make_keypoint_lwdetr(num_classes=num_classes, num_keypoints_per_class=schema)
+        batch, seq = 2, 10
+        fake_kp = _keypoint_tensor(schema, batch=batch, seq=seq)
+
+        out = model._aggregate_keypoint_class_logits(fake_kp)
+
+        assert out.shape == (batch, seq, num_classes + 1), (
+            f"Expected shape {(batch, seq, num_classes + 1)}, got {out.shape}"
+        )


### PR DESCRIPTION
Warning fired when num_keypoints_per_class exactly covered all foreground classes because the comparison used class_embed.out_features (num_classes+1, includes background) instead of num_classes. A schema of length num_classes always satisfied schema_len < detection_num_classes, triggering a false alarm.

- Guard warning behind `class_boost.shape[-1] < foreground_num_classes` so it only fires when schema genuinely misses foreground classes
- Background slot silently receives zero boost (expected, no warning)
- Update warning message to reference "foreground classes" explicitly
- Add TestAggregateKeypointClassLogits with 5 regression tests covering COCO 1-class, basketball 2-class, 3-class full coverage, real mismatch, and output shape
