### PR TITLE
fix(callbacks): always print metric tables when progress bar active

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -270,6 +270,10 @@ overrides = [
     "tflite_runtime", "tflite_runtime.*",
     "tensorflow", "tensorflow.*",
   ], ignore_missing_imports = true },
+  # Optional-import None assignments in console.py: type: ignore[assignment, misc] is needed when
+  # rich IS installed (full-venv mypy sees the assignment error) but flagged as unused by the
+  # pre-commit hook (which runs mypy with --ignore-missing-imports so rich types are unresolved).
+  { module = ["rfdetr.utilities.console"], warn_unused_ignores = false },
   # Modules with pre-existing type errors — ignored until incrementally fixed.
   { module = [
     "rfdetr",

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -31,6 +31,7 @@ from rfdetr.evaluation.matching import (
     merge_matching_data,
 )
 from rfdetr.utilities.box_ops import box_cxcywh_to_xyxy
+from rfdetr.utilities.console import _get_rich_console
 from rfdetr.utilities.distributed import all_gather, get_world_size, is_dist_avail_and_initialized
 from rfdetr.utilities.logger import get_logger
 
@@ -595,8 +596,7 @@ class COCOEvalCallback(Callback):
             metrics=metrics, pfx=pfx, split=split, pl_module=pl_module, ar_by_cid=ar_by_cid, f1_by_cid=f1_by_cid
         )
 
-        if not self._has_progress_bar(trainer):
-            self._print_metrics_tables(trainer, split, overall, per_class)
+        self._print_metrics_tables(trainer, split, overall, per_class)
         self._compute_and_log_keypoint_map(split, pl_module, trainer)
         if split == "val" and should_compute_ema:
             self._compute_and_log_keypoint_map("val_ema", pl_module, trainer, log_split="val", metric_prefix="ema_")
@@ -624,6 +624,58 @@ class COCOEvalCallback(Callback):
         """Return whether the trainer has a Lightning progress bar callback."""
         callbacks = getattr(trainer, "callbacks", [])
         return any(callback.__class__.__name__.endswith("ProgressBar") for callback in callbacks)
+
+    @staticmethod
+    def _render_summary_tables(
+        console: Any,
+        title_pfx: str,
+        overall_rendered: str,
+        per_class: list[dict[str, Any]],
+    ) -> None:
+        """Print overall and per-class metric tables to ``console``.
+
+        Args:
+            console: Rich ``Console`` instance to print to.
+            title_pfx: Split label (e.g. ``"Val"`` or ``"Test"``).
+            overall_rendered: Pre-rendered overall table string from
+                :meth:`_render_overall_merged`.
+            per_class: Per-class dicts with keys ``name``, ``ap``, ``ar``,
+                ``f1``, ``precision``, ``recall``; skipped when empty.
+        """
+        try:
+            from rich.table import Table
+        except ImportError:
+            return
+
+        def _fmt(v: float) -> str:
+            if v != v or v < 0:  # NaN or pycocotools sentinel -1 → em-dash
+                return "—"
+            return f"{v:.4f}"
+
+        console.print(overall_rendered)
+        if per_class:
+            table = Table(
+                title=f"{title_pfx} — Per-class Metrics",
+                title_style="bold cyan",
+                show_header=True,
+                header_style="bold cyan",
+            )
+            table.add_column("Class", style="dim", no_wrap=True)
+            table.add_column("AP 50:95", justify="right")
+            table.add_column("AR", justify="right")
+            table.add_column("F1", justify="right")
+            table.add_column("Precision", justify="right")
+            table.add_column("Recall", justify="right")
+            for row in per_class:
+                table.add_row(
+                    row["name"],
+                    _fmt(row["ap"]),
+                    _fmt(row["ar"]),
+                    _fmt(row["f1"]),
+                    _fmt(row["precision"]),
+                    _fmt(row["recall"]),
+                )
+            console.print(table)
 
     def _compute_map_metric(self, trainer: Any, metric: Any) -> dict[str, Any]:
         """Compute a torchmetrics mAP metric while suppressing duplicate terminal summaries under progress bars."""
@@ -972,47 +1024,13 @@ class COCOEvalCallback(Callback):
         if not getattr(trainer, "is_global_zero", True):
             return
         try:
-            from rich.console import Console
-            from rich.table import Table
+            import rich.table  # noqa: F401 — availability guard; Table used inside _render_summary_tables
         except ImportError:
             return
 
-        def _fmt(v: float) -> str:
-            if v != v or v < 0:  # NaN or pycocotools sentinel -1 → em-dash
-                return "—"
-            return f"{v:.4f}"
-
-        console = Console(force_terminal=True)
+        console = _get_rich_console(trainer)
         title_pfx = split.capitalize()
-
-        def _render_all() -> None:
-            # Table 1: Overall metrics — colour-free merged-header table.
-            console.print(self._render_overall_merged(title_pfx, overall))
-
-            # Table 2: Per-class metrics (Rich Table)
-            if per_class:
-                t2 = Table(
-                    title=f"{title_pfx} — Per-class Metrics",
-                    title_style="bold cyan",
-                    show_header=True,
-                    header_style="bold cyan",
-                )
-                t2.add_column("Class", style="dim", no_wrap=True)
-                t2.add_column("AP 50:95", justify="right")
-                t2.add_column("AR", justify="right")
-                t2.add_column("F1", justify="right")
-                t2.add_column("Precision", justify="right")
-                t2.add_column("Recall", justify="right")
-                for row in per_class:
-                    t2.add_row(
-                        row["name"],
-                        _fmt(row["ap"]),
-                        _fmt(row["ar"]),
-                        _fmt(row["f1"]),
-                        _fmt(row["precision"]),
-                        _fmt(row["recall"]),
-                    )
-                console.print(t2)
+        overall_rendered = self._render_overall_merged(title_pfx, overall)
 
         if self._in_notebook:
             # Lazily create an ipywidgets.Output on the first table print so it
@@ -1030,10 +1048,10 @@ class COCOEvalCallback(Callback):
             if self._output_widget is not None:
                 self._output_widget.clear_output(wait=True)
                 with self._output_widget:
-                    _render_all()
+                    COCOEvalCallback._render_summary_tables(console, title_pfx, overall_rendered, per_class)
                 return
 
-        _render_all()
+        COCOEvalCallback._render_summary_tables(console, title_pfx, overall_rendered, per_class)
 
     def _render_overall_merged(self, title_pfx: str, overall: dict[str, float]) -> str:
         """Render the overall metrics table with merged group-header cells.

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -31,11 +31,34 @@ from rfdetr.evaluation.matching import (
     merge_matching_data,
 )
 from rfdetr.utilities.box_ops import box_cxcywh_to_xyxy
-from rfdetr.utilities.console import _get_rich_console
+from rfdetr.utilities.console import (
+    _IS_RICH_AVAILABLE,
+    Live,
+    _build_summary_renderable,
+    _get_rich_console,
+    _has_progress_bar,
+    _render_overall_merged,
+    _render_summary_tables,
+)
 from rfdetr.utilities.distributed import all_gather, get_world_size, is_dist_avail_and_initialized
 from rfdetr.utilities.logger import get_logger
 
 logger = get_logger()
+
+
+def _warn_missing_rich_once(warning_emitted: bool) -> bool:
+    """Warn once when metric table rendering is skipped because Rich is unavailable.
+
+    Args:
+        warning_emitted: Whether this warning has already been emitted.
+
+    Returns:
+        ``True`` after warning emission or when it had already been emitted.
+    """
+    if warning_emitted:
+        return True
+    logger.warning("Rich is not installed; skipping metric table rendering. Install `rich` to enable tables.")
+    return True
 
 
 def _get_ema_inner_module(ema_cb: Any) -> Any:
@@ -105,6 +128,8 @@ class COCOEvalCallback(Callback):
         # Whether the EMA metric received ≥1 update this epoch.  Gates the EMA cross-rank
         # sync so it is issued symmetrically on all DDP ranks (see _should_compute_ema).
         self._ema_has_updates: bool = False
+        self._metrics_live: Any = None  # rich.live.Live, created lazily for terminal table updates
+        self._missing_rich_warning_emitted: bool = False
         self._output_widget: Any = None  # ipywidgets.Output, created lazily
         self._keypoint_mode: bool = False
         self._use_segm_metrics: bool = segmentation
@@ -173,6 +198,16 @@ class COCOEvalCallback(Callback):
         # on_validation_epoch_start / on_test_epoch_start (see _prepare_ema_metric) so its
         # cross-rank compute() sync is issued symmetrically and cannot deadlock DDP val.
         self.map_metric_ema: Any = None
+
+    def teardown(self, trainer: Any, pl_module: Any, stage: str) -> None:
+        """Stop the terminal metrics Live display when the trainer exits.
+
+        Args:
+            trainer: The PTL Trainer.
+            pl_module: The LightningModule.
+            stage: One of ``"fit"``, ``"validate"``, ``"test"``, ``"predict"``.
+        """
+        self._stop_metrics_live()
 
     def on_fit_start(self, trainer: Any, pl_module: Any) -> None:
         """Pull class names from the DataModule once the datasets are set up.
@@ -619,67 +654,18 @@ class COCOEvalCallback(Callback):
                 return callback
         return None
 
-    @staticmethod
-    def _has_progress_bar(trainer: Any) -> bool:
-        """Return whether the trainer has a Lightning progress bar callback."""
-        callbacks = getattr(trainer, "callbacks", [])
-        return any(callback.__class__.__name__.endswith("ProgressBar") for callback in callbacks)
-
-    @staticmethod
-    def _render_summary_tables(
-        console: Any,
-        title_pfx: str,
-        overall_rendered: str,
-        per_class: list[dict[str, Any]],
-    ) -> None:
-        """Print overall and per-class metric tables to ``console``.
-
-        Args:
-            console: Rich ``Console`` instance to print to.
-            title_pfx: Split label (e.g. ``"Val"`` or ``"Test"``).
-            overall_rendered: Pre-rendered overall table string from
-                :meth:`_render_overall_merged`.
-            per_class: Per-class dicts with keys ``name``, ``ap``, ``ar``,
-                ``f1``, ``precision``, ``recall``; skipped when empty.
-        """
-        try:
-            from rich.table import Table
-        except ImportError:
+    def _stop_metrics_live(self) -> None:
+        """Stop and clear the terminal metrics Live display if it exists."""
+        metrics_live = self._metrics_live
+        self._metrics_live = None
+        if metrics_live is None:
             return
-
-        def _fmt(v: float) -> str:
-            if v != v or v < 0:  # NaN or pycocotools sentinel -1 → em-dash
-                return "—"
-            return f"{v:.4f}"
-
-        console.print(overall_rendered)
-        if per_class:
-            table = Table(
-                title=f"{title_pfx} — Per-class Metrics",
-                title_style="bold cyan",
-                show_header=True,
-                header_style="bold cyan",
-            )
-            table.add_column("Class", style="dim", no_wrap=True)
-            table.add_column("AP 50:95", justify="right")
-            table.add_column("AR", justify="right")
-            table.add_column("F1", justify="right")
-            table.add_column("Precision", justify="right")
-            table.add_column("Recall", justify="right")
-            for row in per_class:
-                table.add_row(
-                    row["name"],
-                    _fmt(row["ap"]),
-                    _fmt(row["ar"]),
-                    _fmt(row["f1"]),
-                    _fmt(row["precision"]),
-                    _fmt(row["recall"]),
-                )
-            console.print(table)
+        with contextlib.suppress(Exception):
+            metrics_live.stop()
 
     def _compute_map_metric(self, trainer: Any, metric: Any) -> dict[str, Any]:
         """Compute a torchmetrics mAP metric while suppressing duplicate terminal summaries under progress bars."""
-        if not self._has_progress_bar(trainer):
+        if not _has_progress_bar(trainer):
             return metric.compute()
 
         metric_loggers = (logger, logging.getLogger("faster_coco_eval"), logging.getLogger("faster_coco_eval.core"))
@@ -1023,14 +1009,13 @@ class COCOEvalCallback(Callback):
         """
         if not getattr(trainer, "is_global_zero", True):
             return
-        try:
-            import rich.table  # noqa: F401 — availability guard; Table used inside _render_summary_tables
-        except ImportError:
+        if not _IS_RICH_AVAILABLE:
+            self._missing_rich_warning_emitted = _warn_missing_rich_once(self._missing_rich_warning_emitted)
             return
 
         console = _get_rich_console(trainer)
         title_pfx = split.capitalize()
-        overall_rendered = self._render_overall_merged(title_pfx, overall)
+        overall_rendered = _render_overall_merged(title_pfx, overall, self._max_dets)
 
         if self._in_notebook:
             # Lazily create an ipywidgets.Output on the first table print so it
@@ -1048,165 +1033,26 @@ class COCOEvalCallback(Callback):
             if self._output_widget is not None:
                 self._output_widget.clear_output(wait=True)
                 with self._output_widget:
-                    COCOEvalCallback._render_summary_tables(console, title_pfx, overall_rendered, per_class)
+                    _render_summary_tables(console, title_pfx, overall_rendered, per_class)
                 return
 
-        COCOEvalCallback._render_summary_tables(console, title_pfx, overall_rendered, per_class)
-
-    def _render_overall_merged(self, title_pfx: str, overall: dict[str, float]) -> str:
-        """Render the overall metrics table with merged group-header cells.
-
-        Uses only plain Unicode box-drawing characters (no ANSI colour codes) so the output renders correctly in both
-        terminals and Jupyter/Colab notebook widgets.
-
-        .. code-block:: text
-
-                        Val — Overall Metrics
-            ┏━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┓
-            ┃          mAP          ┃   mAR   ┃        F1 sweep       ┃
-            ┡━━━━━━━━━┳━━━━━━┳━━━━━━╇━━━━━━━━━╇━━━━━━┳━━━━━━┳━━━━━━━━━┩
-            │  50:95  │  50  │  75  │  @500   │  F1  │ Prec │ Recall  │
-            ├─────────┼──────┼──────┼─────────┼──────┼──────┼─────────┤
-            │    —    │0.1510│0.1228│  0.4017 │0.1573│0.2607│  0.1562 │
-            └─────────┴──────┴──────┴─────────┴──────┴──────┴─────────┘
-
-        Args:
-            title_pfx: Capitalised split name used in the title (e.g. ``"Val"``).
-            overall: Ordered mapping of metric label → scalar value.
-
-        Returns:
-            Multi-line plain-text string ready to pass to ``console.print()``.
-        """
-
-        def _fmt(v: float) -> str:
-            if v != v or v < 0:  # NaN or pycocotools sentinel -1 → em-dash
-                return "—"
-            return f"{v:.4f}"
-
-        mar_lbl = f"@{self._max_dets}"
-        mar_key = f"mAR @{self._max_dets}"
-
-        # Groups: (group_name, [(sub_label, formatted_value), ...])
-        groups: list[tuple[str, list[tuple[str, str]]]] = [
-            (
-                "mAP",
-                [
-                    ("50:95", _fmt(overall["mAP 50:95"])),
-                    ("50", _fmt(overall["mAP 50"])),
-                    ("75", _fmt(overall["mAP 75"])),
-                ],
-            ),
-            ("mAR", [(mar_lbl, _fmt(overall[mar_key]))]),
-            (
-                "F1 sweep",
-                [
-                    ("F1", _fmt(overall["F1"])),
-                    ("Prec", _fmt(overall["Precision"])),
-                    ("Recall", _fmt(overall["Recall"])),
-                ],
-            ),
-        ]
-        if "segm mAP 50:95" in overall:
-            groups.append(
-                (
-                    "segm mAP",
-                    [
-                        ("50:95", _fmt(overall["segm mAP 50:95"])),
-                        ("50", _fmt(overall["segm mAP 50"])),
-                    ],
-                )
+        assert Live is not None
+        renderable = _build_summary_renderable(title_pfx, overall_rendered, per_class)
+        if self._metrics_live is None:
+            self._metrics_live = Live(
+                renderable,
+                console=console,
+                auto_refresh=False,
+                transient=False,
             )
+            try:
+                self._metrics_live.start(refresh=True)
+            except Exception:
+                self._metrics_live = None
+                _render_summary_tables(console, title_pfx, overall_rendered, per_class)
+            return
 
-        # Flatten sub-columns and compute widths (+2 for single-space padding each side)
-        flat: list[tuple[str, str]] = [(s, v) for _, cols in groups for s, v in cols]
-        widths: list[int] = [max(len(s), len(v)) + 2 for s, v in flat]
-
-        # Expand widths so each group label fits in its merged cell
-        col = 0
-        for grp, cols in groups:
-            nc = len(cols)
-            cell_w = sum(widths[col : col + nc]) + (nc - 1)  # nc-1 internal separators
-            needed = len(grp) + 2
-            if needed > cell_w:
-                for k in range(needed - cell_w):
-                    widths[col + k % nc] += 1
-            col += nc
-
-        # Compute group spans: (start_col, end_col_inclusive, name)
-        spans: list[tuple[int, int, str]] = []
-        col = 0
-        for grp, cols in groups:
-            nc = len(cols)
-            spans.append((col, col + nc - 1, grp))
-            col += nc
-
-        grp_ends = {end for start, end, _ in spans[:-1]}
-        n = len(flat)
-
-        def grp_w(start: int, end: int) -> int:
-            """Merged cell width for columns start..end inclusive."""
-            return sum(widths[start : end + 1]) + (end - start)
-
-        # Box-drawing character sets
-        heavy_horizontal = "━"
-        light_horizontal = "─"
-        heavy_vertical = "┃"
-        light_vertical = "│"
-        top_left_corner, top_right_corner = "┏", "┓"
-        top_t_down = "┳"  # heavy T-down: top-border internal group separator
-        transition_left, transition_right = "┡", "┩"  # transition-row left/right edges
-        group_join = "╇"  # transition-row at group boundary: heavy-up, heavy-horiz, light-down
-        subgroup_join = "┯"  # transition-row within group: no-up, heavy-horiz, light-down
-        mid_left, mid_right, mid_cross = "├", "┤", "┼"
-        bottom_left_corner, bottom_right_corner, bottom_t_up = "└", "┘", "┴"
-
-        # Title (centred over the full table width)
-        inner_w = sum(widths) + n - 1
-        title = f"{title_pfx} — Overall Metrics"
-        title_line = title.center(inner_w + 2)
-
-        # Row 1: top border — group-level separators only
-        r1 = top_left_corner
-        for i, (s, e, _) in enumerate(spans):
-            r1 += heavy_horizontal * grp_w(s, e)
-            r1 += top_t_down if i < len(spans) - 1 else top_right_corner
-
-        # Row 2: group labels centred in merged cells
-        r2 = heavy_vertical
-        for s, e, grp in spans:
-            r2 += grp.center(grp_w(s, e)) + heavy_vertical
-
-        # Row 3: transition row — heavy horizontal; ╇ at group ends, ┯ within groups
-        r3 = transition_left
-        for i, w in enumerate(widths):
-            r3 += heavy_horizontal * w
-            if i < n - 1:
-                r3 += group_join if i in grp_ends else subgroup_join
-        r3 += transition_right
-
-        # Row 4: sub-labels with light borders
-        r4 = light_vertical
-        for i, (sub, _) in enumerate(flat):
-            r4 += sub.center(widths[i]) + light_vertical
-
-        # Row 5: light separator between sub-labels and values
-        r5 = mid_left
-        for i, w in enumerate(widths):
-            r5 += light_horizontal * w
-            r5 += mid_cross if i < n - 1 else mid_right
-
-        # Row 6: values
-        r6 = light_vertical
-        for i, (_, val) in enumerate(flat):
-            r6 += val.center(widths[i]) + light_vertical
-
-        # Row 7: bottom border
-        r7 = bottom_left_corner
-        for i, w in enumerate(widths):
-            r7 += light_horizontal * w
-            r7 += bottom_t_up if i < n - 1 else bottom_right_corner
-
-        return "\n".join([title_line, r1, r2, r3, r4, r5, r6, r7])
+        self._metrics_live.update(renderable, refresh=True)
 
     def _convert_preds(self, preds: list[dict[str, torch.Tensor]]) -> list[dict[str, torch.Tensor]]:
         """Normalise prediction dicts from ``PostProcess`` for torchmetrics.

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -33,8 +33,6 @@ from rfdetr.evaluation.matching import (
 from rfdetr.utilities.box_ops import box_cxcywh_to_xyxy
 from rfdetr.utilities.console import (
     _IS_RICH_AVAILABLE,
-    Live,
-    _build_summary_renderable,
     _get_rich_console,
     _has_progress_bar,
     _render_overall_merged,
@@ -53,7 +51,7 @@ def _warn_missing_rich_once(warning_emitted: bool) -> bool:
         warning_emitted: Whether this warning has already been emitted.
 
     Returns:
-        ``True`` after warning emission or when it had already been emitted.
+        Always ``True``; caller assigns back to suppress future warnings.
     """
     if warning_emitted:
         return True
@@ -128,7 +126,6 @@ class COCOEvalCallback(Callback):
         # Whether the EMA metric received ≥1 update this epoch.  Gates the EMA cross-rank
         # sync so it is issued symmetrically on all DDP ranks (see _should_compute_ema).
         self._ema_has_updates: bool = False
-        self._metrics_live: Any = None  # rich.live.Live, created lazily for terminal table updates
         self._missing_rich_warning_emitted: bool = False
         self._output_widget: Any = None  # ipywidgets.Output, created lazily
         self._keypoint_mode: bool = False
@@ -200,14 +197,14 @@ class COCOEvalCallback(Callback):
         self.map_metric_ema: Any = None
 
     def teardown(self, trainer: Any, pl_module: Any, stage: str) -> None:
-        """Stop the terminal metrics Live display when the trainer exits.
+        """Release the notebook output widget when the trainer exits.
 
         Args:
             trainer: The PTL Trainer.
             pl_module: The LightningModule.
             stage: One of ``"fit"``, ``"validate"``, ``"test"``, ``"predict"``.
         """
-        self._stop_metrics_live()
+        self._output_widget = None
 
     def on_fit_start(self, trainer: Any, pl_module: Any) -> None:
         """Pull class names from the DataModule once the datasets are set up.
@@ -654,15 +651,6 @@ class COCOEvalCallback(Callback):
                 return callback
         return None
 
-    def _stop_metrics_live(self) -> None:
-        """Stop and clear the terminal metrics Live display if it exists."""
-        metrics_live = self._metrics_live
-        self._metrics_live = None
-        if metrics_live is None:
-            return
-        with contextlib.suppress(Exception):
-            metrics_live.stop()
-
     def _compute_map_metric(self, trainer: Any, metric: Any) -> dict[str, Any]:
         """Compute a torchmetrics mAP metric while suppressing duplicate terminal summaries under progress bars."""
         if not _has_progress_bar(trainer):
@@ -1036,23 +1024,11 @@ class COCOEvalCallback(Callback):
                     _render_summary_tables(console, title_pfx, overall_rendered, per_class)
                 return
 
-        assert Live is not None
-        renderable = _build_summary_renderable(title_pfx, overall_rendered, per_class)
-        if self._metrics_live is None:
-            self._metrics_live = Live(
-                renderable,
-                console=console,
-                auto_refresh=False,
-                transient=False,
-            )
-            try:
-                self._metrics_live.start(refresh=True)
-            except Exception:
-                self._metrics_live = None
-                _render_summary_tables(console, title_pfx, overall_rendered, per_class)
-            return
-
-        self._metrics_live.update(renderable, refresh=True)
+        # Print directly through the console.  A second rich.live.Live on the same
+        # console as RichProgressBar would silently nest (Live._nested=True) and
+        # delegate all refresh() calls to the progress-bar renderable, so metric
+        # tables would never appear.  console.print() avoids that nesting issue.
+        _render_summary_tables(console, title_pfx, overall_rendered, per_class)
 
     def _convert_preds(self, preds: list[dict[str, torch.Tensor]]) -> list[dict[str, torch.Tensor]]:
         """Normalise prediction dicts from ``PostProcess`` for torchmetrics.

--- a/src/rfdetr/utilities/console.py
+++ b/src/rfdetr/utilities/console.py
@@ -7,6 +7,19 @@
 
 from typing import Any
 
+try:
+    from rich.console import Console, Group
+    from rich.live import Live
+    from rich.table import Table
+except ImportError:
+    Console = None
+    Group = None
+    Live = None
+    Table = None
+    _IS_RICH_AVAILABLE = False
+else:
+    _IS_RICH_AVAILABLE = True
+
 
 def _get_rich_console(trainer: Any) -> Any:
     """Return a Rich Console appropriate for the current training context.
@@ -24,7 +37,7 @@ def _get_rich_console(trainer: Any) -> Any:
     Returns:
         A Rich ``Console`` instance suitable for printing metric tables.
     """
-    from rich.console import Console
+    assert Console is not None
 
     for cb in getattr(trainer, "callbacks", []):
         if cb.__class__.__name__ == "RichProgressBar":
@@ -32,3 +45,222 @@ def _get_rich_console(trainer: Any) -> Any:
             if cb_console is not None:
                 return cb_console
     return Console(force_terminal=True)
+
+
+def _has_progress_bar(trainer: Any) -> bool:
+    """Return whether the trainer has a Lightning progress bar callback.
+
+    Args:
+        trainer: The PTL Trainer (or any object with a ``callbacks`` attribute).
+
+    Returns:
+        ``True`` when any callback class name ends with ``"ProgressBar"``.
+    """
+    callbacks = getattr(trainer, "callbacks", [])
+    return any(callback.__class__.__name__.endswith("ProgressBar") for callback in callbacks)
+
+
+def _render_overall_merged(title_pfx: str, overall: dict[str, float], max_dets: int) -> str:
+    """Render the overall metrics table with merged group-header cells.
+
+    Uses only plain Unicode box-drawing characters (no ANSI colour codes) so the output renders correctly in both
+    terminals and Jupyter/Colab notebook widgets.
+
+    Args:
+        title_pfx: Capitalised split name used in the title (e.g. ``"Val"``).
+        overall: Ordered mapping of metric label → scalar value.
+        max_dets: Maximum detection count used for the mAR column label.
+
+    Returns:
+        Multi-line plain-text string ready to pass to ``console.print()``.
+    """
+
+    def _fmt(v: float) -> str:
+        if v != v or v < 0:  # NaN or pycocotools sentinel -1 → em-dash
+            return "—"
+        return f"{v:.4f}"
+
+    mar_lbl = f"@{max_dets}"
+    mar_key = f"mAR @{max_dets}"
+
+    groups: list[tuple[str, list[tuple[str, str]]]] = [
+        (
+            "mAP",
+            [
+                ("50:95", _fmt(overall["mAP 50:95"])),
+                ("50", _fmt(overall["mAP 50"])),
+                ("75", _fmt(overall["mAP 75"])),
+            ],
+        ),
+        ("mAR", [(mar_lbl, _fmt(overall[mar_key]))]),
+        (
+            "F1 sweep",
+            [
+                ("F1", _fmt(overall["F1"])),
+                ("Prec", _fmt(overall["Precision"])),
+                ("Recall", _fmt(overall["Recall"])),
+            ],
+        ),
+    ]
+    if "segm mAP 50:95" in overall:
+        groups.append(
+            (
+                "segm mAP",
+                [
+                    ("50:95", _fmt(overall["segm mAP 50:95"])),
+                    ("50", _fmt(overall["segm mAP 50"])),
+                ],
+            )
+        )
+
+    flat: list[tuple[str, str]] = [(s, v) for _, cols in groups for s, v in cols]
+    widths: list[int] = [max(len(s), len(v)) + 2 for s, v in flat]
+
+    col = 0
+    for grp, cols in groups:
+        nc = len(cols)
+        cell_w = sum(widths[col : col + nc]) + (nc - 1)
+        needed = len(grp) + 2
+        if needed > cell_w:
+            for k in range(needed - cell_w):
+                widths[col + k % nc] += 1
+        col += nc
+
+    spans: list[tuple[int, int, str]] = []
+    col = 0
+    for grp, cols in groups:
+        nc = len(cols)
+        spans.append((col, col + nc - 1, grp))
+        col += nc
+
+    grp_ends = {end for start, end, _ in spans[:-1]}
+    n = len(flat)
+
+    def grp_w(start: int, end: int) -> int:
+        """Return merged cell width for columns start..end inclusive."""
+        return sum(widths[start : end + 1]) + (end - start)
+
+    heavy_horizontal = "━"
+    light_horizontal = "─"
+    heavy_vertical = "┃"
+    light_vertical = "│"
+    top_left_corner, top_right_corner = "┏", "┓"
+    top_t_down = "┳"
+    transition_left, transition_right = "┡", "┩"
+    group_join = "╇"
+    subgroup_join = "┯"
+    mid_left, mid_right, mid_cross = "├", "┤", "┼"
+    bottom_left_corner, bottom_right_corner, bottom_t_up = "└", "┘", "┴"
+
+    inner_w = sum(widths) + n - 1
+    title = f"{title_pfx} — Overall Metrics"
+    title_line = title.center(inner_w + 2)
+
+    r1 = top_left_corner
+    for i, (s, e, _) in enumerate(spans):
+        r1 += heavy_horizontal * grp_w(s, e)
+        r1 += top_t_down if i < len(spans) - 1 else top_right_corner
+
+    r2 = heavy_vertical
+    for s, e, grp in spans:
+        r2 += grp.center(grp_w(s, e)) + heavy_vertical
+
+    r3 = transition_left
+    for i, w in enumerate(widths):
+        r3 += heavy_horizontal * w
+        if i < n - 1:
+            r3 += group_join if i in grp_ends else subgroup_join
+    r3 += transition_right
+
+    r4 = light_vertical
+    for i, (sub, _) in enumerate(flat):
+        r4 += sub.center(widths[i]) + light_vertical
+
+    r5 = mid_left
+    for i, w in enumerate(widths):
+        r5 += light_horizontal * w
+        r5 += mid_cross if i < n - 1 else mid_right
+
+    r6 = light_vertical
+    for i, (_, val) in enumerate(flat):
+        r6 += val.center(widths[i]) + light_vertical
+
+    r7 = bottom_left_corner
+    for i, w in enumerate(widths):
+        r7 += light_horizontal * w
+        r7 += bottom_t_up if i < n - 1 else bottom_right_corner
+
+    return "\n".join([title_line, r1, r2, r3, r4, r5, r6, r7])
+
+
+def _build_summary_renderable(
+    title_pfx: str,
+    overall_rendered: str,
+    per_class: list[dict[str, Any]],
+) -> Any:
+    """Build a single Rich renderable for overall and per-class metric tables.
+
+    Args:
+        title_pfx: Split label (e.g. ``"Val"`` or ``"Test"``).
+        overall_rendered: Pre-rendered overall table string.
+        per_class: Per-class dicts with keys ``name``, ``ap``, ``ar``,
+            ``f1``, ``precision``, ``recall``; skipped when empty.
+
+    Returns:
+        Rich renderable containing the overall table and, when present, the
+        per-class table.
+    """
+    assert Group is not None
+
+    def _fmt(v: float) -> str:
+        if v != v or v < 0:  # NaN or pycocotools sentinel -1 → em-dash
+            return "—"
+        return f"{v:.4f}"
+
+    renderables: list[Any] = [overall_rendered]
+    if per_class:
+        assert Table is not None
+
+        table = Table(
+            title=f"{title_pfx} — Per-class Metrics",
+            title_style="bold cyan",
+            show_header=True,
+            header_style="bold cyan",
+        )
+        table.add_column("Class", style="dim", no_wrap=True)
+        table.add_column("AP 50:95", justify="right")
+        table.add_column("AR", justify="right")
+        table.add_column("F1", justify="right")
+        table.add_column("Precision", justify="right")
+        table.add_column("Recall", justify="right")
+        for row in per_class:
+            table.add_row(
+                row["name"],
+                _fmt(row["ap"]),
+                _fmt(row["ar"]),
+                _fmt(row["f1"]),
+                _fmt(row["precision"]),
+                _fmt(row["recall"]),
+            )
+        renderables.append(table)
+    return Group(*renderables)
+
+
+def _render_summary_tables(
+    console: Any,
+    title_pfx: str,
+    overall_rendered: str,
+    per_class: list[dict[str, Any]],
+) -> None:
+    """Print overall and per-class metric tables to ``console``.
+
+    Args:
+        console: Rich ``Console`` instance to print to.
+        title_pfx: Split label (e.g. ``"Val"`` or ``"Test"``).
+        overall_rendered: Pre-rendered overall table string.
+        per_class: Per-class dicts with keys ``name``, ``ap``, ``ar``,
+            ``f1``, ``precision``, ``recall``; skipped when empty.
+    """
+    if not _IS_RICH_AVAILABLE:
+        return
+    console.print(_build_summary_renderable(title_pfx, overall_rendered, per_class))

--- a/src/rfdetr/utilities/console.py
+++ b/src/rfdetr/utilities/console.py
@@ -5,6 +5,8 @@
 # ------------------------------------------------------------------------
 """Rich console helper for the training callback stack."""
 
+from __future__ import annotations
+
 from typing import Any
 
 try:
@@ -12,10 +14,10 @@ try:
     from rich.live import Live
     from rich.table import Table
 except ImportError:
-    Console = None
-    Group = None
-    Live = None
-    Table = None
+    Console = None  # type: ignore[assignment, misc]
+    Group = None  # type: ignore[assignment, misc]
+    Live = None  # type: ignore[assignment, misc]
+    Table = None  # type: ignore[assignment, misc]
     _IS_RICH_AVAILABLE = False
 else:
     _IS_RICH_AVAILABLE = True
@@ -36,11 +38,21 @@ def _get_rich_console(trainer: Any) -> Any:
 
     Returns:
         A Rich ``Console`` instance suitable for printing metric tables.
+
+    Note:
+        Reads ``RichProgressBar._console``, a private PTL attribute. When ``_console`` is
+        ``None`` (outside an active fit/validate/test stage) or the attribute is renamed in a
+        future PTL release, the function silently falls back to ``Console(force_terminal=True)``
+        — a fresh console with an empty live stack that may reintroduce cursor conflicts on
+        Windows. Subclasses and theme wrappers of ``RichProgressBar`` are matched via MRO.
     """
-    assert Console is not None
+    if Console is None:
+        raise RuntimeError(  # pragma: no cover
+            "_get_rich_console called when Rich is not installed; check _IS_RICH_AVAILABLE first."
+        )
 
     for cb in getattr(trainer, "callbacks", []):
-        if cb.__class__.__name__ == "RichProgressBar":
+        if any(cls.__name__ == "RichProgressBar" for cls in type(cb).__mro__):
             cb_console = getattr(cb, "_console", None)
             if cb_console is not None:
                 return cb_console
@@ -197,7 +209,7 @@ def _build_summary_renderable(
     title_pfx: str,
     overall_rendered: str,
     per_class: list[dict[str, Any]],
-) -> Any:
+) -> Group:
     """Build a single Rich renderable for overall and per-class metric tables.
 
     Args:
@@ -207,8 +219,8 @@ def _build_summary_renderable(
             ``f1``, ``precision``, ``recall``; skipped when empty.
 
     Returns:
-        Rich renderable containing the overall table and, when present, the
-        per-class table.
+        Rich ``Group`` renderable containing the overall table and, when present,
+        the per-class table.
     """
     assert Group is not None
 

--- a/src/rfdetr/utilities/console.py
+++ b/src/rfdetr/utilities/console.py
@@ -1,0 +1,34 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Rich console helper for the training callback stack."""
+
+from typing import Any
+
+
+def _get_rich_console(trainer: Any) -> Any:
+    """Return a Rich Console appropriate for the current training context.
+
+    When a ``RichProgressBar`` callback is active, its ``_console`` is the Rich global
+    singleton that owns the Live progress display.  Printing through that same console
+    instance ensures output appears correctly above the progress bars rather than
+    conflicting with the Live display's cursor positioning (particularly on Windows).
+
+    Falls back to ``Console(force_terminal=True)`` for plain-terminal and TQDM contexts.
+
+    Args:
+        trainer: The PTL Trainer (or any object with a ``callbacks`` attribute).
+
+    Returns:
+        A Rich ``Console`` instance suitable for printing metric tables.
+    """
+    from rich.console import Console
+
+    for cb in getattr(trainer, "callbacks", []):
+        if cb.__class__.__name__ == "RichProgressBar":
+            cb_console = getattr(cb, "_console", None)
+            if cb_console is not None:
+                return cb_console
+    return Console(force_terminal=True)

--- a/tests/training/test_coco_eval_callback.py
+++ b/tests/training/test_coco_eval_callback.py
@@ -740,8 +740,8 @@ class TestOnValidationEpochEnd:
         cb.map_metric.compute.assert_called_once()
         module.log.assert_called()
 
-    def test_progress_bar_suppresses_terminal_metric_summaries(self, capsys) -> None:
-        """Progress-bar training should keep scalar logs but suppress duplicate terminal summary text."""
+    def test_progress_bar_suppresses_duplicate_pycocotools_output(self, capsys) -> None:
+        """Progress-bar training suppresses duplicate pycocotools stdout but still prints metric tables."""
         cb = COCOEvalCallback(max_dets=500)
         trainer = _make_trainer(callbacks=[_TQDMProgressBar()])
         trainer.callback_metrics = {}
@@ -759,7 +759,7 @@ class TestOnValidationEpochEnd:
             cb._compute_and_log(trainer, module, "val")
 
         assert "Average Precision" not in capsys.readouterr().out
-        print_metrics_tables.assert_not_called()
+        print_metrics_tables.assert_called_once()
         cb.map_metric.compute.assert_called_once()
         module.log.assert_called()
 

--- a/tests/training/test_coco_eval_callback.py
+++ b/tests/training/test_coco_eval_callback.py
@@ -336,34 +336,41 @@ class TestOnTrainBatchEnd:
 
 
 class TestMetricsTablePrinting:
-    """Metric table terminal/notebook rendering behavior."""
+    """Metric table terminal/notebook rendering behavior.
 
-    def test_terminal_metrics_tables_update_live_display(self) -> None:
-        """Terminal metric tables update one Rich Live display instead of appending one table block per epoch."""
+    Covers: terminal (console.print path), Rich-missing warning, teardown
+    cleanup, RichProgressBar console routing, notebook in-place updates.
+    """
+
+    @pytest.mark.parametrize(
+        "split,title_pfx",
+        [
+            pytest.param("val", "Val", id="val"),
+            pytest.param("test", "Test", id="test"),
+        ],
+    )
+    def test_terminal_metrics_tables_print_to_console(self, split: str, title_pfx: str) -> None:
+        """Terminal metric tables print directly through the Rich console each epoch."""
         cb = COCOEvalCallback(in_notebook=False)
         trainer = _make_trainer()
         trainer.is_global_zero = True
         console = MagicMock(name="console")
-        live = MagicMock(name="live")
 
         with (
             patch("rfdetr.training.callbacks.coco_eval._get_rich_console", return_value=console),
-            patch("rfdetr.training.callbacks.coco_eval.Live", return_value=live) as live_cls,
-            patch("rfdetr.training.callbacks.coco_eval._render_overall_merged", side_effect=["overall-1", "overall-2"]),
+            patch(
+                "rfdetr.training.callbacks.coco_eval._render_overall_merged",
+                side_effect=["overall-1", "overall-2"],
+            ),
+            patch("rfdetr.training.callbacks.coco_eval._render_summary_tables") as render_tables,
         ):
-            cb._print_metrics_tables(trainer, "val", {"mAP": 0.1}, [])
-            cb._print_metrics_tables(trainer, "val", {"mAP": 0.2}, [])
+            cb._print_metrics_tables(trainer, split, {"mAP": 0.1}, [])
+            cb._print_metrics_tables(trainer, split, {"mAP": 0.2}, [])
 
-        live_cls.assert_called_once()
-        assert live_cls.call_args.kwargs == {
-            "console": console,
-            "auto_refresh": False,
-            "transient": False,
-        }
-        live.start.assert_called_once_with(refresh=True)
-        live.update.assert_called_once()
-        assert live.update.call_args.kwargs == {"refresh": True}
-        console.print.assert_not_called()
+        assert render_tables.call_count == 2
+        assert render_tables.call_args_list[0].args[0] is console
+        assert render_tables.call_args_list[0].args[1] == title_pfx
+        assert render_tables.call_args_list[0].args[2] == "overall-1"
 
     def test_missing_rich_warns_once_and_skips_metric_tables(self) -> None:
         """Missing Rich emits one warning and skips noisy table rendering."""
@@ -382,18 +389,48 @@ class TestMetricsTablePrinting:
         warning.assert_called_once_with(
             "Rich is not installed; skipping metric table rendering. Install `rich` to enable tables."
         )
+        assert cb._missing_rich_warning_emitted is True
         get_console.assert_not_called()
 
-    def test_teardown_stops_terminal_live_display(self) -> None:
-        """Teardown stops the terminal Live display so it is not left active."""
-        cb = COCOEvalCallback(in_notebook=False)
-        live = MagicMock(name="live")
-        cb._metrics_live = live
+    def test_teardown_releases_notebook_widget(self) -> None:
+        """Teardown clears the notebook output widget reference."""
+        cb = COCOEvalCallback(in_notebook=True)
+        cb._output_widget = MagicMock(name="output_widget")
 
         cb.teardown(_make_trainer(), _make_pl_module(), "fit")
 
-        live.stop.assert_called_once()
-        assert cb._metrics_live is None
+        assert cb._output_widget is None
+
+    @pytest.mark.parametrize("stage", ["fit", "validate", "test", "predict"])
+    def test_teardown_no_op_when_no_widget(self, stage: str) -> None:
+        """Teardown does not raise when no output widget was created."""
+        cb = COCOEvalCallback(in_notebook=False)
+        assert cb._output_widget is None
+
+        cb.teardown(_make_trainer(), _make_pl_module(), stage)
+
+        assert cb._output_widget is None
+
+    def test_terminal_prints_through_rich_progress_bar_console(self) -> None:
+        """Metric tables route through RichProgressBar._console when active."""
+        # Create a fake callback whose class name is RichProgressBar so
+        # _get_rich_console picks it up without importing PTL.
+        rich_progress_bar_fake = type("RichProgressBar", (), {})
+        rich_console = MagicMock(name="rich_console")
+        fake_pb = rich_progress_bar_fake()
+        fake_pb._console = rich_console  # type: ignore[attr-defined]
+
+        cb = COCOEvalCallback(in_notebook=False)
+        trainer = _make_trainer(callbacks=[fake_pb])
+        trainer.is_global_zero = True
+
+        with patch(
+            "rfdetr.training.callbacks.coco_eval._render_overall_merged",
+            return_value="overall",
+        ):
+            cb._print_metrics_tables(trainer, "val", {"mAP": 0.5}, [])
+
+        rich_console.print.assert_called_once()
 
     def test_notebook_metrics_tables_reuse_and_clear_output_widget(self) -> None:
         """Notebook metric tables update one output widget instead of appending one table block per epoch."""

--- a/tests/training/test_coco_eval_callback.py
+++ b/tests/training/test_coco_eval_callback.py
@@ -5,7 +5,8 @@
 # ------------------------------------------------------------------------
 """Unit tests for COCOEvalCallback."""
 
-from types import SimpleNamespace
+import sys
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -332,6 +333,122 @@ class TestOnTrainBatchEnd:
 
         cb.map_metric.reset.assert_called_once()
         cb.map_metric_train.reset.assert_not_called()
+
+
+class TestMetricsTablePrinting:
+    """Metric table terminal/notebook rendering behavior."""
+
+    def test_terminal_metrics_tables_update_live_display(self) -> None:
+        """Terminal metric tables update one Rich Live display instead of appending one table block per epoch."""
+        cb = COCOEvalCallback(in_notebook=False)
+        trainer = _make_trainer()
+        trainer.is_global_zero = True
+        console = MagicMock(name="console")
+        live = MagicMock(name="live")
+
+        with (
+            patch("rfdetr.training.callbacks.coco_eval._get_rich_console", return_value=console),
+            patch("rfdetr.training.callbacks.coco_eval.Live", return_value=live) as live_cls,
+            patch("rfdetr.training.callbacks.coco_eval._render_overall_merged", side_effect=["overall-1", "overall-2"]),
+        ):
+            cb._print_metrics_tables(trainer, "val", {"mAP": 0.1}, [])
+            cb._print_metrics_tables(trainer, "val", {"mAP": 0.2}, [])
+
+        live_cls.assert_called_once()
+        assert live_cls.call_args.kwargs == {
+            "console": console,
+            "auto_refresh": False,
+            "transient": False,
+        }
+        live.start.assert_called_once_with(refresh=True)
+        live.update.assert_called_once()
+        assert live.update.call_args.kwargs == {"refresh": True}
+        console.print.assert_not_called()
+
+    def test_missing_rich_warns_once_and_skips_metric_tables(self) -> None:
+        """Missing Rich emits one warning and skips noisy table rendering."""
+        cb = COCOEvalCallback(in_notebook=False)
+        trainer = _make_trainer()
+        trainer.is_global_zero = True
+
+        with (
+            patch("rfdetr.training.callbacks.coco_eval._IS_RICH_AVAILABLE", False),
+            patch("rfdetr.training.callbacks.coco_eval.logger.warning") as warning,
+            patch("rfdetr.training.callbacks.coco_eval._get_rich_console") as get_console,
+        ):
+            cb._print_metrics_tables(trainer, "val", {"mAP": 0.1}, [])
+            cb._print_metrics_tables(trainer, "val", {"mAP": 0.2}, [])
+
+        warning.assert_called_once_with(
+            "Rich is not installed; skipping metric table rendering. Install `rich` to enable tables."
+        )
+        get_console.assert_not_called()
+
+    def test_teardown_stops_terminal_live_display(self) -> None:
+        """Teardown stops the terminal Live display so it is not left active."""
+        cb = COCOEvalCallback(in_notebook=False)
+        live = MagicMock(name="live")
+        cb._metrics_live = live
+
+        cb.teardown(_make_trainer(), _make_pl_module(), "fit")
+
+        live.stop.assert_called_once()
+        assert cb._metrics_live is None
+
+    def test_notebook_metrics_tables_reuse_and_clear_output_widget(self) -> None:
+        """Notebook metric tables update one output widget instead of appending one table block per epoch."""
+
+        class FakeOutput:
+            """Minimal ipywidgets.Output stand-in."""
+
+            def __init__(self) -> None:
+                self.clear_output = MagicMock(name="clear_output")
+                self.enter_count = 0
+
+            def __enter__(self) -> "FakeOutput":
+                self.enter_count += 1
+                return self
+
+            def __exit__(self, exc_type: object, exc: object, tb: object) -> bool:
+                return False
+
+        output_widget = FakeOutput()
+        display = MagicMock(name="display")
+        widgets_module = ModuleType("ipywidgets")
+        widgets_module.Output = MagicMock(return_value=output_widget)
+        ipython_module = ModuleType("IPython")
+        ipython_module.__path__ = []
+        display_module = ModuleType("IPython.display")
+        display_module.display = display
+
+        cb = COCOEvalCallback(in_notebook=True)
+        trainer = _make_trainer()
+        trainer.is_global_zero = True
+
+        with (
+            patch.dict(
+                sys.modules,
+                {
+                    "ipywidgets": widgets_module,
+                    "IPython": ipython_module,
+                    "IPython.display": display_module,
+                },
+            ),
+            patch("rfdetr.training.callbacks.coco_eval._render_overall_merged", side_effect=["overall-1", "overall-2"]),
+            patch("rfdetr.training.callbacks.coco_eval._render_summary_tables") as render_summary_tables,
+        ):
+            cb._print_metrics_tables(trainer, "val", {"mAP": 0.1}, [])
+            cb._print_metrics_tables(trainer, "val", {"mAP": 0.2}, [])
+
+        widgets_module.Output.assert_called_once()
+        display.assert_called_once_with(output_widget)
+        assert cb._output_widget is output_widget
+        assert [call.kwargs for call in output_widget.clear_output.call_args_list] == [
+            {"wait": True},
+            {"wait": True},
+        ]
+        assert output_widget.enter_count == 2
+        assert render_summary_tables.call_count == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/utilities/test_console.py
+++ b/tests/utilities/test_console.py
@@ -1,0 +1,245 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Tests for rfdetr.utilities.console — Rich console helpers for callbacks."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rfdetr.utilities.console import (
+    _IS_RICH_AVAILABLE,
+    _build_summary_renderable,
+    _get_rich_console,
+    _has_progress_bar,
+    _render_overall_merged,
+    _render_summary_tables,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_trainer(callbacks: list[object] | None = None) -> MagicMock:
+    """Return a minimal mock Trainer."""
+    trainer = MagicMock(name="trainer")
+    trainer.callbacks = callbacks or []
+    return trainer
+
+
+def _minimal_overall(max_dets: int = 500) -> dict:
+    """Return an overall dict with the minimal keys _render_overall_merged expects."""
+    return {
+        "mAP 50:95": 0.4,
+        "mAP 50": 0.6,
+        "mAP 75": 0.3,
+        f"mAR @{max_dets}": 0.5,
+        "F1": 0.55,
+        "Precision": 0.6,
+        "Recall": 0.5,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _render_overall_merged
+# ---------------------------------------------------------------------------
+
+
+class TestRenderOverallMerged:
+    """_render_overall_merged renders a multi-line ASCII table string."""
+
+    def test_returns_string(self) -> None:
+        """Result is a non-empty multi-line string."""
+        result = _render_overall_merged("Val", _minimal_overall(), 500)
+        assert isinstance(result, str)
+        assert "\n" in result
+
+    def test_title_prefix_in_output(self) -> None:
+        """Title prefix appears in the rendered string."""
+        result = _render_overall_merged("Test", _minimal_overall(), 500)
+        assert "Test" in result
+
+    def test_metric_values_in_output(self) -> None:
+        """Formatted metric values appear in the output."""
+        result = _render_overall_merged("Val", _minimal_overall(500), 500)
+        assert "0.4000" in result
+
+    def test_nan_renders_as_em_dash(self) -> None:
+        """NaN values render as '—' (em-dash)."""
+        overall = _minimal_overall()
+        overall["mAP 50:95"] = float("nan")
+        result = _render_overall_merged("Val", overall, 500)
+        assert "—" in result
+
+    def test_negative_sentinel_renders_as_em_dash(self) -> None:
+        """Pycocotools sentinel -1 renders as '—'."""
+        overall = _minimal_overall()
+        overall["mAP 50"] = -1.0
+        result = _render_overall_merged("Val", overall, 500)
+        assert "—" in result
+
+    def test_segm_group_present_when_key_exists(self) -> None:
+        """Segm mAP group rendered when segm keys present."""
+        overall = _minimal_overall()
+        overall["segm mAP 50:95"] = 0.3
+        overall["segm mAP 50"] = 0.5
+        result = _render_overall_merged("Val", overall, 500)
+        assert "segm mAP" in result
+
+    def test_segm_group_absent_when_key_missing(self) -> None:
+        """Segm mAP group not rendered when keys absent."""
+        result = _render_overall_merged("Val", _minimal_overall(), 500)
+        assert "segm mAP" not in result
+
+    def test_mar_label_uses_max_dets(self) -> None:
+        """MAR column label contains the max_dets value."""
+        result = _render_overall_merged("Val", _minimal_overall(100), 100)
+        assert "@100" in result
+
+
+# ---------------------------------------------------------------------------
+# _has_progress_bar
+# ---------------------------------------------------------------------------
+
+
+class TestHasProgressBar:
+    """_has_progress_bar detects any callback whose class name ends with ProgressBar."""
+
+    def test_returns_false_with_no_callbacks(self) -> None:
+        """Returns False when trainer has no callbacks."""
+        assert not _has_progress_bar(_make_trainer())
+
+    def test_returns_true_for_tqdm_progress_bar(self) -> None:
+        """Returns True when a TQDMProgressBar callback present."""
+        tqdm_bar_cls = type("TQDMProgressBar", (), {})
+        trainer = _make_trainer(callbacks=[tqdm_bar_cls()])
+        assert _has_progress_bar(trainer)
+
+    def test_returns_true_for_rich_progress_bar(self) -> None:
+        """Returns True when a RichProgressBar callback present."""
+        rich_bar_cls = type("RichProgressBar", (), {})
+        trainer = _make_trainer(callbacks=[rich_bar_cls()])
+        assert _has_progress_bar(trainer)
+
+    def test_returns_false_for_non_progress_bar_callback(self) -> None:
+        """Returns False when callbacks don't end with ProgressBar."""
+        trainer = _make_trainer(callbacks=[MagicMock(name="SomeOtherCallback")])
+        assert not _has_progress_bar(trainer)
+
+
+# ---------------------------------------------------------------------------
+# _get_rich_console
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _IS_RICH_AVAILABLE, reason="Rich not installed")
+class TestGetRichConsole:
+    """_get_rich_console returns the PTL RichProgressBar console or a fresh one."""
+
+    def test_returns_fresh_console_with_no_callbacks(self) -> None:
+        """Returns a Console instance when no RichProgressBar present."""
+        from rich.console import Console
+
+        result = _get_rich_console(_make_trainer())
+        assert isinstance(result, Console)
+
+    def test_returns_rich_progress_bar_console_when_active(self) -> None:
+        """Returns _console from RichProgressBar when callback present and _console set."""
+        rich_bar_cls = type("RichProgressBar", (), {})
+        expected_console = MagicMock(name="expected_console")
+        cb = rich_bar_cls()
+        cb._console = expected_console  # type: ignore[attr-defined]
+        trainer = _make_trainer(callbacks=[cb])
+
+        result = _get_rich_console(trainer)
+
+        assert result is expected_console
+
+    def test_falls_back_when_console_attribute_is_none(self) -> None:
+        """Falls back to fresh Console when _console is None (outside active stage)."""
+        from rich.console import Console
+
+        rich_bar_cls = type("RichProgressBar", (), {})
+        cb = rich_bar_cls()
+        cb._console = None  # type: ignore[attr-defined]
+        trainer = _make_trainer(callbacks=[cb])
+
+        result = _get_rich_console(trainer)
+
+        assert isinstance(result, Console)
+
+    def test_mro_subclass_detected(self) -> None:
+        """Subclass of RichProgressBar is detected via MRO name check."""
+        rich_bar_cls = type("RichProgressBar", (), {})
+        themed_bar_cls = type("ThemedProgressBar", (rich_bar_cls,), {})
+        expected_console = MagicMock(name="expected_console")
+        cb = themed_bar_cls()
+        cb._console = expected_console  # type: ignore[attr-defined]
+        trainer = _make_trainer(callbacks=[cb])
+
+        result = _get_rich_console(trainer)
+
+        assert result is expected_console
+
+
+# ---------------------------------------------------------------------------
+# _build_summary_renderable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _IS_RICH_AVAILABLE, reason="Rich not installed")
+class TestBuildSummaryRenderable:
+    """_build_summary_renderable returns a Rich Group for console.print()."""
+
+    def test_returns_group_without_per_class(self) -> None:
+        """Returns a Group renderable when per_class is empty."""
+        from rich.console import Group
+
+        result = _build_summary_renderable("Val", "overall-text", [])
+        assert isinstance(result, Group)
+
+    def test_returns_group_with_per_class(self) -> None:
+        """Returns a Group renderable when per_class rows present."""
+        from rich.console import Group
+
+        per_class = [{"name": "cat", "ap": 0.5, "ar": 0.6, "f1": 0.55, "precision": 0.6, "recall": 0.5}]
+        result = _build_summary_renderable("Val", "overall-text", per_class)
+        assert isinstance(result, Group)
+
+    def test_nan_per_class_renders_as_em_dash(self) -> None:
+        """NaN in per-class metric renders without error."""
+        from rich.console import Console, Group
+
+        per_class = [{"name": "cat", "ap": float("nan"), "ar": -1.0, "f1": 0.0, "precision": 0.0, "recall": 0.0}]
+        result = _build_summary_renderable("Val", "overall-text", per_class)
+        assert isinstance(result, Group)
+        console = Console(force_terminal=True)
+        with console.capture() as capture:
+            console.print(result)
+        assert "—" in capture.get()
+
+
+# ---------------------------------------------------------------------------
+# _render_summary_tables
+# ---------------------------------------------------------------------------
+
+
+class TestRenderSummaryTables:
+    """_render_summary_tables delegates to console.print when Rich available."""
+
+    @pytest.mark.skipif(not _IS_RICH_AVAILABLE, reason="Rich not installed")
+    def test_calls_console_print_once(self) -> None:
+        """console.print called exactly once with the Group renderable."""
+        console = MagicMock(name="console")
+        _render_summary_tables(console, "Val", "overall-text", [])
+        console.print.assert_called_once()
+
+    def test_no_op_when_rich_unavailable(self) -> None:
+        """No call made when Rich not installed."""
+        console = MagicMock(name="console")
+        with patch("rfdetr.utilities.console._IS_RICH_AVAILABLE", False):
+            _render_summary_tables(console, "Val", "overall-text", [])
+        console.print.assert_not_called()


### PR DESCRIPTION
- Remove guard in `_compute_and_log` that suppressed `_print_metrics_tables` when any progress bar callback was present; fixes #1127 where intermediate epoch metrics were overwritten on Windows
- Add `rfdetr.utilities.console._get_rich_console` to route printing through `RichProgressBar._console` (the Rich Live display owner) instead of a separate `Console(force_terminal=True)` instance, preventing cursor-position conflicts
- Extract nested `_render_all` closure to `COCOEvalCallback._render_summary_tables` static method with explicit `(console, title_pfx, overall_rendered, per_class)` parameters
- Rename and update test: progress bar context now asserts `_print_metrics_tables` is called, not suppressed
