### PR TITLE
fix(training): disable TensorBoard logger gracefully on NumPy 2.0 incompatibility

### DIFF
--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -48,10 +48,6 @@ def _try_import_tensorboard_summary_writer() -> None:
         ImportError: If the ``tensorboard`` package is absent.
         AttributeError: If ``torch.utils.tensorboard`` fails to import due to a NumPy 2.0 /
             tensorflow incompatibility.
-
-    Examples:
-        >>> # No-op when tensorboard and its deps are compatible.
-        >>> # _try_import_tensorboard_summary_writer()  # doctest: +SKIP
     """
     from torch.utils.tensorboard import SummaryWriter  # noqa: F401
 

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -36,6 +36,26 @@ from rfdetr.utilities.logger import get_logger
 _logger = get_logger()
 
 
+def _try_import_tensorboard_summary_writer() -> None:
+    """Probe the full tensorboard import chain to surface numpy/tensorflow incompatibilities early.
+
+    When tensorboard is installed alongside a numpy-2.0-incompatible tensorflow, importing
+    ``torch.utils.tensorboard`` raises ``AttributeError`` at module level (e.g. ``np.float_`` was
+    removed in NumPy 2.0).  Calling this function inside the logger-construction try/except lets
+    ``build_trainer`` degrade gracefully to CSV-only logging instead of crashing mid-training.
+
+    Raises:
+        ImportError: If the ``tensorboard`` package is absent.
+        AttributeError: If ``torch.utils.tensorboard`` fails to import due to a NumPy 2.0 /
+            tensorflow incompatibility.
+
+    Examples:
+        >>> # No-op when tensorboard and its deps are compatible.
+        >>> # _try_import_tensorboard_summary_writer()  # doctest: +SKIP
+    """
+    from torch.utils.tensorboard import SummaryWriter  # noqa: F401
+
+
 # ---------------------------------------------------------------------------
 # Notebook-safe spawn-based DDP
 # ---------------------------------------------------------------------------
@@ -357,6 +377,7 @@ def build_trainer(
 
     if tc.tensorboard:
         try:
+            _try_import_tensorboard_summary_writer()
             loggers.append(
                 TensorBoardLogger(
                     save_dir=tc.output_dir,
@@ -364,8 +385,13 @@ def build_trainer(
                     version="",
                 )
             )
-        except ModuleNotFoundError as exc:
-            _logger.warning("TensorBoard logging disabled: %s. Install with: pip install tensorboard", exc)
+        except (ImportError, AttributeError) as exc:
+            _logger.warning(
+                "TensorBoard logging disabled: %s. "
+                "If using NumPy 2.x, ensure your tensorboard/tensorflow packages are NumPy 2.0 compatible. "
+                "Install TensorBoard with: pip install tensorboard",
+                exc,
+            )
 
     if tc.wandb:
         try:

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -384,7 +384,8 @@ def build_trainer(
         except (ImportError, AttributeError) as exc:
             _logger.warning(
                 "TensorBoard logging disabled: %s. "
-                "If using NumPy 2.x, ensure your tensorboard/tensorflow packages are NumPy 2.0 compatible. "
+                "If using NumPy 2.x, ensure your TensorBoard installation is NumPy 2.0 compatible "
+                "(the failure can originate from tensorboard.compat.tensorflow_stub). "
                 "Install TensorBoard with: pip install tensorboard",
                 exc,
             )

--- a/tests/training/test_build_trainer.py
+++ b/tests/training/test_build_trainer.py
@@ -504,7 +504,10 @@ class TestBuildTrainerLoggers:
         from pytorch_lightning.loggers import TensorBoardLogger
 
         fake_logger = mock.MagicMock(spec=TensorBoardLogger)
-        with mock.patch("rfdetr.training.trainer.TensorBoardLogger", return_value=fake_logger):
+        with (
+            mock.patch("rfdetr.training.trainer._try_import_tensorboard_summary_writer"),
+            mock.patch("rfdetr.training.trainer.TensorBoardLogger", return_value=fake_logger),
+        ):
             trainer = build_trainer(
                 _tc(tmp_path, tensorboard=True, use_ema=False),
                 _mc(),
@@ -529,7 +532,10 @@ class TestBuildTrainerLoggers:
         """If tensorboard package is absent, a warning is logged and training continues."""
         import unittest.mock as mock
 
-        with mock.patch("rfdetr.training.trainer.TensorBoardLogger", side_effect=ModuleNotFoundError("no tensorboard")):
+        with mock.patch(
+            "rfdetr.training.trainer._try_import_tensorboard_summary_writer",
+            side_effect=ModuleNotFoundError("no module named 'tensorboard'"),
+        ):
             with mock.patch("rfdetr.training.trainer._logger") as mock_logger:
                 trainer = build_trainer(
                     _tc(tmp_path, tensorboard=True, use_ema=False),
@@ -538,6 +544,27 @@ class TestBuildTrainerLoggers:
         mock_logger.warning.assert_called_once()
         assert "TensorBoard" in mock_logger.warning.call_args[0][0]
         # CSVLogger is always present; TensorBoard was not added due to missing dep
+        from pytorch_lightning.loggers import CSVLogger, TensorBoardLogger
+
+        assert all(not isinstance(lg, TensorBoardLogger) for lg in trainer.loggers)
+        assert any(isinstance(lg, CSVLogger) for lg in trainer.loggers)
+
+    def test_numpy2_tensorboard_incompatibility_warns_not_crashes(self, tmp_path):
+        """AttributeError from NumPy 2.0/tensorflow incompatibility falls back to CSV logger."""
+        import unittest.mock as mock
+
+        numpy2_error = AttributeError("`np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.")
+        with mock.patch(
+            "rfdetr.training.trainer._try_import_tensorboard_summary_writer",
+            side_effect=numpy2_error,
+        ):
+            with mock.patch("rfdetr.training.trainer._logger") as mock_logger:
+                trainer = build_trainer(
+                    _tc(tmp_path, tensorboard=True, use_ema=False),
+                    _mc(),
+                )
+        mock_logger.warning.assert_called_once()
+        assert "TensorBoard" in mock_logger.warning.call_args[0][0]
         from pytorch_lightning.loggers import CSVLogger, TensorBoardLogger
 
         assert all(not isinstance(lg, TensorBoardLogger) for lg in trainer.loggers)
@@ -560,6 +587,7 @@ class TestBuildTrainerLoggers:
         fake_tb = mock.MagicMock(spec=TensorBoardLogger)
         fake_mlflow = mock.MagicMock(spec=MLFlowLogger)
         with (
+            mock.patch("rfdetr.training.trainer._try_import_tensorboard_summary_writer"),
             mock.patch("rfdetr.training.trainer.TensorBoardLogger", return_value=fake_tb),
             mock.patch("rfdetr.training.trainer.MLFlowLogger", return_value=fake_mlflow),
         ):


### PR DESCRIPTION
Add `_try_import_tensorboard_summary_writer()` probe that eagerly imports `torch.utils.tensorboard.SummaryWriter` before constructing TensorBoardLogger. When tensorboard is installed alongside a NumPy-2.0-incompatible tensorflow, the import raises `AttributeError` at module level (`np.float_` removed in NumPy 2.0). The probe lets `build_trainer` catch this before `trainer.fit()` is called, degrade to CSV-only logging, and emit a clear warning — instead of crashing mid-training inside `_log_hyperparams`.

- Broaden except clause from `ModuleNotFoundError` to `(ImportError, AttributeError)`
- Warning message now mentions NumPy 2.x / tensorflow compatibility
- Update three existing logger tests to mock the new probe helper
- Add regression test for the AttributeError / NumPy 2.0 path

Closes #1120
