### PR TITLE
fix(transformer): guard enc keypoint embed loop with `self.training`

### DIFF
--- a/docs/cookbooks/fine-tune_keypoints.ipynb
+++ b/docs/cookbooks/fine-tune_keypoints.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "faa5686c",
+   "id": "6d361242",
    "metadata": {},
    "source": [
     "# RF-DETR keypoint training demo on multiple Roboflow Universe datasets\n",
@@ -14,32 +14,30 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4fb73557",
+   "id": "ca1b5461",
    "metadata": {},
    "source": [
     "## Setup\n",
     "\n",
-    "Run this setup cell from the checked-out repository root before importing `rfdetr`. If an older installed `rfdetr` package was already imported, restart the runtime after this cell.\n",
-    "\n",
-    "Installing from source with `pip install -e \".[train,visual]\"` gives you the exact code you see in the repository rather than a potentially older PyPI release. The `train` extra pulls in the training loop dependencies (PyTorch Lightning, COCO evaluation tools, and data augmentation libraries), while `visual` adds the visualisation helpers used later in the notebook. The `roboflow` package handles dataset download; `pandas` and `seaborn` are needed for the metrics table and optional plot styling. If you hit an `ImportError` after running this cell, the most likely cause is a stale in-memory import — restart the Python runtime once and re-run from the top."
+    "Install `rfdetr` with the `train` and `visual` extras. The `train` extra pulls in the training loop dependencies (PyTorch Lightning, COCO evaluation tools, and data augmentation libraries), while `visual` adds the visualisation helpers used later in the notebook. The `roboflow` package handles dataset download; `pandas` and `seaborn` are needed for the metrics table and optional plot styling. If you hit an `ImportError` after running this cell, the most likely cause is a stale in-memory import — restart the Python runtime once and re-run from the top."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f7ea56d7a98aea36",
+   "id": "d89771c9",
    "metadata": {
     "title": "[bash]"
    },
    "outputs": [],
    "source": [
-    "!pip install -q \".[train,visual]\" roboflow pandas seaborn"
+    "!pip install -q \"rfdetr[train,visual]\" roboflow pandas seaborn"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5964c1295fbe27ce",
+   "id": "0b7de4e2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,7 +71,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8a5759eb",
+   "id": "3d1ca469",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -174,7 +172,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd0d4604",
+   "id": "b7920201",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -187,7 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3606868c",
+   "id": "08de3f94",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -209,7 +207,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fcc9561c",
+   "id": "b2109a1e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -222,7 +220,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68c741ec",
+   "id": "2f59cc9e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -260,7 +258,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6febe5dd",
+   "id": "3111b71a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -273,7 +271,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29686813",
+   "id": "4c9b5a6b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -301,7 +299,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9d524c2",
+   "id": "e0bd03c1",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -312,7 +310,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3e340c7d",
+   "id": "f516409d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -343,7 +341,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8bc88b23",
+   "id": "80f4317b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -354,7 +352,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77458c24",
+   "id": "80f50cd8",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -375,7 +373,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a8128e7",
+   "id": "51734ce1",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -386,7 +384,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "354dbef6",
+   "id": "2e548c8c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -414,7 +412,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4801d8c8",
+   "id": "757c151a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -425,7 +423,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4aa3f873",
+   "id": "105aefc9",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -456,7 +454,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6049319",
+   "id": "fe060e29",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -469,7 +467,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3eb9aa14",
+   "id": "4cdfa696",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -529,7 +527,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6485a3ca",
+   "id": "df126db6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -542,7 +540,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "be85e121",
+   "id": "76be07a3",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -560,7 +558,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "762acc31",
+   "id": "71d28853",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -573,7 +571,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6236f709",
+   "id": "e1e72b80",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -585,7 +583,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a0816a1",
+   "id": "5a052495",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -598,7 +596,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c3c921cb",
+   "id": "1482fa79",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -610,7 +608,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f87253a7",
+   "id": "7aa26516",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -625,7 +623,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4f5a7717",
+   "id": "0aa1a943",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -649,7 +647,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35bd8879",
+   "id": "37589b33",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -662,7 +660,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5d0fcc26",
+   "id": "a5608045",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -675,7 +673,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e778f49b",
+   "id": "690a200a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -688,7 +686,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "305b07ab",
+   "id": "c8d75b0f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -701,7 +699,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7e6a41e9",
+   "id": "7bee8d28",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -712,7 +710,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e75598c8",
+   "id": "a5182f47",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -725,7 +723,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ce59867f",
+   "id": "1c7654a9",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -754,7 +752,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2175b026",
+   "id": "e520b84c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -767,7 +765,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d718efc9",
+   "id": "005f3543",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/src/rfdetr/models/backbone/dinov2_with_windowed_attn.py
+++ b/src/rfdetr/models/backbone/dinov2_with_windowed_attn.py
@@ -1013,7 +1013,7 @@ class WindowedDinov2WithRegistersModel(WindowedDinov2WithRegistersPreTrainedMode
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
         )
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+        return_dict = return_dict if return_dict is not None else self.config.return_dict
 
         if pixel_values is None:
             raise ValueError("You have to specify pixel_values")
@@ -1124,7 +1124,7 @@ class WindowedDinov2WithRegistersForImageClassification(WindowedDinov2WithRegist
         >>> list(outputs.logits.shape)
         [1, 3]
         """
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+        return_dict = return_dict if return_dict is not None else self.config.return_dict
 
         outputs = self.dinov2_with_registers(
             pixel_values,
@@ -1238,7 +1238,7 @@ class WindowedDinov2WithRegistersBackbone(WindowedDinov2WithRegistersPreTrainedM
         [1, 32, 2, 2]
 
         """
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+        return_dict = return_dict if return_dict is not None else self.config.return_dict
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
         )

--- a/src/rfdetr/models/transformer.py
+++ b/src/rfdetr/models/transformer.py
@@ -375,7 +375,7 @@ class Transformer(nn.Module):
             batch_size, _, _ = memory_ts.shape
             keypoint_memory_ts = self.keypoint_query_initializer_enc(memory_ts)
             boxes_ref = boxes_ts if self.bbox_reparam else boxes_ts.sigmoid()
-            group_detr = len(self.enc_out_keypoint_embed)
+            group_detr = len(self.enc_out_keypoint_embed) if self.training else 1
 
             kp_mem_chunks = keypoint_memory_ts.chunk(group_detr, dim=1)
             boxes_chunks = boxes_ref.chunk(group_detr, dim=1)

--- a/tests/models/test_transformer_keypoints.py
+++ b/tests/models/test_transformer_keypoints.py
@@ -178,8 +178,8 @@ def test_enc_keypoint_embed_eval_uses_only_head_zero() -> None:
     sentinel = 50.0
 
     srcs, masks, pos_embeds, _, _ = _build_transformer_inputs(batch_size=batch_size, hidden_dim=hidden_dim)
-    refpoint_embed = torch.rand(num_queries * group_detr, 4)
-    query_feat = torch.randn(num_queries * group_detr, hidden_dim)
+    refpoint_embed = torch.rand(num_queries, 4)
+    query_feat = torch.randn(num_queries, hidden_dim)
 
     transformer = Transformer(
         d_model=hidden_dim,
@@ -201,7 +201,7 @@ def test_enc_keypoint_embed_eval_uses_only_head_zero() -> None:
 
     # Zero all keypoint head weights and biases; give head 0 a distinctive output.
     with torch.no_grad():
-        for g_idx, head in enumerate(transformer.enc_out_keypoint_embed):
+        for _, head in enumerate(transformer.enc_out_keypoint_embed):
             for layer in head.layers:
                 layer.weight.zero_()
                 layer.bias.zero_()
@@ -218,7 +218,7 @@ def test_enc_keypoint_embed_eval_uses_only_head_zero() -> None:
     kp_beyond_xy = enc_kp_predictions[..., 2:]
     assert (kp_beyond_xy == sentinel).all(), (
         f"Eval mode must route all {num_queries} queries through head 0 (bias={sentinel}). "
-        f"Got min={kp_beyond_xy.min():.2f}, max={kp_beyond_xy.max():.2f}. "
+        f"Got min={kp_beyond_xy.min().item():.2f}, max={kp_beyond_xy.max().item():.2f}. "
         "Bug: group_detr not guarded by self.training in enc_out_keypoint_embed loop."
     )
 

--- a/tests/models/test_transformer_keypoints.py
+++ b/tests/models/test_transformer_keypoints.py
@@ -157,6 +157,72 @@ def test_keypoint_class_mask_person_only() -> None:
     assert not decoder.keypoint_class_mask.any()
 
 
+def test_enc_keypoint_embed_eval_uses_only_head_zero() -> None:
+    """Encoder keypoint path must use a single head (head 0) in eval mode.
+
+    Regression: ``group_detr = len(self.enc_out_keypoint_embed)`` without a
+    ``self.training`` guard caused eval mode to split ``num_queries`` across all
+    group heads instead of routing every query through head 0. Fix:
+    ``group_detr = len(...) if self.training else 1``.
+
+    Strategy: zero all head weights/biases; set head-0 last-layer bias to
+    ``sentinel``. In eval mode every query routes through head 0, so
+    ``kp_pred[..., 2:]`` (the pure-delta dims unaffected by ref_xy/wh) must all
+    equal ``sentinel``. In training mode only the first 1/group_detr queries go
+    through head 0 (the rest equal 0.0).
+    """
+    group_detr = 3
+    num_queries = 6  # divisible by group_detr
+    hidden_dim = 16
+    batch_size = 1
+    sentinel = 50.0
+
+    srcs, masks, pos_embeds, _, _ = _build_transformer_inputs(batch_size=batch_size, hidden_dim=hidden_dim)
+    refpoint_embed = torch.rand(num_queries * group_detr, 4)
+    query_feat = torch.randn(num_queries * group_detr, hidden_dim)
+
+    transformer = Transformer(
+        d_model=hidden_dim,
+        num_queries=num_queries,
+        num_decoder_layers=1,
+        sa_nhead=4,
+        ca_nhead=4,
+        num_feature_levels=2,
+        dec_n_points=1,
+        return_intermediate_dec=True,
+        lite_refpoint_refine=True,
+        two_stage=True,
+        group_detr=group_detr,
+        use_grouppose_keypoints=True,
+        num_keypoints_per_class=[2],
+    )
+    transformer.enc_out_class_embed = nn.ModuleList([nn.Linear(hidden_dim, 2) for _ in range(group_detr)])
+    transformer.enc_out_bbox_embed = nn.ModuleList([nn.Linear(hidden_dim, 4) for _ in range(group_detr)])
+
+    # Zero all keypoint head weights and biases; give head 0 a distinctive output.
+    with torch.no_grad():
+        for g_idx, head in enumerate(transformer.enc_out_keypoint_embed):
+            for layer in head.layers:
+                layer.weight.zero_()
+                layer.bias.zero_()
+        transformer.enc_out_keypoint_embed[0].layers[-1].bias.fill_(sentinel)
+
+    transformer.eval()
+    with torch.no_grad():
+        outputs = transformer(srcs, masks, pos_embeds, refpoint_embed, query_feat, cross_attn_srcs=None)
+
+    _, _, _, _, _, enc_kp_predictions, _ = outputs
+    assert enc_kp_predictions is not None, "enc_kp_predictions should not be None in keypoint mode"
+
+    # kp_pred = [kp_xy(2 dims), kp_delta[2:]]; dims 2: are pure MLP output unaffected by ref_xy/wh.
+    kp_beyond_xy = enc_kp_predictions[..., 2:]
+    assert (kp_beyond_xy == sentinel).all(), (
+        f"Eval mode must route all {num_queries} queries through head 0 (bias={sentinel}). "
+        f"Got min={kp_beyond_xy.min():.2f}, max={kp_beyond_xy.max():.2f}. "
+        "Bug: group_detr not guarded by self.training in enc_out_keypoint_embed loop."
+    )
+
+
 def test_cross_attn_srcs_none_backward_compat() -> None:
     """`cross_attn_srcs=None` must remain equivalent to passing the primary feature stream."""
     srcs, masks, pos_embeds, refpoint_embed, query_feat = _build_transformer_inputs()


### PR DESCRIPTION
In eval mode, `group_detr = len(self.enc_out_keypoint_embed)` caused the encoder keypoint path to split `num_queries` queries across all group heads instead of routing them through head 0. Fix adds the same `if self.training else 1` guard already present at line 329 and 416.

- transformer.py: `group_detr = len(...) if self.training else 1`
- dinov2_with_windowed_attn.py: replace deprecated `config.use_return_dict` with `config.return_dict` (3 sites)
- test_transformer_keypoints.py: regression test verifying all eval queries route through head 0
