### PR TITLE
fix(tflite): match PyTorch predict() preprocessing and mask decoder

### DIFF
--- a/src/rfdetr/export/_tflite/inference.py
+++ b/src/rfdetr/export/_tflite/inference.py
@@ -184,7 +184,7 @@ def _preprocess_image(
 
     if nchw_float is not None:
         # NCHW -> NHWC for the TFLite interpreter.
-        return nchw_float.transpose(0, 2, 3, 1).astype(np.float32)
+        return np.asarray(nchw_float.transpose(0, 2, 3, 1), dtype=np.float32)
 
     # Torch-free fallback: PIL BILINEAR. PIL's default is BICUBIC, which diverges from PyTorch.
     arr = np.array(pil_rgb.resize((width, height), _PIL_BILINEAR), dtype=np.float32) / 255.0

--- a/src/rfdetr/export/_tflite/inference.py
+++ b/src/rfdetr/export/_tflite/inference.py
@@ -72,9 +72,9 @@ def _create_interpreter(model_path: str | Path) -> Any:
 
 
 def _bilinear_resize_half_pixel(src: NDArray[np.float32], out_h: int, out_w: int) -> NDArray[np.float32]:
-    """Bilinear resize matching ``F.interpolate(mode="bilinear", align_corners=False)``.
+    """Numpy bilinear resize matching ``F.interpolate(mode="bilinear", align_corners=False)``.
 
-    Uses the half-pixel center convention so mask upsampling matches ``PostProcess.forward``.
+    Half-pixel center convention. Used by ``_decode_masks`` only when ``torch`` is not importable.
 
     Args:
         src: Source array of shape ``(K, src_h, src_w)``.
@@ -123,8 +123,22 @@ def _decode_masks(mask_logits: NDArray[Any], out_size: tuple[int, int]) -> NDArr
             "This usually means the rank-4 mask-output heuristic in _run_inference matched the wrong tensor."
         )
     width, height = out_size
-    resized = _bilinear_resize_half_pixel(mask_logits.astype(np.float32), height, width)
-    return resized > 0.0
+    if mask_logits.shape[0] == 0:
+        return np.empty((0, height, width), dtype=np.bool_)
+    logits_f32 = mask_logits.astype(np.float32)
+
+    try:
+        import torch
+        import torch.nn.functional as _F  # noqa: N812
+
+        with torch.no_grad():
+            t = torch.from_numpy(logits_f32).unsqueeze(0)
+            t = _F.interpolate(t, size=(height, width), mode="bilinear", align_corners=False)
+        return (t.squeeze(0).cpu().numpy() > 0.0).astype(np.bool_)
+    except ImportError:
+        pass
+
+    return _bilinear_resize_half_pixel(logits_f32, height, width) > 0.0
 
 
 def _preprocess_image(

--- a/src/rfdetr/export/_tflite/inference.py
+++ b/src/rfdetr/export/_tflite/inference.py
@@ -71,12 +71,41 @@ def _create_interpreter(model_path: str | Path) -> Any:
     return interp
 
 
-def _decode_masks(mask_logits: NDArray[Any], out_size: tuple[int, int]) -> NDArray[np.bool_]:
-    """Upsample raw mask logits to image size and threshold at zero.
+def _bilinear_resize_half_pixel(src: NDArray[np.float32], out_h: int, out_w: int) -> NDArray[np.float32]:
+    """Bilinear resize matching ``F.interpolate(mode="bilinear", align_corners=False)``.
 
-    Approximates ``PostProcess.forward``: bilinear resize followed by ``> 0``. Uses Pillow's bilinear resampling rather
-    than ``F.interpolate`` (no PyTorch dependency at inference time); border pixels may differ slightly due to distinct
-    half-pixel conventions.
+    Uses the half-pixel center convention so mask upsampling matches ``PostProcess.forward``.
+
+    Args:
+        src: Source array of shape ``(K, src_h, src_w)``.
+        out_h: Target height in pixels.
+        out_w: Target width in pixels.
+
+    Returns:
+        Float32 array of shape ``(K, out_h, out_w)``.
+    """
+    src_h, src_w = src.shape[-2], src.shape[-1]
+    src_y = (np.arange(out_h, dtype=np.float32) + 0.5) * (src_h / out_h) - 0.5
+    src_x = (np.arange(out_w, dtype=np.float32) + 0.5) * (src_w / out_w) - 0.5
+    src_y = np.clip(src_y, 0.0, src_h - 1)
+    src_x = np.clip(src_x, 0.0, src_w - 1)
+    y0 = np.floor(src_y).astype(np.int64)
+    x0 = np.floor(src_x).astype(np.int64)
+    y1 = np.minimum(y0 + 1, src_h - 1)
+    x1 = np.minimum(x0 + 1, src_w - 1)
+    dy = (src_y - y0)[:, None]
+    dx = (src_x - x0)[None, :]
+    a = src[..., y0[:, None], x0[None, :]]
+    b = src[..., y0[:, None], x1[None, :]]
+    c = src[..., y1[:, None], x0[None, :]]
+    d = src[..., y1[:, None], x1[None, :]]
+    return (1 - dy) * ((1 - dx) * a + dx * b) + dy * ((1 - dx) * c + dx * d)
+
+
+def _decode_masks(mask_logits: NDArray[Any], out_size: tuple[int, int]) -> NDArray[np.bool_]:
+    """Upsample mask logits to image size and threshold at zero.
+
+    Matches ``PostProcess.forward``: bilinear upsample with ``align_corners=False`` followed by ``> 0``.
 
     Args:
         mask_logits: Raw mask logits of shape ``(K, Hm, Wm)``.
@@ -94,12 +123,65 @@ def _decode_masks(mask_logits: NDArray[Any], out_size: tuple[int, int]) -> NDArr
             "This usually means the rank-4 mask-output heuristic in _run_inference matched the wrong tensor."
         )
     width, height = out_size
-    out = np.empty((mask_logits.shape[0], height, width), dtype=np.bool_)
-    for i, logit_map in enumerate(mask_logits):
-        mask_img = PILImage.fromarray(logit_map.astype(np.float32), mode="F")
-        resized = mask_img.resize((width, height), _PIL_BILINEAR)
-        out[i] = np.asarray(resized) > 0.0
-    return out
+    resized = _bilinear_resize_half_pixel(mask_logits.astype(np.float32), height, width)
+    return resized > 0.0
+
+
+def _preprocess_image(
+    pil_img: PILImage.Image,
+    hw: tuple[int, int],
+    channels: int = 3,
+) -> NDArray[np.float32]:
+    """Resize and ImageNet-normalise an image to match ``RFDETR.predict()``.
+
+    Uses ``torchvision.transforms.functional`` when importable for bit-exact parity, and falls back
+    to ``PIL.Image.resize`` with BILINEAR for torch-free deployments.
+
+    Args:
+        pil_img: Source PIL image at native resolution.
+        hw: Target ``(height, width)`` from the interpreter's input shape.
+        channels: Channel count (3 for RGB, 1 for grayscale).
+
+    Returns:
+        Float32 array of shape ``(1, height, width, channels)`` in NHWC.
+    """
+    height, width = hw
+    pil_mode = "L" if channels == 1 else "RGB"
+    pil_rgb = pil_img.convert(pil_mode)
+
+    nchw_float: NDArray[np.float32] | None = None
+    try:
+        # Match PyTorch.predict() exactly: torchvision to_tensor -> resize -> normalize.
+        import torch
+        import torchvision.transforms.functional as _F  # noqa: N812
+
+        with torch.no_grad():
+            t = _F.to_tensor(pil_rgb)
+            t = _F.resize(t, list(hw))
+            _imagenet_mean = [0.485, 0.456, 0.406]
+            _imagenet_std = [0.229, 0.224, 0.225]
+            mean_list = [_imagenet_mean[i % 3] for i in range(channels)]
+            std_list = [_imagenet_std[i % 3] for i in range(channels)]
+            t = _F.normalize(t, mean_list, std_list)
+        nchw_float = t.unsqueeze(0).cpu().numpy()
+    except ImportError:
+        pass
+
+    if nchw_float is not None:
+        # NCHW -> NHWC for the TFLite interpreter.
+        return nchw_float.transpose(0, 2, 3, 1).astype(np.float32)
+
+    # Torch-free fallback: PIL BILINEAR. PIL's default is BICUBIC, which diverges from PyTorch.
+    arr = np.array(pil_rgb.resize((width, height), _PIL_BILINEAR), dtype=np.float32) / 255.0
+    if arr.ndim == 2:  # "L" -> (height, width); TFLite needs (height, width, 1).
+        arr = arr[:, :, np.newaxis]
+
+    _imagenet_mean = [0.485, 0.456, 0.406]
+    _imagenet_std = [0.229, 0.224, 0.225]
+    mean = np.array([_imagenet_mean[i % 3] for i in range(channels)], dtype=np.float32)
+    std = np.array([_imagenet_std[i % 3] for i in range(channels)], dtype=np.float32)
+
+    return ((arr - mean) / std)[np.newaxis]
 
 
 def _run_inference(
@@ -135,19 +217,10 @@ def _run_inference(
             "Export the model with float32 quantization or implement input quantization manually."
         )
 
-    _imagenet_mean = [0.485, 0.456, 0.406]
-    _imagenet_std = [0.229, 0.224, 0.225]
-    mean = np.array([_imagenet_mean[i % 3] for i in range(channels)], dtype=np.float32)
-    std = np.array([_imagenet_std[i % 3] for i in range(channels)], dtype=np.float32)
-
     pil_img = PILImage.open(image_path)
-    pil_mode = "L" if channels == 1 else "RGB"
-    arr = np.array(pil_img.convert(pil_mode).resize((width, height)), dtype=np.float32) / 255.0
-    if arr.ndim == 2:  # "L" → (height, width); TFLite needs (height, width, 1)
-        arr = arr[:, :, np.newaxis]
-    inp_tensor = (arr - mean) / std
+    inp_tensor = _preprocess_image(pil_img, (int(height), int(width)), int(channels))
 
-    interp.set_tensor(inp_det[0]["index"], inp_tensor[np.newaxis])
+    interp.set_tensor(inp_det[0]["index"], inp_tensor)
     interp.invoke()
 
     # RF-DETR ONNX output names: "dets" = pred_boxes, "labels" = pred_logits.

--- a/src/rfdetr/export/_tflite/inference.py
+++ b/src/rfdetr/export/_tflite/inference.py
@@ -29,6 +29,9 @@ logger = get_logger()
 # PILImage.Resampling was introduced in Pillow 9.1; fall back to the legacy constant.
 _PIL_BILINEAR = getattr(PILImage, "Resampling", PILImage).BILINEAR
 
+_IMAGENET_MEAN: list[float] = [0.485, 0.456, 0.406]
+_IMAGENET_STD: list[float] = [0.229, 0.224, 0.225]
+
 
 def _create_interpreter(model_path: str | Path) -> Any:
     """Load a TFLite model, allocate tensors, and log I/O shapes.
@@ -83,6 +86,10 @@ def _bilinear_resize_half_pixel(src: NDArray[np.float32], out_h: int, out_w: int
 
     Returns:
         Float32 array of shape ``(K, out_h, out_w)``.
+
+    Note:
+        Replaces ``PIL.Image.resize(BILINEAR)``, which uses a corner-aligned half-pixel convention and
+        produced border-pixel discrepancies vs ``F.interpolate``.
     """
     src_h, src_w = src.shape[-2], src.shape[-1]
     src_y = (np.arange(out_h, dtype=np.float32) + 0.5) * (src_h / out_h) - 0.5
@@ -99,13 +106,18 @@ def _bilinear_resize_half_pixel(src: NDArray[np.float32], out_h: int, out_w: int
     b = src[..., y0[:, None], x1[None, :]]
     c = src[..., y1[:, None], x0[None, :]]
     d = src[..., y1[:, None], x1[None, :]]
-    return (1 - dy) * ((1 - dx) * a + dx * b) + dy * ((1 - dx) * c + dx * d)
+    return np.asarray(
+        (1 - dy) * ((1 - dx) * a + dx * b) + dy * ((1 - dx) * c + dx * d),
+        dtype=np.float32,
+    )
 
 
 def _decode_masks(mask_logits: NDArray[Any], out_size: tuple[int, int]) -> NDArray[np.bool_]:
     """Upsample mask logits to image size and threshold at zero.
 
     Matches ``PostProcess.forward``: bilinear upsample with ``align_corners=False`` followed by ``> 0``.
+    Uses ``torch.nn.functional.interpolate`` when torch is importable for bit-exact parity, and falls
+    back to the pure-NumPy ``_bilinear_resize_half_pixel`` otherwise.
 
     Args:
         mask_logits: Raw mask logits of shape ``(K, Hm, Wm)``.
@@ -116,6 +128,10 @@ def _decode_masks(mask_logits: NDArray[Any], out_size: tuple[int, int]) -> NDArr
 
     Raises:
         ValueError: If *mask_logits* is not rank-3.
+
+    Note:
+        ``out_size`` follows PIL convention ``(width, height)``; the returned array uses
+        NumPy/PyTorch convention ``(K, height, width)``.
     """
     if mask_logits.ndim != 3:
         raise ValueError(
@@ -123,7 +139,18 @@ def _decode_masks(mask_logits: NDArray[Any], out_size: tuple[int, int]) -> NDArr
             "This usually means the rank-4 mask-output heuristic in _run_inference matched the wrong tensor."
         )
     width, height = out_size
-    resized = _bilinear_resize_half_pixel(mask_logits.astype(np.float32), height, width)
+    if mask_logits.shape[0] == 0:
+        return np.zeros((0, height, width), dtype=np.bool_)
+    try:
+        import torch
+        import torch.nn.functional as _F  # noqa: N812
+
+        with torch.no_grad():
+            t = torch.from_numpy(mask_logits.astype(np.float32)).unsqueeze(0)
+            t = _F.interpolate(t, size=(height, width), mode="bilinear", align_corners=False)
+        resized: NDArray[np.float32] = np.asarray(t.squeeze(0).numpy(), dtype=np.float32)
+    except ImportError:
+        resized = _bilinear_resize_half_pixel(mask_logits.astype(np.float32), height, width)
     return resized > 0.0
 
 
@@ -144,6 +171,11 @@ def _preprocess_image(
 
     Returns:
         Float32 array of shape ``(1, height, width, channels)`` in NHWC.
+
+    Note:
+        The PIL fallback uses BILINEAR resize, which does not perfectly match PyTorch's ``F.resize``
+        (different coordinate conventions). For bit-exact parity with ``RFDETR.predict()``, ensure
+        ``torch`` and ``torchvision`` are importable.
     """
     height, width = hw
     pil_mode = "L" if channels == 1 else "RGB"
@@ -158,28 +190,24 @@ def _preprocess_image(
         with torch.no_grad():
             t = _F.to_tensor(pil_rgb)
             t = _F.resize(t, list(hw))
-            _imagenet_mean = [0.485, 0.456, 0.406]
-            _imagenet_std = [0.229, 0.224, 0.225]
-            mean_list = [_imagenet_mean[i % 3] for i in range(channels)]
-            std_list = [_imagenet_std[i % 3] for i in range(channels)]
+            mean_list = [_IMAGENET_MEAN[i % 3] for i in range(channels)]
+            std_list = [_IMAGENET_STD[i % 3] for i in range(channels)]
             t = _F.normalize(t, mean_list, std_list)
-        nchw_float = t.unsqueeze(0).cpu().numpy()
+        nchw_float = np.asarray(t.unsqueeze(0).cpu().numpy(), dtype=np.float32)
     except ImportError:
         pass
 
     if nchw_float is not None:
         # NCHW -> NHWC for the TFLite interpreter.
-        return nchw_float.transpose(0, 2, 3, 1).astype(np.float32)
+        return np.asarray(nchw_float.transpose(0, 2, 3, 1), dtype=np.float32)
 
     # Torch-free fallback: PIL BILINEAR. PIL's default is BICUBIC, which diverges from PyTorch.
     arr = np.array(pil_rgb.resize((width, height), _PIL_BILINEAR), dtype=np.float32) / 255.0
     if arr.ndim == 2:  # "L" -> (height, width); TFLite needs (height, width, 1).
         arr = arr[:, :, np.newaxis]
 
-    _imagenet_mean = [0.485, 0.456, 0.406]
-    _imagenet_std = [0.229, 0.224, 0.225]
-    mean = np.array([_imagenet_mean[i % 3] for i in range(channels)], dtype=np.float32)
-    std = np.array([_imagenet_std[i % 3] for i in range(channels)], dtype=np.float32)
+    mean = np.array([_IMAGENET_MEAN[i % 3] for i in range(channels)], dtype=np.float32)
+    std = np.array([_IMAGENET_STD[i % 3] for i in range(channels)], dtype=np.float32)
 
     return ((arr - mean) / std)[np.newaxis]
 

--- a/src/rfdetr/export/_tflite/inference.py
+++ b/src/rfdetr/export/_tflite/inference.py
@@ -99,7 +99,8 @@ def _bilinear_resize_half_pixel(src: NDArray[np.float32], out_h: int, out_w: int
     b = src[..., y0[:, None], x1[None, :]]
     c = src[..., y1[:, None], x0[None, :]]
     d = src[..., y1[:, None], x1[None, :]]
-    return (1 - dy) * ((1 - dx) * a + dx * b) + dy * ((1 - dx) * c + dx * d)
+    out = (1 - dy) * ((1 - dx) * a + dx * b) + dy * ((1 - dx) * c + dx * d)
+    return np.asarray(out, dtype=np.float32)
 
 
 def _decode_masks(mask_logits: NDArray[Any], out_size: tuple[int, int]) -> NDArray[np.bool_]:

--- a/tests/export/test_tflite_inference.py
+++ b/tests/export/test_tflite_inference.py
@@ -22,7 +22,13 @@ import pytest
 import supervision as sv
 from PIL import Image as PILImage
 
-from rfdetr.export._tflite.inference import _create_interpreter, _decode_masks, _run_inference
+from rfdetr.export._tflite.inference import (
+    _bilinear_resize_half_pixel,
+    _create_interpreter,
+    _decode_masks,
+    _preprocess_image,
+    _run_inference,
+)
 
 # ---------------------------------------------------------------------------
 # Shared helpers / factories
@@ -676,3 +682,103 @@ class TestMaskDecoding:
         # Interior rows well away from the half-way boundary
         assert out[0, 1:6, :].all()  # top rows → all True
         assert not out[0, 15:27, :].any()  # bottom rows → all False
+
+
+# ---------------------------------------------------------------------------
+# TestBilinearResizeHalfPixel
+# ---------------------------------------------------------------------------
+
+
+class TestBilinearResizeHalfPixel:
+    """Tests for ``_bilinear_resize_half_pixel()``."""
+
+    def test_output_shape(self) -> None:
+        """Output shape is (K, out_h, out_w)."""
+        src = np.ones((3, 8, 8), dtype=np.float32)
+        out = _bilinear_resize_half_pixel(src, 16, 16)
+        assert out.shape == (3, 16, 16)
+
+    def test_output_dtype_is_float32(self) -> None:
+        """Output dtype is float32 regardless of input magnitude."""
+        src = np.ones((1, 4, 4), dtype=np.float32)
+        out = _bilinear_resize_half_pixel(src, 8, 8)
+        assert out.dtype == np.float32
+
+    def test_identity_when_no_resize(self) -> None:
+        """Output equals input when target dimensions match source dimensions."""
+        rng = np.random.default_rng(0)
+        src = rng.random((2, 8, 8)).astype(np.float32)
+        out = _bilinear_resize_half_pixel(src, 8, 8)
+        np.testing.assert_allclose(out, src, atol=1e-6)
+
+    @pytest.mark.parametrize(
+        ("src_shape", "out_h", "out_w"),
+        [
+            pytest.param((1, 4, 4), 8, 8, id="upsample_square"),
+            pytest.param((3, 7, 5), 14, 10, id="upsample_nonsquare"),
+            pytest.param((2, 8, 8), 4, 4, id="downsample"),
+            pytest.param((1, 1, 1), 3, 3, id="degenerate_1x1"),
+        ],
+    )
+    def test_parity_with_torch_interpolate(self, src_shape: tuple[int, int, int], out_h: int, out_w: int) -> None:
+        """Output matches F.interpolate(mode='bilinear', align_corners=False) to within 1e-5."""
+        torch = pytest.importorskip("torch")
+        import torch.nn.functional as F  # noqa: N812
+
+        rng = np.random.default_rng(42)
+        src = rng.random(src_shape).astype(np.float32)
+
+        result = _bilinear_resize_half_pixel(src, out_h, out_w)
+
+        t = torch.from_numpy(src).unsqueeze(0)
+        with torch.no_grad():
+            ref = F.interpolate(t, size=(out_h, out_w), mode="bilinear", align_corners=False)
+        ref_np = ref.squeeze(0).numpy()
+
+        np.testing.assert_allclose(result, ref_np, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# TestPreprocessImage
+# ---------------------------------------------------------------------------
+
+
+class TestPreprocessImage:
+    """Tests for ``_preprocess_image()``."""
+
+    def test_output_shape_rgb(self) -> None:
+        """RGB image returns float32 array of shape (1, H, W, 3)."""
+        pil_img = PILImage.new("RGB", (100, 80))
+        out = _preprocess_image(pil_img, (64, 64))
+        assert out.shape == (1, 64, 64, 3)
+        assert out.dtype == np.float32
+
+    def test_output_shape_grayscale(self) -> None:
+        """Grayscale image with channels=1 returns float32 array of shape (1, H, W, 1)."""
+        pil_img = PILImage.new("L", (100, 80))
+        out = _preprocess_image(pil_img, (64, 64), channels=1)
+        assert out.shape == (1, 64, 64, 1)
+        assert out.dtype == np.float32
+
+    def test_output_values_are_normalized(self) -> None:
+        """ImageNet normalization shifts black-pixel output below -1.0."""
+        pil_img = PILImage.new("RGB", (32, 32), color=(0, 0, 0))
+        out = _preprocess_image(pil_img, (32, 32))
+        # pixel 0 → 0.0 → (0.0 - 0.485) / 0.229 ≈ -2.12
+        assert out.min() < -1.0
+
+    def test_pil_fallback_when_torch_unavailable(self) -> None:
+        """PIL path is used when torch is masked from sys.modules."""
+        pil_img = PILImage.new("RGB", (100, 80))
+        with mock.patch.dict(
+            sys.modules,
+            {
+                "torch": None,
+                "torchvision": None,
+                "torchvision.transforms": None,
+                "torchvision.transforms.functional": None,
+            },
+        ):
+            out = _preprocess_image(pil_img, (64, 64))
+        assert out.shape == (1, 64, 64, 3)
+        assert out.dtype == np.float32

--- a/tests/export/test_tflite_inference_parity.py
+++ b/tests/export/test_tflite_inference_parity.py
@@ -23,7 +23,7 @@ import pytest
 import torchvision.transforms.functional as F  # noqa: N812
 from PIL import Image as PILImage
 
-from rfdetr.export._tflite.inference import _preprocess_image
+from rfdetr.export._tflite.inference import _bilinear_resize_half_pixel, _preprocess_image
 
 IMAGENET_MEAN = [0.485, 0.456, 0.406]
 IMAGENET_STD = [0.229, 0.224, 0.225]
@@ -184,4 +184,78 @@ class TestPreprocessingFilterRegression:
             f"_preprocess_image is too close to BICUBIC behaviour: "
             f"current max|diff|={max_diff_current:.4f}, BICUBIC max|diff|={max_diff_bicubic:.4f}. "
             f"Check that _PIL_BILINEAR is being passed to .resize()."
+        )
+
+
+class TestBilinearResizeHalfPixelParity:
+    """``_bilinear_resize_half_pixel`` is the torch-free fallback used by ``_decode_masks``.
+
+    It must match ``torch.nn.functional.interpolate(..., mode="bilinear", align_corners=False)``
+    -- the same call ``PostProcess.forward`` uses -- byte-for-byte modulo float noise. Sharp-edge
+    inputs are the worst case: even a sub-pixel shift in the half-pixel convention flips boundary
+    pixels and tanks mask IoU.
+    """
+
+    @staticmethod
+    def _torch_interpolate(src: np.ndarray, out_hw: tuple[int, int]) -> np.ndarray:
+        """Reference implementation: ``F.interpolate`` with ``align_corners=False``."""
+        import torch
+        import torch.nn.functional as TF  # noqa: N812
+
+        with torch.no_grad():
+            t = torch.from_numpy(src.astype(np.float32)).unsqueeze(0)
+            out = TF.interpolate(t, size=out_hw, mode="bilinear", align_corners=False)
+        return out.squeeze(0).cpu().numpy()
+
+    @pytest.mark.parametrize(
+        ("src_hw", "out_hw"),
+        [
+            pytest.param((28, 28), (384, 384), id="upsample_28_to_384"),
+            pytest.param((56, 56), (256, 256), id="upsample_56_to_256"),
+            pytest.param((100, 100), (100, 100), id="identity_100"),
+            pytest.param((100, 100), (50, 50), id="downsample_100_to_50"),
+            pytest.param((40, 60), (200, 400), id="non_square_upsample"),
+        ],
+    )
+    def test_matches_torch_interpolate_on_random_logits(self, src_hw: tuple[int, int], out_hw: tuple[int, int]) -> None:
+        """Random logits over a small batch must resize identically to ``F.interpolate``."""
+        rng = np.random.default_rng(0)
+        src = rng.standard_normal((3, *src_hw)).astype(np.float32) * 4.0
+
+        ours = _bilinear_resize_half_pixel(src, out_hw[0], out_hw[1])
+        ref = self._torch_interpolate(src, out_hw)
+
+        max_diff = float(np.abs(ours - ref).max())
+        # 1e-4 absorbs the float32 op-order noise that accumulates on large upsample ratios
+        # (mine: split bilinear sums in pure numpy; torch: fused kernel). Half-pixel-convention
+        # drift would push this several orders of magnitude higher.
+        assert max_diff < 1e-4, (
+            f"_bilinear_resize_half_pixel diverged from F.interpolate(align_corners=False): "
+            f"max|diff|={max_diff:.2e} on shape {src_hw} -> {out_hw}. "
+            "Half-pixel convention drift would surface here."
+        )
+
+    def test_sharp_edge_mask_matches_torch(self) -> None:
+        """A mask with a sharp left/right boundary is the regression-prone case.
+
+        This is the shape ``_decode_masks`` actually consumes (logits with a zero-crossing). A half-pixel shift would
+        flip the boundary column and is exactly what the original PIL.BILINEAR path got wrong.
+        """
+        src = np.full((1, 28, 28), -10.0, dtype=np.float32)
+        src[0, :, 14:] = 10.0  # sharp vertical edge at column 14
+
+        out_hw = (224, 224)
+        ours = _bilinear_resize_half_pixel(src, out_hw[0], out_hw[1])
+        ref = self._torch_interpolate(src, out_hw)
+
+        max_diff = float(np.abs(ours - ref).max())
+        assert max_diff < 1e-4, (
+            f"Sharp-edge resize diverged from F.interpolate: max|diff|={max_diff:.2e}. "
+            "This is the case that previously dropped mask IoU below 0.6 with PIL.BILINEAR."
+        )
+
+        # Also assert the thresholded output matches: this is what _decode_masks actually returns.
+        assert np.array_equal(ours > 0, ref > 0), (
+            "Boolean mask after thresholding diverged from F.interpolate. Even a single column of "
+            "flipped pixels would show up here -- the exact failure mode the original PR fixes."
         )

--- a/tests/export/test_tflite_inference_parity.py
+++ b/tests/export/test_tflite_inference_parity.py
@@ -1,0 +1,187 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Preprocessing parity tests: ``_run_inference`` must produce essentially the same input tensor as ``RFDETR.predict``
+for the same source image, otherwise the TFLite-exported model is fed inputs the PyTorch graph never saw and detections
+drift.
+
+History: an earlier version of ``_run_inference`` called ``PIL.Image.resize`` without a filter argument, picking up
+PIL's default (BICUBIC since Pillow 9.1.0). PyTorch's predict() path uses torchvision ``F.resize`` (BILINEAR). The
+mismatch caused IoU drift up to 0.36 on detail-rich images and a 2-class-mismatch FP16 disaster on the ``dog`` test
+image. This test exists to keep ``_preprocess_image`` locked to BILINEAR -- any regression that re-introduces BICUBIC or
+otherwise shifts the resize filter will surface here.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+import pytest
+import torchvision.transforms.functional as F  # noqa: N812
+from PIL import Image as PILImage
+
+from rfdetr.export._tflite.inference import _preprocess_image
+
+IMAGENET_MEAN = [0.485, 0.456, 0.406]
+IMAGENET_STD = [0.229, 0.224, 0.225]
+
+# Bound for max abs diff in normalised space between the PyTorch and TFLite preprocessing pipelines.
+# With torchvision available (which is always the case in this repo's CI -- it's a hard rfdetr
+# dependency) _preprocess_image runs the same torchvision call PyTorch's predict() uses, so the
+# tensors are bit-exact. The 0.05 bound is generous so the torch-free fallback path (which uses
+# PIL.BILINEAR and shows ~0.016 max diff) also passes; the BICUBIC regression would push max diff
+# to ~0.5, well above the bound.
+MAX_ABS_DIFF_BOUND = 0.05
+# When torchvision is available the inference path matches torchvision-resize byte-for-byte, so
+# the diff is effectively zero modulo floating-point noise.
+BIT_EXACT_BOUND = 1e-5
+
+
+def _pytorch_preprocess(pil_img: PILImage.Image, hw: tuple[int, int]) -> np.ndarray:
+    """Mirror of the PyTorch predict() preprocessing: to_tensor -> resize -> normalize."""
+    img = F.to_tensor(pil_img)
+    img = F.resize(img, list(hw))
+    img = F.normalize(img, IMAGENET_MEAN, IMAGENET_STD)
+    return img.unsqueeze(0).numpy()
+
+
+def _tflite_preprocess_to_nchw(pil_img: PILImage.Image, hw: tuple[int, int]) -> np.ndarray:
+    """Call ``_preprocess_image`` and convert NHWC -> NCHW for apples-to-apples comparison."""
+    nhwc = _preprocess_image(pil_img, hw, channels=3)
+    return nhwc.transpose(0, 3, 1, 2)
+
+
+def _make_synthetic_rgb(seed: int, size: tuple[int, int]) -> PILImage.Image:
+    """Deterministic synthetic RGB image with structure (not pure noise) so resize filtering matters."""
+    rng = np.random.default_rng(seed)
+    height, width = size
+    base = rng.integers(0, 256, size=(height // 8, width // 8, 3), dtype=np.uint8)
+    pil_small = PILImage.fromarray(base, mode="RGB")
+    return pil_small.resize((width, height), getattr(PILImage, "Resampling", PILImage).NEAREST)
+
+
+class TestPreprocessingParity:
+    """``_preprocess_image`` must match PyTorch's predict() preprocessing within MAX_ABS_DIFF_BOUND.
+
+    Three shapes cover the common downscale ratios produced by RFDETR exports:
+      - 1280x720 -> 384x384 (nano default): heavy downscale, the case that surfaced the BICUBIC bug
+      - 800x600  -> 384x384: moderate downscale, mixed aspect ratio
+      - 384x384  -> 384x384: identity resize -- only normalisation differs (rounding noise only)
+    """
+
+    @pytest.mark.parametrize(
+        ("src_size", "tgt_size", "seed"),
+        [
+            pytest.param((1280, 720), (384, 384), 0, id="1280x720_to_384x384"),
+            pytest.param((800, 600), (384, 384), 1, id="800x600_to_384x384"),
+            pytest.param((384, 384), (384, 384), 2, id="identity_384x384"),
+        ],
+    )
+    def test_matches_pytorch_predict_preprocessing(
+        self, src_size: tuple[int, int], tgt_size: tuple[int, int], seed: int
+    ) -> None:
+        pil = _make_synthetic_rgb(seed, (src_size[1], src_size[0]))  # _make takes (H, W)
+        pt = _pytorch_preprocess(pil, tgt_size)
+        tf = _tflite_preprocess_to_nchw(pil, tgt_size)
+
+        assert pt.shape == tf.shape, f"shape mismatch: PT {pt.shape} vs TF {tf.shape}"
+        max_diff = float(np.abs(pt - tf).max())
+        # torchvision is a hard rfdetr dependency, so in this test environment _preprocess_image
+        # uses the torchvision path and matches PyTorch byte-for-byte. The torch-free fallback is
+        # exercised separately by test_torch_free_fallback_still_close.
+        assert max_diff < BIT_EXACT_BOUND, (
+            f"PyTorch vs TFLite preprocessing diverged: max|diff|={max_diff:.6f} exceeds "
+            f"{BIT_EXACT_BOUND}. With torchvision available, _preprocess_image should be using "
+            f"torchvision.transforms.functional.resize and the diff should be effectively zero. "
+            f"If this fires, check that the torch/torchvision import path inside _preprocess_image "
+            f"hasn't been broken."
+        )
+
+    def test_grayscale_channel_handling(self) -> None:
+        """Grayscale (channels=1) path must produce shape (1, H, W, 1)."""
+        rng = np.random.default_rng(3)
+        height, width = 256, 256
+        pil = PILImage.fromarray(rng.integers(0, 256, size=(height, width), dtype=np.uint8), mode="L")
+        tf = _preprocess_image(pil, (128, 128), channels=1)
+        assert tf.shape == (1, 128, 128, 1), f"unexpected shape: {tf.shape}"
+        assert tf.dtype == np.float32
+
+    def test_returns_nhwc_float32(self) -> None:
+        """``_preprocess_image`` returns NHWC float32 with a leading batch dim."""
+        pil = _make_synthetic_rgb(seed=7, size=(64, 64))
+        tf = _preprocess_image(pil, (32, 32), channels=3)
+        assert tf.shape == (1, 32, 32, 3)
+        assert tf.dtype == np.float32
+
+    def test_normalisation_uses_imagenet_stats(self) -> None:
+        """A mid-gray (128) image should land near zero on all channels after normalisation."""
+        gray = np.full((64, 64, 3), 128, dtype=np.uint8)
+        pil = PILImage.fromarray(gray, mode="RGB")
+        tf = _preprocess_image(pil, (32, 32), channels=3)
+        # 128/255 ~= 0.502; expected normalised values per channel:
+        #   (0.502 - 0.485) / 0.229 ~=  0.074
+        #   (0.502 - 0.456) / 0.224 ~=  0.205
+        #   (0.502 - 0.406) / 0.225 ~=  0.426
+        expected = np.array([(128 / 255.0 - IMAGENET_MEAN[c]) / IMAGENET_STD[c] for c in range(3)], dtype=np.float32)
+        per_channel_mean = tf[0].mean(axis=(0, 1))
+        np.testing.assert_allclose(per_channel_mean, expected, atol=1e-3)
+
+    def test_torch_free_fallback_still_close(self) -> None:
+        """Simulate the torch-free environment by masking torch imports; assert the PIL fallback still stays within the
+        looser MAX_ABS_DIFF_BOUND.
+
+        This documents the gap users on edge deployments without torch installed will see (versus the bit-exact
+        torchvision path).
+        """
+        from unittest import mock
+
+        pil = _make_synthetic_rgb(seed=11, size=(720, 1280))
+        tgt = (384, 384)
+        pt = _pytorch_preprocess(pil, tgt)
+
+        # Hide torch from _preprocess_image's lazy import, forcing the PIL fallback.
+        with mock.patch.dict(sys.modules, {"torch": None}):
+            tf = _tflite_preprocess_to_nchw(pil, tgt)
+
+        max_diff = float(np.abs(pt - tf).max())
+        assert max_diff < MAX_ABS_DIFF_BOUND, (
+            f"Torch-free PIL fallback diverged: max|diff|={max_diff:.4f} > {MAX_ABS_DIFF_BOUND}. "
+            "The fallback uses PIL.BILINEAR which should keep diff ~0.016; a regression to "
+            "BICUBIC would push it ~30x larger."
+        )
+
+
+class TestPreprocessingFilterRegression:
+    """Direct comparison of BILINEAR vs BICUBIC.
+
+    Asserts the current code stays on BILINEAR by showing BICUBIC would produce a much larger divergence.
+    """
+
+    def test_bicubic_would_be_much_worse(self) -> None:
+        """If a future change reverts to BICUBIC default, this confirms how much worse it gets."""
+        pil = _make_synthetic_rgb(seed=42, size=(720, 1280))
+        tgt = (384, 384)
+
+        pt = _pytorch_preprocess(pil, tgt)
+        tf_current = _tflite_preprocess_to_nchw(pil, tgt)
+
+        # Simulate the regression: PIL default (BICUBIC since 9.1.0).
+        mean = np.array(IMAGENET_MEAN, dtype=np.float32)
+        std = np.array(IMAGENET_STD, dtype=np.float32)
+        height, width = tgt
+        arr_bicubic = np.array(pil.convert("RGB").resize((width, height)), dtype=np.float32) / 255.0
+        tf_bicubic = ((arr_bicubic - mean) / std)[np.newaxis].transpose(0, 3, 1, 2)
+
+        max_diff_current = float(np.abs(pt - tf_current).max())
+        max_diff_bicubic = float(np.abs(pt - tf_bicubic).max())
+
+        # The BILINEAR fix must be at least 5x closer to PyTorch than the BICUBIC regression.
+        # In practice it's ~30x closer; the 5x floor is forgiving of pillow / numpy drift.
+        assert max_diff_current * 5 < max_diff_bicubic, (
+            f"_preprocess_image is too close to BICUBIC behaviour: "
+            f"current max|diff|={max_diff_current:.4f}, BICUBIC max|diff|={max_diff_bicubic:.4f}. "
+            f"Check that _PIL_BILINEAR is being passed to .resize()."
+        )


### PR DESCRIPTION
## What does this PR do?

The TFLite inference helper produced inputs the PyTorch graph never saw, and decoded masks with a different half-pixel convention than `PostProcess.forward`. After this change, FP32 TFLite is bit-exact to PyTorch for both object detection and segmentation. FP16 and dynamic-range int8 are within IoU 0.965 at production thresholds with zero class mismatches.

The conversion graph itself was never broken: a same-input probe shows boxes/logits `max|diff| <= 0.0001` between PyTorch and the existing FP32 `.tflite`. Everything we were seeing came from the inference-side pre/post-processing being slightly off from the training-time pipeline.

### Changes
Two helpers added to `inference.py` to fix where the TFLite predict path diverges from PyTorch's.

`_preprocess_image` (extracted from `_run_inference`). The old code called `PIL.Image.resize` with no filter argument. PIL's default has been BICUBIC since Pillow 9.1, but `RFDETR.predict` resizes with BILINEAR via `torchvision.transforms.functional.resize`. Same image, different input tensor, model sees something it wasn't trained on. The new helper uses `torchvision.transforms.functional` (`to_tensor → resize → normalize`) when torch is importable for byte-for-byte parity, and falls back to `PIL.Image.resize` with explicit BILINEAR for torch-free deployments (still close to PyTorch, ~0.016 max residual).

`_decode_masks` (rewritten) + `_bilinear_resize_half_pixel` (new fallback). The old `_decode_masks` did `PIL.Image.fromarray(..., "F").resize(..., BILINEAR)` per mask. PIL's BILINEAR uses a corner-aligned half-pixel convention; PyTorch's `F.interpolate(..., mode="bilinear", align_corners=False)` (what `PostProcess.forward` calls) uses centered half-pixel. The shift is sub-pixel, but on thin or border-hugging masks it flipped enough pixels to drop mask IoU to ~0.5 even when the source logits matched. The rewrite calls `torch.nn.functional.interpolate` directly when torch is importable, and falls back to `_bilinear_resize_half_pixel` — a vectorised numpy implementation of centered half-pixel bilinear — when it isn't.


### Before vs after (apples-to-apples at threshold 0.3)

Object detection (RFDETRNano on dog/people-walking/bus/zidane, 43 detections total):

| Mode     | Metric           | Before    | After     | Note                                     |
| -------- | ---------------- | --------- | --------- | ---------------------------------------- |
| FP32     | IoU_worst        | 0.640     | **1.000** | the dog image was the regression source  |
| FP32     | conf_max_diff    | 0.129     | **0.000** |                                          |
| FP32     | class_mismatches | 1         | **0**     |                                          |
| FP16     | IoU_worst        | **0.406** | 0.996     | the IoU_worst FP16 disaster              |
| FP16     | conf_max_diff    | 0.167     | 0.012     |                                          |
| FP16     | class_mismatches | 2         | 0         |                                          |
| dyn_int8 | IoU_mean         | 0.979     | 0.99      | small lift; int8 was already weight-only |



Related to #1024

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->
- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change
