### PR TITLE
Fix loss scaling under grad accumulation

### DIFF
--- a/docs/learn/train/customization.md
+++ b/docs/learn/train/customization.md
@@ -53,17 +53,17 @@ module = RFDETRModelModule(model_config, train_config)
 
 ### Lifecycle hooks
 
-| Hook                       | Behaviour                                                                                       |
-| -------------------------- | ----------------------------------------------------------------------------------------------- |
-| `on_fit_start`             | Seeds RNGs when `train_config.seed` is set.                                                     |
-| `on_train_batch_start`     | Applies multi-scale random resize when `train_config.multi_scale=True`.                         |
-| `transfer_batch_to_device` | Moves `NestedTensor` batches to the target device.                                              |
-| `training_step`            | Computes loss, divides by `accumulate_grad_batches`, and logs `train/loss` and per-term losses. |
-| `validation_step`          | Runs forward pass and postprocessing; returns `{results, targets}` for `COCOEvalCallback`.      |
-| `test_step`                | Same as `validation_step`, logs under `test/`.                                                  |
-| `predict_step`             | Runs inference-only forward pass and returns postprocessed detections.                          |
-| `configure_optimizers`     | Builds AdamW with layer-wise LR decay and a LambdaLR scheduler (cosine or step).                |
-| `on_load_checkpoint`       | Auto-converts legacy `.pth` checkpoints to PTL format.                                          |
+| Hook                       | Behaviour                                                                                                        |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `on_fit_start`             | Seeds RNGs when `train_config.seed` is set.                                                                      |
+| `on_train_batch_start`     | Applies multi-scale random resize when `train_config.multi_scale=True`.                                          |
+| `transfer_batch_to_device` | Moves `NestedTensor` batches to the target device.                                                               |
+| `training_step`            | Computes box-normalized loss, performs manual gradient accumulation, and logs `train/loss` plus per-term losses. |
+| `validation_step`          | Runs forward pass and postprocessing; returns `{results, targets}` for `COCOEvalCallback`.                       |
+| `test_step`                | Same as `validation_step`, logs under `test/`.                                                                   |
+| `predict_step`             | Runs inference-only forward pass and returns postprocessed detections.                                           |
+| `configure_optimizers`     | Builds AdamW with layer-wise LR decay and a LambdaLR scheduler (cosine or step).                                 |
+| `on_load_checkpoint`       | Auto-converts legacy `.pth` checkpoints to PTL format.                                                           |
 
 ### Accessing the underlying model
 
@@ -117,8 +117,8 @@ trainer = build_trainer(train_config, model_config)
 | Concern               | Source                                                                                                                                                     |
 | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Max epochs            | `train_config.epochs`                                                                                                                                      |
-| Gradient accumulation | `train_config.grad_accum_steps`                                                                                                                            |
-| Gradient clipping     | `train_config.clip_max_norm` (default `0.1`)                                                                                                               |
+| Gradient accumulation | `train_config.grad_accum_steps`; owned by `RFDETRModelModule` manual optimization                                                                          |
+| Gradient clipping     | `train_config.clip_max_norm` (default `0.1`); owned by `RFDETRModelModule` manual optimization                                                             |
 | Mixed precision       | Resolved from `model_config.amp` and device capability (`bf16-mixed` on Ampere+, `16-mixed` otherwise)                                                     |
 | Accelerator           | `train_config.accelerator` (default `"auto"`)                                                                                                              |
 | Strategy              | Pass `strategy=` as a `**trainer_kwarg` to `build_trainer`. `TrainConfig` has no `strategy` field — setting it on `TrainConfig` will raise a `ValueError`. |
@@ -129,14 +129,13 @@ trainer = build_trainer(train_config, model_config)
 
 ### Overriding PTL Trainer kwargs
 
-Pass any keyword argument accepted by `pytorch_lightning.Trainer` via `**trainer_kwargs`. These override the built configuration:
+Pass keyword arguments accepted by `pytorch_lightning.Trainer` via `**trainer_kwargs`. Most keys override the built configuration. RF-DETR keeps `accumulate_grad_batches=1` and `gradient_clip_val=None` internally because `RFDETRModelModule` owns accumulation and clipping under manual optimization:
 
 ```python
 trainer = build_trainer(
     train_config,
     model_config,
     fast_dev_run=2,  # run 2 batches per epoch for a smoke test
-    accumulate_grad_batches=8,  # override TrainConfig.grad_accum_steps
     log_every_n_steps=10,
 )
 ```

--- a/docs/learn/train/customization.md
+++ b/docs/learn/train/customization.md
@@ -53,17 +53,17 @@ module = RFDETRModelModule(model_config, train_config)
 
 ### Lifecycle hooks
 
-| Hook                       | Behaviour                                                                                                        |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `on_fit_start`             | Seeds RNGs when `train_config.seed` is set.                                                                      |
-| `on_train_batch_start`     | Applies multi-scale random resize when `train_config.multi_scale=True`.                                          |
-| `transfer_batch_to_device` | Moves `NestedTensor` batches to the target device.                                                               |
-| `training_step`            | Computes box-normalized loss, performs manual gradient accumulation, and logs `train/loss` plus per-term losses. |
-| `validation_step`          | Runs forward pass and postprocessing; returns `{results, targets}` for `COCOEvalCallback`.                       |
-| `test_step`                | Same as `validation_step`, logs under `test/`.                                                                   |
-| `predict_step`             | Runs inference-only forward pass and returns postprocessed detections.                                           |
-| `configure_optimizers`     | Builds AdamW with layer-wise LR decay and a LambdaLR scheduler (cosine or step).                                 |
-| `on_load_checkpoint`       | Auto-converts legacy `.pth` checkpoints to PTL format.                                                           |
+| Hook                       | Behaviour                                                                                                                                                                                                                       |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `on_fit_start`             | Seeds RNGs when `train_config.seed` is set.                                                                                                                                                                                     |
+| `on_train_batch_start`     | Applies multi-scale random resize when `train_config.multi_scale=True`.                                                                                                                                                         |
+| `transfer_batch_to_device` | Moves `NestedTensor` batches to the target device.                                                                                                                                                                              |
+| `training_step`            | Computes loss and logs `train/loss` plus per-term losses. Keypoint models use manual optimization with box-normalized accumulation across microbatches; detection and segmentation use Lightning's automatic optimization path. |
+| `validation_step`          | Runs forward pass and postprocessing; returns `{results, targets}` for `COCOEvalCallback`.                                                                                                                                      |
+| `test_step`                | Same as `validation_step`, logs under `test/`.                                                                                                                                                                                  |
+| `predict_step`             | Runs inference-only forward pass and returns postprocessed detections.                                                                                                                                                          |
+| `configure_optimizers`     | Builds AdamW with layer-wise LR decay and a LambdaLR scheduler (cosine or step).                                                                                                                                                |
+| `on_load_checkpoint`       | Auto-converts legacy `.pth` checkpoints to PTL format.                                                                                                                                                                          |
 
 ### Accessing the underlying model
 
@@ -114,22 +114,26 @@ trainer = build_trainer(train_config, model_config)
 
 ### What build_trainer configures
 
-| Concern               | Source                                                                                                                                                     |
-| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Max epochs            | `train_config.epochs`                                                                                                                                      |
-| Gradient accumulation | `train_config.grad_accum_steps`; owned by `RFDETRModelModule` manual optimization                                                                          |
-| Gradient clipping     | `train_config.clip_max_norm` (default `0.1`); owned by `RFDETRModelModule` manual optimization                                                             |
-| Mixed precision       | Resolved from `model_config.amp` and device capability (`bf16-mixed` on Ampere+, `16-mixed` otherwise)                                                     |
-| Accelerator           | `train_config.accelerator` (default `"auto"`)                                                                                                              |
-| Strategy              | Pass `strategy=` as a `**trainer_kwarg` to `build_trainer`. `TrainConfig` has no `strategy` field — setting it on `TrainConfig` will raise a `ValueError`. |
-| Sync batch norm       | `train_config.sync_bn`                                                                                                                                     |
-| Progress bar          | `train_config.progress_bar`                                                                                                                                |
-| Loggers               | CSVLogger always; TensorBoard, WandB, MLflow when their `train_config` flags are `True`                                                                    |
-| Callbacks             | `RFDETREMACallback`, `DropPathCallback`, `COCOEvalCallback`, `BestModelCallback`, `RFDETREarlyStopping` (conditional)                                      |
+| Concern               | Source                                                                                                                                                                     |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Max epochs            | `train_config.epochs`                                                                                                                                                      |
+| Gradient accumulation | Detection/segmentation: `train_config.grad_accum_steps` forwarded to Trainer. Keypoint models: owned by `RFDETRModelModule` manual optimization (Trainer always sees `1`). |
+| Gradient clipping     | Detection/segmentation: `train_config.clip_max_norm` forwarded to Trainer. Keypoint models: owned by `RFDETRModelModule` manual optimization (Trainer always sees `None`). |
+| Mixed precision       | Resolved from `model_config.amp` and device capability (`bf16-mixed` on Ampere+, `16-mixed` otherwise)                                                                     |
+| Accelerator           | `train_config.accelerator` (default `"auto"`)                                                                                                                              |
+| Strategy              | Pass `strategy=` as a `**trainer_kwarg` to `build_trainer`. `TrainConfig` has no `strategy` field — setting it on `TrainConfig` will raise a `ValueError`.                 |
+| Sync batch norm       | `train_config.sync_bn`                                                                                                                                                     |
+| Progress bar          | `train_config.progress_bar`                                                                                                                                                |
+| Loggers               | CSVLogger always; TensorBoard, WandB, MLflow when their `train_config` flags are `True`                                                                                    |
+| Callbacks             | `RFDETREMACallback`, `DropPathCallback`, `COCOEvalCallback`, `BestModelCallback`, `RFDETREarlyStopping` (conditional)                                                      |
 
 ### Overriding PTL Trainer kwargs
 
-Pass keyword arguments accepted by `pytorch_lightning.Trainer` via `**trainer_kwargs`. Most keys override the built configuration. RF-DETR keeps `accumulate_grad_batches=1` and `gradient_clip_val=None` internally because `RFDETRModelModule` owns accumulation and clipping under manual optimization:
+Pass keyword arguments accepted by `pytorch_lightning.Trainer` via `**trainer_kwargs`. Most keys override the built configuration.
+
+**Detection and segmentation models** forward `accumulate_grad_batches` and `gradient_clip_val` to the Trainer normally — you can override them via `trainer_kwargs` or configure them on `TrainConfig` (`grad_accum_steps`, `clip_max_norm`).
+
+**Keypoint models** use manual optimization, so `RFDETRModelModule` owns accumulation and clipping internally. `build_trainer()` forces `accumulate_grad_batches=1` and `gradient_clip_val=None` regardless of what is passed, and emits a `UserWarning` if those keys appear in `trainer_kwargs` so the override is visible:
 
 ```python
 trainer = build_trainer(

--- a/src/rfdetr/models/criterion.py
+++ b/src/rfdetr/models/criterion.py
@@ -134,8 +134,6 @@ class SetCriterion(nn.Module):
     2) we supervise each pair of matched ground-truth / prediction (supervise class and box).
     """
 
-    supports_loss_normalizer_override = True
-
     def __init__(
         self,
         num_classes,

--- a/src/rfdetr/models/criterion.py
+++ b/src/rfdetr/models/criterion.py
@@ -9,6 +9,8 @@
 # ------------------------------------------------------------------------
 """Loss functions and criterion for RF-DETR training."""
 
+from typing import Any
+
 import torch
 import torch.nn.functional as F  # noqa: N812
 from torch import nn
@@ -174,14 +176,15 @@ class SetCriterion(nn.Module):
         self.num_keypoints_per_class = num_keypoints_per_class or []
 
     @staticmethod
-    def _output_device(outputs: dict) -> torch.device:
+    def _output_device(outputs: dict[str, Any]) -> torch.device:
         """Return the device used by tensor outputs.
 
         Args:
-            outputs: Model output dictionary.
+            outputs: Model output dictionary. Values may be tensors, lists, or nested dicts;
+                non-tensor entries are skipped when probing for a device.
 
         Returns:
-            Device of the first tensor value in ``outputs``.
+            Device of the first tensor value found in ``outputs``.
 
         Raises:
             ValueError: If no tensor output is present.
@@ -191,15 +194,50 @@ class SetCriterion(nn.Module):
                 return value.device
         raise ValueError("SetCriterion requires at least one tensor output to infer the loss device.")
 
-    def num_boxes_for_targets(self, outputs: dict, targets: list) -> torch.Tensor:
+    def num_boxes_for_targets(
+        self,
+        outputs: dict[str, Any],
+        targets: list[dict[str, torch.Tensor]],
+    ) -> torch.Tensor:
         """Compute the distributed target-box denominator for a target batch.
 
+        The denominator is the total number of ground-truth boxes in the batch, multiplied by the active number of
+        DETR groups (unless ``sum_group_losses`` collapses them), reduced across all distributed ranks, divided by the
+        world size, and finally clamped to be at least ``1.0`` so divide-by-zero never occurs on empty batches.
+
         Args:
-            outputs: Model output dictionary used to infer device placement.
-            targets: Target dictionaries for the current batch.
+            outputs: Model output dictionary; used only to infer the device for the
+                returned scalar tensor.
+            targets: Per-image target dictionaries for the current batch. Each must
+                contain a ``"labels"`` tensor whose length equals the number of
+                ground-truth boxes for that image.
 
         Returns:
-            Scalar tensor with the box-count normalizer used by criterion losses.
+            Scalar tensor on the same device as the model outputs, holding the
+            average box-count denominator used to normalize criterion losses.
+
+        Note:
+            When ``torch.distributed`` is initialized this method performs an
+            in-place ``all_reduce`` collective on the returned tensor. Every rank
+            must reach this call together or the program will deadlock.
+
+        Note:
+            ``group_detr`` is multiplied in only when ``self.training`` is ``True``.
+            During evaluation (``self.training`` is ``False``) the denominator
+            collapses to a single group, so train-time and eval-time normalizers
+            cannot be compared directly.
+
+        Examples:
+            >>> import torch
+            >>> from rfdetr.models.criterion import SetCriterion
+            >>> criterion = SetCriterion.__new__(SetCriterion)
+            >>> criterion.training = False
+            >>> criterion.group_detr = 1
+            >>> criterion.sum_group_losses = False
+            >>> outputs = {"pred_logits": torch.zeros(1, 1, 1)}
+            >>> targets = [{"labels": torch.tensor([0, 1, 2])}]
+            >>> criterion.num_boxes_for_targets(outputs, targets).item()
+            3.0
         """
         group_detr = self.group_detr if self.training else 1
         num_boxes = sum(len(t["labels"]) for t in targets)
@@ -482,9 +520,18 @@ class SetCriterion(nn.Module):
                 mode="nearest",
             ).squeeze(1)
 
+        # ``sigmoid_ce_loss_jit`` and ``dice_loss_jit`` are TorchScripted with
+        # ``num_masks: float`` in their signatures, so they reject Tensor inputs at
+        # runtime with a "expected float, got Tensor" error.  ``SetCriterion.forward``
+        # now hands the criterion a Tensor denominator (so it can be all-reduced across
+        # ranks and accumulated across grad-accum microbatches), so it must be unwrapped
+        # to a Python scalar exactly here before the JIT call boundary.  Using
+        # ``float(...)`` instead of ``.item()`` keeps the conversion safe whether
+        # ``num_boxes`` arrives as a Tensor, a Python int/float, or a numpy scalar.
+        num_boxes_scalar = float(num_boxes)
         losses = {
-            "loss_mask_ce": sigmoid_ce_loss_jit(point_logits, point_labels, num_boxes),
-            "loss_mask_dice": dice_loss_jit(point_logits, point_labels, num_boxes),
+            "loss_mask_ce": sigmoid_ce_loss_jit(point_logits, point_labels, num_boxes_scalar),
+            "loss_mask_dice": dice_loss_jit(point_logits, point_labels, num_boxes_scalar),
         }
 
         del src_masks
@@ -545,14 +592,61 @@ class SetCriterion(nn.Module):
         assert loss in loss_map, f"do you really want to compute {loss} loss?"
         return loss_map[loss](outputs, targets, indices, num_boxes, **kwargs)
 
-    def forward(self, outputs, targets, num_boxes: torch.Tensor | float | None = None):
-        """This performs the loss computation.
+    def forward(
+        self,
+        outputs: dict[str, Any],
+        targets: list[dict[str, torch.Tensor]],
+        num_boxes: torch.Tensor | float | None = None,
+    ) -> dict[str, torch.Tensor]:
+        """Compute every configured loss for one (outputs, targets) pair.
 
-        Parameters:
-             outputs: dict of tensors, see the output specification of the model for the format
-             targets: list of dicts, such that len(targets) == batch_size.
-                      The expected keys in each dict depends on the losses applied, see each loss' doc
-             num_boxes: Optional explicit box-count denominator. Supplying ``1.0`` returns loss numerators.
+        The Hungarian matcher is invoked on the last layer's outputs and reused for the auxiliary intermediate layers
+        and the optional encoder outputs; each loss is then evaluated on the matched indices and normalized by
+        ``num_boxes``.
+
+        Args:
+            outputs: Model output dictionary. Must contain the tensors required by
+                every loss in ``self.losses`` (for example ``"pred_logits"``,
+                ``"pred_boxes"``, ``"pred_masks"``, ``"pred_keypoints"``). May also
+                contain ``"aux_outputs"`` (list of layer-wise outputs) and
+                ``"enc_outputs"`` (encoder outputs); both are processed identically
+                to the last layer and contribute prefixed keys to the returned dict.
+            targets: Per-image target dictionaries; ``len(targets) == batch_size``.
+                The expected keys depend on the losses being applied — see each
+                ``loss_*`` method for its target requirements.
+            num_boxes: Optional explicit box-count denominator.
+
+                - ``None`` (default): call :meth:`num_boxes_for_targets` to derive
+                  the distributed-reduced normalizer for the current batch.
+                - ``float`` / ``int``: cast to a tensor on the model output device
+                  and used verbatim. Passing ``1.0`` yields *unnormalized* loss
+                  numerators (used by the manual-optimization path so the caller
+                  can apply its own accumulated denominator).
+                - ``torch.Tensor``: moved to the model output device and used
+                  verbatim. The caller is responsible for any cross-rank reduction;
+                  no extra all-reduce is performed in this branch.
+
+        Returns:
+            Dictionary of named loss tensors. Last-layer losses keep their base
+            names (``"loss_ce"``, ``"loss_bbox"``, ``"loss_giou"``,
+            ``"loss_mask_ce"``, ``"loss_mask_dice"``, ``"loss_keypoints_*"``).
+            Auxiliary-layer losses get a ``"_<i>"`` suffix; encoder-layer losses
+            get an ``"_enc"`` suffix.
+
+        Examples:
+            >>> from unittest.mock import MagicMock
+            >>> import torch
+            >>> from rfdetr.models.criterion import SetCriterion
+            >>> criterion = SetCriterion.__new__(SetCriterion)
+            >>> criterion.training = False
+            >>> criterion.group_detr = 1
+            >>> criterion.sum_group_losses = False
+            >>> criterion.losses = []
+            >>> criterion.matcher = MagicMock(return_value=[])
+            >>> outputs = {"pred_logits": torch.zeros(1, 1, 1)}
+            >>> targets = [{"labels": torch.tensor([0])}]
+            >>> criterion.forward(outputs, targets, num_boxes=1.0)
+            {}
         """
         group_detr = self.group_detr if self.training else 1
         outputs_without_aux = {k: v for k, v in outputs.items() if k != "aux_outputs"}

--- a/src/rfdetr/models/criterion.py
+++ b/src/rfdetr/models/criterion.py
@@ -134,6 +134,8 @@ class SetCriterion(nn.Module):
     2) we supervise each pair of matched ground-truth / prediction (supervise class and box).
     """
 
+    supports_loss_normalizer_override = True
+
     def __init__(
         self,
         num_classes,
@@ -172,6 +174,43 @@ class SetCriterion(nn.Module):
         self.ia_bce_loss = ia_bce_loss
         self.mask_point_sample_ratio = mask_point_sample_ratio
         self.num_keypoints_per_class = num_keypoints_per_class or []
+
+    @staticmethod
+    def _output_device(outputs: dict) -> torch.device:
+        """Return the device used by tensor outputs.
+
+        Args:
+            outputs: Model output dictionary.
+
+        Returns:
+            Device of the first tensor value in ``outputs``.
+
+        Raises:
+            ValueError: If no tensor output is present.
+        """
+        for value in outputs.values():
+            if torch.is_tensor(value):
+                return value.device
+        raise ValueError("SetCriterion requires at least one tensor output to infer the loss device.")
+
+    def num_boxes_for_targets(self, outputs: dict, targets: list) -> torch.Tensor:
+        """Compute the distributed target-box denominator for a target batch.
+
+        Args:
+            outputs: Model output dictionary used to infer device placement.
+            targets: Target dictionaries for the current batch.
+
+        Returns:
+            Scalar tensor with the box-count normalizer used by criterion losses.
+        """
+        group_detr = self.group_detr if self.training else 1
+        num_boxes = sum(len(t["labels"]) for t in targets)
+        if not self.sum_group_losses:
+            num_boxes = num_boxes * group_detr
+        num_boxes_tensor = torch.as_tensor(num_boxes, dtype=torch.float, device=self._output_device(outputs))
+        if is_dist_avail_and_initialized():
+            torch.distributed.all_reduce(num_boxes_tensor)
+        return torch.clamp(num_boxes_tensor / get_world_size(), min=1.0)
 
     def loss_labels(self, outputs, targets, indices, num_boxes, log=True):
         """Classification loss (Binary focal loss) targets dicts must contain the key "labels" containing a tensor of
@@ -508,13 +547,14 @@ class SetCriterion(nn.Module):
         assert loss in loss_map, f"do you really want to compute {loss} loss?"
         return loss_map[loss](outputs, targets, indices, num_boxes, **kwargs)
 
-    def forward(self, outputs, targets):
+    def forward(self, outputs, targets, num_boxes: torch.Tensor | float | None = None):
         """This performs the loss computation.
 
         Parameters:
              outputs: dict of tensors, see the output specification of the model for the format
              targets: list of dicts, such that len(targets) == batch_size.
                       The expected keys in each dict depends on the losses applied, see each loss' doc
+             num_boxes: Optional explicit box-count denominator. Supplying ``1.0`` returns loss numerators.
         """
         group_detr = self.group_detr if self.training else 1
         outputs_without_aux = {k: v for k, v in outputs.items() if k != "aux_outputs"}
@@ -522,14 +562,12 @@ class SetCriterion(nn.Module):
         # Retrieve the matching between the outputs of the last layer and the targets
         indices = self.matcher(outputs_without_aux, targets, group_detr=group_detr)
 
-        # Compute the average number of target boxes across all nodes, for normalization purposes
-        num_boxes = sum(len(t["labels"]) for t in targets)
-        if not self.sum_group_losses:
-            num_boxes = num_boxes * group_detr
-        num_boxes = torch.as_tensor([num_boxes], dtype=torch.float, device=next(iter(outputs.values())).device)
-        if is_dist_avail_and_initialized():
-            torch.distributed.all_reduce(num_boxes)
-        num_boxes = torch.clamp(num_boxes / get_world_size(), min=1).item()
+        if num_boxes is None:
+            num_boxes = self.num_boxes_for_targets(outputs, targets)
+        elif not torch.is_tensor(num_boxes):
+            num_boxes = torch.as_tensor(num_boxes, dtype=torch.float, device=self._output_device(outputs))
+        else:
+            num_boxes = num_boxes.to(device=self._output_device(outputs), dtype=torch.float)
 
         # Compute all the requested losses
         losses = {}

--- a/src/rfdetr/models/criterion.py
+++ b/src/rfdetr/models/criterion.py
@@ -9,6 +9,8 @@
 # ------------------------------------------------------------------------
 """Loss functions and criterion for RF-DETR training."""
 
+from __future__ import annotations
+
 from typing import Any
 
 import torch
@@ -136,6 +138,12 @@ class SetCriterion(nn.Module):
     2) we supervise each pair of matched ground-truth / prediction (supervise class and box).
     """
 
+    # Signals that forward() accepts an explicit num_boxes denominator and exposes
+    # num_boxes_for_targets() for cross-microbatch accumulation.  Subclasses that
+    # override forward() with the legacy 2-arg signature should set this to False so
+    # RFDETRModelModule._compute_train_losses() can skip the kwarg.
+    supports_loss_normalizer_override: bool = True
+
     def __init__(
         self,
         num_classes,
@@ -180,8 +188,8 @@ class SetCriterion(nn.Module):
         """Return the device used by tensor outputs.
 
         Args:
-            outputs: Model output dictionary. Values may be tensors, lists, or nested dicts;
-                non-tensor entries are skipped when probing for a device.
+            outputs: Model output dictionary. Top-level values are probed for tensors;
+                nested structures (lists, nested dicts) are not traversed.
 
         Returns:
             Device of the first tensor value found in ``outputs``.
@@ -634,8 +642,8 @@ class SetCriterion(nn.Module):
             get an ``"_enc"`` suffix.
 
         Examples:
-            >>> from unittest.mock import MagicMock
             >>> import torch
+            >>> from unittest.mock import MagicMock
             >>> from rfdetr.models.criterion import SetCriterion
             >>> criterion = SetCriterion.__new__(SetCriterion)
             >>> criterion.training = False

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -166,12 +166,15 @@ class RFDETRModelModule(LightningModule):
         ``num_training_batches``) a partial window may survive epoch end with un-stepped gradients; those are
         discarded here and the optimizer is zeroed so the first microbatch of the new epoch starts from a clean state.
         """
-        if self._accumulated_box_normalizer is not None and self._trainer is not None:
+        if self._accumulated_box_normalizer is not None:
             # Discard any partial accumulation window that survived the epoch boundary
             # (only possible for IterableDatasets where num_training_batches is infinite).
-            opts = self.optimizers()
-            for opt in opts if isinstance(opts, list) else [opts]:
-                opt.zero_grad()
+            try:
+                opts = self.optimizers()
+                for opt in opts if isinstance(opts, list) else [opts]:
+                    opt.zero_grad()
+            except RuntimeError:
+                pass  # Not attached to Trainer (unit-test context); nothing to zero.
         self._accumulated_box_normalizer = None
 
     def training_step(self, batch: Tuple, batch_idx: int) -> torch.Tensor | dict[str, Any]:
@@ -269,6 +272,13 @@ class RFDETRModelModule(LightningModule):
             A tuple of normalized loss dictionary, unnormalized weighted loss numerator, and box normalizer.
         """
         weight_dict = self.criterion.weight_dict
+        if not getattr(self.criterion, "supports_loss_normalizer_override", False):
+            raise ValueError(
+                f"{type(self.criterion).__name__}.supports_loss_normalizer_override is False; "
+                "manual optimization (keypoint models) requires a criterion that accepts a "
+                "num_boxes keyword argument. Set supports_loss_normalizer_override = True on "
+                "your criterion subclass and implement the num_boxes parameter in forward()."
+            )
         normalizer = self.criterion.num_boxes_for_targets(outputs, targets)
         numerator_loss_dict = self.criterion(outputs, targets, num_boxes=torch.ones_like(normalizer))
         # Keys in weight_dict are loss terms whose criterion implementation divides by num_boxes

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -51,7 +51,7 @@ class RFDETRModelModule(LightningModule):
         super().__init__()
         self.model_config = model_config
         self.train_config = train_config
-        self.automatic_optimization = not model_config.use_grouppose_keypoints
+        self.automatic_optimization = False
         self._accumulated_box_normalizer: torch.Tensor | None = None
         # Allow partial state-dict loading when resuming from a .pth checkpoint
         # (which contains only model weights, not criterion/postprocess state).
@@ -147,9 +147,9 @@ class RFDETRModelModule(LightningModule):
     def training_step(self, batch: Tuple, batch_idx: int) -> torch.Tensor | dict[str, Any]:
         """Compute loss for one training step and log metrics.
 
-        PTL handles AMP (``precision``) without a manual ``GradScaler``. Non-keypoint models use Lightning automatic
-        optimization. Keypoint models use manual optimization so box-count loss normalization is based on the full
-        accumulated effective batch rather than each microbatch independently.
+        PTL handles AMP (``precision``) without a manual ``GradScaler``. The module performs manual optimization so
+        box-count loss normalization is based on the full accumulated effective batch rather than each microbatch
+        independently.
 
         Args:
             batch: Tuple of (NestedTensor samples, list of target dicts).
@@ -163,12 +163,8 @@ class RFDETRModelModule(LightningModule):
         samples, targets = batch
         batch_size = len(targets)
         outputs = self.model(samples, targets)
-        if self.automatic_optimization:
-            loss_dict = self.criterion(outputs, targets)
-            loss_for_backward = None
-        else:
-            loss_dict, raw_loss, normalizer = self._compute_train_losses(outputs, targets)
-            loss_for_backward = self._scale_loss_for_accumulation(raw_loss, normalizer)
+        loss_dict, raw_loss, normalizer = self._compute_train_losses(outputs, targets)
+        loss_for_backward = self._scale_loss_for_accumulation(raw_loss, normalizer)
         weight_dict = self.criterion.weight_dict
         loss = sum(loss_dict[k] * weight_dict[k] for k in loss_dict if k in weight_dict)
         train_log_sync_dist = bool(self.train_config.train_log_sync_dist)
@@ -204,35 +200,25 @@ class RFDETRModelModule(LightningModule):
             self.log("train/lr", base_lr, prog_bar=False, on_step=True, on_epoch=False)
             self.log("train/lr_min", min_lr, prog_bar=False, on_step=True, on_epoch=False)
             self.log("train/lr_max", max_lr, prog_bar=False, on_step=True, on_epoch=False)
-        if loss_for_backward is not None:
-            self.manual_backward(loss_for_backward)
-            if self._should_step_optimizer(batch_idx):
-                self._step_optimizer(optimizer)
+        self.manual_backward(loss_for_backward)
+        if self._should_step_optimizer(batch_idx):
+            self._step_optimizer(optimizer)
         if self.train_config.compute_train_metrics:
             with torch.no_grad():
                 orig_sizes = torch.stack([t["orig_size"] for t in targets])
                 results = self.postprocess(outputs, orig_sizes)
             return {
-                "loss": loss if self.automatic_optimization else loss.detach(),
+                "loss": loss.detach(),
                 "results": self._detach_results(results),
                 "targets": targets,
             }
-        return loss if self.automatic_optimization else loss.detach()
-
-    def _criterion_supports_loss_normalizer_override(self) -> bool:
-        """Return whether the criterion can emit loss numerators.
-
-        Returns:
-            ``True`` when the criterion supports the ``num_boxes`` override needed for exact box-normalized gradient
-            accumulation.
-        """
-        return bool(getattr(type(self.criterion), "supports_loss_normalizer_override", False))
+        return loss.detach()
 
     def _compute_train_losses(
         self,
         outputs: dict[str, torch.Tensor],
         targets: list[dict[str, torch.Tensor]],
-    ) -> tuple[dict[str, torch.Tensor], torch.Tensor, torch.Tensor | None]:
+    ) -> tuple[dict[str, torch.Tensor], torch.Tensor, torch.Tensor]:
         """Compute normalized losses for logging and raw weighted loss for backward.
 
         Args:
@@ -240,40 +226,31 @@ class RFDETRModelModule(LightningModule):
             targets: Target dictionaries for the current batch.
 
         Returns:
-            A tuple of normalized loss dictionary, unnormalized weighted loss numerator, and optional box normalizer.
+            A tuple of normalized loss dictionary, unnormalized weighted loss numerator, and box normalizer.
         """
         weight_dict = self.criterion.weight_dict
-        if self._criterion_supports_loss_normalizer_override():
-            normalizer = self.criterion.num_boxes_for_targets(outputs, targets)
-            numerator_loss_dict = self.criterion(outputs, targets, num_boxes=torch.ones_like(normalizer))
-            loss_dict = {
-                key: value / normalizer if key in weight_dict else value for key, value in numerator_loss_dict.items()
-            }
-            raw_loss = sum(numerator_loss_dict[k] * weight_dict[k] for k in numerator_loss_dict if k in weight_dict)
-            return loss_dict, raw_loss, normalizer
-
-        loss_dict = self.criterion(outputs, targets)
-        loss = sum(loss_dict[k] * weight_dict[k] for k in loss_dict if k in weight_dict)
-        accum_steps = max(1, int(getattr(self.trainer, "accumulate_grad_batches", 1)))
-        return loss_dict, loss / accum_steps, None
+        normalizer = self.criterion.num_boxes_for_targets(outputs, targets)
+        numerator_loss_dict = self.criterion(outputs, targets, num_boxes=torch.ones_like(normalizer))
+        loss_dict = {
+            key: value / normalizer if key in weight_dict else value for key, value in numerator_loss_dict.items()
+        }
+        raw_loss = sum(numerator_loss_dict[k] * weight_dict[k] for k in numerator_loss_dict if k in weight_dict)
+        return loss_dict, raw_loss, normalizer
 
     def _scale_loss_for_accumulation(
         self,
         raw_loss: torch.Tensor,
-        normalizer: torch.Tensor | None,
+        normalizer: torch.Tensor,
     ) -> torch.Tensor:
         """Scale the current numerator loss by the accumulated box denominator.
 
         Args:
             raw_loss: Current microbatch weighted loss numerator.
-            normalizer: Current microbatch box denominator, or ``None`` for criteria without numerator support.
+            normalizer: Current microbatch box denominator.
 
         Returns:
             Loss scalar to pass to ``manual_backward``.
         """
-        if normalizer is None:
-            return raw_loss
-
         normalizer = normalizer.detach()
         previous_normalizer = self._accumulated_box_normalizer
         accumulated_normalizer = normalizer if previous_normalizer is None else previous_normalizer + normalizer
@@ -301,7 +278,7 @@ class RFDETRModelModule(LightningModule):
         Returns:
             ``True`` when the optimizer should step after this batch.
         """
-        accum_steps = max(1, int(getattr(self.trainer, "accumulate_grad_batches", 1)))
+        accum_steps = max(1, int(self.train_config.grad_accum_steps))
         if (batch_idx + 1) % accum_steps == 0:
             return True
         num_training_batches = getattr(self.trainer, "num_training_batches", None)

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -160,7 +160,18 @@ class RFDETRModelModule(LightningModule):
 
         This is a no-op for non-keypoint models because they use Lightning's automatic optimization path and never
         populate ``self._accumulated_box_normalizer``.
+
+        Note: on finite datasets the final-batch fallback in ``_should_step_optimizer`` always flushes a partial
+        trailing window, so this reset is the only change needed.  On IterableDatasets (infinite
+        ``num_training_batches``) a partial window may survive epoch end with un-stepped gradients; those are
+        discarded here and the optimizer is zeroed so the first microbatch of the new epoch starts from a clean state.
         """
+        if self._accumulated_box_normalizer is not None and self._trainer is not None:
+            # Discard any partial accumulation window that survived the epoch boundary
+            # (only possible for IterableDatasets where num_training_batches is infinite).
+            opts = self.optimizers()
+            for opt in opts if isinstance(opts, list) else [opts]:
+                opt.zero_grad()
         self._accumulated_box_normalizer = None
 
     def training_step(self, batch: Tuple, batch_idx: int) -> torch.Tensor | dict[str, Any]:
@@ -260,6 +271,13 @@ class RFDETRModelModule(LightningModule):
         weight_dict = self.criterion.weight_dict
         normalizer = self.criterion.num_boxes_for_targets(outputs, targets)
         numerator_loss_dict = self.criterion(outputs, targets, num_boxes=torch.ones_like(normalizer))
+        # Keys in weight_dict are loss terms whose criterion implementation divides by num_boxes
+        # (so passing num_boxes=1.0 yields raw numerators that we divide by normalizer here).
+        # Keys outside weight_dict (e.g. "class_error", "cardinality_error") are diagnostics
+        # that do NOT divide by num_boxes internally — they are passed through unchanged.
+        # If a future loss term divides by num_boxes AND is omitted from weight_dict, its
+        # logged value will be on a different scale than the keypoint path; verify when adding
+        # new criterion terms.
         loss_dict = {
             key: value / normalizer if key in weight_dict else value for key, value in numerator_loss_dict.items()
         }
@@ -532,7 +550,13 @@ class RFDETRModelModule(LightningModule):
         # division below is a no-op (``grad_accum_steps`` would be 1 in that path).
         grad_accum_steps = max(1, int(tc.grad_accum_steps))
         microbatches = int(self.trainer.estimated_stepping_batches)
-        total_steps = max(1, microbatches // grad_accum_steps) if self._use_manual_optimization else microbatches
+        # _should_step_optimizer steps the final partial window at epoch end, so the true
+        # number of optimizer steps is ceil(microbatches / grad_accum_steps).  Using floor
+        # would undercount when the epoch is not evenly divisible, causing warmup / cosine
+        # schedules to finish one step earlier than the last actual step fires.
+        total_steps = (
+            max(1, math.ceil(microbatches / grad_accum_steps)) if self._use_manual_optimization else microbatches
+        )
         steps_per_epoch = max(1, total_steps // tc.epochs)
         warmup_steps = int(steps_per_epoch * tc.warmup_epochs)
 

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -51,6 +51,8 @@ class RFDETRModelModule(LightningModule):
         super().__init__()
         self.model_config = model_config
         self.train_config = train_config
+        self.automatic_optimization = not model_config.use_grouppose_keypoints
+        self._accumulated_box_normalizer: torch.Tensor | None = None
         # Allow partial state-dict loading when resuming from a .pth checkpoint
         # (which contains only model weights, not criterion/postprocess state).
         self.strict_loading = False
@@ -145,10 +147,9 @@ class RFDETRModelModule(LightningModule):
     def training_step(self, batch: Tuple, batch_idx: int) -> torch.Tensor | dict[str, Any]:
         """Compute loss for one training step and log metrics.
 
-        PTL handles gradient accumulation (``accumulate_grad_batches``), AMP (``precision``), and gradient clipping
-        (``gradient_clip_val``) — no manual ``GradScaler`` or loss scaling here.  The loss is divided by
-        ``trainer.accumulate_grad_batches`` so that the accumulated gradient magnitude matches the legacy engine (which
-        scales each sub-batch by ``1/grad_accum_steps`` before calling ``backward()``).
+        PTL handles AMP (``precision``) without a manual ``GradScaler``. Non-keypoint models use Lightning automatic
+        optimization. Keypoint models use manual optimization so box-count loss normalization is based on the full
+        accumulated effective batch rather than each microbatch independently.
 
         Args:
             batch: Tuple of (NestedTensor samples, list of target dicts).
@@ -162,16 +163,14 @@ class RFDETRModelModule(LightningModule):
         samples, targets = batch
         batch_size = len(targets)
         outputs = self.model(samples, targets)
-        loss_dict = self.criterion(outputs, targets)
+        if self.automatic_optimization:
+            loss_dict = self.criterion(outputs, targets)
+            loss_for_backward = None
+        else:
+            loss_dict, raw_loss, normalizer = self._compute_train_losses(outputs, targets)
+            loss_for_backward = self._scale_loss_for_accumulation(raw_loss, normalizer)
         weight_dict = self.criterion.weight_dict
         loss = sum(loss_dict[k] * weight_dict[k] for k in loss_dict if k in weight_dict)
-        # Normalise by grad-accum steps so the accumulated gradient matches the
-        # legacy engine, which scales each sub-batch by 1/grad_accum_steps before
-        # backward().  PTL accumulates full-scale gradients by default; dividing
-        # here keeps the effective LR identical to the non-PTL training path.
-        # We return the scaled loss to PTL but log the unscaled value so that
-        # train/loss and val/loss are on the same scale.
-        loss_scaled = loss / self.trainer.accumulate_grad_batches
         train_log_sync_dist = bool(self.train_config.train_log_sync_dist)
         train_log_on_step = bool(self.train_config.train_log_on_step)
         self.log_dict(
@@ -205,12 +204,147 @@ class RFDETRModelModule(LightningModule):
             self.log("train/lr", base_lr, prog_bar=False, on_step=True, on_epoch=False)
             self.log("train/lr_min", min_lr, prog_bar=False, on_step=True, on_epoch=False)
             self.log("train/lr_max", max_lr, prog_bar=False, on_step=True, on_epoch=False)
+        if loss_for_backward is not None:
+            self.manual_backward(loss_for_backward)
+            if self._should_step_optimizer(batch_idx):
+                self._step_optimizer(optimizer)
         if self.train_config.compute_train_metrics:
             with torch.no_grad():
                 orig_sizes = torch.stack([t["orig_size"] for t in targets])
                 results = self.postprocess(outputs, orig_sizes)
-            return {"loss": loss_scaled, "results": self._detach_results(results), "targets": targets}
-        return loss_scaled
+            return {
+                "loss": loss if self.automatic_optimization else loss.detach(),
+                "results": self._detach_results(results),
+                "targets": targets,
+            }
+        return loss if self.automatic_optimization else loss.detach()
+
+    def _criterion_supports_loss_normalizer_override(self) -> bool:
+        """Return whether the criterion can emit loss numerators.
+
+        Returns:
+            ``True`` when the criterion supports the ``num_boxes`` override needed for exact box-normalized gradient
+            accumulation.
+        """
+        return bool(getattr(type(self.criterion), "supports_loss_normalizer_override", False))
+
+    def _compute_train_losses(
+        self,
+        outputs: dict[str, torch.Tensor],
+        targets: list[dict[str, torch.Tensor]],
+    ) -> tuple[dict[str, torch.Tensor], torch.Tensor, torch.Tensor | None]:
+        """Compute normalized losses for logging and raw weighted loss for backward.
+
+        Args:
+            outputs: Model output dictionary.
+            targets: Target dictionaries for the current batch.
+
+        Returns:
+            A tuple of normalized loss dictionary, unnormalized weighted loss numerator, and optional box normalizer.
+        """
+        weight_dict = self.criterion.weight_dict
+        if self._criterion_supports_loss_normalizer_override():
+            normalizer = self.criterion.num_boxes_for_targets(outputs, targets)
+            numerator_loss_dict = self.criterion(outputs, targets, num_boxes=torch.ones_like(normalizer))
+            loss_dict = {
+                key: value / normalizer if key in weight_dict else value for key, value in numerator_loss_dict.items()
+            }
+            raw_loss = sum(numerator_loss_dict[k] * weight_dict[k] for k in numerator_loss_dict if k in weight_dict)
+            return loss_dict, raw_loss, normalizer
+
+        loss_dict = self.criterion(outputs, targets)
+        loss = sum(loss_dict[k] * weight_dict[k] for k in loss_dict if k in weight_dict)
+        accum_steps = max(1, int(getattr(self.trainer, "accumulate_grad_batches", 1)))
+        return loss_dict, loss / accum_steps, None
+
+    def _scale_loss_for_accumulation(
+        self,
+        raw_loss: torch.Tensor,
+        normalizer: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """Scale the current numerator loss by the accumulated box denominator.
+
+        Args:
+            raw_loss: Current microbatch weighted loss numerator.
+            normalizer: Current microbatch box denominator, or ``None`` for criteria without numerator support.
+
+        Returns:
+            Loss scalar to pass to ``manual_backward``.
+        """
+        if normalizer is None:
+            return raw_loss
+
+        normalizer = normalizer.detach()
+        previous_normalizer = self._accumulated_box_normalizer
+        accumulated_normalizer = normalizer if previous_normalizer is None else previous_normalizer + normalizer
+        if previous_normalizer is not None:
+            self._rescale_accumulated_gradients(previous_normalizer / accumulated_normalizer)
+        self._accumulated_box_normalizer = accumulated_normalizer.detach()
+        return raw_loss / accumulated_normalizer
+
+    def _rescale_accumulated_gradients(self, scale: torch.Tensor) -> None:
+        """Rescale gradients already accumulated in the current optimizer window.
+
+        Args:
+            scale: Multiplicative factor that converts previous gradients from the old denominator to the new one.
+        """
+        for parameter in self.parameters():
+            if parameter.grad is not None:
+                parameter.grad.mul_(scale.to(device=parameter.grad.device, dtype=parameter.grad.dtype))
+
+    def _should_step_optimizer(self, batch_idx: int) -> bool:
+        """Return whether the current batch closes an optimizer accumulation window.
+
+        Args:
+            batch_idx: Batch index within the epoch.
+
+        Returns:
+            ``True`` when the optimizer should step after this batch.
+        """
+        accum_steps = max(1, int(getattr(self.trainer, "accumulate_grad_batches", 1)))
+        if (batch_idx + 1) % accum_steps == 0:
+            return True
+        num_training_batches = getattr(self.trainer, "num_training_batches", None)
+        return isinstance(num_training_batches, int) and batch_idx + 1 >= num_training_batches
+
+    def _step_optimizer(self, optimizer: torch.optim.Optimizer) -> None:
+        """Clip gradients, step optimizer and scheduler, then reset accumulation state.
+
+        Args:
+            optimizer: Optimizer returned by Lightning.
+        """
+        trainer_gradient_clip_val = getattr(self.trainer, "gradient_clip_val", None)
+        if trainer_gradient_clip_val is None:
+            gradient_clip_val = self.train_config.clip_max_norm
+        elif isinstance(trainer_gradient_clip_val, (int, float)):
+            gradient_clip_val = trainer_gradient_clip_val
+        else:
+            gradient_clip_val = None
+        gradient_clip_algorithm = getattr(self.trainer, "gradient_clip_algorithm", None)
+        if not isinstance(gradient_clip_algorithm, str):
+            gradient_clip_algorithm = None
+        if gradient_clip_val is not None and gradient_clip_val > 0:
+            self.clip_gradients(
+                optimizer,
+                gradient_clip_val=gradient_clip_val,
+                gradient_clip_algorithm=gradient_clip_algorithm,
+            )
+        optimizer.step()
+        optimizer.zero_grad()
+        self._step_lr_scheduler()
+        self._accumulated_box_normalizer = None
+
+    def _step_lr_scheduler(self) -> None:
+        """Step Lightning's scheduler object when one is configured."""
+        try:
+            scheduler = self.lr_schedulers()
+        except (AttributeError, RuntimeError):
+            return
+        if scheduler is None:
+            return
+        schedulers = scheduler if isinstance(scheduler, list) else [scheduler]
+        for scheduler_item in schedulers:
+            scheduler_item.step()
 
     @staticmethod
     def _detach_results(results: list[dict[str, torch.Tensor]]) -> list[dict[str, torch.Tensor]]:

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -51,7 +51,13 @@ class RFDETRModelModule(LightningModule):
         super().__init__()
         self.model_config = model_config
         self.train_config = train_config
-        self.automatic_optimization = False
+        # Manual optimization is enabled only for keypoint models so that the box-count
+        # normalizer can be accumulated across grad-accum microbatches. Detection and
+        # segmentation use Lightning's automatic optimization (PTL handles accumulation,
+        # AMP, and gradient clipping), which keeps their step semantics unchanged from
+        # the pre-fix/scaling behaviour.
+        self._use_manual_optimization: bool = bool(getattr(model_config, "use_grouppose_keypoints", False))
+        self.automatic_optimization = not self._use_manual_optimization
         self._accumulated_box_normalizer: torch.Tensor | None = None
         # Allow partial state-dict loading when resuming from a .pth checkpoint
         # (which contains only model weights, not criterion/postprocess state).
@@ -144,12 +150,25 @@ class RFDETRModelModule(LightningModule):
                     F.interpolate(samples.mask.unsqueeze(1).float(), size=scale, mode="nearest").squeeze(1).bool()
                 )
 
+    def on_train_epoch_start(self) -> None:
+        """Reset the accumulated box normalizer at the start of every training epoch.
+
+        Lightning may reuse the module across epochs without calling ``_step_optimizer`` at the boundary (for example
+        when an epoch ends mid-accumulation window with a non-divisible batch count). Clearing the accumulator here
+        guarantees the manual-optimization path always starts each epoch from a known state, so the first microbatch's
+        gradients are scaled by its own box count and not by a stale previous-epoch denominator.
+
+        This is a no-op for non-keypoint models because they use Lightning's automatic optimization path and never
+        populate ``self._accumulated_box_normalizer``.
+        """
+        self._accumulated_box_normalizer = None
+
     def training_step(self, batch: Tuple, batch_idx: int) -> torch.Tensor | dict[str, Any]:
         """Compute loss for one training step and log metrics.
 
-        PTL handles AMP (``precision``) without a manual ``GradScaler``. The module performs manual optimization so
+        PTL handles AMP (``precision``) without a manual ``GradScaler``. Keypoint models perform manual optimization so
         box-count loss normalization is based on the full accumulated effective batch rather than each microbatch
-        independently.
+        independently; detection and segmentation models keep Lightning's automatic optimization path.
 
         Args:
             batch: Tuple of (NestedTensor samples, list of target dicts).
@@ -163,10 +182,19 @@ class RFDETRModelModule(LightningModule):
         samples, targets = batch
         batch_size = len(targets)
         outputs = self.model(samples, targets)
-        loss_dict, raw_loss, normalizer = self._compute_train_losses(outputs, targets)
-        loss_for_backward = self._scale_loss_for_accumulation(raw_loss, normalizer)
+        if self._use_manual_optimization:
+            loss_dict, raw_loss, normalizer = self._compute_train_losses(outputs, targets)
+            loss_for_backward = self._scale_loss_for_accumulation(raw_loss, normalizer)
+        else:
+            loss_dict = self.criterion(outputs, targets)
+            loss_for_backward = None
         weight_dict = self.criterion.weight_dict
         loss = sum(loss_dict[k] * weight_dict[k] for k in loss_dict if k in weight_dict)
+        # Automatic optimization path: divide by accumulate_grad_batches so the accumulated
+        # gradient matches a single large batch, matching the legacy engine.  PTL accumulates
+        # full-scale gradients by default; dividing here keeps the effective LR identical.
+        accumulate_grad_batches = max(1, int(self.trainer.accumulate_grad_batches))
+        loss_for_return = loss if self._use_manual_optimization else loss / accumulate_grad_batches
         train_log_sync_dist = bool(self.train_config.train_log_sync_dist)
         train_log_on_step = bool(self.train_config.train_log_on_step)
         self.log_dict(
@@ -200,19 +228,20 @@ class RFDETRModelModule(LightningModule):
             self.log("train/lr", base_lr, prog_bar=False, on_step=True, on_epoch=False)
             self.log("train/lr_min", min_lr, prog_bar=False, on_step=True, on_epoch=False)
             self.log("train/lr_max", max_lr, prog_bar=False, on_step=True, on_epoch=False)
-        self.manual_backward(loss_for_backward)
-        if self._should_step_optimizer(batch_idx):
-            self._step_optimizer(optimizer)
+        if self._use_manual_optimization:
+            self.manual_backward(loss_for_backward)
+            if self._should_step_optimizer(batch_idx):
+                self._step_optimizer(optimizer)
         if self.train_config.compute_train_metrics:
             with torch.no_grad():
                 orig_sizes = torch.stack([t["orig_size"] for t in targets])
                 results = self.postprocess(outputs, orig_sizes)
             return {
-                "loss": loss.detach(),
+                "loss": loss_for_return.detach() if self._use_manual_optimization else loss_for_return,
                 "results": self._detach_results(results),
                 "targets": targets,
             }
-        return loss.detach()
+        return loss_for_return.detach() if self._use_manual_optimization else loss_for_return
 
     def _compute_train_losses(
         self,
@@ -272,6 +301,18 @@ class RFDETRModelModule(LightningModule):
     def _should_step_optimizer(self, batch_idx: int) -> bool:
         """Return whether the current batch closes an optimizer accumulation window.
 
+        The optimizer steps when either:
+
+        - The current batch closes a complete ``grad_accum_steps`` window
+          (``(batch_idx + 1) % grad_accum_steps == 0``), or
+        - This is the final batch of the epoch and a partial accumulation window
+          is still open, so the trailing microbatches are not silently dropped.
+
+        Lightning's ``Trainer.num_training_batches`` may be reported as ``float('inf')``
+        for iterable / streaming datasets where the epoch length is unknown. In that case
+        only the modulo path can ever close the window — the final-batch fallback is
+        skipped because ``batch_idx + 1`` can never reach infinity.
+
         Args:
             batch_idx: Batch index within the epoch.
 
@@ -282,7 +323,11 @@ class RFDETRModelModule(LightningModule):
         if (batch_idx + 1) % accum_steps == 0:
             return True
         num_training_batches = getattr(self.trainer, "num_training_batches", None)
-        return isinstance(num_training_batches, int) and batch_idx + 1 >= num_training_batches
+        return (
+            isinstance(num_training_batches, (int, float))
+            and math.isfinite(num_training_batches)
+            and batch_idx + 1 >= num_training_batches
+        )
 
     def _step_optimizer(self, optimizer: torch.optim.Optimizer) -> None:
         """Clip gradients, step optimizer and scheduler, then reset accumulation state.
@@ -476,7 +521,18 @@ class RFDETRModelModule(LightningModule):
             fused=self._use_fused_optimizer,
         )
 
-        total_steps = int(self.trainer.estimated_stepping_batches)
+        # ``trainer.estimated_stepping_batches`` is reported in *microbatch* units when
+        # the keypoint path runs with ``Trainer(accumulate_grad_batches=1)`` and manages
+        # accumulation manually. ``LambdaLR.step()`` is called once per optimizer-step
+        # (i.e. every ``grad_accum_steps`` microbatches), so the schedule must be sized
+        # in optimizer-step units rather than microbatches; otherwise warmup and cosine
+        # decay finish ``grad_accum_steps``× too early. Detection / segmentation models
+        # still rely on Lightning's automatic optimization, where PTL already accounts
+        # for ``accumulate_grad_batches`` inside ``estimated_stepping_batches`` and the
+        # division below is a no-op (``grad_accum_steps`` would be 1 in that path).
+        grad_accum_steps = max(1, int(tc.grad_accum_steps))
+        microbatches = int(self.trainer.estimated_stepping_batches)
+        total_steps = max(1, microbatches // grad_accum_steps) if self._use_manual_optimization else microbatches
         steps_per_epoch = max(1, total_steps // tc.epochs)
         warmup_steps = int(steps_per_epoch * tc.warmup_epochs)
 

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -435,12 +435,13 @@ def build_trainer(
         # coercion has historically masked subtle gradient-scaling bugs on this code path.
         for key in ("accumulate_grad_batches", "gradient_clip_val"):
             if key in trainer_kwargs:
+                effective = "1" if key == "accumulate_grad_batches" else "None"
+                alt = "grad_accum_steps" if key == "accumulate_grad_batches" else "clip_max_norm"
                 warnings.warn(
-                    f"build_trainer() ignored Trainer kwarg {key}={trainer_kwargs[key]!r} for a keypoint "
-                    f"model: RFDETRModelModule owns gradient accumulation and clipping under manual "
-                    f"optimization and forces {key}="
-                    + ("1" if key == "accumulate_grad_batches" else "None")
-                    + ". Pass clip_max_norm / grad_accum_steps on TrainConfig instead.",
+                    f"build_trainer() ignored trainer_kwargs[{key!r}]={trainer_kwargs[key]!r} for a keypoint "
+                    f"model. The model will train with {key}={effective} regardless of the value passed here "
+                    f"because RFDETRModelModule owns gradient accumulation and clipping under manual "
+                    f"optimization. To change the effective value, set TrainConfig.{alt} instead.",
                     UserWarning,
                     stacklevel=2,
                 )

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -394,6 +394,7 @@ def build_trainer(
     # --- Promoted config fields (T4-2 added these to TrainConfig) ---
     clip_max_norm: float = tc.clip_max_norm
     sync_bn: bool = tc.sync_bn
+    use_manual_optimization = bool(model_config.use_grouppose_keypoints)
 
     trainer_config: dict[str, Any] = {
         "max_epochs": tc.epochs,
@@ -403,7 +404,10 @@ def build_trainer(
         "strategy": strategy,
         "precision": _resolve_precision(),
         "accumulate_grad_batches": tc.grad_accum_steps,
-        "gradient_clip_val": clip_max_norm,
+        # Keypoint RFDETRModelModule uses manual optimization so it can normalize losses by
+        # the full accumulated box count. Lightning forbids Trainer-owned gradient clipping
+        # in manual optimization; the module applies tc.clip_max_norm for that path.
+        "gradient_clip_val": None if use_manual_optimization else clip_max_norm,
         "sync_batchnorm": sync_bn,
         "callbacks": callbacks,
         "logger": loggers if loggers else False,

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -127,7 +127,7 @@ def build_trainer(
     """Assemble a PTL ``Trainer`` with the full RF-DETR callback and logger stack.
 
     Resolves training precision from ``model_config.amp`` and device capability, guards EMA against sharded strategies,
-    wires conditional loggers, and applies promoted training knobs (gradient clipping, sync_batchnorm, strategy).
+    wires conditional loggers, and applies promoted training knobs (sync_batchnorm, strategy).
 
     Args:
         train_config: Training hyperparameter configuration.
@@ -138,14 +138,14 @@ def build_trainer(
             Defaults to ``None`` which reads from ``train_config.accelerator`` (itself defaulting to ``"auto"``). Pass
             ``"cpu"`` to override auto-detection (e.g. when the caller explicitly requests CPU training via
             ``device="cpu"``).
-        **trainer_kwargs: Extra keyword arguments forwarded verbatim to
-            ``pytorch_lightning.Trainer``.  Use this to pass PTL-native flags that are not exposed through
-            ``TrainConfig``, for example::
+        **trainer_kwargs: Extra keyword arguments forwarded to ``pytorch_lightning.Trainer``. Use this to pass
+            PTL-native flags that are not exposed through ``TrainConfig``, for example::
 
                 build_trainer(tc, mc, fast_dev_run=2)
 
-            Any key present in both ``trainer_kwargs`` and the built config dict will be overridden by the value in
-            ``trainer_kwargs``.
+            Most keys present in both ``trainer_kwargs`` and the built config dict are overridden by the value in
+            ``trainer_kwargs``. RF-DETR keeps ``accumulate_grad_batches=1`` and ``gradient_clip_val=None`` because
+            ``RFDETRModelModule`` owns both operations under manual optimization.
 
     Returns:
         A configured ``pytorch_lightning.Trainer`` instance.
@@ -392,9 +392,7 @@ def build_trainer(
         raise NotImplementedError("ClearML logging is not yet supported. Remove clearml=True from TrainConfig.")
 
     # --- Promoted config fields (T4-2 added these to TrainConfig) ---
-    clip_max_norm: float = tc.clip_max_norm
     sync_bn: bool = tc.sync_bn
-    use_manual_optimization = bool(model_config.use_grouppose_keypoints)
 
     trainer_config: dict[str, Any] = {
         "max_epochs": tc.epochs,
@@ -403,11 +401,13 @@ def build_trainer(
         "num_nodes": tc.num_nodes,
         "strategy": strategy,
         "precision": _resolve_precision(),
-        "accumulate_grad_batches": tc.grad_accum_steps,
-        # Keypoint RFDETRModelModule uses manual optimization so it can normalize losses by
-        # the full accumulated box count. Lightning forbids Trainer-owned gradient clipping
-        # in manual optimization; the module applies tc.clip_max_norm for that path.
-        "gradient_clip_val": None if use_manual_optimization else clip_max_norm,
+        # RFDETRModelModule owns accumulation so denominator scaling is based on
+        # total boxes across the effective batch, independent of Lightning internals.
+        "accumulate_grad_batches": 1,
+        # RFDETRModelModule uses manual optimization so it can normalize losses by
+        # the full accumulated box count. Lightning forbids Trainer-owned gradient
+        # clipping in manual optimization; the module applies tc.clip_max_norm.
+        "gradient_clip_val": None,
         "sync_batchnorm": sync_bn,
         "callbacks": callbacks,
         "logger": loggers if loggers else False,
@@ -418,4 +418,6 @@ def build_trainer(
     }
     trainer_config.update(trainer_kwargs)
     trainer_config["strategy"] = strategy
+    trainer_config["accumulate_grad_batches"] = 1
+    trainer_config["gradient_clip_val"] = None
     return Trainer(**trainer_config)

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -144,9 +144,11 @@ def build_trainer(
                 build_trainer(tc, mc, fast_dev_run=2)
 
             Most keys present in both ``trainer_kwargs`` and the built config dict are overridden by the value in
-            ``trainer_kwargs``. Keypoint models additionally force ``accumulate_grad_batches=1`` and
-            ``gradient_clip_val=None`` because ``RFDETRModelModule`` owns both operations under manual optimization;
-            passing those keys for a keypoint config raises a ``UserWarning`` to make the override explicit.
+            ``trainer_kwargs``. Detection and segmentation models forward ``accumulate_grad_batches`` from
+            ``train_config.grad_accum_steps`` and ``gradient_clip_val`` from ``train_config.clip_max_norm`` to the
+            Trainer normally. Keypoint models force ``accumulate_grad_batches=1`` and ``gradient_clip_val=None``
+            because ``RFDETRModelModule`` owns both operations under manual optimization; passing those keys for a
+            keypoint config raises a ``UserWarning`` to make the override explicit.
 
     Returns:
         A configured ``pytorch_lightning.Trainer`` instance.

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -144,8 +144,9 @@ def build_trainer(
                 build_trainer(tc, mc, fast_dev_run=2)
 
             Most keys present in both ``trainer_kwargs`` and the built config dict are overridden by the value in
-            ``trainer_kwargs``. RF-DETR keeps ``accumulate_grad_batches=1`` and ``gradient_clip_val=None`` because
-            ``RFDETRModelModule`` owns both operations under manual optimization.
+            ``trainer_kwargs``. Keypoint models additionally force ``accumulate_grad_batches=1`` and
+            ``gradient_clip_val=None`` because ``RFDETRModelModule`` owns both operations under manual optimization;
+            passing those keys for a keypoint config raises a ``UserWarning`` to make the override explicit.
 
     Returns:
         A configured ``pytorch_lightning.Trainer`` instance.
@@ -392,7 +393,21 @@ def build_trainer(
         raise NotImplementedError("ClearML logging is not yet supported. Remove clearml=True from TrainConfig.")
 
     # --- Promoted config fields (T4-2 added these to TrainConfig) ---
+    clip_max_norm: float = tc.clip_max_norm
     sync_bn: bool = tc.sync_bn
+
+    # Manual optimization (currently scoped to keypoint models) owns gradient accumulation
+    # and clipping inside ``RFDETRModelModule._step_optimizer`` so the box-count denominator
+    # spans the full effective batch.  Detection and segmentation models keep Lightning's
+    # automatic optimization, which means ``accumulate_grad_batches`` and ``gradient_clip_val``
+    # must flow through to the Trainer as usual for them.
+    manual_optimization = has_keypoints
+    if manual_optimization:
+        accumulate_grad_batches: int = 1
+        gradient_clip_val: float | None = None
+    else:
+        accumulate_grad_batches = tc.grad_accum_steps
+        gradient_clip_val = clip_max_norm
 
     trainer_config: dict[str, Any] = {
         "max_epochs": tc.epochs,
@@ -401,13 +416,8 @@ def build_trainer(
         "num_nodes": tc.num_nodes,
         "strategy": strategy,
         "precision": _resolve_precision(),
-        # RFDETRModelModule owns accumulation so denominator scaling is based on
-        # total boxes across the effective batch, independent of Lightning internals.
-        "accumulate_grad_batches": 1,
-        # RFDETRModelModule uses manual optimization so it can normalize losses by
-        # the full accumulated box count. Lightning forbids Trainer-owned gradient
-        # clipping in manual optimization; the module applies tc.clip_max_norm.
-        "gradient_clip_val": None,
+        "accumulate_grad_batches": accumulate_grad_batches,
+        "gradient_clip_val": gradient_clip_val,
         "sync_batchnorm": sync_bn,
         "callbacks": callbacks,
         "logger": loggers if loggers else False,
@@ -418,6 +428,22 @@ def build_trainer(
     }
     trainer_config.update(trainer_kwargs)
     trainer_config["strategy"] = strategy
-    trainer_config["accumulate_grad_batches"] = 1
-    trainer_config["gradient_clip_val"] = None
+    if manual_optimization:
+        # Re-apply manual-optimization invariants so a caller-supplied trainer_kwargs
+        # value cannot silently re-enable Lightning-owned accumulation or clipping while
+        # the module is doing its own.  Warn loudly so the override is visible — silent
+        # coercion has historically masked subtle gradient-scaling bugs on this code path.
+        for key in ("accumulate_grad_batches", "gradient_clip_val"):
+            if key in trainer_kwargs:
+                warnings.warn(
+                    f"build_trainer() ignored Trainer kwarg {key}={trainer_kwargs[key]!r} for a keypoint "
+                    f"model: RFDETRModelModule owns gradient accumulation and clipping under manual "
+                    f"optimization and forces {key}="
+                    + ("1" if key == "accumulate_grad_batches" else "None")
+                    + ". Pass clip_max_norm / grad_accum_steps on TrainConfig instead.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+        trainer_config["accumulate_grad_batches"] = 1
+        trainer_config["gradient_clip_val"] = None
     return Trainer(**trainer_config)

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -323,11 +323,23 @@ class TestBuildTrainerUsesRealFields:
         defaults.update(kwargs)
         return RFDETRBaseConfig(**defaults)
 
-    def test_clip_max_norm_owned_by_model_module(self, tmp_path):
-        """Trainer-owned clipping is disabled because RFDETRModelModule clips manually."""
+    def test_clip_max_norm_forwarded_to_trainer_for_detection(self, tmp_path):
+        """Detection models use Lightning's automatic optimization, so ``gradient_clip_val`` flows through to the
+        Trainer from ``TrainConfig.clip_max_norm`` unchanged."""
         from rfdetr.training import build_trainer
 
         trainer = build_trainer(self._tc(tmp_path, clip_max_norm=0.25), self._mc())
+        assert trainer.gradient_clip_val == pytest.approx(0.25)
+
+    def test_clip_max_norm_owned_by_model_module_for_keypoints(self, tmp_path):
+        """Keypoint models use manual optimization; trainer-owned clipping is disabled and ``clip_max_norm`` is applied
+        inside ``RFDETRModelModule._step_optimizer`` instead."""
+        from rfdetr.training import build_trainer
+
+        trainer = build_trainer(
+            self._tc(tmp_path, clip_max_norm=0.25),
+            self._mc(use_grouppose_keypoints=True),
+        )
         assert trainer.gradient_clip_val is None
 
     def test_seed_not_applied_in_build_trainer_factory(self, tmp_path):

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -323,12 +323,12 @@ class TestBuildTrainerUsesRealFields:
         defaults.update(kwargs)
         return RFDETRBaseConfig(**defaults)
 
-    def test_clip_max_norm_forwarded_to_trainer(self, tmp_path):
-        """gradient_clip_val on the Trainer matches TrainConfig.clip_max_norm."""
+    def test_clip_max_norm_owned_by_model_module(self, tmp_path):
+        """Trainer-owned clipping is disabled because RFDETRModelModule clips manually."""
         from rfdetr.training import build_trainer
 
         trainer = build_trainer(self._tc(tmp_path, clip_max_norm=0.25), self._mc())
-        assert trainer.gradient_clip_val == pytest.approx(0.25)
+        assert trainer.gradient_clip_val is None
 
     def test_seed_not_applied_in_build_trainer_factory(self, tmp_path):
         """Seeding is deferred to RFDETRModule.on_fit_start, not build_trainer()."""

--- a/tests/models/test_criterion.py
+++ b/tests/models/test_criterion.py
@@ -1,0 +1,106 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Unit tests for SetCriterion edge paths: _output_device and num_boxes_for_targets."""
+
+import pytest
+import torch
+
+from rfdetr.models.criterion import SetCriterion
+
+
+class _MatcherStub:
+    """Minimal matcher that returns identity indices for every target in the batch."""
+
+    def __call__(self, outputs, targets, group_detr=1):
+        return [(torch.arange(len(t["labels"])), torch.arange(len(t["labels"]))) for t in targets]
+
+
+def _bare_criterion() -> SetCriterion:
+    """Return a SetCriterion with no losses so forward() is a no-op."""
+    criterion = SetCriterion.__new__(SetCriterion)
+    criterion.training = True
+    criterion.group_detr = 1
+    criterion.sum_group_losses = False
+    criterion.losses = []
+    criterion.weight_dict = {}
+    criterion.matcher = _MatcherStub()
+    criterion.num_keypoints_per_class = []
+    return criterion
+
+
+class TestOutputDevice:
+    """Tests for SetCriterion._output_device — probes top-level tensor values only."""
+
+    def test_returns_device_of_first_tensor(self):
+        """Device inferred from the first tensor value in outputs."""
+        outputs = {"pred_logits": torch.zeros(1, 1, 1)}
+
+        device = SetCriterion._output_device(outputs)
+
+        assert device == torch.device("cpu")
+
+    def test_raises_when_no_tensor_present(self):
+        """ValueError raised when no top-level value is a tensor."""
+        outputs = {"meta": "string_value", "count": 42}
+
+        with pytest.raises(ValueError, match="at least one tensor"):
+            SetCriterion._output_device(outputs)
+
+    def test_skips_non_tensor_values(self):
+        """Non-tensor entries at the top level are skipped; first tensor wins."""
+        outputs = {"meta": "ignored", "pred_logits": torch.zeros(1, 1, 1)}
+
+        device = SetCriterion._output_device(outputs)
+
+        assert device == torch.device("cpu")
+
+
+class TestNumBoxesForTargets:
+    """Tests for SetCriterion.num_boxes_for_targets — clamp and empty-target edge cases."""
+
+    def test_returns_tensor_gte_one(self):
+        """Result must be clamped to >= 1.0 to prevent division by zero."""
+        criterion = _bare_criterion()
+        outputs = {"pred_logits": torch.zeros(1, 1, 1)}
+        targets = [{"labels": torch.tensor([0, 1])}]
+
+        result = criterion.num_boxes_for_targets(outputs, targets)
+
+        assert result.item() >= 1.0
+
+    def test_clamps_zero_box_count_to_one(self):
+        """Empty targets (no labels) must clamp to 1.0 to avoid zero denominator."""
+        criterion = _bare_criterion()
+        outputs = {"pred_logits": torch.zeros(1, 1, 1)}
+        targets = [{"labels": torch.zeros(0, dtype=torch.int64)}]
+
+        result = criterion.num_boxes_for_targets(outputs, targets)
+
+        assert result.item() == pytest.approx(1.0)
+
+    def test_clamps_empty_target_list(self):
+        """Empty target list (batch_size=0 edge case) must also clamp to 1.0."""
+        criterion = _bare_criterion()
+        outputs = {"pred_logits": torch.zeros(1, 1, 1)}
+        targets = []
+
+        result = criterion.num_boxes_for_targets(outputs, targets)
+
+        assert result.item() == pytest.approx(1.0)
+
+    def test_counts_labels_correctly(self):
+        """Box count equals total number of labels across all targets in the batch."""
+        criterion = _bare_criterion()
+        outputs = {"pred_logits": torch.zeros(1, 1, 1)}
+        targets = [
+            {"labels": torch.tensor([0, 1])},
+            {"labels": torch.tensor([0])},
+        ]
+
+        result = criterion.num_boxes_for_targets(outputs, targets)
+
+        # 2 + 1 = 3 boxes; single-process so no all-reduce
+        assert result.item() == pytest.approx(3.0)

--- a/tests/training/helpers.py
+++ b/tests/training/helpers.py
@@ -51,9 +51,14 @@ class _FakeCriterion:
 
     weight_dict = {"loss_ce": 1.0}
 
-    def __call__(self, outputs, targets):
+    def num_boxes_for_targets(self, outputs, targets):
         dummy = outputs.get("dummy", torch.zeros(1))
-        return {"loss_ce": dummy.mean()}
+        return torch.ones((), dtype=dummy.dtype, device=dummy.device)
+
+    def __call__(self, outputs, targets, num_boxes=None):
+        dummy = outputs.get("dummy", torch.zeros(1))
+        denominator = self.num_boxes_for_targets(outputs, targets) if num_boxes is None else num_boxes
+        return {"loss_ce": dummy.mean() / denominator}
 
 
 class _FakeDataset(torch.utils.data.Dataset):

--- a/tests/training/test_build_trainer.py
+++ b/tests/training/test_build_trainer.py
@@ -574,23 +574,18 @@ class TestBuildTrainerLoggers:
 class TestBuildTrainerKwargs:
     """build_trainer() must pass the correct kwargs to Trainer."""
 
-    def test_gradient_clip_val_default_for_automatic_optimization(self, tmp_path):
-        """Non-keypoint models keep Trainer-owned gradient clipping."""
-        trainer = build_trainer(_tc(tmp_path, use_ema=False), _mc())
-        assert trainer.gradient_clip_val == pytest.approx(0.1)
-
-    def test_gradient_clip_val_disabled_for_keypoint_manual_optimization(self, tmp_path):
-        """Keypoint models disable Trainer-owned clipping because RFDETRModelModule clips manually."""
+    def test_gradient_clip_val_disabled_for_manual_optimization(self, tmp_path):
+        """Trainer-owned clipping is disabled because RFDETRModelModule clips manually."""
         trainer = build_trainer(
             _tc(tmp_path, use_ema=False),
-            _mc(use_grouppose_keypoints=True, num_keypoints_per_class=[17]),
+            _mc(),
         )
         assert trainer.gradient_clip_val is None
 
-    def test_accumulate_grad_batches(self, tmp_path):
-        """accumulate_grad_batches maps from grad_accum_steps."""
+    def test_accumulate_grad_batches_disabled_for_manual_optimization(self, tmp_path):
+        """Trainer-owned accumulation is disabled because RFDETRModelModule accumulates manually."""
         trainer = build_trainer(_tc(tmp_path, grad_accum_steps=8, use_ema=False), _mc())
-        assert trainer.accumulate_grad_batches == 8
+        assert trainer.accumulate_grad_batches == 1
 
     def test_max_epochs(self, tmp_path):
         """max_epochs maps from config.epochs."""
@@ -625,6 +620,27 @@ class TestBuildTrainerKwargs:
                 precision="32-true",
             )
         assert captured["precision"] == "32-true"
+
+    def test_trainer_kwargs_cannot_override_manual_optimization_ownership(self, tmp_path):
+        """Lightning accumulation and clipping remain disabled even when passed as trainer kwargs."""
+        import unittest.mock as mock
+
+        captured: dict = {}
+
+        def _fake_trainer(**kwargs):
+            captured.update(kwargs)
+            return mock.MagicMock()
+
+        with mock.patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer):
+            build_trainer(
+                _tc(tmp_path, use_ema=False),
+                _mc(),
+                accumulate_grad_batches=8,
+                gradient_clip_val=0.25,
+            )
+
+        assert captured["accumulate_grad_batches"] == 1
+        assert captured["gradient_clip_val"] is None
 
 
 class TestBuildTrainerSeed:

--- a/tests/training/test_build_trainer.py
+++ b/tests/training/test_build_trainer.py
@@ -574,10 +574,18 @@ class TestBuildTrainerLoggers:
 class TestBuildTrainerKwargs:
     """build_trainer() must pass the correct kwargs to Trainer."""
 
-    def test_gradient_clip_val_default(self, tmp_path):
-        """gradient_clip_val defaults to 0.1 when clip_max_norm is not yet in TrainConfig."""
+    def test_gradient_clip_val_default_for_automatic_optimization(self, tmp_path):
+        """Non-keypoint models keep Trainer-owned gradient clipping."""
         trainer = build_trainer(_tc(tmp_path, use_ema=False), _mc())
         assert trainer.gradient_clip_val == pytest.approx(0.1)
+
+    def test_gradient_clip_val_disabled_for_keypoint_manual_optimization(self, tmp_path):
+        """Keypoint models disable Trainer-owned clipping because RFDETRModelModule clips manually."""
+        trainer = build_trainer(
+            _tc(tmp_path, use_ema=False),
+            _mc(use_grouppose_keypoints=True, num_keypoints_per_class=[17]),
+        )
+        assert trainer.gradient_clip_val is None
 
     def test_accumulate_grad_batches(self, tmp_path):
         """accumulate_grad_batches maps from grad_accum_steps."""

--- a/tests/training/test_build_trainer.py
+++ b/tests/training/test_build_trainer.py
@@ -574,18 +574,34 @@ class TestBuildTrainerLoggers:
 class TestBuildTrainerKwargs:
     """build_trainer() must pass the correct kwargs to Trainer."""
 
-    def test_gradient_clip_val_disabled_for_manual_optimization(self, tmp_path):
-        """Trainer-owned clipping is disabled because RFDETRModelModule clips manually."""
+    def test_gradient_clip_val_disabled_for_keypoint_manual_optimization(self, tmp_path):
+        """Trainer-owned clipping is disabled for keypoint models because RFDETRModelModule clips manually."""
         trainer = build_trainer(
-            _tc(tmp_path, use_ema=False),
-            _mc(),
+            _tc(tmp_path, use_ema=False, clip_max_norm=0.25),
+            _mc(use_grouppose_keypoints=True),
         )
         assert trainer.gradient_clip_val is None
 
-    def test_accumulate_grad_batches_disabled_for_manual_optimization(self, tmp_path):
-        """Trainer-owned accumulation is disabled because RFDETRModelModule accumulates manually."""
-        trainer = build_trainer(_tc(tmp_path, grad_accum_steps=8, use_ema=False), _mc())
+    def test_gradient_clip_val_forwarded_for_detection_automatic_optimization(self, tmp_path):
+        """Detection models use Lightning's automatic optimization; trainer-owned clipping must flow through."""
+        trainer = build_trainer(
+            _tc(tmp_path, use_ema=False, clip_max_norm=0.25),
+            _mc(),
+        )
+        assert trainer.gradient_clip_val == pytest.approx(0.25)
+
+    def test_accumulate_grad_batches_disabled_for_keypoint_manual_optimization(self, tmp_path):
+        """Trainer-owned accumulation is disabled for keypoint models because RFDETRModelModule accumulates manually."""
+        trainer = build_trainer(
+            _tc(tmp_path, grad_accum_steps=8, use_ema=False),
+            _mc(use_grouppose_keypoints=True),
+        )
         assert trainer.accumulate_grad_batches == 1
+
+    def test_accumulate_grad_batches_forwarded_for_detection_automatic_optimization(self, tmp_path):
+        """Detection models use Lightning's automatic optimization; ``accumulate_grad_batches`` must flow through."""
+        trainer = build_trainer(_tc(tmp_path, grad_accum_steps=8, use_ema=False), _mc())
+        assert trainer.accumulate_grad_batches == 8
 
     def test_max_epochs(self, tmp_path):
         """max_epochs maps from config.epochs."""
@@ -621,8 +637,33 @@ class TestBuildTrainerKwargs:
             )
         assert captured["precision"] == "32-true"
 
-    def test_trainer_kwargs_cannot_override_manual_optimization_ownership(self, tmp_path):
-        """Lightning accumulation and clipping remain disabled even when passed as trainer kwargs."""
+    def test_keypoint_trainer_kwargs_cannot_override_manual_optimization_ownership(self, tmp_path):
+        """Keypoint accumulation and clipping remain disabled even when passed as trainer kwargs, and the override emits
+        a UserWarning so the caller can spot the silent coercion."""
+        import unittest.mock as mock
+
+        captured: dict = {}
+
+        def _fake_trainer(**kwargs):
+            captured.update(kwargs)
+            return mock.MagicMock()
+
+        with (
+            mock.patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer),
+            pytest.warns(UserWarning, match="manual optimization"),
+        ):
+            build_trainer(
+                _tc(tmp_path, use_ema=False),
+                _mc(use_grouppose_keypoints=True),
+                accumulate_grad_batches=8,
+                gradient_clip_val=0.25,
+            )
+
+        assert captured["accumulate_grad_batches"] == 1
+        assert captured["gradient_clip_val"] is None
+
+    def test_detection_trainer_kwargs_override_takes_effect(self, tmp_path):
+        """Detection models use automatic optimization; trainer kwargs must override the built-in defaults."""
         import unittest.mock as mock
 
         captured: dict = {}
@@ -639,8 +680,8 @@ class TestBuildTrainerKwargs:
                 gradient_clip_val=0.25,
             )
 
-        assert captured["accumulate_grad_batches"] == 1
-        assert captured["gradient_clip_val"] is None
+        assert captured["accumulate_grad_batches"] == 8
+        assert captured["gradient_clip_val"] == pytest.approx(0.25)
 
 
 class TestBuildTrainerSeed:

--- a/tests/training/test_metrics_csv.py
+++ b/tests/training/test_metrics_csv.py
@@ -134,10 +134,15 @@ class TestDetectionMetricsCSV:
         class _FixedCriterion:
             weight_dict = {"loss_ce": 1.0}
 
-            def __call__(self, outputs, targets):
+            def num_boxes_for_targets(self, outputs, targets):
+                dummy = outputs.get("dummy", torch.zeros(1))
+                return torch.ones((), dtype=dummy.dtype, device=dummy.device)
+
+            def __call__(self, outputs, targets, num_boxes=None):
                 # Loss is always fixed_loss_value, connected to model params for gradient.
                 dummy = outputs.get("dummy", torch.zeros(1))
-                return {"loss_ce": dummy.mean() * 0 + fixed_loss_value}
+                denominator = self.num_boxes_for_targets(outputs, targets) if num_boxes is None else num_boxes
+                return {"loss_ce": (dummy.mean() * 0 + fixed_loss_value) / denominator}
 
         mc = base_model_config()
         tc = base_train_config(use_ema=False, run_test=False, grad_accum_steps=grad_accum_steps)

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -72,6 +72,7 @@ def _fake_criterion():
     """Return a MagicMock criterion with a realistic weight_dict."""
     criterion = MagicMock()
     criterion.weight_dict = {"loss_ce": 1.0, "loss_bbox": 5.0, "loss_giou": 2.0}
+    criterion.num_boxes_for_targets.return_value = torch.tensor(1.0)
     return criterion
 
 
@@ -163,7 +164,6 @@ class _ScalarLossModel(nn.Module):
 class _BoxNormalizedCriterion:
     """Criterion with controllable per-target loss numerators and box counts."""
 
-    supports_loss_normalizer_override = True
     weight_dict = {"loss_ce": 1.0}
 
     def num_boxes_for_targets(self, outputs, targets):
@@ -206,17 +206,20 @@ class TestInit:
     """Tests for RFDETRModelModule.__init__ — covers attribute assignment and delegation to build_model() /
     build_criterion_and_postprocessors() when pretrain_weights is None."""
 
-    def test_non_keypoint_models_use_automatic_optimization(self, build_module):
-        """Detection and segmentation models should keep Lightning automatic optimization."""
-        module, _, _, _ = build_module(model_config=_base_model_config(use_grouppose_keypoints=False))
-
-        assert module.automatic_optimization is True
-
-    def test_keypoint_models_use_manual_optimization(self, build_module):
-        """Keypoint models need manual optimization for box-normalized accumulation."""
-        module, _, _, _ = build_module(
-            model_config=_base_model_config(use_grouppose_keypoints=True, num_keypoints_per_class=[17])
-        )
+    @pytest.mark.parametrize(
+        "model_config",
+        [
+            pytest.param(_base_model_config(use_grouppose_keypoints=False), id="detection"),
+            pytest.param(_base_model_config(segmentation_head=True), id="segmentation"),
+            pytest.param(
+                _base_model_config(use_grouppose_keypoints=True, num_keypoints_per_class=[17]),
+                id="keypoints",
+            ),
+        ],
+    )
+    def test_models_use_manual_optimization(self, build_module, model_config):
+        """All DETR-style losses need manual optimization for box-normalized accumulation."""
+        module, _, _, _ = build_module(model_config=model_config)
 
         assert module.automatic_optimization is False
 
@@ -690,7 +693,11 @@ class TestTrainingStep:
     visibility, scalar tensor output, and that losses absent from weight_dict are excluded from the total."""
 
     def _run_step(self, tmp_path, loss_dict=None, weight_dict=None, accumulate_grad_batches=1, model_config=None):
-        module, fake_model, fake_criterion, _ = _build_module(model_config=model_config, tmp_path=tmp_path)
+        module, fake_model, fake_criterion, _ = _build_module(
+            model_config=model_config,
+            train_config=_base_train_config(tmp_path, grad_accum_steps=accumulate_grad_batches),
+            tmp_path=tmp_path,
+        )
         samples, targets = _make_batch()
         fake_model.return_value = {}
         fake_criterion.return_value = loss_dict or {"loss_ce": torch.tensor(1.0)}
@@ -704,7 +711,7 @@ class TestTrainingStep:
         module.manual_backward = MagicMock()
         module.lr_schedulers = MagicMock(return_value=None)
         trainer = MagicMock()
-        trainer.accumulate_grad_batches = accumulate_grad_batches
+        trainer.accumulate_grad_batches = 1
         trainer.num_training_batches = 1
         trainer.gradient_clip_val = 0.0
         trainer.gradient_clip_algorithm = "norm"
@@ -722,8 +729,8 @@ class TestTrainingStep:
 
         assert loss.item() == pytest.approx(1.0 + 10.0 + 6.0)
 
-    def test_fallback_loss_backward_normalised_by_accum_steps(self, tmp_path):
-        """Fallback criteria without raw numerators still receive accumulation-step scaling."""
+    def test_loss_backward_uses_box_normalizer_contract(self, tmp_path):
+        """Backward loss is scaled by criterion box normalizer, not Lightning accumulation."""
         loss_dict = {"loss_ce": torch.tensor(4.0)}
         weight_dict = {"loss_ce": 1.0}
         module, samples, targets, _, _ = self._run_step(
@@ -731,19 +738,33 @@ class TestTrainingStep:
             loss_dict,
             weight_dict,
             accumulate_grad_batches=4,
-            model_config=_base_model_config(use_grouppose_keypoints=True, num_keypoints_per_class=[17]),
         )
+        module.criterion.num_boxes_for_targets.return_value = torch.tensor(4.0)
 
         loss = module.training_step((samples, targets), batch_idx=0)
 
-        assert loss.item() == pytest.approx(4.0)
+        assert loss.item() == pytest.approx(1.0)
         backward_loss = module.manual_backward.call_args.args[0]
         assert backward_loss.item() == pytest.approx(1.0)
 
-    def test_box_normalized_accumulation_matches_large_effective_batch(self, tmp_path):
+    @pytest.mark.parametrize(
+        "model_config",
+        [
+            pytest.param(_base_model_config(use_grouppose_keypoints=False), id="detection"),
+            pytest.param(_base_model_config(segmentation_head=True), id="segmentation"),
+            pytest.param(
+                _base_model_config(use_grouppose_keypoints=True, num_keypoints_per_class=[17]),
+                id="keypoints",
+            ),
+        ],
+    )
+    def test_box_normalized_accumulation_matches_large_effective_batch(self, tmp_path, model_config):
         """Accumulated gradients should match a large batch normalized by total boxes."""
-        keypoint_config = _base_model_config(use_grouppose_keypoints=True, num_keypoints_per_class=[17])
-        large_module, _, _, _ = _build_module(model_config=keypoint_config, tmp_path=tmp_path)
+        large_module, _, _, _ = _build_module(
+            model_config=model_config,
+            train_config=_base_train_config(tmp_path, grad_accum_steps=1),
+            tmp_path=tmp_path,
+        )
         large_model = _ScalarLossModel()
         large_optimizer = torch.optim.SGD(large_model.parameters(), lr=1.0)
         large_module.model = large_model
@@ -762,7 +783,11 @@ class TestTrainingStep:
         large_module._trainer = large_trainer
         type(large_module).trainer = property(lambda self: self._trainer)
 
-        accum_module, _, _, _ = _build_module(model_config=keypoint_config, tmp_path=tmp_path)
+        accum_module, _, _, _ = _build_module(
+            model_config=model_config,
+            train_config=_base_train_config(tmp_path, grad_accum_steps=2),
+            tmp_path=tmp_path,
+        )
         accum_model = _ScalarLossModel()
         accum_optimizer = torch.optim.SGD(accum_model.parameters(), lr=1.0)
         accum_module.model = accum_model
@@ -774,7 +799,7 @@ class TestTrainingStep:
         accum_module.manual_backward = lambda loss: loss.backward()
         accum_module.lr_schedulers = MagicMock(return_value=None)
         accum_trainer = MagicMock()
-        accum_trainer.accumulate_grad_batches = 2
+        accum_trainer.accumulate_grad_batches = 1
         accum_trainer.num_training_batches = 2
         accum_trainer.gradient_clip_val = 0.0
         accum_trainer.gradient_clip_algorithm = "norm"

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -149,6 +149,36 @@ def _make_batch(batch_size=2, channels=3, h=16, w=16):
     return samples, targets
 
 
+class _ScalarLossModel(nn.Module):
+    """Tiny model exposing one scalar parameter for gradient-scaling tests."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.value = nn.Parameter(torch.zeros(()))
+
+    def forward(self, samples, targets=None):
+        return {"loss_scale": self.value}
+
+
+class _BoxNormalizedCriterion:
+    """Criterion with controllable per-target loss numerators and box counts."""
+
+    supports_loss_normalizer_override = True
+    weight_dict = {"loss_ce": 1.0}
+
+    def num_boxes_for_targets(self, outputs, targets):
+        return torch.as_tensor(
+            sum(int(target["labels"].numel()) for target in targets),
+            dtype=torch.float32,
+            device=outputs["loss_scale"].device,
+        ).clamp(min=1.0)
+
+    def __call__(self, outputs, targets, num_boxes=None):
+        denominator = self.num_boxes_for_targets(outputs, targets) if num_boxes is None else num_boxes
+        numerator = outputs["loss_scale"] * sum(target["loss_numerator"] for target in targets)
+        return {"loss_ce": numerator / denominator}
+
+
 # ---------------------------------------------------------------------------
 # Fixtures — inject common test infrastructure; prefer these over private
 # helpers in test methods.  Class-level _setup_* helpers still use the private
@@ -175,6 +205,20 @@ def make_batch():
 class TestInit:
     """Tests for RFDETRModelModule.__init__ — covers attribute assignment and delegation to build_model() /
     build_criterion_and_postprocessors() when pretrain_weights is None."""
+
+    def test_non_keypoint_models_use_automatic_optimization(self, build_module):
+        """Detection and segmentation models should keep Lightning automatic optimization."""
+        module, _, _, _ = build_module(model_config=_base_model_config(use_grouppose_keypoints=False))
+
+        assert module.automatic_optimization is True
+
+    def test_keypoint_models_use_manual_optimization(self, build_module):
+        """Keypoint models need manual optimization for box-normalized accumulation."""
+        module, _, _, _ = build_module(
+            model_config=_base_model_config(use_grouppose_keypoints=True, num_keypoints_per_class=[17])
+        )
+
+        assert module.automatic_optimization is False
 
     def test_model_is_set(self, build_module):
         """__init__ must assign the built model to module.model."""
@@ -645,8 +689,8 @@ class TestTrainingStep:
     """Tests for training_step() — covers weighted loss aggregation, per-loss logging under the train/ prefix, prog_bar
     visibility, scalar tensor output, and that losses absent from weight_dict are excluded from the total."""
 
-    def _run_step(self, tmp_path, loss_dict=None, weight_dict=None, accumulate_grad_batches=1):
-        module, fake_model, fake_criterion, _ = _build_module(tmp_path=tmp_path)
+    def _run_step(self, tmp_path, loss_dict=None, weight_dict=None, accumulate_grad_batches=1, model_config=None):
+        module, fake_model, fake_criterion, _ = _build_module(model_config=model_config, tmp_path=tmp_path)
         samples, targets = _make_batch()
         fake_model.return_value = {}
         fake_criterion.return_value = loss_dict or {"loss_ce": torch.tensor(1.0)}
@@ -657,8 +701,13 @@ class TestTrainingStep:
         real_param = nn.Parameter(torch.randn(4))
         real_optimizer = torch.optim.SGD([real_param], lr=1e-3)
         module.optimizers = MagicMock(return_value=real_optimizer)
+        module.manual_backward = MagicMock()
+        module.lr_schedulers = MagicMock(return_value=None)
         trainer = MagicMock()
         trainer.accumulate_grad_batches = accumulate_grad_batches
+        trainer.num_training_batches = 1
+        trainer.gradient_clip_val = 0.0
+        trainer.gradient_clip_algorithm = "norm"
         module._trainer = trainer
         type(module).trainer = property(lambda self: self._trainer)
         return module, samples, targets, fake_model, fake_criterion
@@ -673,15 +722,82 @@ class TestTrainingStep:
 
         assert loss.item() == pytest.approx(1.0 + 10.0 + 6.0)
 
-    def test_loss_normalised_by_accum_steps(self, tmp_path):
-        """Loss must be divided by accumulate_grad_batches to match legacy engine scaling."""
+    def test_fallback_loss_backward_normalised_by_accum_steps(self, tmp_path):
+        """Fallback criteria without raw numerators still receive accumulation-step scaling."""
         loss_dict = {"loss_ce": torch.tensor(4.0)}
         weight_dict = {"loss_ce": 1.0}
-        module, samples, targets, _, _ = self._run_step(tmp_path, loss_dict, weight_dict, accumulate_grad_batches=4)
+        module, samples, targets, _, _ = self._run_step(
+            tmp_path,
+            loss_dict,
+            weight_dict,
+            accumulate_grad_batches=4,
+            model_config=_base_model_config(use_grouppose_keypoints=True, num_keypoints_per_class=[17]),
+        )
 
         loss = module.training_step((samples, targets), batch_idx=0)
 
-        assert loss.item() == pytest.approx(1.0)  # 4.0 / 4
+        assert loss.item() == pytest.approx(4.0)
+        backward_loss = module.manual_backward.call_args.args[0]
+        assert backward_loss.item() == pytest.approx(1.0)
+
+    def test_box_normalized_accumulation_matches_large_effective_batch(self, tmp_path):
+        """Accumulated gradients should match a large batch normalized by total boxes."""
+        keypoint_config = _base_model_config(use_grouppose_keypoints=True, num_keypoints_per_class=[17])
+        large_module, _, _, _ = _build_module(model_config=keypoint_config, tmp_path=tmp_path)
+        large_model = _ScalarLossModel()
+        large_optimizer = torch.optim.SGD(large_model.parameters(), lr=1.0)
+        large_module.model = large_model
+        large_module.criterion = _BoxNormalizedCriterion()
+        large_module.postprocess = MagicMock()
+        large_module.log = MagicMock()
+        large_module.log_dict = MagicMock()
+        large_module.optimizers = MagicMock(return_value=large_optimizer)
+        large_module.manual_backward = lambda loss: loss.backward()
+        large_module.lr_schedulers = MagicMock(return_value=None)
+        large_trainer = MagicMock()
+        large_trainer.accumulate_grad_batches = 1
+        large_trainer.num_training_batches = 1
+        large_trainer.gradient_clip_val = 0.0
+        large_trainer.gradient_clip_algorithm = "norm"
+        large_module._trainer = large_trainer
+        type(large_module).trainer = property(lambda self: self._trainer)
+
+        accum_module, _, _, _ = _build_module(model_config=keypoint_config, tmp_path=tmp_path)
+        accum_model = _ScalarLossModel()
+        accum_optimizer = torch.optim.SGD(accum_model.parameters(), lr=1.0)
+        accum_module.model = accum_model
+        accum_module.criterion = _BoxNormalizedCriterion()
+        accum_module.postprocess = MagicMock()
+        accum_module.log = MagicMock()
+        accum_module.log_dict = MagicMock()
+        accum_module.optimizers = MagicMock(return_value=accum_optimizer)
+        accum_module.manual_backward = lambda loss: loss.backward()
+        accum_module.lr_schedulers = MagicMock(return_value=None)
+        accum_trainer = MagicMock()
+        accum_trainer.accumulate_grad_batches = 2
+        accum_trainer.num_training_batches = 2
+        accum_trainer.gradient_clip_val = 0.0
+        accum_trainer.gradient_clip_algorithm = "norm"
+        accum_module._trainer = accum_trainer
+
+        samples, _ = _make_batch(batch_size=2)
+        first_target = {
+            "labels": torch.ones(2, dtype=torch.int64),
+            "loss_numerator": torch.tensor(10.0),
+            "orig_size": torch.tensor([16, 16]),
+        }
+        second_target = {
+            "labels": torch.ones(6, dtype=torch.int64),
+            "loss_numerator": torch.tensor(6.0),
+            "orig_size": torch.tensor([16, 16]),
+        }
+
+        large_module.training_step((samples, [first_target, second_target]), batch_idx=0)
+        accum_module.training_step((samples, [first_target]), batch_idx=0)
+        accum_module.training_step((samples, [second_target]), batch_idx=1)
+
+        torch.testing.assert_close(accum_model.value, large_model.value)
+        assert large_model.value.item() == pytest.approx(-2.0)
 
     def test_logs_live_train_loss_to_progress_bar(self, tmp_path):
         """Aggregate training loss must be logged every step as a progress-only metric."""

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -800,6 +800,7 @@ class TestTrainingStep:
     @pytest.mark.parametrize(
         "grad_accum_steps,box_counts,loss_numerators,expected_value",
         [
+            pytest.param(1, (4,), (8.0,), -2.0, id="ga1-single-microbatch"),
             pytest.param(2, (2, 6), (10.0, 6.0), -2.0, id="ga2-balanced"),
             pytest.param(3, (2, 4, 6), (4.0, 8.0, 12.0), -2.0, id="ga3-balanced"),
             pytest.param(4, (1, 1, 1, 1), (2.0, 2.0, 2.0, 2.0), -2.0, id="ga4-uniform"),
@@ -1011,6 +1012,91 @@ class TestOnTrainEpochStart:
         module.on_train_epoch_start()
 
         assert module._accumulated_box_normalizer is None
+
+    def test_is_noop_for_detection_module(self, tmp_path):
+        """Detection models never populate _accumulated_box_normalizer; reset must leave it None."""
+        module, *_ = _build_module(tmp_path=tmp_path)
+
+        module.on_train_epoch_start()
+
+        assert module._accumulated_box_normalizer is None
+
+    def test_zeros_optimizer_grad_on_stale_accumulator(self, tmp_path):
+        """When a partial window survived epoch end, optimizer gradients must be zeroed before reset."""
+        module, *_ = _build_module(
+            model_config=_base_model_config(use_grouppose_keypoints=True, num_keypoints_per_class=[17]),
+            tmp_path=tmp_path,
+        )
+        real_param = nn.Parameter(torch.randn(4))
+        real_param.grad = torch.ones(4)
+        optimizer = torch.optim.SGD([real_param], lr=1.0)
+        module.optimizers = MagicMock(return_value=optimizer)
+        module._accumulated_box_normalizer = torch.tensor(7.0)
+        # Wire a trainer so on_train_epoch_start can call self.optimizers().
+        trainer = MagicMock()
+        module._trainer = trainer
+
+        module.on_train_epoch_start()
+
+        assert module._accumulated_box_normalizer is None
+        assert real_param.grad is None or real_param.grad.abs().sum().item() == pytest.approx(0.0)
+
+
+class TestRescaleAccumulatedGradients:
+    """Direct contract tests for _rescale_accumulated_gradients."""
+
+    def test_scales_all_parameter_grads_by_factor(self, tmp_path):
+        """Calling _rescale with factor 0.5 must halve every parameter's .grad tensor."""
+        module, *_ = _build_module(
+            model_config=_base_model_config(use_grouppose_keypoints=True, num_keypoints_per_class=[17]),
+            tmp_path=tmp_path,
+        )
+        param_a = nn.Parameter(torch.zeros(3))
+        param_b = nn.Parameter(torch.zeros(5))
+        param_a.grad = torch.full((3,), 4.0)
+        param_b.grad = torch.full((5,), 8.0)
+        # Wire a real model with the two params so _rescale iterates over them.
+        nano_model = nn.Linear(3, 5)
+        # weight: [5, 3], bias: [5]
+        nano_model.weight.grad = torch.full((5, 3), 4.0)
+        nano_model.bias.grad = torch.full((5,), 8.0)
+        module.model = nano_model
+
+        module._rescale_accumulated_gradients(torch.tensor(0.5))
+
+        torch.testing.assert_close(nano_model.weight.grad, torch.full((5, 3), 2.0))
+        torch.testing.assert_close(nano_model.bias.grad, torch.full((5,), 4.0))
+
+    def test_scale_one_leaves_grads_unchanged(self, tmp_path):
+        """Scale factor 1.0 must leave gradients exactly unchanged (identity)."""
+        module, *_ = _build_module(
+            model_config=_base_model_config(use_grouppose_keypoints=True, num_keypoints_per_class=[17]),
+            tmp_path=tmp_path,
+        )
+        nano_model = nn.Linear(2, 2)
+        nano_model.weight.grad = torch.full((2, 2), 3.0)
+        nano_model.bias.grad = torch.full((2,), 7.0)
+        module.model = nano_model
+
+        module._rescale_accumulated_gradients(torch.tensor(1.0))
+
+        torch.testing.assert_close(nano_model.weight.grad, torch.full((2, 2), 3.0))
+        torch.testing.assert_close(nano_model.bias.grad, torch.full((2,), 7.0))
+
+    def test_skips_params_with_no_grad(self, tmp_path):
+        """Parameters without .grad must remain None after rescaling."""
+        module, *_ = _build_module(
+            model_config=_base_model_config(use_grouppose_keypoints=True, num_keypoints_per_class=[17]),
+            tmp_path=tmp_path,
+        )
+        nano_model = nn.Linear(2, 2)
+        # No backward pass — all grads are None
+        module.model = nano_model
+
+        module._rescale_accumulated_gradients(torch.tensor(0.5))
+
+        assert nano_model.weight.grad is None
+        assert nano_model.bias.grad is None
 
 
 class TestValidationStep:
@@ -1364,6 +1450,48 @@ class TestConfigureOptimizers:
         module._trainer.precision = "bf16-mixed"
 
         assert not module._use_fused_optimizer
+
+    @patch("rfdetr.training.module_model.get_param_dict")
+    def test_total_steps_divided_by_grad_accum_for_keypoint_module(self, mock_get_param_dict, tmp_path):
+        """Keypoint (manual-opt) path must divide estimated_stepping_batches by grad_accum_steps for LR scheduling.
+
+        With microbatches=100, grad_accum_steps=4, epochs=1, warmup_epochs=0 the scheduler should span 25 optimizer
+        steps (ceil(100/4)).  At step 24 (0-indexed last step) a cosine LR schedule should be nearly at lr_min_factor;
+        if total_steps were mistakenly 100 the LR would still be near its peak at step 24.
+        """
+        import math
+
+        grad_accum_steps = 4
+        microbatches = 100
+        lr_min_factor = 0.1
+        tc = _base_train_config(
+            tmp_path,
+            grad_accum_steps=grad_accum_steps,
+            warmup_epochs=0,
+            epochs=1,
+            lr_scheduler="cosine",
+            lr_min_factor=lr_min_factor,
+        )
+        module, _, _, _ = _build_module(
+            model_config=_base_model_config(use_grouppose_keypoints=True, num_keypoints_per_class=[17]),
+            train_config=tc,
+        )
+        trainer = MagicMock()
+        trainer.estimated_stepping_batches = microbatches
+        module._trainer = trainer
+        type(module).trainer = property(lambda self: self._trainer)
+        real_param = nn.Parameter(torch.randn(4, 4))
+        mock_get_param_dict.return_value = [{"params": real_param, "lr": tc.lr}]
+
+        result = module.configure_optimizers()
+        scheduler = result["lr_scheduler"]["scheduler"]
+        lr_lambda = scheduler.lr_lambdas[0]
+
+        expected_total_steps = max(1, math.ceil(microbatches / grad_accum_steps))  # 25
+        # The cosine schedule reaches lr_min_factor exactly at step == total_steps (progress=1.0).
+        # If total_steps were wrongly 100, lr at step 25 would still be ~0.87 (near peak).
+        lr_at_decay_end = lr_lambda(expected_total_steps)
+        assert lr_at_decay_end == pytest.approx(lr_min_factor, abs=1e-6)
 
 
 class TestClipGradients:

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -207,21 +207,24 @@ class TestInit:
     build_criterion_and_postprocessors() when pretrain_weights is None."""
 
     @pytest.mark.parametrize(
-        "model_config",
+        "model_config,expected_manual",
         [
-            pytest.param(_base_model_config(use_grouppose_keypoints=False), id="detection"),
-            pytest.param(_base_model_config(segmentation_head=True), id="segmentation"),
+            pytest.param(_base_model_config(use_grouppose_keypoints=False), False, id="detection"),
+            pytest.param(_base_model_config(segmentation_head=True), False, id="segmentation"),
             pytest.param(
                 _base_model_config(use_grouppose_keypoints=True, num_keypoints_per_class=[17]),
+                True,
                 id="keypoints",
             ),
         ],
     )
-    def test_models_use_manual_optimization(self, build_module, model_config):
-        """All DETR-style losses need manual optimization for box-normalized accumulation."""
+    def test_optimization_mode_per_model_type(self, build_module, model_config, expected_manual):
+        """Only keypoint models need manual optimization for box-normalized accumulation; detection and segmentation
+        keep Lightning's automatic optimization path."""
         module, _, _, _ = build_module(model_config=model_config)
 
-        assert module.automatic_optimization is False
+        assert module._use_manual_optimization is expected_manual
+        assert module.automatic_optimization is (not expected_manual)
 
     def test_model_is_set(self, build_module):
         """__init__ must assign the built model to module.model."""
@@ -730,14 +733,17 @@ class TestTrainingStep:
         assert loss.item() == pytest.approx(1.0 + 10.0 + 6.0)
 
     def test_loss_backward_uses_box_normalizer_contract(self, tmp_path):
-        """Backward loss is scaled by criterion box normalizer, not Lightning accumulation."""
+        """Backward loss for keypoint models is scaled by the criterion box normalizer (manual optimization owns
+        accumulation), not by Lightning's ``accumulate_grad_batches``."""
         loss_dict = {"loss_ce": torch.tensor(4.0)}
         weight_dict = {"loss_ce": 1.0}
+        keypoint_config = _base_model_config(use_grouppose_keypoints=True, num_keypoints_per_class=[17])
         module, samples, targets, _, _ = self._run_step(
             tmp_path,
             loss_dict,
             weight_dict,
             accumulate_grad_batches=4,
+            model_config=keypoint_config,
         )
         module.criterion.num_boxes_for_targets.return_value = torch.tensor(4.0)
 
@@ -747,82 +753,86 @@ class TestTrainingStep:
         backward_loss = module.manual_backward.call_args.args[0]
         assert backward_loss.item() == pytest.approx(1.0)
 
+    def test_detection_loss_uses_lightning_grad_accum_scaling(self, tmp_path):
+        """Detection (automatic optimization) divides loss by ``trainer.accumulate_grad_batches`` so the returned loss
+        matches the legacy non-manual training path."""
+        loss_dict = {"loss_ce": torch.tensor(4.0)}
+        weight_dict = {"loss_ce": 1.0}
+        module, samples, targets, _, _ = self._run_step(
+            tmp_path,
+            loss_dict,
+            weight_dict,
+            accumulate_grad_batches=1,
+        )
+        module._trainer.accumulate_grad_batches = 4
+
+        loss = module.training_step((samples, targets), batch_idx=0)
+
+        assert loss.item() == pytest.approx(1.0)
+        module.manual_backward.assert_not_called()
+
+    def _make_keypoint_module(self, tmp_path, grad_accum_steps, num_training_batches):
+        """Build a keypoint module wired with ``_ScalarLossModel`` and ``_BoxNormalizedCriterion`` for accum tests."""
+        module, *_ = _build_module(
+            model_config=_base_model_config(use_grouppose_keypoints=True, num_keypoints_per_class=[17]),
+            train_config=_base_train_config(tmp_path, grad_accum_steps=grad_accum_steps),
+            tmp_path=tmp_path,
+        )
+        model = _ScalarLossModel()
+        optimizer = torch.optim.SGD(model.parameters(), lr=1.0)
+        module.model = model
+        module.criterion = _BoxNormalizedCriterion()
+        module.postprocess = MagicMock()
+        module.log = MagicMock()
+        module.log_dict = MagicMock()
+        module.optimizers = MagicMock(return_value=optimizer)
+        module.manual_backward = lambda loss: loss.backward()
+        module.lr_schedulers = MagicMock(return_value=None)
+        trainer = MagicMock()
+        trainer.accumulate_grad_batches = 1
+        trainer.num_training_batches = num_training_batches
+        trainer.gradient_clip_val = 0.0
+        trainer.gradient_clip_algorithm = "norm"
+        module._trainer = trainer
+        type(module).trainer = property(lambda self: self._trainer)
+        return module, model
+
     @pytest.mark.parametrize(
-        "model_config",
+        "grad_accum_steps,box_counts,loss_numerators,expected_value",
         [
-            pytest.param(_base_model_config(use_grouppose_keypoints=False), id="detection"),
-            pytest.param(_base_model_config(segmentation_head=True), id="segmentation"),
-            pytest.param(
-                _base_model_config(use_grouppose_keypoints=True, num_keypoints_per_class=[17]),
-                id="keypoints",
-            ),
+            pytest.param(2, (2, 6), (10.0, 6.0), -2.0, id="ga2-balanced"),
+            pytest.param(3, (2, 4, 6), (4.0, 8.0, 12.0), -2.0, id="ga3-balanced"),
+            pytest.param(4, (1, 1, 1, 1), (2.0, 2.0, 2.0, 2.0), -2.0, id="ga4-uniform"),
+            pytest.param(2, (1, 99), (1.0, 99.0), -1.0, id="ga2-skewed-1-vs-99"),
+            pytest.param(4, (1, 1, 1, 97), (1.0, 1.0, 1.0, 97.0), -1.0, id="ga4-skewed-1-1-1-97"),
         ],
     )
-    def test_box_normalized_accumulation_matches_large_effective_batch(self, tmp_path, model_config):
-        """Accumulated gradients should match a large batch normalized by total boxes."""
-        large_module, _, _, _ = _build_module(
-            model_config=model_config,
-            train_config=_base_train_config(tmp_path, grad_accum_steps=1),
-            tmp_path=tmp_path,
+    def test_box_normalized_accumulation_matches_large_effective_batch(
+        self, tmp_path, grad_accum_steps, box_counts, loss_numerators, expected_value
+    ):
+        """Accumulated gradients across ``grad_accum_steps`` microbatches must equal a single large batch normalized by
+        total boxes, regardless of how lopsided the per-microbatch box counts are."""
+        large_module, large_model = self._make_keypoint_module(tmp_path, grad_accum_steps=1, num_training_batches=1)
+        accum_module, accum_model = self._make_keypoint_module(
+            tmp_path, grad_accum_steps=grad_accum_steps, num_training_batches=grad_accum_steps
         )
-        large_model = _ScalarLossModel()
-        large_optimizer = torch.optim.SGD(large_model.parameters(), lr=1.0)
-        large_module.model = large_model
-        large_module.criterion = _BoxNormalizedCriterion()
-        large_module.postprocess = MagicMock()
-        large_module.log = MagicMock()
-        large_module.log_dict = MagicMock()
-        large_module.optimizers = MagicMock(return_value=large_optimizer)
-        large_module.manual_backward = lambda loss: loss.backward()
-        large_module.lr_schedulers = MagicMock(return_value=None)
-        large_trainer = MagicMock()
-        large_trainer.accumulate_grad_batches = 1
-        large_trainer.num_training_batches = 1
-        large_trainer.gradient_clip_val = 0.0
-        large_trainer.gradient_clip_algorithm = "norm"
-        large_module._trainer = large_trainer
-        type(large_module).trainer = property(lambda self: self._trainer)
 
-        accum_module, _, _, _ = _build_module(
-            model_config=model_config,
-            train_config=_base_train_config(tmp_path, grad_accum_steps=2),
-            tmp_path=tmp_path,
-        )
-        accum_model = _ScalarLossModel()
-        accum_optimizer = torch.optim.SGD(accum_model.parameters(), lr=1.0)
-        accum_module.model = accum_model
-        accum_module.criterion = _BoxNormalizedCriterion()
-        accum_module.postprocess = MagicMock()
-        accum_module.log = MagicMock()
-        accum_module.log_dict = MagicMock()
-        accum_module.optimizers = MagicMock(return_value=accum_optimizer)
-        accum_module.manual_backward = lambda loss: loss.backward()
-        accum_module.lr_schedulers = MagicMock(return_value=None)
-        accum_trainer = MagicMock()
-        accum_trainer.accumulate_grad_batches = 1
-        accum_trainer.num_training_batches = 2
-        accum_trainer.gradient_clip_val = 0.0
-        accum_trainer.gradient_clip_algorithm = "norm"
-        accum_module._trainer = accum_trainer
-
+        microbatch_targets = [
+            {
+                "labels": torch.ones(box_count, dtype=torch.int64),
+                "loss_numerator": torch.tensor(loss_numerator),
+                "orig_size": torch.tensor([16, 16]),
+            }
+            for box_count, loss_numerator in zip(box_counts, loss_numerators, strict=True)
+        ]
         samples, _ = _make_batch(batch_size=2)
-        first_target = {
-            "labels": torch.ones(2, dtype=torch.int64),
-            "loss_numerator": torch.tensor(10.0),
-            "orig_size": torch.tensor([16, 16]),
-        }
-        second_target = {
-            "labels": torch.ones(6, dtype=torch.int64),
-            "loss_numerator": torch.tensor(6.0),
-            "orig_size": torch.tensor([16, 16]),
-        }
 
-        large_module.training_step((samples, [first_target, second_target]), batch_idx=0)
-        accum_module.training_step((samples, [first_target]), batch_idx=0)
-        accum_module.training_step((samples, [second_target]), batch_idx=1)
+        large_module.training_step((samples, microbatch_targets), batch_idx=0)
+        for batch_idx, target in enumerate(microbatch_targets):
+            accum_module.training_step((samples, [target]), batch_idx=batch_idx)
 
         torch.testing.assert_close(accum_model.value, large_model.value)
-        assert large_model.value.item() == pytest.approx(-2.0)
+        assert large_model.value.item() == pytest.approx(expected_value)
 
     def test_logs_live_train_loss_to_progress_bar(self, tmp_path):
         """Aggregate training loss must be logged every step as a progress-only metric."""
@@ -921,6 +931,86 @@ class TestTrainingStep:
         loss = module.training_step((samples, targets), batch_idx=0)
 
         assert loss.item() == pytest.approx(2.0)
+
+
+class TestShouldStepOptimizer:
+    """Tests for ``_should_step_optimizer`` — covers the modulo path, the end-of-epoch fallback, and the iterable /
+    infinite dataset case where ``trainer.num_training_batches`` is ``float('inf')``."""
+
+    def _make_module_with_trainer(self, tmp_path, grad_accum_steps, num_training_batches):
+        """Build a module with a stub trainer exposing ``num_training_batches`` for the test scenario."""
+        module, *_ = _build_module(
+            model_config=_base_model_config(use_grouppose_keypoints=True, num_keypoints_per_class=[17]),
+            train_config=_base_train_config(tmp_path, grad_accum_steps=grad_accum_steps),
+            tmp_path=tmp_path,
+        )
+        trainer = MagicMock()
+        trainer.num_training_batches = num_training_batches
+        module._trainer = trainer
+        type(module).trainer = property(lambda self: self._trainer)
+        return module
+
+    @pytest.mark.parametrize(
+        "grad_accum_steps,num_training_batches,batch_idx,expected",
+        [
+            pytest.param(1, 10, 0, True, id="ga1-bidx0-steps-every-batch"),
+            pytest.param(1, 10, 9, True, id="ga1-bidx9-steps-every-batch"),
+            pytest.param(2, 10, 0, False, id="ga2-bidx0-mid-window"),
+            pytest.param(2, 10, 1, True, id="ga2-bidx1-closes-window"),
+            pytest.param(2, 10, 2, False, id="ga2-bidx2-opens-new-window"),
+            pytest.param(2, 10, 9, True, id="ga2-bidx9-closes-final-window"),
+            pytest.param(4, 10, 7, True, id="ga4-bidx7-closes-second-window"),
+            pytest.param(4, 10, 8, False, id="ga4-bidx8-opens-partial-window"),
+            pytest.param(4, 10, 9, True, id="ga4-bidx9-final-batch-flushes-partial"),
+            pytest.param(4, 11, 8, False, id="ga4-bidx8-of-11-mid-window"),
+            pytest.param(4, 11, 10, True, id="ga4-bidx10-final-batch-flushes-partial"),
+        ],
+    )
+    def test_finite_dataset_steps_at_window_close_and_epoch_end(
+        self, tmp_path, grad_accum_steps, num_training_batches, batch_idx, expected
+    ):
+        """Optimizer steps when the accumulation window closes or when the epoch ends with a partial window."""
+        module = self._make_module_with_trainer(tmp_path, grad_accum_steps, num_training_batches)
+
+        assert module._should_step_optimizer(batch_idx) is expected
+
+    @pytest.mark.parametrize(
+        "grad_accum_steps,batch_idx,expected",
+        [
+            pytest.param(2, 0, False, id="ga2-bidx0-mid-window"),
+            pytest.param(2, 1, True, id="ga2-bidx1-closes-window"),
+            pytest.param(4, 2, False, id="ga4-bidx2-mid-window"),
+            pytest.param(4, 3, True, id="ga4-bidx3-closes-window"),
+        ],
+    )
+    def test_infinite_dataset_uses_modulo_only(self, tmp_path, grad_accum_steps, batch_idx, expected):
+        """Iterable datasets report ``num_training_batches=float('inf')``; only the modulo path can close the window."""
+        module = self._make_module_with_trainer(tmp_path, grad_accum_steps, float("inf"))
+
+        assert module._should_step_optimizer(batch_idx) is expected
+
+    def test_none_num_training_batches_uses_modulo_only(self, tmp_path):
+        """If trainer.num_training_batches is None (very early in fit), only the modulo path can trigger a step."""
+        module = self._make_module_with_trainer(tmp_path, grad_accum_steps=2, num_training_batches=None)
+
+        assert module._should_step_optimizer(batch_idx=0) is False
+        assert module._should_step_optimizer(batch_idx=1) is True
+
+
+class TestOnTrainEpochStart:
+    """Tests for ``on_train_epoch_start`` — must reset the accumulated box normalizer between epochs."""
+
+    def test_reset_clears_stale_accumulator(self, tmp_path):
+        """A stale normalizer from a previous epoch must not leak into the new epoch's first microbatch."""
+        module, *_ = _build_module(
+            model_config=_base_model_config(use_grouppose_keypoints=True, num_keypoints_per_class=[17]),
+            tmp_path=tmp_path,
+        )
+        module._accumulated_box_normalizer = torch.tensor(42.0)
+
+        module.on_train_epoch_start()
+
+        assert module._accumulated_box_normalizer is None
 
 
 class TestValidationStep:

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -165,6 +165,7 @@ class _BoxNormalizedCriterion:
     """Criterion with controllable per-target loss numerators and box counts."""
 
     weight_dict = {"loss_ce": 1.0}
+    supports_loss_normalizer_override: bool = True
 
     def num_boxes_for_targets(self, outputs, targets):
         return torch.as_tensor(
@@ -1032,9 +1033,6 @@ class TestOnTrainEpochStart:
         optimizer = torch.optim.SGD([real_param], lr=1.0)
         module.optimizers = MagicMock(return_value=optimizer)
         module._accumulated_box_normalizer = torch.tensor(7.0)
-        # Wire a trainer so on_train_epoch_start can call self.optimizers().
-        trainer = MagicMock()
-        module._trainer = trainer
 
         module.on_train_epoch_start()
 
@@ -1051,11 +1049,6 @@ class TestRescaleAccumulatedGradients:
             model_config=_base_model_config(use_grouppose_keypoints=True, num_keypoints_per_class=[17]),
             tmp_path=tmp_path,
         )
-        param_a = nn.Parameter(torch.zeros(3))
-        param_b = nn.Parameter(torch.zeros(5))
-        param_a.grad = torch.full((3,), 4.0)
-        param_b.grad = torch.full((5,), 8.0)
-        # Wire a real model with the two params so _rescale iterates over them.
         nano_model = nn.Linear(3, 5)
         # weight: [5, 3], bias: [5]
         nano_model.weight.grad = torch.full((5, 3), 4.0)

--- a/tests/training/test_trainer_smoke.py
+++ b/tests/training/test_trainer_smoke.py
@@ -169,14 +169,16 @@ class TestDetectionSmoke:
 
         losses = []
 
-        def _recording_criterion(outputs, targets):
+        def _recording_criterion(outputs, targets, num_boxes=None):
             dummy = outputs.get("dummy", torch.zeros(1))
-            loss = dummy.mean()
+            denominator = fake_criterion.num_boxes_for_targets(outputs, targets) if num_boxes is None else num_boxes
+            loss = dummy.mean() / denominator
             losses.append(loss.detach().item())
             return {"loss_ce": loss}
 
         fake_criterion = MagicMock(side_effect=_recording_criterion)
         fake_criterion.weight_dict = {"loss_ce": 1.0}
+        fake_criterion.num_boxes_for_targets.return_value = torch.tensor(1.0)
 
         with (
             patch("rfdetr.training.module_model.build_model_from_config", return_value=tiny_model),


### PR DESCRIPTION
This pull request introduces a new training mode for keypoint models that enables precise loss normalization across gradient accumulation steps by switching from Lightning's automatic optimization to manual optimization. It adds logic to manually handle loss scaling, gradient clipping, and optimizer stepping for keypoint models, while maintaining the standard Lightning behavior for detection and segmentation models. The changes also include new tests to verify correct behavior for both optimization modes.

The most important changes are:

**Manual optimization for keypoint models:**

* The `RFDETRModelModule` now uses manual optimization (`automatic_optimization = False`) when training keypoint models (`use_grouppose_keypoints=True`), allowing loss normalization by the full accumulated box count instead of per-microbatch normalization. [[1]](diffhunk://#diff-23abcb291c6af5b421635bdc43a4a852b0a25d82e899a099609e9b82d60343d7R54-R55) [[2]](diffhunk://#diff-23abcb291c6af5b421635bdc43a4a852b0a25d82e899a099609e9b82d60343d7L148-R152) [[3]](diffhunk://#diff-23abcb291c6af5b421635bdc43a4a852b0a25d82e899a099609e9b82d60343d7R166-L174) [[4]](diffhunk://#diff-23abcb291c6af5b421635bdc43a4a852b0a25d82e899a099609e9b82d60343d7R207-R347) [[5]](diffhunk://#diff-c75a0b594c4b4ce5ab4c09bcdad344a039991a64d0707fe35569c22130bfdb68R397) [[6]](diffhunk://#diff-c75a0b594c4b4ce5ab4c09bcdad344a039991a64d0707fe35569c22130bfdb68L406-R410)
* Added custom logic to manually handle backward passes, gradient scaling, optimizer stepping, and learning rate scheduling when in manual optimization mode.

**Criterion and loss normalization improvements:**

* The `SetCriterion` class now supports an explicit loss normalizer override (`supports_loss_normalizer_override = True`), and exposes a `num_boxes_for_targets` method to compute the appropriate denominator for box-normalized losses. [[1]](diffhunk://#diff-4955035c04a6063e454aa55c109b352e387f32c0f7420b2b89b17e0f308d9a07R137-R138) [[2]](diffhunk://#diff-4955035c04a6063e454aa55c109b352e387f32c0f7420b2b89b17e0f308d9a07R178-R214) [[3]](diffhunk://#diff-4955035c04a6063e454aa55c109b352e387f32c0f7420b2b89b17e0f308d9a07L511-R570)
* The `forward` method of `SetCriterion` now accepts an optional `num_boxes` argument, enabling the emission of loss numerators for custom normalization.

**Trainer and gradient clipping adjustments:**

* The Lightning `Trainer` is now configured to disable built-in gradient clipping for keypoint models, since manual optimization handles it internally. [[1]](diffhunk://#diff-c75a0b594c4b4ce5ab4c09bcdad344a039991a64d0707fe35569c22130bfdb68R397) [[2]](diffhunk://#diff-c75a0b594c4b4ce5ab4c09bcdad344a039991a64d0707fe35569c22130bfdb68L406-R410)

**Testing enhancements:**

* Added new tests to verify that keypoint models use manual optimization and non-keypoint models use automatic optimization.
* Added tests to ensure correct handling of gradient clipping configuration in both modes.
* Introduced test fixtures and helpers for custom criteria and models to support gradient-scaling and normalization tests. [[1]](diffhunk://#diff-02213cce950e5e71095a209a611da4e411626e08b07e725e48e09617808d08f9R152-R181) [[2]](diffhunk://#diff-02213cce950e5e71095a209a611da4e411626e08b07e725e48e09617808d08f9L648-R693) [[3]](diffhunk://#diff-02213cce950e5e71095a209a611da4e411626e08b07e725e48e09617808d08f9R704-R710)