### PR TITLE
fix(callbacks): always print validation summary tables under progress bar (#1119)

### DIFF
--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -595,8 +595,11 @@ class COCOEvalCallback(Callback):
             metrics=metrics, pfx=pfx, split=split, pl_module=pl_module, ar_by_cid=ar_by_cid, f1_by_cid=f1_by_cid
         )
 
-        if not self._has_progress_bar(trainer):
-            self._print_metrics_tables(trainer, split, overall, per_class)
+        # Always render the curated Rich summary tables. The noisy raw
+        # pycocotools/faster-coco-eval stdout dump is suppressed under an active
+        # progress bar in _compute_map_metric; these summary tables are not
+        # duplicate output and were previously hidden as a side effect (#1119).
+        self._print_metrics_tables(trainer, split, overall, per_class)
         self._compute_and_log_keypoint_map(split, pl_module, trainer)
         if split == "val" and should_compute_ema:
             self._compute_and_log_keypoint_map("val_ema", pl_module, trainer, log_split="val", metric_prefix="ema_")

--- a/tests/training/test_coco_eval_callback.py
+++ b/tests/training/test_coco_eval_callback.py
@@ -740,8 +740,8 @@ class TestOnValidationEpochEnd:
         cb.map_metric.compute.assert_called_once()
         module.log.assert_called()
 
-    def test_progress_bar_suppresses_terminal_metric_summaries(self, capsys) -> None:
-        """Progress-bar training should keep scalar logs but suppress duplicate terminal summary text."""
+    def test_progress_bar_suppresses_raw_coco_dump(self, capsys) -> None:
+        """Progress-bar training suppresses the noisy raw pycocotools/faster-coco-eval stdout dump."""
         cb = COCOEvalCallback(max_dets=500)
         trainer = _make_trainer(callbacks=[_TQDMProgressBar()])
         trainer.callback_metrics = {}
@@ -755,13 +755,25 @@ class TestOnValidationEpochEnd:
 
         cb.map_metric.compute.side_effect = _compute_with_terminal_summary
 
-        with patch.object(cb, "_print_metrics_tables") as print_metrics_tables:
+        with patch.object(cb, "_print_metrics_tables"):
             cb._compute_and_log(trainer, module, "val")
 
         assert "Average Precision" not in capsys.readouterr().out
-        print_metrics_tables.assert_not_called()
-        cb.map_metric.compute.assert_called_once()
-        module.log.assert_called()
+
+    def test_summary_tables_printed_even_with_progress_bar(self) -> None:
+        """Curated summary tables render at epoch end even when a progress bar is active (#1119)."""
+        cb = COCOEvalCallback(max_dets=500)
+        trainer = _make_trainer(callbacks=[_TQDMProgressBar()])
+        trainer.callback_metrics = {}
+        cb.map_metric = MagicMock(name="map_metric")
+        cb.map_metric.compute.return_value = _minimal_metrics()
+        cb.map_metric_ema = None
+        module = _make_pl_module()
+
+        with patch.object(cb, "_print_metrics_tables") as print_metrics_tables:
+            cb._compute_and_log(trainer, module, "val")
+
+        print_metrics_tables.assert_called_once()
 
     def test_per_class_ap_can_be_disabled(self) -> None:
         """log_per_class_metrics=False suppresses val/AP/<class> logging."""


### PR DESCRIPTION
## What does this PR do?
Fixes a regression where the per-epoch validation summary tables (Overall + Per-class metrics) stopped appearing in the terminal after v1.8.0 for anyone training with a progress bar.

COCOEvalCallback produces two distinct kinds of terminal output at epoch end:
- the raw pycocotools / faster-coco-eval stdout dump (noisy, multi-line), and
- the curated Rich summary tables (the clean Overall + Per-class metrics view).

## Root cause
The duplicate-output suppression added in ef14e363 gated both of these on the same _has_progress_bar(trainer) check in _compute_and_log.  The result: with progress_bar="tqdm" or "rich", no summary tables; with the config default progress_bar=None.

## Fix
Decouple the two concerns:

- Keep suppressing the raw COCO stdout dump under an active progress bar (unchanged — handled in _compute_map_metric).
- Always render the summary tables at epoch end. 

Related Issue(s): Closes [#1119](https://github.com/roboflow/rf-detr/issues/1119)

## Type of Change
☑ Bug fix (non-breaking change that fixes an issue)
Testing
☑ I have tested this change locally
☑ I have added/updated tests for this change

## Test details:
- Split the prior test_progress_bar_suppresses_terminal_metric_summaries into two focused tests in tests/training/test_coco_eval_callback.py:
  - test_progress_bar_suppresses_raw_coco_dump — verifies the raw stdout dump is still suppressed under a progress bar   (unchanged behavior).
  - test_summary_tables_printed_even_with_progress_bar — regression guard: summary tables render even when a progress bar is attached.
- Confirmed the regression test fails on pre-fix code and passes with the fix.
- Full tests/training/test_coco_eval_callback.py suite: 77 passed; ruff check / ruff format --check clean.