### PR TITLE
fix(transforms): handle albumentations 2.x ndarray bboxes in _detect_horizontal_flip

### DIFF
--- a/src/rfdetr/datasets/transforms.py
+++ b/src/rfdetr/datasets/transforms.py
@@ -500,7 +500,7 @@ class AlbumentationsWrapper:
         Returns:
             True if a horizontal flip was applied, False otherwise.
         """
-        if not bboxes_aug or not kept_idxs or boxes_np.shape[0] == 0:
+        if len(bboxes_aug) == 0 or len(kept_idxs) == 0 or boxes_np.shape[0] == 0:
             return False
         first_kept_orig_idx = kept_idxs[0]
         try:

--- a/tests/datasets/test_augmentations.py
+++ b/tests/datasets/test_augmentations.py
@@ -116,22 +116,21 @@ class TestAlbumentationsWrapper:
         )
 
     @pytest.mark.parametrize(
-    "num_instances",
-    [
-        pytest.param(0, id="zero_instances"),
-        pytest.param(1, id="one_instance"),
-        pytest.param(2, id="two_instances"),
-    ],
-    )   
+        "num_instances",
+        [
+            pytest.param(0, id="zero_instances"),
+            pytest.param(1, id="one_instance"),
+            pytest.param(2, id="two_instances"),
+        ],
+    )
     def test_horizontal_flip_with_keypoint_flip_pairs_handles_ndarray_bboxes(self, num_instances):
         """Regression test for #1125.
 
         Albumentations 2.x returns ``bboxes`` as a NumPy ndarray of shape (N, 4); 1.x returned a list of tuples.
-        ``_detect_horizontal_flip`` previously used ``not bboxes_aug`` as an empty-check, which raises
-        ``ValueError: The truth value of an array with more than one element is ambiguous`` on any ndarray with
-        more than one element — i.e. any sample with N >= 1 under Albumentations 2.x. The call is reached only
-        when ``keypoint_flip_pairs`` is configured, so this test exercises that path across multi/single/empty
-        instance counts.
+        ``_detect_horizontal_flip`` previously used ``not bboxes_aug`` as an empty-check, which raises ``ValueError: The
+        truth value of an array with more than one element is ambiguous`` on any ndarray with more than one element —
+        i.e. any sample with N >= 1 under Albumentations 2.x. The call is reached only when ``keypoint_flip_pairs`` is
+        configured, so this test exercises that path across multi/single/empty instance counts.
         """
         wrapper = AlbumentationsWrapper(
             alb.HorizontalFlip(p=1.0),

--- a/tests/datasets/test_augmentations.py
+++ b/tests/datasets/test_augmentations.py
@@ -115,6 +115,57 @@ class TestAlbumentationsWrapper:
             atol=1e-6,
         )
 
+    @pytest.mark.parametrize(
+    "num_instances",
+    [
+        pytest.param(0, id="zero_instances"),
+        pytest.param(1, id="one_instance"),
+        pytest.param(2, id="two_instances"),
+    ],
+    )   
+    def test_horizontal_flip_with_keypoint_flip_pairs_handles_ndarray_bboxes(self, num_instances):
+        """Regression test for #1125.
+
+        Albumentations 2.x returns ``bboxes`` as a NumPy ndarray of shape (N, 4); 1.x returned a list of tuples.
+        ``_detect_horizontal_flip`` previously used ``not bboxes_aug`` as an empty-check, which raises
+        ``ValueError: The truth value of an array with more than one element is ambiguous`` on any ndarray with
+        more than one element — i.e. any sample with N >= 1 under Albumentations 2.x. The call is reached only
+        when ``keypoint_flip_pairs`` is configured, so this test exercises that path across multi/single/empty
+        instance counts.
+        """
+        wrapper = AlbumentationsWrapper(
+            alb.HorizontalFlip(p=1.0),
+            keypoint_flip_pairs=[0, 1],
+        )
+
+        image = Image.new("RGB", (100, 50))
+
+        if num_instances == 0:
+            target = {
+                "boxes": torch.zeros((0, 4), dtype=torch.float32),
+                "labels": torch.zeros((0,), dtype=torch.long),
+                "keypoints": torch.zeros((0, 2, 3), dtype=torch.float32),
+            }
+        else:
+            boxes = []
+            keypoints = []
+            for i in range(num_instances):
+                x = 10.0 + i * 30.0
+                boxes.append([x, 5.0, x + 20.0, 25.0])
+                keypoints.append([[x + 5.0, 10.0, 2.0], [x + 15.0, 20.0, 2.0]])
+            target = {
+                "boxes": torch.tensor(boxes, dtype=torch.float32),
+                "labels": torch.tensor([1] * num_instances, dtype=torch.long),
+                "keypoints": torch.tensor(keypoints, dtype=torch.float32),
+            }
+
+        # Pre-fix: this call raised ValueError for num_instances >= 1 under Albumentations 2.x.
+        aug_image, aug_target = wrapper(image, target)
+
+        assert isinstance(aug_image, Image.Image)
+        assert aug_target["boxes"].shape[0] == num_instances
+        assert aug_target["keypoints"].shape[0] == num_instances
+
     def test_crop_filters_keypoints_with_removed_boxes(self):
         """When a crop removes a box, its keypoints are removed with the same instance."""
         wrapper = AlbumentationsWrapper(alb.Crop(x_min=0, y_min=0, x_max=50, y_max=50, p=1.0))


### PR DESCRIPTION
## What does this PR do?

<!-- Provide a clear and concise description of the changes -->

### Summary

  Fixes `ValueError: The truth value of an array with more than one element is ambiguous` raised from `_detect_horizontal_flip` (`src/rfdetr/datasets/transforms.py:503`) when keypoint training runs under Albumentations 2.x with `keypoint_flip_pairs` configured. The crash is deterministic on the first sample regardless of instance count.
  
 Albumentations 2.x returns `bboxes` as a NumPy `ndarray` of shape `(N, 4)`; 1.x returned a list of tuples. The existing empty-check used `not bboxes_aug`, which is ambiguous on ndarrays with more than one element. `len(x) == 0` is semantically identical to `not x` for built-in lists (so this is a no-op on Albumentations 1.x) and is the correct empty-check for ndarrays — a no-op on 1.x, a correctness fix on 2.x. No dependency pin tightening needed.

Fixes #1125.

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)


## Testing

<!-- Describe how you tested your changes -->

- [X] I have tested this change locally
- [X] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

  - [x] `pre-commit run --all-files` clean
  - [x] New parametrized regression test fails on `develop` and passes on this branch under Albumentations 2.x (verified locally)
  - [x] No regressions in `tests/datasets/` or other suites under `pytest -m "not gpu" --ignore=tests/benchmarks
  --ignore=tests/run_smoke_all_models.py`

  ### TDD notes

  Per CONTRIBUTING.md:176-183, the regression test was committed first (failing on `develop` under Albumentations 2.x), then the fix
  landed in a follow-up commit with all tests green.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code where necessary, particularly in hard-to-understand areas
- [X] My changes generate no new warnings or errors
- [X] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->

### CLA

I have read the CLA Document and I sign the CLA.
