### PR TITLE
fix(matcher): use the configured `focal_alpha` in the classification cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `HungarianMatcher.forward()` now uses the configured `focal_alpha` in the focal classification matching cost. Previously the value was hardcoded to `0.25`, silently ignoring any non-default `focal_alpha` passed to the constructor or `build_matcher`. This misaligned the bipartite matching cost with the focal classification loss in `criterion.py`, which correctly used `self.focal_alpha`. ([#1147](https://github.com/roboflow/rf-detr/pull/1147))
+
 ---
 
 ## [1.8.1] — 2026-06-19

--- a/src/rfdetr/models/matcher.py
+++ b/src/rfdetr/models/matcher.py
@@ -32,6 +32,7 @@ from rfdetr.utilities.logger import get_logger
 
 logger = get_logger()
 _SANITIZED_COST_MARGIN = 1.0
+_FOCAL_LOSS_GAMMA = 2.0
 
 
 class HungarianMatcher(nn.Module):
@@ -42,8 +43,8 @@ class HungarianMatcher(nn.Module):
     best predictions, while the others are un-matched (and thus treated as non-objects).
 
     Note:
-        The focal loss exponent ``gamma`` is hardcoded to 2.0 and is not configurable.
-        Only ``focal_alpha`` can be adjusted at construction time.
+        The focal loss exponent ``gamma`` is fixed at ``_FOCAL_LOSS_GAMMA`` (2.0) and is not
+        configurable. Only ``focal_alpha`` can be adjusted at construction time.
     """
 
     def __init__(
@@ -182,7 +183,7 @@ class HungarianMatcher(nn.Module):
 
         # Compute the classification cost.
         alpha = self.focal_alpha
-        gamma = 2.0
+        gamma = _FOCAL_LOSS_GAMMA
 
         # neg_cost_class = (1 - alpha) * (out_prob ** gamma) * (-(1 - out_prob + 1e-8).log())
         # pos_cost_class = alpha * ((1 - out_prob) ** gamma) * (-(out_prob + 1e-8).log())

--- a/src/rfdetr/models/matcher.py
+++ b/src/rfdetr/models/matcher.py
@@ -304,7 +304,9 @@ def build_matcher(args) -> HungarianMatcher:
         args: Namespace supplying ``focal_alpha``, ``set_cost_class``, ``set_cost_bbox``,
             ``set_cost_giou``, ``segmentation_head``, and optional keypoint cost
             coefficients (``keypoint_l1_loss_coef``, ``keypoint_findable_loss_coef``,
-            ``keypoint_visible_loss_coef``, ``keypoint_nll_loss_coef``).
+            ``keypoint_visible_loss_coef``, ``keypoint_nll_loss_coef``). When
+            ``segmentation_head`` is truthy, also requires ``mask_ce_loss_coef``,
+            ``mask_dice_loss_coef``, and ``mask_point_sample_ratio``.
 
     Returns:
         Configured HungarianMatcher instance.

--- a/src/rfdetr/models/matcher.py
+++ b/src/rfdetr/models/matcher.py
@@ -176,7 +176,7 @@ class HungarianMatcher(nn.Module):
         cost_giou = -giou
 
         # Compute the classification cost.
-        alpha = 0.25
+        alpha = self.focal_alpha
         gamma = 2.0
 
         # neg_cost_class = (1 - alpha) * (out_prob ** gamma) * (-(1 - out_prob + 1e-8).log())

--- a/src/rfdetr/models/matcher.py
+++ b/src/rfdetr/models/matcher.py
@@ -40,6 +40,10 @@ class HungarianMatcher(nn.Module):
 
     Because of this, in general, there are more predictions than targets. In this case, we do a 1-to-1 matching of the
     best predictions, while the others are un-matched (and thus treated as non-objects).
+
+    Note:
+        The focal loss exponent ``gamma`` is hardcoded to 2.0 and is not configurable.
+        Only ``focal_alpha`` can be adjusted at construction time.
     """
 
     def __init__(
@@ -136,11 +140,12 @@ class HungarianMatcher(nn.Module):
         group_detr: int = 1,
     ) -> list[tuple[torch.Tensor, torch.Tensor]]:
         """Performs the matching
-        Params:
-            outputs: This is a dict that contains at least these entries:
+
+        Args:
+            outputs: Dict containing at least these entries:
                  "pred_logits": Tensor of dim [batch_size, num_queries, num_classes] with the classification logits
                  "pred_boxes": Tensor of dim [batch_size, num_queries, 4] with the predicted box coordinates
-            targets: This is a list of targets (len(targets) = batch_size), where each target is a dict containing:
+            targets: List of targets (len(targets) = batch_size), where each target is a dict containing:
                  "labels": Tensor of dim [num_target_boxes] (where num_target_boxes is the number of ground-truth
                            objects in the target) containing the class labels
                  "boxes": Tensor of dim [num_target_boxes, 4] containing the target box coordinates "masks": Tensor of
@@ -292,7 +297,18 @@ class HungarianMatcher(nn.Module):
         return [(torch.as_tensor(i, dtype=torch.int64), torch.as_tensor(j, dtype=torch.int64)) for i, j in indices]
 
 
-def build_matcher(args):
+def build_matcher(args) -> HungarianMatcher:
+    """Build a HungarianMatcher from a training argument namespace.
+
+    Args:
+        args: Namespace supplying ``focal_alpha``, ``set_cost_class``, ``set_cost_bbox``,
+            ``set_cost_giou``, ``segmentation_head``, and optional keypoint cost
+            coefficients (``keypoint_l1_loss_coef``, ``keypoint_findable_loss_coef``,
+            ``keypoint_visible_loss_coef``, ``keypoint_nll_loss_coef``).
+
+    Returns:
+        Configured HungarianMatcher instance.
+    """
     # Detection-only matcher args may omit keypoint costs; zero defaults disable keypoint matching terms.
     common_kwargs = {
         "cost_class": args.set_cost_class,

--- a/tests/models/test_matcher.py
+++ b/tests/models/test_matcher.py
@@ -315,3 +315,45 @@ class TestHungarianMatcherSanitization:
 
         assert torch.isfinite(sanitized).all()
         assert sanitized[0, 1] == dtype_max
+
+
+class TestHungarianMatcherFocalAlpha:
+    """The configured ``focal_alpha`` must drive the classification matching cost."""
+
+    def test_focal_alpha_changes_assignment(self) -> None:
+        """Two matchers differing only in ``focal_alpha`` must be able to produce
+        different assignments.
+
+        ``focal_alpha`` is accepted, documented as "used in the classification
+        cost", and stored on the matcher, so it must actually influence matching.
+        This input is chosen so the optimal query->target pairing flips between
+        ``focal_alpha=0.25`` and ``focal_alpha=0.90``; if the cost ignores the
+        configured alpha, both assignments collapse to the same result.
+        """
+        outputs = {
+            "pred_logits": torch.tensor(
+                [[[2.3936, -1.4217], [2.3731, -2.1974]]],
+                dtype=torch.float32,
+            ),
+            "pred_boxes": torch.tensor(
+                [[[0.3898, 0.4340, 0.5331, 0.1901], [0.4256, 0.1002, 0.6955, 0.7815]]],
+                dtype=torch.float32,
+            ),
+        }
+        targets = [
+            {
+                "labels": torch.tensor([0, 1], dtype=torch.int64),
+                "boxes": torch.tensor(
+                    [[0.2111, 0.6630, 0.7569, 0.8855], [0.7750, 0.4393, 0.8838, 0.8792]],
+                    dtype=torch.float32,
+                ),
+            }
+        ]
+
+        def assignment(focal_alpha: float) -> list[int]:
+            matcher = HungarianMatcher(cost_class=2.0, cost_bbox=5.0, cost_giou=2.0, focal_alpha=focal_alpha)
+            matched_queries, matched_targets = matcher(outputs, targets)[0]
+            # Queries ordered by the target index they are matched to.
+            return matched_queries[matched_targets.argsort()].tolist()
+
+        assert assignment(0.25) != assignment(0.90)

--- a/tests/models/test_matcher.py
+++ b/tests/models/test_matcher.py
@@ -355,3 +355,46 @@ class TestHungarianMatcherFocalAlpha:
             return matched_queries[matched_targets.argsort()].tolist()
 
         assert assignment(0.25) != assignment(0.90)
+        # Pin the exact expected mappings so a misapplied-alpha refactor is caught even when
+        # the two values remain different for unrelated reasons.
+        assert assignment(0.25) == [0, 1]
+        assert assignment(0.90) == [1, 0]
+
+    @pytest.mark.parametrize(
+        "focal_alpha, expected",
+        [
+            pytest.param(0.0, [0, 1], id="alpha_zero_pos_cost_zeroed"),
+            pytest.param(1.0, [1, 0], id="alpha_one_neg_cost_zeroed"),
+        ],
+    )
+    def test_focal_alpha_boundary_values_no_nan(self, focal_alpha: float, expected: list[int]) -> None:
+        """Degenerate focal_alpha values (0.0 and 1.0) must not produce NaN and must yield a valid assignment.
+
+        focal_alpha=0.0 zeroes ``pos_cost_class``; focal_alpha=1.0 zeroes ``neg_cost_class``. Neither path touches
+        ``log(prob)`` directly (formula uses logsigmoid of logits), so no division-by-zero or NaN can occur.
+        """
+        outputs = {
+            "pred_logits": torch.tensor(
+                [[[2.3936, -1.4217], [2.3731, -2.1974]]],
+                dtype=torch.float32,
+            ),
+            "pred_boxes": torch.tensor(
+                [[[0.3898, 0.4340, 0.5331, 0.1901], [0.4256, 0.1002, 0.6955, 0.7815]]],
+                dtype=torch.float32,
+            ),
+        }
+        targets = [
+            {
+                "labels": torch.tensor([0, 1], dtype=torch.int64),
+                "boxes": torch.tensor(
+                    [[0.2111, 0.6630, 0.7569, 0.8855], [0.7750, 0.4393, 0.8838, 0.8792]],
+                    dtype=torch.float32,
+                ),
+            }
+        ]
+
+        matcher = HungarianMatcher(cost_class=2.0, cost_bbox=5.0, cost_giou=2.0, focal_alpha=focal_alpha)
+        matched_queries, matched_targets = matcher(outputs, targets)[0]
+
+        result = matched_queries[matched_targets.argsort()].tolist()
+        assert result == expected

--- a/tests/models/test_matcher.py
+++ b/tests/models/test_matcher.py
@@ -396,5 +396,6 @@ class TestHungarianMatcherFocalAlpha:
         matcher = HungarianMatcher(cost_class=2.0, cost_bbox=5.0, cost_giou=2.0, focal_alpha=focal_alpha)
         matched_queries, matched_targets = matcher(outputs, targets)[0]
 
+        assert not matcher._warned_non_finite_costs, "boundary focal_alpha produced non-finite costs"
         result = matched_queries[matched_targets.argsort()].tolist()
         assert result == expected

--- a/tests/models/test_matcher.py
+++ b/tests/models/test_matcher.py
@@ -321,14 +321,12 @@ class TestHungarianMatcherFocalAlpha:
     """The configured ``focal_alpha`` must drive the classification matching cost."""
 
     def test_focal_alpha_changes_assignment(self) -> None:
-        """Two matchers differing only in ``focal_alpha`` must be able to produce
-        different assignments.
+        """Two matchers differing only in ``focal_alpha`` must be able to produce different assignments.
 
-        ``focal_alpha`` is accepted, documented as "used in the classification
-        cost", and stored on the matcher, so it must actually influence matching.
-        This input is chosen so the optimal query->target pairing flips between
-        ``focal_alpha=0.25`` and ``focal_alpha=0.90``; if the cost ignores the
-        configured alpha, both assignments collapse to the same result.
+        ``focal_alpha`` is accepted, documented as "used in the classification cost", and stored on the matcher, so it
+        must actually influence matching. This input is chosen so the optimal query->target pairing flips between
+        ``focal_alpha=0.25`` and ``focal_alpha=0.90``; if the cost ignores the configured alpha, both assignments
+        collapse to the same result.
         """
         outputs = {
             "pred_logits": torch.tensor(


### PR DESCRIPTION
## Description

`HungarianMatcher` accepts `focal_alpha`, stores it as `self.focal_alpha`, documents it as *"used in the classification cost"*, and `build_matcher` passes `args.focal_alpha` through — but `forward()` hardcoded the alpha used in the classification cost:

```python
alpha = 0.25   # ignores self.focal_alpha
...
neg_cost_class = (1 - alpha) * (out_prob**gamma) * (-F.logsigmoid(-flat_pred_logits))
pos_cost_class = alpha * ((1 - out_prob) ** gamma) * (-F.logsigmoid(flat_pred_logits))
```

So any non-default `focal_alpha` was silently ignored in matching.

### Why it matters

The criterion's focal classification **loss** does use `self.focal_alpha` (`criterion.py`). With a non-default alpha, the bipartite matching cost and the training loss optimize different objectives — which breaks the DETR design principle that the matching cost mirrors the loss it supervises. (`gamma = 2.0` is genuinely fixed everywhere, so only alpha is affected.)

## Fix

```python
alpha = self.focal_alpha
```

## Test

`test_focal_alpha_changes_assignment`: with a crafted 2-query / 2-target input, the optimal assignment flips between `focal_alpha=0.25` and `0.90`. On the pre-fix code both collapse to the same assignment (alpha ignored), so the test fails before and passes after the fix.