### PR TITLE
docs(benchmarks): add keypoint detection benchmark section

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,29 @@ RF-DETR achieves state-of-the-art results in both object detection and instance 
 
 </details>
 
+### Keypoints
+
+<details>
+<summary>See keypoint detection benchmark numbers</summary>
+
+<br>
+
+| Architecture | COCO AP<sub>50:95</sub> | Latency (ms) | License |
+| :-----------------: | :---------------------: | :----------: | :-----: |
+| RF-DETR Keypoint (Preview) | 71.8 | 9.7 | Apache 2.0 |
+| YOLO11-pose N | 48.9 | 3.2 | AGPL-3.0 |
+| YOLO11-pose S | 57.5 | 3.4 | AGPL-3.0 |
+| YOLO11-pose M | 64.2 | 5.2 | AGPL-3.0 |
+| YOLO11-pose L | 65.2 | 6.6 | AGPL-3.0 |
+| YOLO11-pose X | 68.6 | 10.6 | AGPL-3.0 |
+| YOLO26-pose N | 55.9 | 1.9 | AGPL-3.0 |
+| YOLO26-pose S | 62.0 | 2.7 | AGPL-3.0 |
+| YOLO26-pose M | 68.0 | 4.6 | AGPL-3.0 |
+| YOLO26-pose L | 69.2 | 5.9 | AGPL-3.0 |
+| YOLO26-pose X | 71.0 | 9.8 | AGPL-3.0 |
+
+</details>
+
 ## Run Models
 
 ### Detection

--- a/README.md
+++ b/README.md
@@ -266,9 +266,9 @@ model = RFDETRKeypointPreview()
 key_points = model.predict("image.jpg", threshold=0.5)
 ```
 
-| Size | RF-DETR package class | COCO AP<sub>50:95</sub> | Latency (ms) | Params (M) | Resolution | License |
+|        Size        |  RF-DETR package class  | COCO AP<sub>50:95</sub> | Latency (ms) | Params (M) | Resolution |  License   |
 | :----------------: | :---------------------: | :---------------------: | :----------: | :--------: | :--------: | :--------: |
-| Keypoint (Preview) | `RFDETRKeypointPreview` | 71.8 | 9.7 | 126.4 | 576x576 | Apache 2.0 |
+| Keypoint (Preview) | `RFDETRKeypointPreview` |          71.8           |     9.7      |   126.4    |  576x576   | Apache 2.0 |
 
 ### Train Models
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ RF-DETR achieves state-of-the-art results in both object detection and instance 
 
 ### Keypoints
 
+<img alt="RF-DETR Keypoint mAP vs latency chart comparing against YOLO26-pose and YOLO11-pose on MS COCO" src="docs/assets/keypoints/kp-map-latency.png" />
+
 <details>
 <summary>See keypoint detection benchmark numbers</summary>
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RF-DETR: Real-Time SOTA Detection and Segmentation
+# RF-DETR: Real-Time SOTA Object Detection, Instance Segmentation, and Keypoint Detection
 
 [![version](https://badge.fury.io/py/rfdetr.svg)](https://badge.fury.io/py/rfdetr)
 [![downloads](https://img.shields.io/pypi/dm/rfdetr)](https://pypistats.org/packages/rfdetr)
@@ -12,9 +12,9 @@
 [![roboflow](https://raw.githubusercontent.com/roboflow-ai/notebooks/main/assets/badges/roboflow-blogpost.svg)](https://blog.roboflow.com/rf-detr)
 [![discord](https://img.shields.io/discord/1159501506232451173?logo=discord&label=discord&labelColor=fff&color=5865f2&link=https%3A%2F%2Fdiscord.gg%2FGbfgXGJ8Bk)](https://discord.gg/GbfgXGJ8Bk)
 
-RF-DETR is a real-time transformer architecture for object detection and instance segmentation developed by Roboflow. Built on a DINOv2 vision transformer backbone, RF-DETR delivers state-of-the-art accuracy and latency trade-offs on [Microsoft COCO](https://cocodataset.org/#home) and [RF100-VL](https://github.com/roboflow/rf100-vl).
+RF-DETR is a real-time transformer architecture for object detection, instance segmentation, and keypoint detection (preview) developed by Roboflow. Built on a DINOv2 vision transformer backbone, RF-DETR delivers state-of-the-art accuracy and latency trade-offs on [Microsoft COCO](https://cocodataset.org/#home) and [RF100-VL](https://github.com/roboflow/rf100-vl).
 
-RF-DETR uses a DINOv2 vision transformer backbone and supports both detection and instance segmentation in a single, consistent API. The open-source `rfdetr` package and Apache-designated models are released under Apache 2.0, while Plus components (`rfdetr_plus`, including RF-DETR-XL/2XL detection models) are licensed under PML 1.0.
+RF-DETR uses a DINOv2 vision transformer backbone and supports object detection, instance segmentation, and keypoint detection (preview) in a single, consistent API. The open-source `rfdetr` package and Apache-designated models are released under Apache 2.0, while Plus components (`rfdetr_plus`, including RF-DETR-XL/2XL detection models) are licensed under PML 1.0.
 
 https://github.com/user-attachments/assets/add23fd1-266f-4538-8809-d7dd5767e8e6
 
@@ -41,7 +41,7 @@ pip install https://github.com/roboflow/rf-detr/archive/refs/heads/develop.zip
 
 ## Benchmarks
 
-RF-DETR achieves state-of-the-art results in both object detection and instance segmentation, with benchmarks reported on Microsoft COCO and RF100-VL. The charts and tables below compare RF-DETR against other top real-time models across accuracy and latency for detection and segmentation. All latency numbers were measured on an NVIDIA T4 using TensorRT, FP16, and batch size 1. For full benchmarking methodology and reproducibility details, see [roboflow/sab](https://github.com/roboflow/single_artifact_benchmarking).
+RF-DETR achieves state-of-the-art results in both object detection and instance segmentation, with benchmarks reported on Microsoft COCO and RF100-VL (RF100-VL for detection only). The charts and tables below compare RF-DETR against other top real-time models across accuracy and latency for detection and segmentation. All latency numbers were measured on an NVIDIA T4 using TensorRT, FP16, and batch size 1. For full benchmarking methodology and reproducibility details, see [roboflow/sab](https://github.com/roboflow/single_artifact_benchmarking).
 
 ### Detection
 
@@ -120,7 +120,7 @@ RF-DETR achieves state-of-the-art results in both object detection and instance 
 
 ### Keypoints
 
-<img alt="RF-DETR Keypoint mAP vs latency chart comparing against YOLO26-pose and YOLO11-pose on MS COCO" src="docs/assets/keypoints/kp-map-latency.png" />
+<img alt="RF-DETR Keypoint mAP vs latency chart comparing against YOLO26-pose and YOLO11-pose on MS COCO" src="https://raw.githubusercontent.com/roboflow/rf-detr/develop/docs/assets/keypoints/kp-map-latency.png" />
 
 <details>
 <summary>See keypoint detection benchmark numbers</summary>
@@ -142,6 +142,8 @@ RF-DETR achieves state-of-the-art results in both object detection and instance 
 |       YOLO26-pose X        |          71.0           |     9.8      |  AGPL-3.0  |
 
 </details>
+
+> Keypoint benchmarks report AP<sub>50:95</sub> (OKS-based); this is the standard COCO keypoint comparison metric.
 
 ## Run Models
 
@@ -253,9 +255,24 @@ annotated_image = sv.LabelAnnotator().annotate(annotated_image, detections)
 |  XL  |   `RFDETRSegXLarge`   | `rfdetr-seg-xlarge`     |         72.2         |          48.8           |     13.5     |    38.1    |  624x624   | Apache 2.0 |
 | 2XL  |  `RFDETRSeg2XLarge`   | `rfdetr-seg-2xlarge`    |         73.1         |          49.9           |     21.8     |    38.6    |  768x768   | Apache 2.0 |
 
+### Keypoints
+
+RF-DETR supports keypoint detection (preview) with `RFDETRKeypointPreview`, pretrained on COCO person keypoints.
+
+```python
+from rfdetr import RFDETRKeypointPreview
+
+model = RFDETRKeypointPreview()
+key_points = model.predict("image.jpg", threshold=0.5)
+```
+
+| Size | RF-DETR package class | COCO AP<sub>50:95</sub> | Latency (ms) | Params (M) | Resolution | License |
+| :----------------: | :---------------------: | :---------------------: | :----------: | :--------: | :--------: | :--------: |
+| Keypoint (Preview) | `RFDETRKeypointPreview` | 71.8 | 9.7 | 126.4 | 576x576 | Apache 2.0 |
+
 ### Train Models
 
-RF-DETR supports training for both object detection and instance segmentation. You can train models in [Google Colab](https://colab.research.google.com/github/roboflow-ai/notebooks/blob/main/notebooks/how-to-finetune-rf-detr-on-detection-dataset.ipynb) or directly on the Roboflow platform. Below you will find a step-by-step video fine-tuning tutorial.
+RF-DETR supports training for object detection, instance segmentation, and keypoint detection (preview). You can train models in [Google Colab](https://colab.research.google.com/github/roboflow-ai/notebooks/blob/main/notebooks/how-to-finetune-rf-detr-on-detection-dataset.ipynb) or directly on the Roboflow platform. Below you will find a step-by-step video fine-tuning tutorial.
 
 [![rf-detr-tutorial-banner](https://github.com/user-attachments/assets/555a45c3-96e8-4d8a-ad29-f23403c8edfd)](https://youtu.be/-OvpdLAElFA)
 

--- a/README.md
+++ b/README.md
@@ -125,19 +125,19 @@ RF-DETR achieves state-of-the-art results in both object detection and instance 
 
 <br>
 
-| Architecture | COCO AP<sub>50:95</sub> | Latency (ms) | License |
-| :-----------------: | :---------------------: | :----------: | :-----: |
-| RF-DETR Keypoint (Preview) | 71.8 | 9.7 | Apache 2.0 |
-| YOLO11-pose N | 48.9 | 3.2 | AGPL-3.0 |
-| YOLO11-pose S | 57.5 | 3.4 | AGPL-3.0 |
-| YOLO11-pose M | 64.2 | 5.2 | AGPL-3.0 |
-| YOLO11-pose L | 65.2 | 6.6 | AGPL-3.0 |
-| YOLO11-pose X | 68.6 | 10.6 | AGPL-3.0 |
-| YOLO26-pose N | 55.9 | 1.9 | AGPL-3.0 |
-| YOLO26-pose S | 62.0 | 2.7 | AGPL-3.0 |
-| YOLO26-pose M | 68.0 | 4.6 | AGPL-3.0 |
-| YOLO26-pose L | 69.2 | 5.9 | AGPL-3.0 |
-| YOLO26-pose X | 71.0 | 9.8 | AGPL-3.0 |
+|        Architecture        | COCO AP<sub>50:95</sub> | Latency (ms) |  License   |
+| :------------------------: | :---------------------: | :----------: | :--------: |
+| RF-DETR Keypoint (Preview) |          71.8           |     9.7      | Apache 2.0 |
+|       YOLO11-pose N        |          48.9           |     3.2      |  AGPL-3.0  |
+|       YOLO11-pose S        |          57.5           |     3.4      |  AGPL-3.0  |
+|       YOLO11-pose M        |          64.2           |     5.2      |  AGPL-3.0  |
+|       YOLO11-pose L        |          65.2           |     6.6      |  AGPL-3.0  |
+|       YOLO11-pose X        |          68.6           |     10.6     |  AGPL-3.0  |
+|       YOLO26-pose N        |          55.9           |     1.9      |  AGPL-3.0  |
+|       YOLO26-pose S        |          62.0           |     2.7      |  AGPL-3.0  |
+|       YOLO26-pose M        |          68.0           |     4.6      |  AGPL-3.0  |
+|       YOLO26-pose L        |          69.2           |     5.9      |  AGPL-3.0  |
+|       YOLO26-pose X        |          71.0           |     9.8      |  AGPL-3.0  |
 
 </details>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -151,9 +151,9 @@ RF-DETR achieves the best accuracy–latency trade-off among real-time object de
 
 <img alt="RF-DETR Keypoint mAP vs latency chart comparing against YOLO26-pose and YOLO11-pose on MS COCO" src="assets/keypoints/kp-map-latency.png" width="840" height="630" style="max-width: 840px; height: auto;" />
 
-| Architecture | COCO AP<sub>50:95</sub> | Latency (ms) |
-| --------------- | ----------------------- | ------------ |
-| RF-DETR Keypoint (Preview) | 71.8 | 9.7 |
+| Architecture               | COCO AP<sub>50:95</sub> | Latency (ms) |
+| -------------------------- | ----------------------- | ------------ |
+| RF-DETR Keypoint (Preview) | 71.8                    | 9.7          |
 
 ## Frequently Asked Questions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -119,7 +119,7 @@ You can install and use `rfdetr` in a [**Python>=3.10**](https://www.python.org/
 
 ## Benchmarks
 
-RF-DETR achieves the best accuracy–latency trade-off among real-time object detection and instance segmentation models — both on COCO and on the more demanding RF100-VL benchmark (domain adaptability). For detailed benchmark tables and methodology, check out our [benchmarks](learn/benchmarks.md) page.
+RF-DETR achieves the best accuracy–latency trade-off among real-time object detection, instance segmentation, and keypoint detection models — both on COCO and on the more demanding RF100-VL benchmark (domain adaptability). For detailed benchmark tables and methodology, check out our [benchmarks](learn/benchmarks.md) page.
 
 ### Detection
 
@@ -146,6 +146,14 @@ RF-DETR achieves the best accuracy–latency trade-off among real-time object de
 | RF-DETR-Seg-L   | 70.5                 | 47.1                    | 8.8          | 36.2       | 504×504    |
 | RF-DETR-Seg-XL  | 72.2                 | 48.8                    | 13.5         | 38.1       | 624×624    |
 | RF-DETR-Seg-2XL | 73.1                 | 49.9                    | 21.8         | 38.6       | 768×768    |
+
+### Keypoints
+
+<img alt="RF-DETR Keypoint mAP vs latency chart comparing against YOLO26-pose and YOLO11-pose on MS COCO" src="assets/keypoints/kp-map-latency.png" width="840" height="630" style="max-width: 840px; height: auto;" />
+
+| Architecture | COCO AP<sub>50:95</sub> | Latency (ms) |
+| --------------- | ----------------------- | ------------ |
+| RF-DETR Keypoint (Preview) | 71.8 | 9.7 |
 
 ## Frequently Asked Questions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -156,6 +156,7 @@ RF-DETR achieves the best accuracy–latency trade-off among real-time object de
 | RF-DETR Keypoint (Preview) | 71.8                    | 9.7          | 126.4      | 576×576    |
 
 > Keypoint benchmarks report AP<sub>50:95</sub> (OKS-based); this is the standard COCO keypoint comparison metric.
+> For the full competitor comparison (YOLO11-pose, YOLO26-pose), see the [Benchmarks](learn/benchmarks.md#keypoints) page.
 
 ## Frequently Asked Questions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,14 @@
 ---
-description: RF-DETR is a real-time transformer for object detection and instance segmentation by Roboflow. DINOv2 backbone, SOTA on COCO (60.1 AP50:95). Apache 2.0.
+description: RF-DETR is a real-time transformer for object detection, instance segmentation, and keypoint detection (preview) by Roboflow. DINOv2 backbone, SOTA on COCO (60.1 AP50:95). Apache 2.0.
 hide:
   - navigation
 ---
 
-# RF-DETR: Real-Time SOTA Detection and Segmentation Model
+# RF-DETR: Real-Time SOTA Object Detection, Instance Segmentation, and Keypoint Detection
 
-RF-DETR is a real-time transformer architecture for object detection and instance segmentation developed by Roboflow. Built on a DINOv2 vision transformer backbone, RF-DETR achieves state-of-the-art accuracy–latency trade-offs: RF-DETR-L reaches 56.5 AP50:95 on COCO at 6.8 ms (NVIDIA T4, TensorRT FP16), and RF-DETR-2XL achieves 60.1 AP50:95 — the first real-time model to exceed 60 AP on COCO. Accepted at [ICLR 2026](https://arxiv.org/abs/2511.09554).
+RF-DETR is a real-time transformer architecture for object detection, instance segmentation, and keypoint detection (preview) developed by Roboflow. Built on a DINOv2 vision transformer backbone, RF-DETR achieves state-of-the-art accuracy–latency trade-offs: RF-DETR-L reaches 56.5 AP50:95 on COCO at 6.8 ms (NVIDIA T4, TensorRT FP16), and RF-DETR-2XL achieves 60.1 AP50:95 — the first real-time model to exceed 60 AP on COCO. Accepted at [ICLR 2026](https://arxiv.org/abs/2511.09554).
 
-RF-DETR uses a DINOv2 vision transformer backbone and supports both detection and instance segmentation in a single, consistent API. Core models (Nano through Large) and all code are released under the Apache 2.0 license; XL and 2XLarge detection models require `rfdetr[plus]` and are provided under PML 1.0.
+RF-DETR uses a DINOv2 vision transformer backbone and supports object detection, instance segmentation, and keypoint detection (preview) in a single, consistent API. Core models (Nano through Large) and all code are released under the Apache 2.0 license; XL and 2XLarge detection models require `rfdetr[plus]` and are provided under PML 1.0.
 
 Developed by Isaac Robinson, Peter Robicheaux, Fedor Popov, Deva Ramanan (CMU), and Neehar Peri (CMU) at [Roboflow](https://roboflow.com). If you use RF-DETR in your research, please cite:
 
@@ -119,7 +119,7 @@ You can install and use `rfdetr` in a [**Python>=3.10**](https://www.python.org/
 
 ## Benchmarks
 
-RF-DETR achieves the best accuracy–latency trade-off among real-time object detection, instance segmentation, and keypoint detection models — both on COCO and on the more demanding RF100-VL benchmark (domain adaptability). For detailed benchmark tables and methodology, check out our [benchmarks](learn/benchmarks.md) page.
+RF-DETR achieves the best accuracy–latency trade-off among real-time object detection and instance segmentation models. It also provides keypoint detection (preview) on COCO person keypoints. For detailed benchmark tables and methodology, check out our [benchmarks](learn/benchmarks.md) page.
 
 ### Detection
 
@@ -151,9 +151,11 @@ RF-DETR achieves the best accuracy–latency trade-off among real-time object de
 
 <img alt="RF-DETR Keypoint mAP vs latency chart comparing against YOLO26-pose and YOLO11-pose on MS COCO" src="assets/keypoints/kp-map-latency.png" width="840" height="630" style="max-width: 840px; height: auto;" />
 
-| Architecture               | COCO AP<sub>50:95</sub> | Latency (ms) |
-| -------------------------- | ----------------------- | ------------ |
-| RF-DETR Keypoint (Preview) | 71.8                    | 9.7          |
+| Architecture               | COCO AP<sub>50:95</sub> | Latency (ms) | Params (M) | Resolution |
+| -------------------------- | ----------------------- | ------------ | ---------- | ---------- |
+| RF-DETR Keypoint (Preview) | 71.8                    | 9.7          | 126.4      | 576×576    |
+
+> Keypoint benchmarks report AP<sub>50:95</sub> (OKS-based); this is the standard COCO keypoint comparison metric.
 
 ## Frequently Asked Questions
 
@@ -174,6 +176,9 @@ Yes. RF-DETR-N runs at 2.3 ms per frame on a T4 GPU (TensorRT FP16, batch 1), an
 
 **What is the difference between RF-DETR detection and segmentation models?**
 Detection models (e.g., `RFDETRLarge`) output bounding boxes. Segmentation models (e.g., `RFDETRSegLarge`) additionally output instance masks. Both share the same backbone and training API; segmentation adds a mask head and requires COCO-format segmentation annotations.
+
+**Does RF-DETR support keypoint detection?**
+RF-DETR Keypoint (Preview) detects 17 body keypoints per person on COCO, achieving 71.8 AP50:95 at 9.7 ms on NVIDIA T4. It is available in the `rfdetr` package as `RFDETRKeypointPreview`. See [Run Keypoint Models](learn/run/keypoints.md) for usage.
 
 **Is RF-DETR open source?**
 Yes. Core models (Nano through Large) and all training/inference code are released under the Apache 2.0 license. XLarge and 2XLarge models require the `rfdetr[plus]` package (PML 1.0 license).

--- a/docs/learn/benchmarks.md
+++ b/docs/learn/benchmarks.md
@@ -1,5 +1,5 @@
 ---
-description: RF-DETR benchmark results on COCO and RF100-VL for detection and segmentation. Compare accuracy and latency against YOLO, D-FINE, and LW-DETR.
+description: RF-DETR benchmark results on COCO and RF100-VL for detection, segmentation, and keypoint detection. Compare accuracy and latency against YOLO, D-FINE, and LW-DETR.
 ---
 
 # Benchmarks
@@ -11,8 +11,9 @@ description: RF-DETR benchmark results on COCO and RF100-VL for detection and se
     - Segmentation models range from 40.3 AP (Nano, 3.4 ms) to 49.9 AP (2XL, 21.8 ms) on COCO
     - All latency measured on NVIDIA T4 with TensorRT 10.4, CUDA 12.4, FP16, batch size 1
     - RF100-VL results demonstrate strong domain-shift generalization across 100 diverse datasets
+    - RF-DETR Keypoint (Preview) achieves 71.8 AP50:95 on COCO person keypoints at 9.7 ms (T4, TensorRT FP16)
 
-This page reports RF-DETR benchmark results for object detection and instance segmentation on Microsoft COCO and RF100-VL. All benchmark numbers and plots match the latest released checkpoints and tables shown below. Latency values are measured on an NVIDIA T4 with TensorRT in FP16 at batch size 1. For full methodology details and architectural context, see the RF-DETR paper.
+This page reports RF-DETR benchmark results for object detection, instance segmentation, and keypoint detection on Microsoft COCO and RF100-VL. All benchmark numbers and plots match the latest released checkpoints and tables shown below. Latency values are measured on an NVIDIA T4 with TensorRT in FP16 at batch size 1. For full methodology details and architectural context, see the RF-DETR paper.
 
 ## Methodology
 
@@ -89,3 +90,21 @@ Accuracy and latency are always measured using the same model artifact and the s
 |  YOLO26-M-Seg   |         67.8         |          44.0           |     6.32     |    23.6    |  640x640   |
 |  YOLO26-L-Seg   |         69.8         |          45.5           |     7.58     |    28.0    |  640x640   |
 |  YOLO26-X-Seg   |         71.6         |          46.8           |    12.92     |    62.8    |  640x640   |
+
+## Keypoints
+
+<img alt="RF-DETR Keypoint mAP vs latency chart comparing against YOLO26-pose and YOLO11-pose on MS COCO" src="../../assets/keypoints/kp-map-latency.png" />
+
+| Architecture | COCO AP<sub>50:95</sub> | Latency (ms) |
+| :-------------: | :---------------------: | :----------: |
+| RF-DETR Keypoint (Preview) | 71.8 | 9.7 |
+| YOLO11-pose N | 48.9 | 3.2 |
+| YOLO11-pose S | 57.5 | 3.4 |
+| YOLO11-pose M | 64.2 | 5.2 |
+| YOLO11-pose L | 65.2 | 6.6 |
+| YOLO11-pose X | 68.6 | 10.6 |
+| YOLO26-pose N | 55.9 | 1.9 |
+| YOLO26-pose S | 62.0 | 2.7 |
+| YOLO26-pose M | 68.0 | 4.6 |
+| YOLO26-pose L | 69.2 | 5.9 |
+| YOLO26-pose X | 71.0 | 9.8 |

--- a/docs/learn/benchmarks.md
+++ b/docs/learn/benchmarks.md
@@ -13,7 +13,7 @@ description: RF-DETR benchmark results on COCO and RF100-VL for detection, segme
     - RF100-VL results demonstrate strong domain-shift generalization across 100 diverse datasets
     - RF-DETR Keypoint (Preview) achieves 71.8 AP50:95 on COCO person keypoints at 9.7 ms (T4, TensorRT FP16)
 
-This page reports RF-DETR benchmark results for object detection, instance segmentation, and keypoint detection on Microsoft COCO and RF100-VL. All benchmark numbers and plots match the latest released checkpoints and tables shown below. Latency values are measured on an NVIDIA T4 with TensorRT in FP16 at batch size 1. For full methodology details and architectural context, see the RF-DETR paper.
+This page reports RF-DETR benchmark results for object detection, instance segmentation, and keypoint detection on Microsoft COCO and RF100-VL (detection and segmentation only). All benchmark numbers and plots match the latest released checkpoints and tables shown below. Latency values are measured on an NVIDIA T4 with TensorRT in FP16 at batch size 1. For full methodology details and architectural context, see the RF-DETR paper.
 
 ## Methodology
 
@@ -108,3 +108,5 @@ Accuracy and latency are always measured using the same model artifact and the s
 |       YOLO26-pose M        |          68.0           |     4.6      |
 |       YOLO26-pose L        |          69.2           |     5.9      |
 |       YOLO26-pose X        |          71.0           |     9.8      |
+
+> Keypoint benchmarks report AP<sub>50:95</sub> (OKS-based); this is the standard COCO keypoint comparison metric.

--- a/docs/learn/benchmarks.md
+++ b/docs/learn/benchmarks.md
@@ -13,7 +13,7 @@ description: RF-DETR benchmark results on COCO and RF100-VL for detection, segme
     - RF100-VL results demonstrate strong domain-shift generalization across 100 diverse datasets
     - RF-DETR Keypoint (Preview) achieves 71.8 AP50:95 on COCO person keypoints at 9.7 ms (T4, TensorRT FP16)
 
-This page reports RF-DETR benchmark results for object detection, instance segmentation, and keypoint detection on Microsoft COCO and RF100-VL (detection and segmentation only). All benchmark numbers and plots match the latest released checkpoints and tables shown below. Latency values are measured on an NVIDIA T4 with TensorRT in FP16 at batch size 1. For full methodology details and architectural context, see the RF-DETR paper.
+This page reports RF-DETR benchmark results for object detection, instance segmentation, and keypoint detection on Microsoft COCO and RF100-VL (detection only). All benchmark numbers and plots match the latest released checkpoints and tables shown below. Latency values are measured on an NVIDIA T4 with TensorRT in FP16 at batch size 1. For full methodology details and architectural context, see the RF-DETR paper.
 
 ## Methodology
 
@@ -93,7 +93,7 @@ Accuracy and latency are always measured using the same model artifact and the s
 
 ## Keypoints
 
-<img alt="RF-DETR Keypoint mAP vs latency chart comparing against YOLO26-pose and YOLO11-pose on MS COCO" src="../../assets/keypoints/kp-map-latency.png" />
+<img alt="RF-DETR Keypoint mAP vs latency chart comparing against YOLO26-pose and YOLO11-pose on MS COCO" src="../assets/keypoints/kp-map-latency.png" />
 
 |        Architecture        | COCO AP<sub>50:95</sub> | Latency (ms) |
 | :------------------------: | :---------------------: | :----------: |

--- a/docs/learn/benchmarks.md
+++ b/docs/learn/benchmarks.md
@@ -95,16 +95,16 @@ Accuracy and latency are always measured using the same model artifact and the s
 
 <img alt="RF-DETR Keypoint mAP vs latency chart comparing against YOLO26-pose and YOLO11-pose on MS COCO" src="../../assets/keypoints/kp-map-latency.png" />
 
-| Architecture | COCO AP<sub>50:95</sub> | Latency (ms) |
-| :-------------: | :---------------------: | :----------: |
-| RF-DETR Keypoint (Preview) | 71.8 | 9.7 |
-| YOLO11-pose N | 48.9 | 3.2 |
-| YOLO11-pose S | 57.5 | 3.4 |
-| YOLO11-pose M | 64.2 | 5.2 |
-| YOLO11-pose L | 65.2 | 6.6 |
-| YOLO11-pose X | 68.6 | 10.6 |
-| YOLO26-pose N | 55.9 | 1.9 |
-| YOLO26-pose S | 62.0 | 2.7 |
-| YOLO26-pose M | 68.0 | 4.6 |
-| YOLO26-pose L | 69.2 | 5.9 |
-| YOLO26-pose X | 71.0 | 9.8 |
+|        Architecture        | COCO AP<sub>50:95</sub> | Latency (ms) |
+| :------------------------: | :---------------------: | :----------: |
+| RF-DETR Keypoint (Preview) |          71.8           |     9.7      |
+|       YOLO11-pose N        |          48.9           |     3.2      |
+|       YOLO11-pose S        |          57.5           |     3.4      |
+|       YOLO11-pose M        |          64.2           |     5.2      |
+|       YOLO11-pose L        |          65.2           |     6.6      |
+|       YOLO11-pose X        |          68.6           |     10.6     |
+|       YOLO26-pose N        |          55.9           |     1.9      |
+|       YOLO26-pose S        |          62.0           |     2.7      |
+|       YOLO26-pose M        |          68.0           |     4.6      |
+|       YOLO26-pose L        |          69.2           |     5.9      |
+|       YOLO26-pose X        |          71.0           |     9.8      |

--- a/docs/learn/run/keypoints.md
+++ b/docs/learn/run/keypoints.md
@@ -18,8 +18,8 @@ RF-DETR Keypoint outperforms YOLO26-pose X and YOLO11-pose X at comparable laten
 
 ![RF-DETR Keypoint mAP vs latency chart comparing against YOLO26-pose and YOLO11-pose on MS COCO](../../assets/keypoints/kp-map-latency.png){ width=560 }
 
-|     Size     |  RF-DETR package class  | COCO AP<sub>50:95</sub> | Latency (ms) | Params (M) | Resolution |  License   |
-| :----------: | :---------------------: | :---------------------: | :----------: | :--------: | :--------: | :--------: |
+|        Size        |  RF-DETR package class  | COCO AP<sub>50:95</sub> | Latency (ms) | Params (M) | Resolution |  License   |
+| :----------------: | :---------------------: | :---------------------: | :----------: | :--------: | :--------: | :--------: |
 | Keypoint (Preview) | `RFDETRKeypointPreview` |          71.8           |     9.7      |   126.4    |  576x576   | Apache 2.0 |
 
 > The keypoint model is available in the `rfdetr` package only. It is not yet available via the `inference` package.

--- a/docs/learn/run/keypoints.md
+++ b/docs/learn/run/keypoints.md
@@ -1,5 +1,5 @@
 ---
-description: Run RF-DETR keypoint detection on images, video, and streams. COCO-pretrained preview model predicts 17 person keypoints with 71.9 AP at 9.8 ms on NVIDIA T4.
+description: Run RF-DETR keypoint detection on images, video, and streams. COCO-pretrained preview model predicts 17 person keypoints with 71.8 AP at 9.7 ms on NVIDIA T4.
 ---
 
 # Run an RF-DETR Keypoint Model
@@ -20,7 +20,7 @@ RF-DETR Keypoint outperforms YOLO26-pose X and YOLO11-pose X at comparable laten
 
 |     Size     |  RF-DETR package class  | COCO AP<sub>50:95</sub> | Latency (ms) | Params (M) | Resolution |  License   |
 | :----------: | :---------------------: | :---------------------: | :----------: | :--------: | :--------: | :--------: |
-| XL (Preview) | `RFDETRKeypointPreview` |          71.9           |     9.8      |   126.4    |  576x576   | Apache 2.0 |
+| XL (Preview) | `RFDETRKeypointPreview` |          71.8           |     9.7      |   126.4    |  576x576   | Apache 2.0 |
 
 > The keypoint model is available in the `rfdetr` package only. It is not yet available via the `inference` package.
 

--- a/docs/learn/run/keypoints.md
+++ b/docs/learn/run/keypoints.md
@@ -20,7 +20,7 @@ RF-DETR Keypoint outperforms YOLO26-pose X and YOLO11-pose X at comparable laten
 
 |     Size     |  RF-DETR package class  | COCO AP<sub>50:95</sub> | Latency (ms) | Params (M) | Resolution |  License   |
 | :----------: | :---------------------: | :---------------------: | :----------: | :--------: | :--------: | :--------: |
-| XL (Preview) | `RFDETRKeypointPreview` |          71.8           |     9.7      |   126.4    |  576x576   | Apache 2.0 |
+| Keypoint (Preview) | `RFDETRKeypointPreview` |          71.8           |     9.7      |   126.4    |  576x576   | Apache 2.0 |
 
 > The keypoint model is available in the `rfdetr` package only. It is not yet available via the `inference` package.
 

--- a/docs/learn/run/keypoints.md
+++ b/docs/learn/run/keypoints.md
@@ -18,7 +18,7 @@ RF-DETR Keypoint outperforms YOLO26-pose X and YOLO11-pose X at comparable laten
 
 ![RF-DETR Keypoint mAP vs latency chart comparing against YOLO26-pose and YOLO11-pose on MS COCO](../../assets/keypoints/kp-map-latency.png){ width=560 }
 
-|        Size        |  RF-DETR package class  | COCO AP<sub>50:95</sub> | Latency (ms) | Params (M) | Resolution |  License   |
+|       Model        |  RF-DETR package class  | COCO AP<sub>50:95</sub> | Latency (ms) | Params (M) | Resolution |  License   |
 | :----------------: | :---------------------: | :---------------------: | :----------: | :--------: | :--------: | :--------: |
 | Keypoint (Preview) | `RFDETRKeypointPreview` |          71.8           |     9.7      |   126.4    |  576x576   | Apache 2.0 |
 


### PR DESCRIPTION
- Add Keypoints section to README.md, docs/index.md, and docs/learn/benchmarks.md with full competitor table (YOLO11-pose N/S/M/L/X, YOLO26-pose N/S/M/L/X, RF-DETR Keypoint Preview)
- Fix stale numbers in docs/learn/run/keypoints.md: 71.9 AP / 9.8 ms → 71.8 AP / 9.7 ms

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
