### PR TITLE
releasing `1.8.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.1] — 2026-06-19
+
+### Changed
+
+- Config path parameters (e.g. `dataset_dir`, `output_dir`, `pretrain_weights`) now accept `pathlib.Path` objects in addition to strings. Paths are coerced to `str` automatically via the `expand_paths` validator. No API changes required; existing string usage unaffected. ([#1124](https://github.com/roboflow/rf-detr/pull/1124))
+- Keypoint training now disables horizontal flip augmentation until keypoint flip-pair swapping is implemented. Previously, flipping was applied without reordering keypoint pairs, producing incorrect labels. ([#1122](https://github.com/roboflow/rf-detr/pull/1122))
+- Training metric plots improved with optional seaborn error bands, AP@0.75 metric grouping, and custom AP metric group configuration. ([#1122](https://github.com/roboflow/rf-detr/pull/1122))
+
+### Fixed
+
+- Keypoint encoder in eval mode now routes all queries through head 0 instead of splitting across group heads. Previously, `group_detr = len(self.enc_out_keypoint_embed)` caused the encoder keypoint path to split `num_queries` queries across all group heads in eval; now uses `if self.training else 1` guard. ([#1135](https://github.com/roboflow/rf-detr/pull/1135))
+- `config.use_return_dict` (deprecated in `transformers`) replaced with `config.return_dict` in DINOv2 windowed attention backbone. ([#1135](https://github.com/roboflow/rf-detr/pull/1135))
+- Epoch metric tables now display correctly when a Rich progress bar callback is active. Tables are printed through the progress bar's owned Rich console, preventing cursor conflicts with active live displays. ([#1128](https://github.com/roboflow/rf-detr/pull/1128))
+- Keypoint fine-tuning checkpoint selection stabilised with smoothed (EMA) best-metric comparison to avoid spurious checkpoint switches on noisy OKS metrics. Smoothing state is correctly restored on training resume. ([#1122](https://github.com/roboflow/rf-detr/pull/1122))
+- Group DETR train-time metric evaluation now evaluates only the primary query group, preventing crashes on non-tensor mask outputs from auxiliary decoder layers. ([#1122](https://github.com/roboflow/rf-detr/pull/1122))
+- `_detect_horizontal_flip` in Albumentations transform pipeline now uses `len(bboxes) == 0` instead of `not bboxes` to correctly handle Albumentations 2.x where bboxes is a NumPy array (falsy even when non-empty). ([#1126](https://github.com/roboflow/rf-detr/pull/1126))
+- TensorBoard logger is now disabled gracefully when `tensorboard` is installed alongside a NumPy-2.0-incompatible `tensorflow`. Training degrades to CSV-only logging with a clear warning instead of crashing inside `_log_hyperparams`. ([#1123](https://github.com/roboflow/rf-detr/pull/1123))
+
+---
+
 ## [1.8.0] — 2026-06-13
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rfdetr"
-version = "1.8.0"
+version = "1.8.1"
 description = "RF-DETR"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
# RF-DETR v1.8.1: Compatibility and Stability Fixes

## 📋 Summary

RF-DETR 1.8.1 is a patch release with seven bug fixes and three quality-of-life improvements. The highlights: two compatibility crashes are fixed — one hitting environments that have `tensorflow` alongside NumPy 2.0, another hitting Albumentations 2.x users — and per-epoch metric tables show up again during training instead of being hidden behind the progress bar. No breaking changes, and nothing to migrate from v1.8.0.

## ✨ Spotlights

### Training no longer crashes with TensorBoard on NumPy 2.0

If you had `tensorflow` installed alongside NumPy 2.0, training could crash partway through with an opaque `AttributeError`. RF-DETR now checks whether TensorBoard logging is usable before training starts; if it isn't, training continues with CSV logging and a clear warning instead of stopping.

```python
# Before: training crashes with
# AttributeError: module 'numpy' has no attribute 'float_'
model.train(dataset_dir="my-dataset", epochs=100)

# After: training proceeds, with a warning if TensorBoard is unavailable
# WARNING: TensorBoard disabled (NumPy 2.x / tensorflow incompatibility). Falling back to CSV logging.
model.train(dataset_dir="my-dataset", epochs=100)
```

### Albumentations 2.x no longer crashes during training

Training with Albumentations 2.x could fail with an "ambiguous truth value" error coming from RF-DETR's flip handling. That path now works correctly across both Albumentations 1.x and 2.x.

```python
# Before: training crashes with albumentations >= 2.0
# ValueError: The truth value of an array is ambiguous

# After: training proceeds correctly
model.train(dataset_dir="my-dataset", epochs=50)
```

### Config path parameters accept `pathlib.Path`

You can now pass `pathlib.Path` objects directly to path parameters like `dataset_dir` and `output_dir` — no need to convert to strings first.

```python
from pathlib import Path
from rfdetr import RFDETRSmall

model = RFDETRSmall()
model.train(
    dataset_dir=Path("~/datasets/my-coco").expanduser(),
    output_dir=Path("/tmp/training"),
    epochs=50,
)
```

## 🗒️ Notable changes

### 🌱 Changed

- **`pathlib.Path` accepted for path parameters** — path fields on `TrainConfig` and related config classes now accept `pathlib.Path` objects directly. ([#1124](https://github.com/roboflow/rf-detr/pull/1124))
- **Horizontal flip disabled for keypoint training** — flip augmentation is turned off for keypoint training for now, since it could produce incorrect labels without keypoint flip-pair reordering. ([#1122](https://github.com/roboflow/rf-detr/pull/1122))
- **Training metric plots** — improved plotting with optional error bands, AP@0.75 grouping, and configurable AP metric groups. ([#1122](https://github.com/roboflow/rf-detr/pull/1122))

### 🔧 Fixed

- **TensorBoard + NumPy 2.0 crash** — training falls back to CSV logging with a warning instead of crashing when TensorBoard can't be imported. ([#1123](https://github.com/roboflow/rf-detr/pull/1123))
- **Albumentations 2.x compatibility** — fixed a crash in horizontal-flip detection when using Albumentations 2.x. ([#1126](https://github.com/roboflow/rf-detr/pull/1126))
- **Metric tables hidden by the progress bar** — per-epoch metric tables now render correctly alongside the live training progress bar. ([#1128](https://github.com/roboflow/rf-detr/pull/1128))
- **Keypoint checkpoint selection** — best-checkpoint selection for keypoint models is now smoothed, avoiding spurious switches on noisy OKS metrics; smoothing also survives a training resume. ([#1122](https://github.com/roboflow/rf-detr/pull/1122))
- **Keypoint encoder evaluation** — fixed query routing in eval mode so keypoint predictions are computed correctly. ([#1135](https://github.com/roboflow/rf-detr/pull/1135))
- **Group DETR train-time evaluation** — fixed a crash during train-time evaluation in Group DETR mode. ([#1122](https://github.com/roboflow/rf-detr/pull/1122))
- **DINOv2 backbone config compatibility** — internal call sites updated from deprecated `config.use_return_dict` to `config.return_dict`. ([#1135](https://github.com/roboflow/rf-detr/pull/1135))

---

## Migration guide

No migration required for this release. All changes are bug fixes and backward-compatible improvements. Upgrade with:

```bash
pip install -U rfdetr
```

---

## 🏆 Contributors

Thanks to everyone who contributed to this release:

- **Jirka Borovec** ([@Borda](https://github.com/Borda), [LinkedIn](https://www.linkedin.com/in/jirka-borovec/)) — keypoint encoder fix, metric table display, training stability, TensorBoard compatibility
- **Juan Pablo Oberhauser** ([@jpoberhauser](https://github.com/jpoberhauser), [LinkedIn](https://www.linkedin.com/in/jp-oberhauser/)) — Albumentations 2.x compatibility
- **Brian Cong** ([@congbrian](https://github.com/congbrian)) — `pathlib.Path` config support
- **Stefan Schneider** ([@hinogi](https://github.com/hinogi)) — type hint modernisation

---

**Full changelog**: https://github.com/roboflow/rf-detr/compare/1.8.0...v1.8.1
