### PR TITLE
fix(inference): always re-assert eval mode for unoptimized predict()

### DIFF
--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -749,6 +749,9 @@ class RFDETR:
 
         # Sync the trained weights back so predict() / export() see the updated model.
         self.model.model = module.model
+        # Invalidate any compiled inference snapshot: it was built from the pre-training
+        # weights and must not survive the model reassignment above.
+        self.remove_optimized_model()
         # Sync class names: prefer explicit config.class_names, otherwise fall back to dataset (#509).
         config_class_names = getattr(config, "class_names", None)
         if config_class_names is not None:
@@ -1417,6 +1420,9 @@ class RFDETR:
         is emitted at most once, but eval mode is (re)asserted on every call: ``train()`` reassigns ``self.model.model``
         to a module that PyTorch Lightning leaves in training mode (see ``train()``), so gating ``eval()`` behind the
         once-only warning would let a later ``predict()`` silently run with dropout active.
+
+        When ``_is_optimized_for_inference`` is ``True``, the method returns immediately — the compiled
+        ``inference_model`` snapshot is already in eval mode and ``self.model.model`` is not used for inference.
         """
         if self._is_optimized_for_inference:
             return

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -1413,12 +1413,10 @@ class RFDETR:
     def _ensure_eval_mode_for_unoptimized_inference(self) -> None:
         """Put the underlying module in eval mode before unoptimized inference.
 
-        Inference must never run with dropout / batch-norm in training mode. The
-        warning that the model is not optimized is emitted at most once, but eval
-        mode is (re)asserted on every call: ``train()`` reassigns
-        ``self.model.model`` to a module that PyTorch Lightning leaves in training
-        mode (see ``train()``), so gating ``eval()`` behind the once-only warning
-        would let a later ``predict()`` silently run with dropout active.
+        Inference must never run with dropout / batch-norm in training mode. The warning that the model is not optimized
+        is emitted at most once, but eval mode is (re)asserted on every call: ``train()`` reassigns ``self.model.model``
+        to a module that PyTorch Lightning leaves in training mode (see ``train()``), so gating ``eval()`` behind the
+        once-only warning would let a later ``predict()`` silently run with dropout active.
         """
         if self._is_optimized_for_inference:
             return

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -1410,6 +1410,26 @@ class RFDETR:
 
         return list(COCO_CLASS_NAMES)
 
+    def _ensure_eval_mode_for_unoptimized_inference(self) -> None:
+        """Put the underlying module in eval mode before unoptimized inference.
+
+        Inference must never run with dropout / batch-norm in training mode. The
+        warning that the model is not optimized is emitted at most once, but eval
+        mode is (re)asserted on every call: ``train()`` reassigns
+        ``self.model.model`` to a module that PyTorch Lightning leaves in training
+        mode (see ``train()``), so gating ``eval()`` behind the once-only warning
+        would let a later ``predict()`` silently run with dropout active.
+        """
+        if self._is_optimized_for_inference:
+            return
+        if not self._has_warned_about_not_being_optimized_for_inference:
+            logger.warning(
+                "Model is not optimized for inference. Latency may be higher than expected."
+                " You can optimize the model for inference by calling model.optimize_for_inference().",
+            )
+            self._has_warned_about_not_being_optimized_for_inference = True
+        self.model.model.eval()
+
     @torch.no_grad()
     @_ensure_model_on_device
     def predict(
@@ -1505,14 +1525,7 @@ class RFDETR:
         else:
             shape = _validate_shape_dims(shape, block_size, patch_size, num_windows)
 
-        if not self._is_optimized_for_inference and not self._has_warned_about_not_being_optimized_for_inference:
-            logger.warning(
-                "Model is not optimized for inference. Latency may be higher than expected."
-                " You can optimize the model for inference by calling model.optimize_for_inference().",
-            )
-            self._has_warned_about_not_being_optimized_for_inference = True
-
-            self.model.model.eval()
+        self._ensure_eval_mode_for_unoptimized_inference()
 
         if not isinstance(images, list):
             images = [images]

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -3,9 +3,32 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-"""Shared fixtures for model tests."""
+"""Shared fixtures and test helpers for model tests."""
+
+from types import SimpleNamespace
 
 import pytest
+
+from rfdetr.detr import RFDETR
+
+
+class _BaseFakeRFDETR(RFDETR):
+    """RFDETR test double that skips weight downloads and returns a minimal model config.
+
+    Subclasses must override ``get_model`` to supply the model context appropriate for
+    the scenario under test.
+
+    Examples:
+        This class is imported directly by test modules that need a weight-free RFDETR.
+    """
+
+    def maybe_download_pretrain_weights(self) -> None:
+        """Skip weight download in tests."""
+        return None
+
+    def get_model_config(self, **kwargs: object) -> SimpleNamespace:
+        """Return a minimal config sufficient for most test scenarios."""
+        return SimpleNamespace(num_channels=3)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/models/test_predict_eval_mode.py
+++ b/tests/models/test_predict_eval_mode.py
@@ -7,11 +7,12 @@
 
 from types import SimpleNamespace
 
+import PIL.Image
 import pytest
 import torch
 
 from rfdetr import detr as detr_module
-from rfdetr.detr import RFDETR
+from tests.models.conftest import _BaseFakeRFDETR
 
 
 class _FakeModelWithDropout(torch.nn.Module):
@@ -22,10 +23,13 @@ class _FakeModelWithDropout(torch.nn.Module):
         self.dropout = torch.nn.Dropout(p=0.5)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Pass input through dropout, active only in train mode."""
         return self.dropout(x)
 
 
 class _FakeModelContext:
+    """Minimal model context supplying the attributes predict() and train() need."""
+
     def __init__(self) -> None:
         self.device = torch.device("cpu")
         self.resolution = 28
@@ -33,14 +37,11 @@ class _FakeModelContext:
         self.inference_model = None
 
 
-class _FakeRFDETR(RFDETR):
-    def maybe_download_pretrain_weights(self) -> None:
-        return None
-
-    def get_model_config(self, **kwargs: object) -> SimpleNamespace:
-        return SimpleNamespace(num_channels=3)
+class _FakeRFDETR(_BaseFakeRFDETR):
+    """Concrete test double: provides a dropout-bearing model for eval-mode tests."""
 
     def get_model(self, config: SimpleNamespace) -> _FakeModelContext:
+        """Return a minimal model context with a dropout-bearing module."""
         return _FakeModelContext()
 
 
@@ -48,29 +49,42 @@ class TestUnoptimizedInferenceEvalMode:
     """`_ensure_eval_mode_for_unoptimized_inference` must keep the module in eval mode."""
 
     def test_eval_mode_reasserted_after_train_round_trip(self) -> None:
-        """Eval mode must be (re)applied on every call, not just the first.
+        """Eval mode must be applied to whatever self.model.model currently points to.
 
-        ``train()`` reassigns ``self.model.model`` to a module left in training mode, so a subsequent inference call
-        must put it back in eval mode. Otherwise inference runs with dropout active and yields nondeterministic,
-        degraded predictions.
+        ``train()`` rebinds ``self.model.model`` to a brand-new module left in training mode, so eval must be re-applied
+        to the *current* object on every call — not to a cached reference captured at init.
         """
         rfdetr = _FakeRFDETR()
-        module = rfdetr.model.model
 
         # First inference call: warns once and switches to eval mode.
         rfdetr._ensure_eval_mode_for_unoptimized_inference()
-        assert module.training is False
+        assert rfdetr.model.model.training is False
 
-        # A train() round-trip leaves the (re)assigned module in training mode.
-        module.train()
-        assert module.training is True
+        # Simulate train() rebinding self.model.model to a fresh training-mode module.
+        rfdetr.model.model = _FakeModelWithDropout()
+        assert rfdetr.model.model.training is True  # new object starts in train mode
 
-        # Every later inference call must re-assert eval mode.
+        # Every subsequent inference call must re-assert eval on the *new* object.
         rfdetr._ensure_eval_mode_for_unoptimized_inference()
-        assert module.training is False
+        assert rfdetr.model.model.training is False
+
+    def test_optimized_model_skips_eval_assertion(self) -> None:
+        """When _is_optimized_for_inference is True, the method must be a no-op.
+
+        The compiled inference_model snapshot is already in eval mode; calling eval() on the stale self.model.model
+        would target the wrong object.
+        """
+        rfdetr = _FakeRFDETR()
+        rfdetr._is_optimized_for_inference = True
+        rfdetr.model.model.train()
+        assert rfdetr.model.model.training is True  # confirm starting state
+
+        rfdetr._ensure_eval_mode_for_unoptimized_inference()
+
+        assert rfdetr.model.model.training is True  # must remain unchanged
 
     def test_not_optimized_warning_emitted_only_once(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """The not-optimized warning is logged once even though eval() runs every call."""
+        """The not-optimized warning is logged at most once across repeated calls."""
         warnings: list[str] = []
         monkeypatch.setattr(detr_module.logger, "warning", lambda msg, *a, **k: warnings.append(msg))
 
@@ -81,4 +95,41 @@ class TestUnoptimizedInferenceEvalMode:
         rfdetr._ensure_eval_mode_for_unoptimized_inference()
 
         assert len(warnings) == 1
+
+    def test_eval_mode_applied_on_every_call(self) -> None:
+        """Eval() must run on every call, not just when the warning fires.
+
+        Simulate the code path where the warning has already been emitted
+        (``_has_warned_about_not_being_optimized_for_inference=True``) and verify
+        that ``eval()`` is still applied to the current module.
+        """
+        rfdetr = _FakeRFDETR()
+        rfdetr._has_warned_about_not_being_optimized_for_inference = True
+        rfdetr.model.model.train()
+
+        rfdetr._ensure_eval_mode_for_unoptimized_inference()
+
+        assert rfdetr.model.model.training is False
+
+    def test_predict_puts_module_in_eval_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Predict() must delegate to _ensure_eval_mode_for_unoptimized_inference, leaving module in eval mode."""
+        rfdetr = _FakeRFDETR()
+        img = PIL.Image.new("RGB", (640, 640), color=(128, 128, 128))
+
+        monkeypatch.setattr(
+            rfdetr.model.model,
+            "forward",
+            lambda batch: {"pred_logits": torch.zeros(1, 10, 81), "pred_boxes": torch.zeros(1, 10, 4)},
+        )
+        monkeypatch.setattr(
+            rfdetr.model,
+            "postprocess",
+            lambda preds, target_sizes: [
+                {"scores": torch.zeros(0), "labels": torch.zeros(0, dtype=torch.long), "boxes": torch.zeros(0, 4)}
+            ],
+            raising=False,
+        )
+
+        rfdetr.predict(img)
+
         assert rfdetr.model.model.training is False

--- a/tests/models/test_predict_eval_mode.py
+++ b/tests/models/test_predict_eval_mode.py
@@ -48,11 +48,10 @@ class TestUnoptimizedInferenceEvalMode:
     """`_ensure_eval_mode_for_unoptimized_inference` must keep the module in eval mode."""
 
     def test_eval_mode_reasserted_after_train_round_trip(self) -> None:
-        """eval mode must be (re)applied on every call, not just the first.
+        """Eval mode must be (re)applied on every call, not just the first.
 
-        ``train()`` reassigns ``self.model.model`` to a module left in training
-        mode, so a subsequent inference call must put it back in eval mode.
-        Otherwise inference runs with dropout active and yields nondeterministic,
+        ``train()`` reassigns ``self.model.model`` to a module left in training mode, so a subsequent inference call
+        must put it back in eval mode. Otherwise inference runs with dropout active and yields nondeterministic,
         degraded predictions.
         """
         rfdetr = _FakeRFDETR()

--- a/tests/models/test_predict_eval_mode.py
+++ b/tests/models/test_predict_eval_mode.py
@@ -1,0 +1,85 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Tests that unoptimized inference always runs the module in eval mode."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from rfdetr import detr as detr_module
+from rfdetr.detr import RFDETR
+
+
+class _FakeModelWithDropout(torch.nn.Module):
+    """Minimal module whose behavior differs between train and eval mode."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.dropout = torch.nn.Dropout(p=0.5)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.dropout(x)
+
+
+class _FakeModelContext:
+    def __init__(self) -> None:
+        self.device = torch.device("cpu")
+        self.resolution = 28
+        self.model = _FakeModelWithDropout()
+        self.inference_model = None
+
+
+class _FakeRFDETR(RFDETR):
+    def maybe_download_pretrain_weights(self) -> None:
+        return None
+
+    def get_model_config(self, **kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(num_channels=3)
+
+    def get_model(self, config: SimpleNamespace) -> _FakeModelContext:
+        return _FakeModelContext()
+
+
+class TestUnoptimizedInferenceEvalMode:
+    """`_ensure_eval_mode_for_unoptimized_inference` must keep the module in eval mode."""
+
+    def test_eval_mode_reasserted_after_train_round_trip(self) -> None:
+        """eval mode must be (re)applied on every call, not just the first.
+
+        ``train()`` reassigns ``self.model.model`` to a module left in training
+        mode, so a subsequent inference call must put it back in eval mode.
+        Otherwise inference runs with dropout active and yields nondeterministic,
+        degraded predictions.
+        """
+        rfdetr = _FakeRFDETR()
+        module = rfdetr.model.model
+
+        # First inference call: warns once and switches to eval mode.
+        rfdetr._ensure_eval_mode_for_unoptimized_inference()
+        assert module.training is False
+
+        # A train() round-trip leaves the (re)assigned module in training mode.
+        module.train()
+        assert module.training is True
+
+        # Every later inference call must re-assert eval mode.
+        rfdetr._ensure_eval_mode_for_unoptimized_inference()
+        assert module.training is False
+
+    def test_not_optimized_warning_emitted_only_once(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The not-optimized warning is logged once even though eval() runs every call."""
+        warnings: list[str] = []
+        monkeypatch.setattr(detr_module.logger, "warning", lambda msg, *a, **k: warnings.append(msg))
+
+        rfdetr = _FakeRFDETR()
+        rfdetr._ensure_eval_mode_for_unoptimized_inference()
+        rfdetr.model.model.train()
+        rfdetr._ensure_eval_mode_for_unoptimized_inference()
+        rfdetr._ensure_eval_mode_for_unoptimized_inference()
+
+        assert len(warnings) == 1
+        assert rfdetr.model.model.training is False


### PR DESCRIPTION
## Description

In the unoptimized inference path, `predict()` only switched the underlying module into `eval()` mode on the **first** call. The `eval()` was nested inside the once-only "model is not optimized for inference" warning guard:

```python
if not self._is_optimized_for_inference and not self._has_warned_about_not_being_optimized_for_inference:
    logger.warning("Model is not optimized for inference. ...")
    self._has_warned_about_not_being_optimized_for_inference = True
    self.model.model.eval()   # only runs while the warning is still pending
```

Once the warning has fired, the whole block is skipped, so `eval()` is never re-applied.

### Why it bites

`train()` syncs the trained module back with `self.model.model = module.model`, and the module returned by Lightning's `fit()` is left in **training mode**. So the common inspect → fine-tune → inspect sequence runs the second inference with dropout active:

```python
model.predict(img)   # warns, sets eval()
model.train(...)      # self.model.model reassigned, left in train mode
model.predict(img)    # eval() skipped -> dropout active at inference
```

`@torch.no_grad()` disables gradients but not dropout / batch-norm train mode, so detections become nondeterministic and degraded. In the unoptimized path this is the only `eval()` call.

## Fix

Extract the assertion into `_ensure_eval_mode_for_unoptimized_inference()`: the not-optimized warning is still emitted once, but `eval()` is re-asserted on every `predict()` call (idempotent and ~free).

## Tests

`tests/models/test_predict_eval_mode.py` (both fail on the pre-fix coupling, pass after):
- eval mode is re-asserted after a `train()` round-trip
- the not-optimized warning is still emitted only once

Uses the existing `_FakeRFDETR` test-double pattern (no weight download).