### PR TITLE
fix: fixed python version mismatch dependency overrides for packages …

### DIFF
--- a/.github/workflows/ci-deps-resolution.yml
+++ b/.github/workflows/ci-deps-resolution.yml
@@ -1,0 +1,51 @@
+name: Dependency resolution
+
+on:
+  push:
+    branches: ["main", "release/*", "develop", "feat/*"]
+    paths: ["pyproject.toml"]
+  pull_request:
+    paths: ["pyproject.toml"]
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: deps-resolution-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  tflite-resolution:
+    name: Resolve [tflite] extra — Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        # tflite deps carry python_version>='3.12' markers; tensorflow has no 3.13 wheels yet.
+        # Extend matrix when tensorflow adds 3.13 support.
+        python-version: ["3.12"]
+    steps:
+      - name: 📥 Checkout the repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: 🐍 Install uv and set Python version ${{ matrix.python-version }}
+        uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: 🔍 Resolve [tflite] optional dependencies
+        run: |
+          uv pip compile pyproject.toml \
+            --extra tflite \
+            --python-version ${{ matrix.python-version }} \
+            --no-header \
+            --quiet
+
+      - name: Minimize uv cache
+        continue-on-error: true
+        run: uv cache prune --ci

--- a/.github/workflows/ci-deps-resolution.yml
+++ b/.github/workflows/ci-deps-resolution.yml
@@ -2,7 +2,7 @@ name: Dependency resolution
 
 on:
   push:
-    branches: ["main", "release/*", "develop", "feat/*"]
+    branches: ["main", "release/*", "develop"]
     paths: ["pyproject.toml"]
   pull_request:
     paths: ["pyproject.toml"]

--- a/.github/workflows/ci-deps-resolution.yml
+++ b/.github/workflows/ci-deps-resolution.yml
@@ -2,7 +2,7 @@ name: Dependency resolution
 
 on:
   push:
-    branches: ["main", "release/*", "develop", "feat/*"]
+    branches: ["main", "release/*", "develop"]
     paths: ["pyproject.toml"]
   pull_request:
     paths: ["pyproject.toml"]
@@ -26,8 +26,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # tflite deps carry python_version>='3.12' markers; tensorflow has no 3.13 wheels yet.
-        # Extend matrix when tensorflow adds 3.13 support.
+        # tflite deps carry python_version>='3.12' and <'3.13' markers; tensorflow has no 3.13 wheels yet.
+        # Extend matrix and relax upper bound when tensorflow adds 3.13 support.
         python-version: ["3.12"]
     steps:
       - name: 📥 Checkout the repository

--- a/.github/workflows/ci-deps-resolution.yml
+++ b/.github/workflows/ci-deps-resolution.yml
@@ -26,8 +26,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # tflite deps carry python_version>='3.12' and <'3.13' markers; tensorflow has no 3.13 wheels yet.
-        # Extend matrix and relax upper bound when tensorflow adds 3.13 support.
+        # tflite deps carry python_version>='3.12' and <'3.13' markers; onnx2tf pins numpy==1.26.4
+        # exactly, which conflicts with ml-dtypes>=0.5.1 requiring numpy>=2.1.0 on 3.13.
+        # Add 3.13 and relax the <'3.13' upper bound when onnx2tf drops the exact numpy pin.
         python-version: ["3.12"]
     steps:
       - name: 📥 Checkout the repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,11 +75,11 @@ trt = [
     "polygraphy",
 ]
 tflite = [
-    "onnx2tf>=2.4.0,<3.0.0; python_version >= '3.12'",
-    "flatbuffers>=23.5.26; python_version >= '3.12'",
-    "onnx>=1.20.0,<2.0; python_version >= '3.12'",
-    "tf-keras>=2.16.0; python_version >= '3.12'",
-    "tensorflow>=2.16.0; python_version >= '3.12'",
+    "onnx2tf>=2.4.0,<3.0.0; python_version >= '3.12' and python_version < '3.13'",
+    "flatbuffers>=23.5.26; python_version >= '3.12' and python_version < '3.13'",
+    "onnx>=1.20.0,<2.0; python_version >= '3.12' and python_version < '3.13'",
+    "tf-keras>=2.16.0; python_version >= '3.12' and python_version < '3.13'",
+    "tensorflow>=2.16.0; python_version >= '3.12' and python_version < '3.13'",
 ]
 kornia = [
     "kornia>=0.7,<1",              # GPU-side augmentation via on_after_batch_transfer
@@ -152,9 +152,9 @@ rfdetr = "rfdetr.cli:main"
 [tool.uv]
 # onnx2tf 2.4.0 pins ml-dtypes==0.5.1 unconditionally, but ml-dtypes 0.5.1 requires
 # numpy>=2.1.0 on Python 3.13 while onnx2tf also pins numpy==1.26.4 — contradiction.
-# tflite deps carry python_version>='3.12' markers (onnx2tf requires-python>=3.12), so
-# uv's universal resolver only considers them for 3.12; override ml-dtypes to the same
-# window so the 3.12/3.13 numpy conflict doesn't surface.
+# tflite deps carry python_version>='3.12' and <'3.13' markers (onnx2tf requires-python>=3.12;
+# tensorflow has no 3.13 wheels yet), so uv's universal resolver only considers them for 3.12.*;
+# override ml-dtypes to the same window so the 3.12/3.13 numpy conflict doesn't surface.
 override-dependencies = [
     "ml-dtypes==0.5.1; python_version >= '3.12' and python_version < '3.13'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,11 +150,11 @@ Homepage = "https://github.com/roboflow/rf-detr"
 rfdetr = "rfdetr.cli:main"
 
 [tool.uv]
-# onnx2tf 2.4.0 pins ml-dtypes==0.5.1 unconditionally, but ml-dtypes 0.5.1 requires
-# numpy>=2.1.0 on Python 3.13 while onnx2tf also pins numpy==1.26.4 — contradiction.
-# tflite deps carry python_version>='3.12' and <'3.13' markers (onnx2tf requires-python>=3.12;
-# tensorflow has no 3.13 wheels yet), so uv's universal resolver only considers them for 3.12.*;
-# override ml-dtypes to the same window so the 3.12/3.13 numpy conflict doesn't surface.
+# onnx2tf>=2.4.0 pins numpy==1.26.4 (exact). Its dependency ml-dtypes==0.5.1 in turn requires
+# numpy>=2.1.0 on python_full_version>='3.13' — contradicting the numpy==1.26.4 pin on 3.13.
+# tflite deps carry python_version>='3.12' and <'3.13' markers because onnx2tf's numpy pin
+# cannot be satisfied on 3.13 via any available release; when onnx2tf relaxes the exact pin,
+# remove the <'3.13' upper bound from the tflite deps AND from the override below.
 override-dependencies = [
     "ml-dtypes==0.5.1; python_version >= '3.12' and python_version < '3.13'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,10 @@ rfdetr = "rfdetr.cli:main"
 override-dependencies = [
     "ml-dtypes==0.5.1; python_version >= '3.12' and python_version < '3.13'",
 ]
+environments = [
+    "python_version >= '3.12'",
+]
+
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,11 +75,11 @@ trt = [
     "polygraphy",
 ]
 tflite = [
-    "onnx2tf>=2.4.0,<3.0.0",
-    "flatbuffers>=23.5.26",
-    "onnx>=1.20.0,<2.0",
-    "tf-keras>=2.16.0",
-    "tensorflow>=2.16.0",
+    "onnx2tf>=2.4.0,<3.0.0; python_version >= '3.12'",
+    "flatbuffers>=23.5.26; python_version >= '3.12'",
+    "onnx>=1.20.0,<2.0; python_version >= '3.12'",
+    "tf-keras>=2.16.0; python_version >= '3.12'",
+    "tensorflow>=2.16.0; python_version >= '3.12'",
 ]
 kornia = [
     "kornia>=0.7,<1",              # GPU-side augmentation via on_after_batch_transfer
@@ -152,14 +152,11 @@ rfdetr = "rfdetr.cli:main"
 [tool.uv]
 # onnx2tf 2.4.0 pins ml-dtypes==0.5.1 unconditionally, but ml-dtypes 0.5.1 requires
 # numpy>=2.1.0 on Python 3.13 while onnx2tf also pins numpy==1.26.4 — contradiction.
-# The entire [tflite] extra is gated to python_version>='3.12', and onnx2tf 2.4.0 requires
-# Python>=3.12 and <3.13 (tensorflow constraint); override ml-dtypes to the same window
-# so uv's universal resolver doesn't see the conflict on Python 3.13+.
+# tflite deps carry python_version>='3.12' markers (onnx2tf requires-python>=3.12), so
+# uv's universal resolver only considers them for 3.12; override ml-dtypes to the same
+# window so the 3.12/3.13 numpy conflict doesn't surface.
 override-dependencies = [
     "ml-dtypes==0.5.1; python_version >= '3.12' and python_version < '3.13'",
-]
-environments = [
-    "python_version >= '3.12'",
 ]
 
 


### PR DESCRIPTION
…depending on >=3.13 like numpy

## What does this PR do?

<!-- Provide a clear and concise description of the changes -->

```
❯ uv sync
  × No solution found when resolving dependencies for split (markers: python_full_version >= '3.13'):
  ╰─▶ Because ml-dtypes==0.5.1 depends on numpy{python_full_version >= '3.13'}>=2.1.0 and onnx==1.20.1 depends on ml-dtypes{python_full_version == '3.12.*'}==0.5.1, we can conclude that onnx==1.20.1 depends on numpy>=2.1.0.
      And because onnx2tf>=2.4.0 depends on numpy==1.26.4, we can conclude that onnx==1.20.1 and onnx2tf>=2.4.0 are incompatible.
      And because onnx2tf>=2.4.0 depends on onnx==1.20.1 and only the following versions of onnx2tf are available:
          onnx2tf<=2.4.0
          onnx2tf==2.4.1
          onnx2tf==2.4.2
      we can conclude that onnx2tf>=2.4.0 cannot be used.
      And because rfdetr[tflite] depends on onnx2tf>=2.4.0 and your project requires rfdetr[tflite], we can conclude that your project's requirements are unsatisfiable.

      hint: While the active Python version is 3.12, the resolution failed for other Python versions supported by your project. Consider limiting your project's supported Python versions using `requires-python`.
```

fixing this conundrum

**Related Issue(s):** <!-- Link to related issues, e.g., Fixes #123 or Related to #456 -->

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
