### PR TITLE
Fix: Slice Rank-4 reference-points before inserting broadcast axes.

### DIFF
--- a/src/rfdetr/models/ops/modules/ms_deform_attn.py
+++ b/src/rfdetr/models/ops/modules/ms_deform_attn.py
@@ -150,9 +150,11 @@ class MSDeformAttn(nn.Module):
                 + sampling_offsets / offset_normalizer[None, None, None, :, None, :]
             )
         elif reference_points.shape[-1] == 4:
+            reference_points_xy = reference_points[..., :2]
+            reference_points_wh = reference_points[..., 2:]
             sampling_locations = (
-                reference_points[:, :, None, :, None, :2]
-                + sampling_offsets / self.n_points * reference_points[:, :, None, :, None, 2:] * 0.5
+                reference_points_xy[:, :, None, :, None, :]
+                + sampling_offsets / self.n_points * reference_points_wh[:, :, None, :, None, :] * 0.5
             )
         else:
             raise ValueError(

--- a/src/rfdetr/models/ops/modules/ms_deform_attn.py
+++ b/src/rfdetr/models/ops/modules/ms_deform_attn.py
@@ -150,6 +150,13 @@ class MSDeformAttn(nn.Module):
                 + sampling_offsets / offset_normalizer[None, None, None, :, None, :]
             )
         elif reference_points.shape[-1] == 4:
+            # Slice the rank-4 reference_points BEFORE inserting the broadcast
+            # (None) axes.  Slicing the last axis of the rank-6 expanded tensor
+            # (reference_points[:, :, None, :, None, :2]) emits a rank-6
+            # StridedSlice, which exceeds TFLite's 5-D StridedSlice kernel limit
+            # and forces a Flex (FlexStridedSlice) fallback at conversion time.
+            # Narrowing at rank 4 first, then unsqueezing, is numerically
+            # identical but keeps the slice within TFLite's native op support.
             reference_points_xy = reference_points[..., :2]
             reference_points_wh = reference_points[..., 2:]
             sampling_locations = (

--- a/tests/export/test_tflite_export.py
+++ b/tests/export/test_tflite_export.py
@@ -1084,3 +1084,152 @@ class TestGridSampleOnnxRewrite:
         np.testing.assert_allclose(
             result, ref, atol=1e-5, rtol=0, err_msg="Gather(axis=0) rewrite output diverges from F.grid_sample"
         )
+
+
+# ---------------------------------------------------------------------------
+# TestMSDeformAttnSliceRank — regression guard for the rank-6 StridedSlice fix
+# ---------------------------------------------------------------------------
+
+# TFLite's StridedSlice kernel supports at most 5 dimensions.  A rank-6 Slice in
+# MSDeformAttn's reference-box path is lowered by onnx2tf to a FlexStridedSlice
+# (which needs the Select-TF/Flex delegate, absent from the standalone mobile
+# LiteRT runtime) or, on older onnx2tf, to a native rank-6 STRIDED_SLICE that the
+# mobile kernel rejects at interpreter creation.  Either way the exported model
+# fails to load on-device.  MSDeformAttn must therefore never emit a Slice on a
+# tensor of rank > 5.  See the rank-4 slicing comment in ``MSDeformAttn.forward``.
+_TFLITE_STRIDED_SLICE_MAX_RANK = 5
+
+
+def _export_msdeformattn_to_onnx(path: Path) -> None:
+    """Export a small export-mode ``MSDeformAttn`` (4-coord reference points) to ONNX.
+
+    Uses the ``reference_points.shape[-1] == 4`` (reference-box) branch — the path the
+    rank-4 slicing fix touches — and the legacy ONNX exporter (``dynamo=False`` where
+    available), matching ``rfdetr.export._onnx.exporter``.
+    """
+    import inspect
+
+    import numpy as np
+    import torch
+    from torch import nn
+
+    from rfdetr.models.ops.modules.ms_deform_attn import MSDeformAttn
+
+    class _Wrapper(nn.Module):
+        """Holds the non-tensor args as constants so export takes only tensors."""
+
+        def __init__(self, module: nn.Module, spatial: list[tuple[int, int]], level_start: torch.Tensor) -> None:
+            super().__init__()
+            self.module = module
+            self.spatial = spatial
+            self.register_buffer("spatial_shapes", torch.tensor(spatial, dtype=torch.long))
+            self.register_buffer("level_start_index", level_start)
+
+        def forward(
+            self, query: torch.Tensor, reference_points: torch.Tensor, input_flatten: torch.Tensor
+        ) -> torch.Tensor:
+            return self.module(
+                query,
+                reference_points,
+                input_flatten,
+                self.spatial_shapes,
+                self.level_start_index,
+                None,
+                self.spatial,
+            )
+
+    torch.manual_seed(0)
+    d_model, n_heads, n_levels, n_points = 32, 4, 2, 4
+    module = MSDeformAttn(d_model=d_model, n_levels=n_levels, n_heads=n_heads, n_points=n_points)
+    module.export()  # switch to the export code path (_export=True)
+    module.eval()
+
+    spatial = [(8, 8), (4, 4)]
+    sizes = [h * w for h, w in spatial]
+    level_start = torch.tensor([0, *np.cumsum(sizes)[:-1].tolist()], dtype=torch.long)
+    n, len_q = 1, 6
+    query = torch.rand(n, len_q, d_model)
+    reference_points = torch.rand(n, len_q, n_levels, 4)  # 4-coord (reference-box) path
+    input_flatten = torch.rand(n, sum(sizes), d_model)
+
+    wrapper = _Wrapper(module, spatial, level_start).eval()
+    export_kwargs: dict[str, Any] = {}
+    if "dynamo" in inspect.signature(torch.onnx.export).parameters:
+        export_kwargs["dynamo"] = False
+    with torch.no_grad():
+        torch.onnx.export(
+            wrapper,
+            (query, reference_points, input_flatten),
+            str(path),
+            input_names=["query", "reference_points", "input_flatten"],
+            output_names=["output"],
+            opset_version=17,
+            **export_kwargs,
+        )
+
+
+def _slice_nodes_exceeding_rank(onnx_path: Path, max_rank: int) -> list[tuple[str, int]]:
+    """Return ``(name, rank)`` for every Slice node whose data input exceeds *max_rank*."""
+    import onnx
+    import onnx.shape_inference
+
+    model = onnx.shape_inference.infer_shapes(onnx.load(str(onnx_path)))
+    ranks: dict[str, int] = {}
+    for vi in [*model.graph.input, *model.graph.value_info, *model.graph.output]:
+        if vi.type.tensor_type.HasField("shape"):
+            ranks[vi.name] = len(vi.type.tensor_type.shape.dim)
+    for init in model.graph.initializer:
+        ranks[init.name] = len(init.dims)
+
+    offenders: list[tuple[str, int]] = []
+    for node in model.graph.node:
+        if node.op_type in ("Slice", "StridedSlice") and node.input:
+            rank = ranks.get(node.input[0])
+            if rank is not None and rank > max_rank:
+                offenders.append((node.name or node.op_type, rank))
+    return offenders
+
+
+class TestMSDeformAttnSliceRank:
+    """Regression guard: ``MSDeformAttn`` export must not emit a rank-6 StridedSlice."""
+
+    def test_export_has_no_rank6_slice(self, tmp_path: Path) -> None:
+        """Exported MSDeformAttn must contain no Slice on a tensor of rank > 5.
+
+        Regresses if the reference-box slicing reverts to slicing the rank-6
+        broadcast-expanded tensor (``reference_points[:, :, None, :, None, :2]``),
+        which onnx2tf lowers to a FlexStridedSlice that won't load on a mobile
+        LiteRT runtime.
+        """
+        pytest.importorskip("onnx", reason="onnx not installed")
+        onnx_path = tmp_path / "msdeformattn.onnx"
+        _export_msdeformattn_to_onnx(onnx_path)
+
+        offenders = _slice_nodes_exceeding_rank(onnx_path, _TFLITE_STRIDED_SLICE_MAX_RANK)
+        assert offenders == [], (
+            f"MSDeformAttn export emitted Slice node(s) exceeding TFLite's "
+            f"{_TFLITE_STRIDED_SLICE_MAX_RANK}-D StridedSlice limit: {offenders}. "
+            "This regresses the rank-4 reference-point slicing fix and produces a "
+            "FlexStridedSlice that fails to load on a mobile LiteRT runtime."
+        )
+
+    def test_xy_wh_split_matches_rank6_slice(self) -> None:
+        """The rank-4 slice-then-broadcast is numerically identical to the rank-6 form."""
+        import torch
+
+        torch.manual_seed(0)
+        n, len_q, n_heads, n_levels, n_points = 1, 6, 4, 2, 4
+        reference_points = torch.rand(n, len_q, n_levels, 4)
+        sampling_offsets = torch.rand(n, len_q, n_heads, n_levels, n_points, 2)
+
+        # Original (rank-6 slice) form.
+        old = (
+            reference_points[:, :, None, :, None, :2]
+            + sampling_offsets / n_points * reference_points[:, :, None, :, None, 2:] * 0.5
+        )
+        # Fixed (rank-4 slice, then broadcast) form.
+        xy = reference_points[..., :2]
+        wh = reference_points[..., 2:]
+        new = xy[:, :, None, :, None, :] + sampling_offsets / n_points * wh[:, :, None, :, None, :] * 0.5
+
+        torch.testing.assert_close(new, old)

--- a/tests/export/test_tflite_export.py
+++ b/tests/export/test_tflite_export.py
@@ -1103,9 +1103,8 @@ _TFLITE_STRIDED_SLICE_MAX_RANK = 5
 def _export_msdeformattn_to_onnx(path: Path) -> None:
     """Export a small export-mode ``MSDeformAttn`` (4-coord reference points) to ONNX.
 
-    Uses the ``reference_points.shape[-1] == 4`` (reference-box) branch — the path the
-    rank-4 slicing fix touches — and the legacy ONNX exporter (``dynamo=False`` where
-    available), matching ``rfdetr.export._onnx.exporter``.
+    Uses the ``reference_points.shape[-1] == 4`` (reference-box) branch — the path the rank-4 slicing fix touches — and
+    the legacy ONNX exporter (``dynamo=False`` where available), matching ``rfdetr.export._onnx.exporter``.
     """
     import inspect
 
@@ -1196,10 +1195,9 @@ class TestMSDeformAttnSliceRank:
     def test_export_has_no_rank6_slice(self, tmp_path: Path) -> None:
         """Exported MSDeformAttn must contain no Slice on a tensor of rank > 5.
 
-        Regresses if the reference-box slicing reverts to slicing the rank-6
-        broadcast-expanded tensor (``reference_points[:, :, None, :, None, :2]``),
-        which onnx2tf lowers to a FlexStridedSlice that won't load on a mobile
-        LiteRT runtime.
+        Regresses if the reference-box slicing reverts to slicing the rank-6 broadcast-expanded tensor
+        (``reference_points[:, :, None, :, None, :2]``), which onnx2tf lowers to a FlexStridedSlice that won't load on a
+        mobile LiteRT runtime.
         """
         pytest.importorskip("onnx", reason="onnx not installed")
         onnx_path = tmp_path / "msdeformattn.onnx"


### PR DESCRIPTION
## What does this PR do?

Fixes the 4-coordinate reference-box path in `MSDeformAttn.forward` so it no longer produces an **over-ranked (rank-6) `StridedSlice`** during TFLite export.

Previously the two reference-box slices were taken on the *broadcast-expanded* tensor:

```python
reference_points[:, :, None, :, None, :2]        # rank-6 slice
+ ... reference_points[:, :, None, :, None, 2:]   # rank-6 slice
```

This change slices at **rank 4** (`xy` / `wh`) *before* inserting the broadcast (`None`) axes. The result is **numerically identical** but keeps every slice within TFLite's native **1D–5D** `StridedSlice` kernel limit.

**Why it matters:** the rank-6 slice makes the exported model fail to load on a strict/mobile LiteRT runtime, with the symptom depending on the onnx2tf version:

| onnx2tf | unfixed op | strict/mobile runtime result |
|---|---|---|
| 1.x | native rank-6 `STRIDED_SLICE` | rejected at interpreter creation: *"StridedSlice op only supports 1D-5D input arrays"* |
| 2.4.x | `FlexStridedSlice` (×2) | fails to compile: requires `tensorflow-lite-select-tf-ops` (Flex), not bundled in the standalone LiteRT runtime |

Same root cause (an over-ranked slice), so this single change resolves both. Desktop `tf.lite.Interpreter` (full TF) tolerates both forms, which is why the failure only appears on-device.

**Related Issue(s):** <!-- add issue number if one exists, else delete -->
PR at #1142 may address the same issue

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

Exported TFLite (fp16) from the same converter **with and without** this change and compared the op graphs. The only structural difference:

```
FlexStridedSlice   2 -> 0    (removed)
STRIDED_SLICE     64 -> 66   (+2, native)
RESHAPE          130 -> 132  (+2, native)
```

i.e. the 2 rank-6 `FlexStridedSlice` ops are replaced by native `STRIDED_SLICE` + `RESHAPE`; everything else (incl. the 305 fp16 weight tensors) is identical, so the model becomes Flex-free.

On-device verification (LiteRT standalone runtime, Google Pixel):
- **With this fix:** model loads/compiles and runs (CPU/XNNPACK fallback).
- **Without this fix:** fails to compile — *"Node 1490 (FlexStridedSlice) failed to prepare -> Failed to compile model."*

The change is a slice-reordering that is mathematically identical to the original (the broadcast axes are independent of the sliced last axis), so no numerical behavior changes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

The change includes an inline comment explaining the rank-6 -> Flex/strict-kernel issue so the non-obvious slice ordering isn't "simplified" back later.

Broader context: this surfaced while evaluating RF-DETR for mobile GPU/NPU deployment. The fix is what makes the TFLite export **loadable on a stock mobile runtime at all**; it is independent of (and does not solve) the separate fact that the deformable decoder's `GATHER_ND`/`TOPK_V2`/`FLOOR_MOD` ops aren't supported by the LiteRT GPU delegate (the model runs CPU-only on-device).