### PR TITLE
refactor: pep 604 adjustments to remove Optional from typing

### DIFF
--- a/src/rfdetr/assets/model_weights.py
+++ b/src/rfdetr/assets/model_weights.py
@@ -24,7 +24,6 @@ Download Priority Order:
 import os
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
 
 from rfdetr.platform import _IS_RFDETR_PLUS_AVAILABLE
 from rfdetr.utilities.files import _download_file, _validate_file_md5
@@ -58,7 +57,7 @@ class ModelWeightAsset:
 
     filename: str
     url: str
-    md5_hash: Optional[str] = None
+    md5_hash: str | None = None
 
 
 class ModelWeightsBase(Enum):
@@ -104,12 +103,12 @@ class ModelWeightsBase(Enum):
         return self.value.url
 
     @property
-    def md5_hash(self) -> Optional[str]:
+    def md5_hash(self) -> str | None:
         """Get the MD5 hash from the underlying ModelWeightAsset."""
         return self.value.md5_hash
 
     @classmethod
-    def from_filename(cls, filename: str) -> Optional[ModelWeightAsset]:
+    def from_filename(cls, filename: str) -> ModelWeightAsset | None:
         """Get ModelWeightAsset by filename.
 
         Args:
@@ -129,7 +128,7 @@ class ModelWeightsBase(Enum):
         return None
 
     @classmethod
-    def get_url(cls, filename: str) -> Optional[str]:
+    def get_url(cls, filename: str) -> str | None:
         """Get download URL for a model by filename.
 
         Args:
@@ -142,7 +141,7 @@ class ModelWeightsBase(Enum):
         return asset.url if asset else None
 
     @classmethod
-    def get_md5(cls, filename: str) -> Optional[str]:
+    def get_md5(cls, filename: str) -> str | None:
         """Get expected MD5 hash for a model by filename.
 
         Args:
@@ -335,7 +334,7 @@ def download_pretrain_weights(
         >>> download_pretrain_weights('rf-detr-base.pth')  # doctest: +SKIP
         Downloading pretrained weights for rf-detr-base.pth
     """
-    asset: Optional[ModelWeightAsset] = None
+    asset: ModelWeightAsset | None = None
 
     # Use basename for registry lookup so absolute paths (e.g.
     # "/content/rf-detr-base.pth") match the registered short name.

--- a/src/rfdetr/assets/model_weights.py
+++ b/src/rfdetr/assets/model_weights.py
@@ -20,6 +20,7 @@ Download Priority Order:
     2. rfdetr_plus.assets.ModelWeights.from_filename() - lazy import if not found locally
     3. PLATFORM_MODELS dict - legacy fallback for backward compatibility
 """
+from __future__ import annotations
 
 import os
 from dataclasses import dataclass

--- a/src/rfdetr/assets/model_weights.py
+++ b/src/rfdetr/assets/model_weights.py
@@ -20,6 +20,7 @@ Download Priority Order:
     2. rfdetr_plus.assets.ModelWeights.from_filename() - lazy import if not found locally
     3. PLATFORM_MODELS dict - legacy fallback for backward compatibility
 """
+
 from __future__ import annotations
 
 import os


### PR DESCRIPTION
…pe in model weights.


#564

## What does this PR do?

Adjustment for modern typing in Python without the necessity for `Optional` in favor of using union types.

**Related Issue(s):** <!-- Link to related issues, e.g., Fixes #123 or Related to #456 -->

#564


## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- type changes

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
