### PR TITLE
feat(cookbooks): add instance segmentation fine-tuning notebook

### DIFF
--- a/docs/cookbooks/NOTES.md
+++ b/docs/cookbooks/NOTES.md
@@ -48,8 +48,10 @@ Current tag colours are assigned dynamically by the docs UI, so they may change 
 
 ## Current notebooks
 
-| File                         | Card title                                      | Version |
-| ---------------------------- | ----------------------------------------------- | ------- |
-| `custom-augmentations.ipynb` | Custom Augmentations and Live Training Progress | v1.5.0  |
-| `fine-tune_keypoints.ipynb`  | Fine-Tune RF-DETR Keypoint Detection            | v1.8.0  |
-| `pytorch-lightning.ipynb`    | Training with PyTorch Lightning                 | v1.6.0  |
+| File                                 | Card title                                      | Version |
+| ------------------------------------ | ----------------------------------------------- | ------- |
+| `custom-augmentations.ipynb`         | Custom Augmentations and Live Training Progress | v1.5.0  |
+| `fine-tune_keypoints.ipynb`          | Fine-Tune RF-DETR Keypoint Detection            | v1.8.0  |
+| `fine-tune_segmentation.ipynb`       | Fine-Tune RF-DETR Instance Segmentation         | v1.8.1  |
+| `inference-latency-benchmark.ipynb`  | Inference Latency Benchmark                     | v1.8.1  |
+| `pytorch-lightning.ipynb`            | Training with PyTorch Lightning                 | v1.6.0  |

--- a/docs/cookbooks/NOTES.md
+++ b/docs/cookbooks/NOTES.md
@@ -8,17 +8,17 @@ which renders each entry as a card via a Jinja loop.
 
 ## Converting a jupytext `.py` to `.ipynb`
 
-Cookbook source files live as jupytext percent-format `.py` scripts (e.g. `fine-tune_keypoints.py` at the project root). Each script has **two output notebooks** that must be regenerated together after every edit:
+Cookbook source files live as jupytext percent-format `.py` scripts (e.g. `fine-tune_keypoints.py`) inside `docs/cookbooks/`. Each script requires at minimum a **docs render copy**; some also have a `notebooks/` copy for users who want to run it directly. Regenerate every existing copy after each edit:
 
 ```bash
-# Runnable copy (for users who want to run the notebook directly)
-jupytext --to notebook fine-tune_keypoints.py --output notebooks/fine-tune_keypoints.ipynb
-
-# Docs render copy (served by mkdocs-jupyter at /cookbooks/)
+# Docs render copy (served by mkdocs-jupyter at /cookbooks/) — always required
 jupytext --to notebook fine-tune_keypoints.py --output docs/cookbooks/fine-tune_keypoints.ipynb
+
+# Runnable copy in notebooks/ — only for notebooks explicitly placed there
+jupytext --to notebook fine-tune_keypoints.py --output notebooks/fine-tune_keypoints.ipynb
 ```
 
-Both commands must be run to keep the two copies in sync. Omit `--execute` — notebooks are rendered statically by `mkdocs-jupyter` with `execute: false`, so pre-run outputs in the `.ipynb` are displayed as-is.
+New notebooks default to the docs-only copy. Add a `notebooks/` copy only when there is an explicit need (e.g. a runnable starter notebook shipped with the repo). Omit `--execute` — notebooks are rendered statically by `mkdocs-jupyter` with `execute: false`, so pre-run outputs in the `.ipynb` are displayed as-is.
 
 If jupytext is not installed: `pip install jupytext` (or `uv add jupytext --dev`).
 

--- a/docs/cookbooks/NOTES.md
+++ b/docs/cookbooks/NOTES.md
@@ -48,10 +48,10 @@ Current tag colours are assigned dynamically by the docs UI, so they may change 
 
 ## Current notebooks
 
-| File                                 | Card title                                      | Version |
-| ------------------------------------ | ----------------------------------------------- | ------- |
-| `custom-augmentations.ipynb`         | Custom Augmentations and Live Training Progress | v1.5.0  |
-| `fine-tune_keypoints.ipynb`          | Fine-Tune RF-DETR Keypoint Detection            | v1.8.0  |
-| `fine-tune_segmentation.ipynb`       | Fine-Tune RF-DETR Instance Segmentation         | v1.8.1  |
-| `inference-latency-benchmark.ipynb`  | Inference Latency Benchmark                     | v1.8.1  |
-| `pytorch-lightning.ipynb`            | Training with PyTorch Lightning                 | v1.6.0  |
+| File                                | Card title                                      | Version |
+| ----------------------------------- | ----------------------------------------------- | ------- |
+| `custom-augmentations.ipynb`        | Custom Augmentations and Live Training Progress | v1.5.0  |
+| `fine-tune_keypoints.ipynb`         | Fine-Tune RF-DETR Keypoint Detection            | v1.8.0  |
+| `fine-tune_segmentation.ipynb`      | Fine-Tune RF-DETR Instance Segmentation         | v1.8.1  |
+| `inference-latency-benchmark.ipynb` | Inference Latency Benchmark                     | v1.8.1  |
+| `pytorch-lightning.ipynb`           | Training with PyTorch Lightning                 | v1.6.0  |

--- a/docs/cookbooks/cards.yaml
+++ b/docs/cookbooks/cards.yaml
@@ -5,6 +5,12 @@ cards:
     version: v1.8.1
     author: Borda
     description: "Benchmark detection, segmentation, and keypoint models across FP32, FP16+JIT, and ONNX Runtime — measures latency and FPS on GPU using CUDA events."
+  - href: fine-tune_segmentation/
+    name: "Fine-Tune RF-DETR Instance Segmentation"
+    labels: [TRAINING, PYTORCH LIGHTNING, SEGMENTATION, INFERENCE]
+    version: v1.8.1
+    author: Borda
+    description: "Fine-tune RF-DETR instance segmentation on any COCO segmentation dataset from Roboflow Universe — covers training, mask loss metrics, and inference with mask overlays."
   - href: fine-tune_keypoints/
     name: "Fine-Tune RF-DETR Keypoint Detection"
     labels: [TRAINING, PYTORCH LIGHTNING, INFERENCE]

--- a/docs/cookbooks/fine-tune_segmentation.ipynb
+++ b/docs/cookbooks/fine-tune_segmentation.ipynb
@@ -1,0 +1,832 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d699e571",
+   "metadata": {},
+   "source": [
+    "# RF-DETR instance segmentation fine-tuning on Roboflow Universe datasets\n",
+    "\n",
+    "Select one dataset with `DATASET_KEY`, then run the same fine-tuning, plotting, checkpoint loading, and inference cells.\n",
+    "\n",
+    "RF-DETR extends bounding-box detection with a sparse segmentation head that predicts per-object binary masks — useful\n",
+    "for crack detection, livestock counting, produce grading, sports analytics, and any task where *what shape* matters as\n",
+    "much as *what class*.\n",
+    "\n",
+    "**Datasets** — set `DATASET_KEY` to one of:\n",
+    "\n",
+    "| Key | Dataset | Classes |\n",
+    "|-----|---------|---------|\n",
+    "| `\"crack\"` | Concrete Crack Detection | crack |\n",
+    "| `\"cattle\"` | Cattle Segmentation | cow |\n",
+    "| `\"fruits\"` | Fruits Segmentation | apple, banana, cucumber, orange, grapes, pineapple, water_melon |\n",
+    "| `\"field\"` | Football Field Segmentation | ball, goal, player, center-half, field-half, keeper |\n",
+    "\n",
+    "Every subsequent cell (fine-tuning, plotting, checkpoint loading, inference) adapts automatically.\n",
+    "By the end you will have a fine-tuned model, training curves, and annotated inference images with segmentation masks."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47425a5c",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Install `rfdetr` with the `train` and `visual` extras. The `train` extra pulls in the training loop dependencies\n",
+    "(PyTorch Lightning, COCO evaluation tools, and data augmentation libraries), while `visual` adds the visualisation\n",
+    "helpers used later in the notebook. The `roboflow` package handles dataset download; `pandas` and `seaborn` are needed\n",
+    "for the metrics table and optional plot styling. If you hit an `ImportError` after running this cell, the most likely\n",
+    "cause is a stale in-memory import — restart the Python runtime once and re-run from the top."
+   ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": "!pip install -q \"rfdetr[train,visual]>=1.8.0\" roboflow pandas seaborn",
+   "id": "3101b80780c808fc"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "\"\"\"Shared RF-DETR instance segmentation fine-tuning demo for several Roboflow COCO segmentation exports.\"\"\"\n",
+    "\n",
+    "import json\n",
+    "import os\n",
+    "from pathlib import Path\n",
+    "from typing import Any\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import supervision as sv\n",
+    "import torch\n",
+    "from IPython.display import display\n",
+    "from matplotlib import pyplot as plt\n",
+    "from matplotlib.figure import Figure\n",
+    "from PIL import Image\n",
+    "from roboflow import Roboflow\n",
+    "\n",
+    "from rfdetr import RFDETRSegSmall\n",
+    "from rfdetr.config import SegmentationTrainConfig\n",
+    "from rfdetr.training import RFDETRDataModule, RFDETRModelModule, build_trainer\n",
+    "from rfdetr.training.callbacks.best_model import BestModelCallback\n",
+    "from rfdetr.utilities.reproducibility import seed_all\n",
+    "from rfdetr.visualize.training import plot_loss_metrics, plot_map_metrics"
+   ],
+   "id": "14c77caef413d675"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07e515a0",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "PROJECT_ROOT = Path(__file__).resolve().parent if \"__file__\" in globals() else Path.cwd()\n",
+    "DATASETS_DIR = PROJECT_ROOT / \"datasets\"\n",
+    "\n",
+    "# Resolution must be divisible by patch_size × num_windows (24 for RFDETRSegSmall).\n",
+    "# Larger resolutions capture fine-grained mask boundaries at the cost of GPU memory and time.\n",
+    "DATASETS: dict[str, dict[str, Any]] = {\n",
+    "    \"crack\": {\n",
+    "        \"name\": \"Concrete Crack Detection\",\n",
+    "        \"workspace\": \"university-bswxt\",\n",
+    "        \"project\": \"crack-bphdr\",\n",
+    "        \"version\": 2,\n",
+    "        \"source_url\": \"https://universe.roboflow.com/university-bswxt/crack-bphdr\",\n",
+    "        \"output_name\": \"seg_crack_demo\",\n",
+    "        # 384 — close-up macro shots of concrete surfaces; default resolution resolves\n",
+    "        # thin hairline cracks without requiring extra GPU memory.\n",
+    "        \"resolution\": 384,\n",
+    "    },\n",
+    "    \"cattle\": {\n",
+    "        \"name\": \"Cattle Segmentation\",\n",
+    "        \"workspace\": \"unversity-final-project\",\n",
+    "        \"project\": \"cattle-segmentation-7bhup\",\n",
+    "        \"version\": 2,\n",
+    "        \"source_url\": \"https://universe.roboflow.com/unversity-final-project/cattle-segmentation-7bhup\",\n",
+    "        \"output_name\": \"seg_cattle_demo\",\n",
+    "        # 432 — outdoor field shots at medium distance; a slightly higher resolution\n",
+    "        # helps delineate individual animals when they are partially overlapping.\n",
+    "        \"resolution\": 432,\n",
+    "    },\n",
+    "    \"fruits\": {\n",
+    "        \"name\": \"Fruits Segmentation\",\n",
+    "        \"workspace\": \"wisd-team\",\n",
+    "        \"project\": \"fruits-segmentation-moovf\",\n",
+    "        \"version\": 1,\n",
+    "        \"source_url\": \"https://universe.roboflow.com/wisd-team/fruits-segmentation-moovf\",\n",
+    "        \"output_name\": \"seg_fruits_demo\",\n",
+    "        # 384 — tabletop produce images; default resolution separates adjacent fruits\n",
+    "        # with sufficient boundary precision for the seven-class palette.\n",
+    "        \"resolution\": 384,\n",
+    "    },\n",
+    "    \"field\": {\n",
+    "        \"name\": \"Football Field Segmentation\",\n",
+    "        \"workspace\": \"prototype-models\",\n",
+    "        \"project\": \"field-segmentation-2-yz2xv\",\n",
+    "        \"version\": 2,\n",
+    "        \"source_url\": \"https://universe.roboflow.com/prototype-models/field-segmentation-2-yz2xv\",\n",
+    "        \"output_name\": \"seg_field_demo\",\n",
+    "        # 432 — broadcast-angle shots with players, ball, and field markings; the\n",
+    "        # higher resolution separates small objects (ball, keeper) from field regions.\n",
+    "        \"resolution\": 432,\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "DATASET_KEY = \"crack\"\n",
+    "DATASET_INFO = DATASETS[DATASET_KEY]\n",
+    "\n",
+    "OUTPUT_DIR = PROJECT_ROOT / \"output\" / str(DATASET_INFO[\"output_name\"])\n",
+    "METRICS_CSV = OUTPUT_DIR / \"metrics.csv\"\n",
+    "VALIDATION_METRICS_JSON = OUTPUT_DIR / \"validation_metrics.json\"\n",
+    "FINAL_CHECKPOINT_PATH = OUTPUT_DIR / \"checkpoint_final_demo.pth\"\n",
+    "\n",
+    "RESOLUTION = int(DATASET_INFO[\"resolution\"])\n",
+    "\n",
+    "SEED = 7\n",
+    "EPOCHS = 50\n",
+    "BATCH_SIZE = 8\n",
+    "GRAD_ACCUM_STEPS = 2\n",
+    "NUM_WORKERS = 8\n",
+    "LR = 1e-4\n",
+    "LR_ENCODER = 1e-4\n",
+    "SAMPLE_PREVIEW_COUNT = 6\n",
+    "SAMPLE_PREVIEW_COLUMNS = 3\n",
+    "INFERENCE_COUNT = 6\n",
+    "INFERENCE_COLUMNS = 3\n",
+    "INFERENCE_THRESHOLD = 0.3\n",
+    "PLOT_LOSS_LOG_SCALE = False\n",
+    "\n",
+    "print(f\"dataset_key={DATASET_KEY}\")\n",
+    "print(f\"dataset={DATASET_INFO['name']}\")\n",
+    "print(f\"source_url={DATASET_INFO['source_url']}\")\n",
+    "print(f\"resolution={RESOLUTION}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35be92f4",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "## Notebook display\n",
+    "\n",
+    "This helper registers the `%matplotlib inline` magic so figures render directly beneath each cell when you run the\n",
+    "notebook in Jupyter or Google Colab. If you are running this file as a plain Python script the function detects the\n",
+    "absence of an IPython kernel and exits silently, so it is always safe to call."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "501957b2",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "def _enable_notebook_inline_matplotlib() -> None:\n",
+    "    \"\"\"Enable inline matplotlib figures when running in IPython.\"\"\"\n",
+    "    get_ipython_func = globals().get(\"get_ipython\")\n",
+    "    if not callable(get_ipython_func):\n",
+    "        return\n",
+    "    ipython = get_ipython_func()\n",
+    "    if ipython is not None:\n",
+    "        ipython.run_line_magic(\"matplotlib\", \"inline\")\n",
+    "        ipython.run_line_magic(\"config\", \"InlineBackend.close_figures = True\")\n",
+    "\n",
+    "\n",
+    "_enable_notebook_inline_matplotlib()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bddc8a0a",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "## 1 - Download dataset\n",
+    "\n",
+    "Roboflow exports instance segmentation datasets in COCO format: a JSON file where each annotation contains a\n",
+    "`segmentation` field with polygon coordinates that trace the precise object boundary.  The download cell fetches the\n",
+    "exact dataset version listed in `DATASETS` and places it under `datasets/<DATASET_KEY>/`. You need a Roboflow API key\n",
+    "— get one for free at app.roboflow.com/settings/api and set it as the `ROBOFLOW_API_KEY` environment variable (or as\n",
+    "a Colab secret with the same name). The download is idempotent: if the target directory already exists Roboflow skips\n",
+    "the network transfer, so re-running this cell after a successful download is fast."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13e62476",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from google.colab import userdata\n",
+    "\n",
+    "    try:\n",
+    "        ROBOFLOW_API_KEY = userdata.get(\"ROBOFLOW_API_KEY\") or \"\"\n",
+    "    except Exception:\n",
+    "        ROBOFLOW_API_KEY = \"\"\n",
+    "except ImportError:\n",
+    "    ROBOFLOW_API_KEY = \"\"\n",
+    "\n",
+    "if not ROBOFLOW_API_KEY:\n",
+    "    ROBOFLOW_API_KEY = os.environ.get(\"ROBOFLOW_API_KEY\", \"\")\n",
+    "if not ROBOFLOW_API_KEY:\n",
+    "    raise RuntimeError(\n",
+    "        \"ROBOFLOW_API_KEY not found. \"\n",
+    "        \"In Colab: add it via Secrets (key icon). \"\n",
+    "        \"Locally: set the environment variable before running.\"\n",
+    "    )\n",
+    "\n",
+    "rf = Roboflow(api_key=ROBOFLOW_API_KEY)\n",
+    "dataset = (\n",
+    "    rf.workspace(str(DATASET_INFO[\"workspace\"]))\n",
+    "    .project(str(DATASET_INFO[\"project\"]))\n",
+    "    .version(int(DATASET_INFO[\"version\"]))\n",
+    "    .download(\"coco\", location=str(DATASETS_DIR / DATASET_KEY))\n",
+    ")\n",
+    "DATASET_DIR = Path(dataset.location)\n",
+    "TRAIN_ANNOTATIONS = DATASET_DIR / \"train\" / \"_annotations.coco.json\"\n",
+    "print(f\"dataset_dir={DATASET_DIR}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25ab84a0",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "## 2 - Infer class names\n",
+    "\n",
+    "Read the class names directly from the COCO annotation file.  RF-DETR uses 0-based class indices internally; the\n",
+    "`class_names` list maps each index to a human-readable label so the inference visualisation shows category names\n",
+    "rather than numbers.  If your dataset has a single category the list will have one element — that is expected."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16b7d1fe",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "with TRAIN_ANNOTATIONS.open() as _f:\n",
+    "    _coco = json.load(_f)\n",
+    "\n",
+    "CLASS_NAMES: list[str] = [cat[\"name\"] for cat in sorted(_coco[\"categories\"], key=lambda c: c[\"id\"])]\n",
+    "NUM_CLASSES = len(CLASS_NAMES)\n",
+    "\n",
+    "print(f\"class_names={CLASS_NAMES}\")\n",
+    "print(f\"num_classes={NUM_CLASSES}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61ad130c",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "`_save_final_checkpoint` writes a self-contained `.pth` file that bundles model weights with the full training and\n",
+    "model config. This is separate from the PTL checkpoint because it can be loaded with a single `from_checkpoint` call\n",
+    "on any machine, without reconstructing the original config."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c8b40d7",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "def _save_final_checkpoint(\n",
+    "    module: RFDETRModelModule,\n",
+    "    trainer: Any,\n",
+    "    train_config: SegmentationTrainConfig,\n",
+    "    model_config: Any,\n",
+    "    output_path: Path,\n",
+    ") -> Path:\n",
+    "    \"\"\"Save a final RF-DETR .pth checkpoint that can be loaded with ``from_checkpoint``.\"\"\"\n",
+    "    raw_model: Any = getattr(module.model, \"_orig_mod\", module.model)\n",
+    "    output_path.parent.mkdir(parents=True, exist_ok=True)\n",
+    "    torch.save(\n",
+    "        BestModelCallback._build_checkpoint_payload(\n",
+    "            raw_model.state_dict(),\n",
+    "            train_config.model_dump(),\n",
+    "            trainer,\n",
+    "            model_name=\"RFDETRSegSmall\",\n",
+    "            model_config_dict=model_config.model_dump(),\n",
+    "        ),\n",
+    "        output_path,\n",
+    "    )\n",
+    "    return output_path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60ec455d",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "`_segmentation_grid_figure` arranges multiple annotated images into a fixed-column matplotlib grid.\n",
+    "Masks are drawn with `sv.MaskAnnotator` (translucent colour fill) and bounding boxes with\n",
+    "`sv.BoundingBoxAnnotator`.  Labels show the class name and confidence score."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3d14f4c",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "def _segmentation_grid_figure(\n",
+    "    items: list[tuple[str, np.ndarray, sv.Detections]],\n",
+    "    columns: int,\n",
+    "    class_names: list[str],\n",
+    ") -> Figure:\n",
+    "    \"\"\"Render segmentation masks and bounding boxes in a fixed-column subplot grid.\"\"\"\n",
+    "    if columns <= 0:\n",
+    "        raise ValueError(f\"columns must be positive, got {columns}.\")\n",
+    "\n",
+    "    mask_annotator = sv.MaskAnnotator()\n",
+    "    box_annotator = sv.BoundingBoxAnnotator(thickness=2)\n",
+    "    label_annotator = sv.LabelAnnotator(text_scale=0.5, text_thickness=1, text_padding=4)\n",
+    "\n",
+    "    rows = max(1, (len(items) + columns - 1) // columns)\n",
+    "    figure, axes = plt.subplots(rows, columns, figsize=(5 * columns, 5 * rows))\n",
+    "    axes_array = np.asarray(axes, dtype=object).reshape(-1)\n",
+    "    for axis in axes_array:\n",
+    "        axis.axis(\"off\")\n",
+    "\n",
+    "    for axis, (title, image, detections) in zip(axes_array, items, strict=False):\n",
+    "        scene = image.copy()\n",
+    "        if detections.mask is not None and len(detections) > 0:\n",
+    "            scene = mask_annotator.annotate(scene=scene, detections=detections)\n",
+    "        scene = box_annotator.annotate(scene=scene, detections=detections)\n",
+    "        if len(detections) > 0 and detections.class_id is not None:\n",
+    "            labels = [\n",
+    "                f\"{class_names[cid] if cid < len(class_names) else cid} {conf:.2f}\"\n",
+    "                for cid, conf in zip(\n",
+    "                    detections.class_id.tolist(),\n",
+    "                    detections.confidence.tolist() if detections.confidence is not None else [],\n",
+    "                )\n",
+    "            ]\n",
+    "            scene = label_annotator.annotate(scene=scene, detections=detections, labels=labels)\n",
+    "        axis.imshow(scene)\n",
+    "        axis.set_title(title, fontsize=10)\n",
+    "        axis.axis(\"off\")\n",
+    "\n",
+    "    figure.tight_layout()\n",
+    "    return figure"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23ca942a",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "## 3 - Configure training\n",
+    "\n",
+    "`SegmentationTrainConfig` centralises every hyperparameter the training loop needs, including mask-specific loss\n",
+    "coefficients (`mask_ce_loss_coef` and `mask_dice_loss_coef`).  The defaults (5.0 each) work well for most datasets;\n",
+    "if the segmentation head overfits early you can reduce them towards 2.0 while keeping `cls_loss_coef=5.0`.\n",
+    "\n",
+    "`lr` and `lr_encoder` control the head and backbone learning rates respectively.  For fine-tuning both are usually\n",
+    "set to the same value; if you notice the backbone overfitting early, halve `lr_encoder` to protect the pre-trained\n",
+    "features.  `grad_accum_steps=2` doubles the effective batch size without extra GPU memory.\n",
+    "\n",
+    "`multi_scale=False` and `expanded_scales=False` disable multi-resolution augmentation to shorten epoch time during\n",
+    "fine-tuning — they rarely help on small custom datasets.  The `notes` dict is stored alongside the weights in the\n",
+    "checkpoint, giving you a lightweight experiment log that travels with the model file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5637e624",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "seed_all(SEED)\n",
+    "variant = RFDETRSegSmall(  # type: ignore[no-untyped-call]\n",
+    "    num_classes=NUM_CLASSES,\n",
+    "    resolution=RESOLUTION,\n",
+    ")\n",
+    "variant.model_config.model_name = type(variant).__name__\n",
+    "\n",
+    "train_config = SegmentationTrainConfig(\n",
+    "    dataset_file=\"roboflow\",\n",
+    "    dataset_dir=str(DATASET_DIR),\n",
+    "    output_dir=str(OUTPUT_DIR),\n",
+    "    epochs=EPOCHS,\n",
+    "    batch_size=BATCH_SIZE,\n",
+    "    grad_accum_steps=GRAD_ACCUM_STEPS,\n",
+    "    num_workers=NUM_WORKERS,\n",
+    "    lr=LR,\n",
+    "    lr_encoder=LR_ENCODER,\n",
+    "    use_ema=False,\n",
+    "    run_test=False,\n",
+    "    compute_train_metrics=True,\n",
+    "    compute_val_loss=True,\n",
+    "    multi_scale=False,\n",
+    "    expanded_scales=False,\n",
+    "    do_random_resize_via_padding=False,\n",
+    "    tensorboard=False,\n",
+    "    wandb=False,\n",
+    "    mlflow=False,\n",
+    "    clearml=False,\n",
+    "    class_names=CLASS_NAMES,\n",
+    "    notes={\n",
+    "        \"demo\": f\"segmentation PTL fine-tune on Roboflow Universe {DATASET_INFO['project']}\",\n",
+    "        \"source_url\": DATASET_INFO[\"source_url\"],\n",
+    "        \"roboflow_workspace\": DATASET_INFO[\"workspace\"],\n",
+    "        \"roboflow_project\": DATASET_INFO[\"project\"],\n",
+    "        \"roboflow_version\": DATASET_INFO[\"version\"],\n",
+    "        \"num_classes\": NUM_CLASSES,\n",
+    "        \"class_names\": CLASS_NAMES,\n",
+    "    },\n",
+    "    progress_bar=\"tqdm\",\n",
+    ")\n",
+    "\n",
+    "datamodule = RFDETRDataModule(variant.model_config, train_config)\n",
+    "model = RFDETRModelModule(variant.model_config, train_config)\n",
+    "trainer = build_trainer(train_config, variant.model_config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c7d27de",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "## 4 - Preview dataset inputs\n",
+    "\n",
+    "Always look at your data before you start a long training run. This cell renders a grid of annotated training images\n",
+    "so you can confirm that segmentation masks align with objects, colour jitter and flips look reasonable, and there are\n",
+    "no systematic labelling errors such as masks placed on the wrong object or masks that bleed outside the object\n",
+    "boundary. Catching label noise here costs a few seconds; catching it after 50 epochs costs much more."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "213e9ec5",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "sample_figure = datamodule._show_samples(\n",
+    "    SAMPLE_PREVIEW_COUNT,\n",
+    "    split=\"train\",\n",
+    "    columns=SAMPLE_PREVIEW_COLUMNS,\n",
+    ")\n",
+    "display(sample_figure)\n",
+    "plt.close(sample_figure)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf9ca462",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "## 5 - Fine-tune\n",
+    "\n",
+    "`trainer.fit` hands control to PyTorch Lightning, which drives the full training loop: forward pass, loss\n",
+    "computation (cross-entropy + Dice on sampled mask points), gradient accumulation, weight updates,\n",
+    "learning-rate scheduling, and periodic validation with COCO mask mAP.  After each epoch the trainer appends a row to\n",
+    "`metrics.csv` and, if validation mAP improves, saves a new best checkpoint via `BestModelCallback`. On a single\n",
+    "consumer GPU (RTX 3090 or similar) 50 epochs on the crack dataset takes roughly 20–35 minutes depending on\n",
+    "`BATCH_SIZE` and `NUM_WORKERS`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dfe5d16d",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "trainer.fit(model, datamodule=datamodule, ckpt_path=train_config.resume or None)\n",
+    "print(f\"output_dir={OUTPUT_DIR}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "031bec6c",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "## 6 - Save checkpoint/model\n",
+    "\n",
+    "PTL saves its own checkpoints during training (optimizer state, scheduler state, epoch counter), but those files are\n",
+    "not directly portable — they require the same class hierarchy to load.  The `.pth` file written here is a\n",
+    "self-contained RF-DETR checkpoint: it bundles the model weights together with the full training and model configs,\n",
+    "including the class names.  You can share the file with a colleague and they can run inference with a single\n",
+    "`RFDETRSegSmall.from_checkpoint(path)` call.  For full reproducibility, keep this checkpoint alongside the dataset\n",
+    "version number printed in section 1."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae7e6168",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "final_checkpoint = _save_final_checkpoint(model, trainer, train_config, variant.model_config, FINAL_CHECKPOINT_PATH)\n",
+    "print(f\"saved_checkpoint={final_checkpoint}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de944537",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "## 7 - Validate metrics\n",
+    "\n",
+    "This cell runs a clean post-training validation with no augmentation, using the best checkpoint loaded from\n",
+    "`checkpoint_best_total.pth` written by `BestModelCallback`, and serialises results to JSON. Two metrics are most\n",
+    "important to inspect. `bbox/map` is the standard COCO bounding-box mAP at IoU 0.50:0.95. `segm/map` (when logged)\n",
+    "is the mask mAP — it measures how precisely the predicted binary masks overlap with the annotated polygons. A model\n",
+    "can have high `bbox/map` but low `segm/map` if the detector locates objects well but the mask boundaries are coarse;\n",
+    "this usually improves with more training epochs or by increasing `resolution`.\n",
+    "\n",
+    "**Note:** `checkpoint_best_total.pth` is written after the first completed validation epoch. If training was\n",
+    "interrupted before any epoch finished, this file will not exist and the cell below will raise `FileNotFoundError`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "305344bf",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "# checkpoint_best_total.pth stores plain model weights under key \"model\", not a full\n",
+    "# PTL checkpoint.  Passing it as ckpt_path to trainer.validate() triggers a KeyError\n",
+    "# on \"validate_loop\" because PTL tries to restore loop state that isn't present.\n",
+    "# Load the weights directly and run validate without ckpt_path instead.\n",
+    "_ckpt = torch.load(OUTPUT_DIR / \"checkpoint_best_total.pth\", map_location=\"cpu\", weights_only=False)\n",
+    "model.model.load_state_dict(_ckpt[\"model\"], strict=True)\n",
+    "del _ckpt\n",
+    "validation_results = trainer.validate(model, datamodule=datamodule)\n",
+    "validation_metrics = {key: float(value) for key, value in validation_results[0].items()} if validation_results else {}\n",
+    "VALIDATION_METRICS_JSON.write_text(json.dumps(validation_metrics, indent=2, sort_keys=True), encoding=\"utf-8\")\n",
+    "print(f\"validation_metrics={validation_metrics}\")\n",
+    "print(f\"validation_metrics_json={VALIDATION_METRICS_JSON}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e7b25c6",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "## 8 - Plot CSVLogger metrics\n",
+    "\n",
+    "Reading loss curves is one of the fastest ways to diagnose training problems.  Healthy segmentation runs show the\n",
+    "combined detection + mask loss decreasing together for train and val.  A loss that rises or plateaus from epoch 1 is\n",
+    "usually a sign that the learning rate is too high or the dataset is too small for the chosen `BATCH_SIZE`.  For the\n",
+    "mAP curves, `segm mAP 50` (mask IoU ≥ 0.50) rises fastest and is the clearest signal of whether the model is\n",
+    "learning to segment objects; `segm mAP 50:95` (averaged across stricter thresholds) follows more slowly.\n",
+    "Set `PLOT_LOSS_LOG_SCALE = True` if the loss drops by an order of magnitude in the first few epochs and the later,\n",
+    "more meaningful portion of the curve gets compressed into a flat line."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f22fb91",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"metrics_csv={METRICS_CSV}\")\n",
+    "loss_figure = plot_loss_metrics(str(METRICS_CSV), loss_log_scale=PLOT_LOSS_LOG_SCALE)\n",
+    "display(loss_figure)\n",
+    "plt.close(loss_figure)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3d2fa29",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "map_figure = plot_map_metrics(str(METRICS_CSV))\n",
+    "display(map_figure)\n",
+    "plt.close(map_figure)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3eb9ffae",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "## 9 - Load checkpoint/model\n",
+    "\n",
+    "`from_checkpoint` is the standard entry point for loading a saved RF-DETR model.  It reads both the weights and the\n",
+    "stored config from the `.pth` file, so the reconstructed model has the correct number of classes and resolution\n",
+    "without you having to pass them explicitly.  You can share this file with teammates and they can run inference\n",
+    "immediately — the class names and architecture are all embedded alongside the weights."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ea77ee4",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "loaded_model = RFDETRSegSmall.from_checkpoint(FINAL_CHECKPOINT_PATH)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "edcc13da",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "## 10 - Select inference images\n",
+    "\n",
+    "This cell implements a fallback chain — test split first, then validation, then train — so the notebook always finds\n",
+    "images to run inference on even when the dataset has no dedicated test split. Using images from the test set gives\n",
+    "you an unbiased view of model performance because those images were never seen during training or used to pick the\n",
+    "best checkpoint. Replace `inference_image_paths` with a list of `Path` objects pointing to your own files to run\n",
+    "inference on custom images."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a9f0779",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "_IMAGE_EXTS = {\".jpg\", \".jpeg\", \".png\"}\n",
+    "\n",
+    "\n",
+    "def _find_images(directory: Path) -> list[Path]:\n",
+    "    if not directory.is_dir():\n",
+    "        return []\n",
+    "    return sorted(p for p in directory.glob(\"**/*\") if p.is_file() and p.suffix.lower() in _IMAGE_EXTS)\n",
+    "\n",
+    "\n",
+    "validation_image_paths = _find_images(DATASET_DIR / \"test\")\n",
+    "if not validation_image_paths:\n",
+    "    validation_image_paths = _find_images(DATASET_DIR / \"valid\")\n",
+    "if not validation_image_paths:\n",
+    "    validation_image_paths = _find_images(DATASET_DIR / \"train\")\n",
+    "if not validation_image_paths:\n",
+    "    raise FileNotFoundError(f\"No images ({', '.join(sorted(_IMAGE_EXTS))}) found under {DATASET_DIR}\")\n",
+    "\n",
+    "inference_image_paths = validation_image_paths[:INFERENCE_COUNT]\n",
+    "print(f\"inference_images={[str(p) for p in inference_image_paths]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d62231f",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "## 11 - Visualize inference\n",
+    "\n",
+    "`INFERENCE_THRESHOLD` is a detection confidence threshold: only detections whose bounding-box score exceeds this\n",
+    "value are shown.  Raise it to suppress false positives; lower it to surface low-confidence detections.  Each accepted\n",
+    "detection includes a binary mask resized to the original image dimensions — `sv.MaskAnnotator` renders it as a\n",
+    "translucent colour overlay so you can see both the mask shape and the image beneath it.\n",
+    "\n",
+    "If the mask boundaries look jagged, consider increasing `RESOLUTION` (in multiples of 24) and retraining; higher\n",
+    "resolution gives the segmentation head more spatial detail to work with."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d9c7ea24",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "inference_grid_items: list[tuple[str, np.ndarray, sv.Detections]] = []\n",
+    "for image_path in inference_image_paths:\n",
+    "    with Image.open(image_path) as image:\n",
+    "        image_rgb = image.convert(\"RGB\")\n",
+    "    detections = loaded_model.predict(image_rgb, threshold=INFERENCE_THRESHOLD)\n",
+    "    if not isinstance(detections, sv.Detections):\n",
+    "        raise RuntimeError(f\"Expected RFDETRSegSmall.predict() to return sv.Detections, got {type(detections)!r}.\")\n",
+    "    inference_grid_items.append((image_path.name, np.array(image_rgb), detections))\n",
+    "\n",
+    "if inference_grid_items:\n",
+    "    figure = _segmentation_grid_figure(inference_grid_items, columns=INFERENCE_COLUMNS, class_names=CLASS_NAMES)\n",
+    "    display(figure)\n",
+    "    plt.close(figure)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2915058b",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "## 12 - Detection summary\n",
+    "\n",
+    "Print per-image detection counts and confidence scores as a quick sanity check.  If you see zero detections on most\n",
+    "images, try lowering `INFERENCE_THRESHOLD` (towards 0.1) — the model may be calibrated to lower confidence scores\n",
+    "on a custom dataset than the COCO-pretrained default.  If you see too many false positives, raise the threshold or\n",
+    "add more negative examples to your training set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d5a11820",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "summary_rows = []\n",
+    "for image_path, (_, _, detections) in zip(inference_image_paths, inference_grid_items):\n",
+    "    num_det = len(detections)\n",
+    "    has_masks = detections.mask is not None and detections.mask.shape[0] > 0\n",
+    "    avg_conf = (\n",
+    "        float(np.mean(detections.confidence)) if detections.confidence is not None and num_det > 0 else float(\"nan\")\n",
+    "    )\n",
+    "    summary_rows.append(\n",
+    "        {\n",
+    "            \"image\": image_path.name,\n",
+    "            \"detections\": num_det,\n",
+    "            \"has_masks\": has_masks,\n",
+    "            \"avg_confidence\": round(avg_conf, 3),\n",
+    "        }\n",
+    "    )\n",
+    "\n",
+    "summary_df = pd.DataFrame(summary_rows)\n",
+    "display(summary_df)"
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "title,-all",
+   "main_language": "python",
+   "notebook_metadata_filter": "-all"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/cookbooks/fine-tune_segmentation.ipynb
+++ b/docs/cookbooks/fine-tune_segmentation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d699e571",
+   "id": "64736ca1",
    "metadata": {},
    "source": [
     "# RF-DETR instance segmentation fine-tuning on Roboflow Universe datasets\n",
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47425a5c",
+   "id": "6b4797e9",
    "metadata": {},
    "source": [
     "## Setup\n",
@@ -42,21 +42,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "3101b80780c808fc",
-   "metadata": {
-    "title": "[bash]"
-   },
+   "id": "99f1f539",
+   "metadata": {},
+   "source": "!pip install -q \"rfdetr[train,visual]>=1.8.2\" roboflow pandas seaborn",
    "outputs": [],
-   "source": [
-    "!pip install -q \"rfdetr[train,visual]>=1.8.2\" roboflow pandas seaborn"
-   ]
+   "execution_count": null
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14c77caef413d675",
-   "metadata": {},
+   "id": "b60971f9",
+   "metadata": {
+    "title": "[bash]"
+   },
    "outputs": [],
    "source": [
     "\"\"\"Shared RF-DETR instance segmentation fine-tuning demo for several Roboflow COCO segmentation exports.\"\"\"\n",
@@ -87,10 +85,8 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "07e515a0",
-   "metadata": {
-    "lines_to_next_cell": 2
-   },
+   "id": "1c40c67d",
+   "metadata": {},
    "outputs": [],
    "source": [
     "PROJECT_ROOT = Path(__file__).resolve().parent if \"__file__\" in globals() else Path.cwd()\n",
@@ -164,6 +160,7 @@
     "LR_ENCODER = 1e-4\n",
     "SAMPLE_PREVIEW_COUNT = 6\n",
     "SAMPLE_PREVIEW_COLUMNS = 3\n",
+    "SAMPLE_PREVIEW_FIGURE_SIZE: tuple[float, float] = (15.0, 10.0)\n",
     "INFERENCE_COUNT = 6\n",
     "INFERENCE_COLUMNS = 3\n",
     "INFERENCE_THRESHOLD = 0.3\n",
@@ -177,7 +174,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35be92f4",
+   "id": "7f99c55d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -191,12 +188,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "501957b2",
+   "id": "ab8fdeb6",
    "metadata": {
     "lines_to_next_cell": 2
    },
-   "outputs": [],
    "source": [
     "def _enable_notebook_inline_matplotlib() -> None:\n",
     "    \"\"\"Enable inline matplotlib figures when running in IPython.\"\"\"\n",
@@ -210,11 +205,13 @@
     "\n",
     "\n",
     "_enable_notebook_inline_matplotlib()"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
-   "id": "bddc8a0a",
+   "id": "e38db150",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -231,12 +228,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "13e62476",
+   "id": "2c6b8dc4",
    "metadata": {
     "lines_to_next_cell": 2
    },
-   "outputs": [],
    "source": [
     "try:\n",
     "    from google.colab import userdata\n",
@@ -267,11 +262,13 @@
     "DATASET_DIR = Path(dataset.location)\n",
     "TRAIN_ANNOTATIONS = DATASET_DIR / \"train\" / \"_annotations.coco.json\"\n",
     "print(f\"dataset_dir={DATASET_DIR}\")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
-   "id": "25ab84a0",
+   "id": "945822fa",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -285,12 +282,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "16b7d1fe",
+   "id": "ed36df66",
    "metadata": {
     "lines_to_next_cell": 2
    },
-   "outputs": [],
    "source": [
     "with TRAIN_ANNOTATIONS.open() as _f:\n",
     "    _coco = json.load(_f)\n",
@@ -300,11 +295,13 @@
     "\n",
     "print(f\"class_names={CLASS_NAMES}\")\n",
     "print(f\"num_classes={NUM_CLASSES}\")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
-   "id": "61ad130c",
+   "id": "7000d9a4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -316,12 +313,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "9c8b40d7",
+   "id": "477cd2f6",
    "metadata": {
     "lines_to_next_cell": 2
    },
-   "outputs": [],
    "source": [
     "def _save_final_checkpoint(\n",
     "    module: RFDETRModelModule,\n",
@@ -344,28 +339,28 @@
     "        output_path,\n",
     "    )\n",
     "    return output_path"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
-   "id": "60ec455d",
+   "id": "8e53a5a5",
    "metadata": {
     "lines_to_next_cell": 2
    },
    "source": [
     "`_segmentation_grid_figure` arranges multiple annotated images into a fixed-column matplotlib grid.\n",
     "Masks are drawn with `sv.MaskAnnotator` (translucent colour fill) and bounding boxes with\n",
-    "`sv.BoundingBoxAnnotator`.  Labels show the class name and confidence score."
+    "`sv.BoxAnnotator`.  Labels show the class name and confidence score."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e3d14f4c",
+   "id": "3e71bc58",
    "metadata": {
     "lines_to_next_cell": 2
    },
-   "outputs": [],
    "source": [
     "def _segmentation_grid_figure(\n",
     "    items: list[tuple[str, np.ndarray, sv.Detections]],\n",
@@ -377,7 +372,7 @@
     "        raise ValueError(f\"columns must be positive, got {columns}.\")\n",
     "\n",
     "    mask_annotator = sv.MaskAnnotator()\n",
-    "    box_annotator = sv.BoundingBoxAnnotator(thickness=2)\n",
+    "    box_annotator = sv.BoxAnnotator(thickness=2)\n",
     "    label_annotator = sv.LabelAnnotator(text_scale=0.5, text_thickness=1, text_padding=4)\n",
     "\n",
     "    rows = max(1, (len(items) + columns - 1) // columns)\n",
@@ -392,12 +387,12 @@
     "            scene = mask_annotator.annotate(scene=scene, detections=detections)\n",
     "        scene = box_annotator.annotate(scene=scene, detections=detections)\n",
     "        if len(detections) > 0 and detections.class_id is not None:\n",
+    "            conf_list = (\n",
+    "                detections.confidence.tolist() if detections.confidence is not None else [None] * len(detections)\n",
+    "            )\n",
     "            labels = [\n",
-    "                f\"{class_names[cid] if cid < len(class_names) else cid} {conf:.2f}\"\n",
-    "                for cid, conf in zip(\n",
-    "                    detections.class_id.tolist(),\n",
-    "                    detections.confidence.tolist() if detections.confidence is not None else [],\n",
-    "                )\n",
+    "                f\"{class_names[cid] if cid < len(class_names) else cid}\" + (f\" {conf:.2f}\" if conf is not None else \"\")\n",
+    "                for cid, conf in zip(detections.class_id.tolist(), conf_list)\n",
     "            ]\n",
     "            scene = label_annotator.annotate(scene=scene, detections=detections, labels=labels)\n",
     "        axis.imshow(scene)\n",
@@ -406,11 +401,13 @@
     "\n",
     "    figure.tight_layout()\n",
     "    return figure"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
-   "id": "23ca942a",
+   "id": "5f0ccbd3",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -432,12 +429,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "5637e624",
+   "id": "71e1a7db",
    "metadata": {
     "lines_to_next_cell": 2
    },
-   "outputs": [],
    "source": [
     "seed_all(SEED)\n",
     "variant = RFDETRSegSmall(  # type: ignore[no-untyped-call]\n",
@@ -483,11 +478,13 @@
     "datamodule = RFDETRDataModule(variant.model_config, train_config)\n",
     "model = RFDETRModelModule(variant.model_config, train_config)\n",
     "trainer = build_trainer(train_config, variant.model_config)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
-   "id": "5c7d27de",
+   "id": "993b1cd1",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -502,25 +499,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "213e9ec5",
+   "id": "0564b2c6",
    "metadata": {
     "lines_to_next_cell": 2
    },
-   "outputs": [],
    "source": [
     "sample_figure = datamodule._show_samples(\n",
     "    SAMPLE_PREVIEW_COUNT,\n",
     "    split=\"train\",\n",
     "    columns=SAMPLE_PREVIEW_COLUMNS,\n",
+    "    figure_size=SAMPLE_PREVIEW_FIGURE_SIZE,\n",
     ")\n",
     "display(sample_figure)\n",
     "plt.close(sample_figure)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
-   "id": "cf9ca462",
+   "id": "c746e44d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -537,20 +535,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "dfe5d16d",
+   "id": "684059b3",
    "metadata": {
     "lines_to_next_cell": 2
    },
-   "outputs": [],
    "source": [
     "trainer.fit(model, datamodule=datamodule, ckpt_path=train_config.resume or None)\n",
     "print(f\"output_dir={OUTPUT_DIR}\")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
-   "id": "031bec6c",
+   "id": "dadba8e3",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -567,20 +565,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "ae7e6168",
+   "id": "ea69ee92",
    "metadata": {
     "lines_to_next_cell": 2
    },
-   "outputs": [],
    "source": [
     "final_checkpoint = _save_final_checkpoint(model, trainer, train_config, variant.model_config, FINAL_CHECKPOINT_PATH)\n",
     "print(f\"saved_checkpoint={final_checkpoint}\")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
-   "id": "de944537",
+   "id": "e9b7a1cb",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -600,12 +598,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "305344bf",
+   "id": "abab244f",
    "metadata": {
     "lines_to_next_cell": 2
    },
-   "outputs": [],
    "source": [
     "# checkpoint_best_total.pth stores plain model weights under key \"model\", not a full\n",
     "# PTL checkpoint.  Passing it as ckpt_path to trainer.validate() triggers a KeyError\n",
@@ -619,11 +615,13 @@
     "VALIDATION_METRICS_JSON.write_text(json.dumps(validation_metrics, indent=2, sort_keys=True), encoding=\"utf-8\")\n",
     "print(f\"validation_metrics={validation_metrics}\")\n",
     "print(f\"validation_metrics_json={VALIDATION_METRICS_JSON}\")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
-   "id": "6e7b25c6",
+   "id": "c93477c9",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -641,24 +639,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "5f22fb91",
-   "metadata": {},
-   "outputs": [],
+   "id": "e46c2424",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "print(f\"metrics_csv={METRICS_CSV}\")\n",
     "loss_figure = plot_loss_metrics(str(METRICS_CSV), loss_log_scale=PLOT_LOSS_LOG_SCALE)\n",
     "display(loss_figure)\n",
     "plt.close(loss_figure)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d3d2fa29",
-   "metadata": {
-    "lines_to_next_cell": 2
-   },
+   "id": "58b00247",
+   "metadata": {},
    "outputs": [],
    "source": [
     "map_figure = plot_map_metrics(str(METRICS_CSV))\n",
@@ -668,7 +666,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3eb9ffae",
+   "id": "d2252a7a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -683,19 +681,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "1ea77ee4",
+   "id": "f03e8dcc",
    "metadata": {
     "lines_to_next_cell": 2
    },
+   "source": "loaded_model = RFDETRSegSmall.from_checkpoint(FINAL_CHECKPOINT_PATH)",
    "outputs": [],
-   "source": [
-    "loaded_model = RFDETRSegSmall.from_checkpoint(FINAL_CHECKPOINT_PATH)"
-   ]
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
-   "id": "edcc13da",
+   "id": "74116bbe",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -711,12 +707,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "6a9f0779",
+   "id": "f3a68bfe",
    "metadata": {
     "lines_to_next_cell": 2
    },
-   "outputs": [],
    "source": [
     "_IMAGE_EXTS = {\".jpg\", \".jpeg\", \".png\"}\n",
     "\n",
@@ -737,11 +731,13 @@
     "\n",
     "inference_image_paths = validation_image_paths[:INFERENCE_COUNT]\n",
     "print(f\"inference_images={[str(p) for p in inference_image_paths]}\")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
-   "id": "5d62231f",
+   "id": "63027bc2",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -759,12 +755,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d9c7ea24",
+   "id": "d723ad36",
    "metadata": {
     "lines_to_next_cell": 2
    },
-   "outputs": [],
    "source": [
     "inference_grid_items: list[tuple[str, np.ndarray, sv.Detections]] = []\n",
     "for image_path in inference_image_paths:\n",
@@ -779,11 +773,13 @@
     "    figure = _segmentation_grid_figure(inference_grid_items, columns=INFERENCE_COLUMNS, class_names=CLASS_NAMES)\n",
     "    display(figure)\n",
     "    plt.close(figure)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
-   "id": "2915058b",
+   "id": "29b52678",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -798,10 +794,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d5a11820",
-   "metadata": {},
-   "outputs": [],
+   "id": "7325880c",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "summary_rows = []\n",
     "for image_path, (_, _, detections) in zip(inference_image_paths, inference_grid_items):\n",
@@ -821,7 +817,9 @@
     "\n",
     "summary_df = pd.DataFrame(summary_rows)\n",
     "display(summary_df)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   }
  ],
  "metadata": {

--- a/docs/cookbooks/fine-tune_segmentation.ipynb
+++ b/docs/cookbooks/fine-tune_segmentation.ipynb
@@ -41,18 +41,23 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
-   "source": "!pip install -q \"rfdetr[train,visual]>=1.8.0\" roboflow pandas seaborn",
-   "id": "3101b80780c808fc"
+   "id": "3101b80780c808fc",
+   "metadata": {
+    "title": "[bash]"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install -q \"rfdetr[train,visual]>=1.8.2\" roboflow pandas seaborn"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
+   "id": "14c77caef413d675",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "\"\"\"Shared RF-DETR instance segmentation fine-tuning demo for several Roboflow COCO segmentation exports.\"\"\"\n",
     "\n",
@@ -77,8 +82,7 @@
     "from rfdetr.training.callbacks.best_model import BestModelCallback\n",
     "from rfdetr.utilities.reproducibility import seed_all\n",
     "from rfdetr.visualize.training import plot_loss_metrics, plot_map_metrics"
-   ],
-   "id": "14c77caef413d675"
+   ]
   },
   {
    "cell_type": "code",

--- a/docs/cookbooks/fine-tune_segmentation.ipynb
+++ b/docs/cookbooks/fine-tune_segmentation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "64736ca1",
+   "id": "6eaacf22",
    "metadata": {},
    "source": [
     "# RF-DETR instance segmentation fine-tuning on Roboflow Universe datasets\n",
@@ -10,17 +10,18 @@
     "Select one dataset with `DATASET_KEY`, then run the same fine-tuning, plotting, checkpoint loading, and inference cells.\n",
     "\n",
     "RF-DETR extends bounding-box detection with a sparse segmentation head that predicts per-object binary masks — useful\n",
-    "for crack detection, livestock counting, produce grading, sports analytics, and any task where *what shape* matters as\n",
-    "much as *what class*.\n",
+    "for facade analysis, infrastructure damage inspection, vehicle part assessment, dental imaging, litter mapping, and\n",
+    "any task where *what shape* matters as much as *what class*.\n",
     "\n",
     "**Datasets** — set `DATASET_KEY` to one of:\n",
     "\n",
     "| Key | Dataset | Classes |\n",
     "|-----|---------|---------|\n",
-    "| `\"crack\"` | Concrete Crack Detection | crack |\n",
-    "| `\"cattle\"` | Cattle Segmentation | cow |\n",
-    "| `\"fruits\"` | Fruits Segmentation | apple, banana, cucumber, orange, grapes, pineapple, water_melon |\n",
-    "| `\"field\"` | Football Field Segmentation | ball, goal, player, center-half, field-half, keeper |\n",
+    "| `\"building_facade\"` | Building Facade Segmentation | facade, window, street, vegetation, car, fence, ... |\n",
+    "| `\"spalling_rebar\"` | Spalling and Exposed Rebar | exposed_rebar, spalling |\n",
+    "| `\"car_damage_parts\"` | Car Part Damage Segmentation | bumper, wheel, door, headlight, dent, scratch, ... |\n",
+    "| `\"teeth_numbering\"` | Teeth Numbering Segmentation | tooth IDs 11-48 |\n",
+    "| `\"taco_trash\"` | TACO Trash | bottle, can, carton, cup, lid, straw, wrapper, ... |\n",
     "\n",
     "Every subsequent cell (fine-tuning, plotting, checkpoint loading, inference) adapts automatically.\n",
     "By the end you will have a fine-tuned model, training curves, and annotated inference images with segmentation masks."
@@ -28,7 +29,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b4797e9",
+   "id": "64736ca1",
    "metadata": {},
    "source": [
     "## Setup\n",
@@ -42,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "id": "99f1f539",
+   "id": "6b4797e9",
    "metadata": {},
    "source": "!pip install -q \"rfdetr[train,visual]>=1.8.2\" roboflow pandas seaborn",
    "outputs": [],
@@ -51,7 +52,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b60971f9",
+   "id": "99f1f539",
    "metadata": {
     "title": "[bash]"
    },
@@ -85,7 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c40c67d",
+   "id": "b60971f9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,53 +96,64 @@
     "# Resolution must be divisible by patch_size × num_windows (24 for RFDETRSegSmall).\n",
     "# Larger resolutions capture fine-grained mask boundaries at the cost of GPU memory and time.\n",
     "DATASETS: dict[str, dict[str, Any]] = {\n",
-    "    \"crack\": {\n",
-    "        \"name\": \"Concrete Crack Detection\",\n",
-    "        \"workspace\": \"university-bswxt\",\n",
-    "        \"project\": \"crack-bphdr\",\n",
-    "        \"version\": 2,\n",
-    "        \"source_url\": \"https://universe.roboflow.com/university-bswxt/crack-bphdr\",\n",
-    "        \"output_name\": \"seg_crack_demo\",\n",
-    "        # 384 — close-up macro shots of concrete surfaces; default resolution resolves\n",
-    "        # thin hairline cracks without requiring extra GPU memory.\n",
-    "        \"resolution\": 384,\n",
-    "    },\n",
-    "    \"cattle\": {\n",
-    "        \"name\": \"Cattle Segmentation\",\n",
-    "        \"workspace\": \"unversity-final-project\",\n",
-    "        \"project\": \"cattle-segmentation-7bhup\",\n",
-    "        \"version\": 2,\n",
-    "        \"source_url\": \"https://universe.roboflow.com/unversity-final-project/cattle-segmentation-7bhup\",\n",
-    "        \"output_name\": \"seg_cattle_demo\",\n",
-    "        # 432 — outdoor field shots at medium distance; a slightly higher resolution\n",
-    "        # helps delineate individual animals when they are partially overlapping.\n",
+    "    \"building_facade\": {\n",
+    "        \"name\": \"Building Facade Segmentation\",\n",
+    "        \"workspace\": \"building-facade\",\n",
+    "        \"project\": \"building-facade-segmentation-instance\",\n",
+    "        \"version\": 4,\n",
+    "        \"source_url\": \"https://universe.roboflow.com/building-facade/building-facade-segmentation-instance\",\n",
+    "        \"output_name\": \"seg_building_facade\",\n",
+    "        # 432 — structured street scenes with medium-to-large facade regions plus\n",
+    "        # smaller windows, cars, vegetation, and infrastructure boundaries.\n",
     "        \"resolution\": 432,\n",
     "    },\n",
-    "    \"fruits\": {\n",
-    "        \"name\": \"Fruits Segmentation\",\n",
-    "        \"workspace\": \"wisd-team\",\n",
-    "        \"project\": \"fruits-segmentation-moovf\",\n",
-    "        \"version\": 1,\n",
-    "        \"source_url\": \"https://universe.roboflow.com/wisd-team/fruits-segmentation-moovf\",\n",
-    "        \"output_name\": \"seg_fruits_demo\",\n",
-    "        # 384 — tabletop produce images; default resolution separates adjacent fruits\n",
-    "        # with sufficient boundary precision for the seven-class palette.\n",
-    "        \"resolution\": 384,\n",
+    "    \"spalling_rebar\": {\n",
+    "        \"name\": \"Spalling and Exposed Rebar\",\n",
+    "        \"workspace\": \"uni-of-birmingham\",\n",
+    "        \"project\": \"spalling-and-exposed-rebar\",\n",
+    "        \"version\": 7,\n",
+    "        \"source_url\": \"https://universe.roboflow.com/uni-of-birmingham/spalling-and-exposed-rebar\",\n",
+    "        \"output_name\": \"seg_spalling_rebar\",\n",
+    "        # 432 — civil-infrastructure damage masks with irregular thin regions and\n",
+    "        # exposed-rebar details that stress boundary quality.\n",
+    "        \"resolution\": 432,\n",
     "    },\n",
-    "    \"field\": {\n",
-    "        \"name\": \"Football Field Segmentation\",\n",
-    "        \"workspace\": \"prototype-models\",\n",
-    "        \"project\": \"field-segmentation-2-yz2xv\",\n",
-    "        \"version\": 2,\n",
-    "        \"source_url\": \"https://universe.roboflow.com/prototype-models/field-segmentation-2-yz2xv\",\n",
-    "        \"output_name\": \"seg_field_demo\",\n",
-    "        # 432 — broadcast-angle shots with players, ball, and field markings; the\n",
-    "        # higher resolution separates small objects (ball, keeper) from field regions.\n",
+    "    \"car_damage_parts\": {\n",
+    "        \"name\": \"Car Part Damage Segmentation\",\n",
+    "        \"workspace\": \"car-damaged-detection-e66m0\",\n",
+    "        \"project\": \"car-part-detection-with-damage-part\",\n",
+    "        \"version\": 1,\n",
+    "        \"source_url\": \"https://universe.roboflow.com/car-damaged-detection-e66m0/car-part-detection-with-damage-part\",\n",
+    "        \"output_name\": \"seg_car_damage_parts\",\n",
+    "        # 432 — fine-grained automotive part masks with many adjacent classes and\n",
+    "        # damage regions, useful for checking class-specific mask boundaries.\n",
+    "        \"resolution\": 432,\n",
+    "    },\n",
+    "    \"teeth_numbering\": {\n",
+    "        \"name\": \"Teeth Numbering Segmentation\",\n",
+    "        \"workspace\": \"godento2\",\n",
+    "        \"project\": \"teeth-seg-3537-iaky1\",\n",
+    "        \"version\": 1,\n",
+    "        \"source_url\": \"https://universe.roboflow.com/godento2/teeth-seg-3537-iaky1\",\n",
+    "        \"output_name\": \"seg_teeth_numbering\",\n",
+    "        # 432 — dental images with many repeated small instances whose labels are\n",
+    "        # tied to position, stressing class confusion and small-mask quality.\n",
+    "        \"resolution\": 432,\n",
+    "    },\n",
+    "    \"taco_trash\": {\n",
+    "        \"name\": \"TACO Trash\",\n",
+    "        \"workspace\": \"mohamed-traore-2ekkp\",\n",
+    "        \"project\": \"taco-trash-annotations-in-context\",\n",
+    "        \"version\": 13,\n",
+    "        \"source_url\": \"https://universe.roboflow.com/mohamed-traore-2ekkp/taco-trash-annotations-in-context\",\n",
+    "        \"output_name\": \"seg_taco_trash\",\n",
+    "        # 432 — long-tail litter segmentation with many small, cluttered object\n",
+    "        # categories. Use as a harder stress test after the simpler datasets.\n",
     "        \"resolution\": 432,\n",
     "    },\n",
     "}\n",
     "\n",
-    "DATASET_KEY = \"crack\"\n",
+    "DATASET_KEY = \"building_facade\"\n",
     "DATASET_INFO = DATASETS[DATASET_KEY]\n",
     "\n",
     "OUTPUT_DIR = PROJECT_ROOT / \"output\" / str(DATASET_INFO[\"output_name\"])\n",
@@ -174,7 +186,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7f99c55d",
+   "id": "1c40c67d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -188,7 +200,7 @@
   },
   {
    "cell_type": "code",
-   "id": "ab8fdeb6",
+   "id": "7f99c55d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -211,7 +223,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e38db150",
+   "id": "ab8fdeb6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -228,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "id": "2c6b8dc4",
+   "id": "e38db150",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -268,7 +280,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "945822fa",
+   "id": "2c6b8dc4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -282,7 +294,7 @@
   },
   {
    "cell_type": "code",
-   "id": "ed36df66",
+   "id": "945822fa",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -301,7 +313,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7000d9a4",
+   "id": "ed36df66",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -313,7 +325,7 @@
   },
   {
    "cell_type": "code",
-   "id": "477cd2f6",
+   "id": "7000d9a4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -345,7 +357,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8e53a5a5",
+   "id": "477cd2f6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -357,7 +369,7 @@
   },
   {
    "cell_type": "code",
-   "id": "3e71bc58",
+   "id": "8e53a5a5",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -407,7 +419,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5f0ccbd3",
+   "id": "3e71bc58",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -429,7 +441,7 @@
   },
   {
    "cell_type": "code",
-   "id": "71e1a7db",
+   "id": "5f0ccbd3",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -484,7 +496,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "993b1cd1",
+   "id": "71e1a7db",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -499,7 +511,7 @@
   },
   {
    "cell_type": "code",
-   "id": "0564b2c6",
+   "id": "993b1cd1",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -518,7 +530,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c746e44d",
+   "id": "0564b2c6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -535,7 +547,7 @@
   },
   {
    "cell_type": "code",
-   "id": "684059b3",
+   "id": "c746e44d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -548,7 +560,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dadba8e3",
+   "id": "684059b3",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -565,7 +577,7 @@
   },
   {
    "cell_type": "code",
-   "id": "ea69ee92",
+   "id": "dadba8e3",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -578,7 +590,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9b7a1cb",
+   "id": "ea69ee92",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -598,7 +610,7 @@
   },
   {
    "cell_type": "code",
-   "id": "abab244f",
+   "id": "e9b7a1cb",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -621,7 +633,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c93477c9",
+   "id": "abab244f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -639,7 +651,7 @@
   },
   {
    "cell_type": "code",
-   "id": "e46c2424",
+   "id": "c93477c9",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -655,7 +667,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58b00247",
+   "id": "e46c2424",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -666,7 +678,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d2252a7a",
+   "id": "58b00247",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -681,7 +693,7 @@
   },
   {
    "cell_type": "code",
-   "id": "f03e8dcc",
+   "id": "d2252a7a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -691,7 +703,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74116bbe",
+   "id": "f03e8dcc",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -707,7 +719,7 @@
   },
   {
    "cell_type": "code",
-   "id": "f3a68bfe",
+   "id": "74116bbe",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -737,7 +749,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63027bc2",
+   "id": "f3a68bfe",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -755,7 +767,7 @@
   },
   {
    "cell_type": "code",
-   "id": "d723ad36",
+   "id": "63027bc2",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -779,7 +791,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29b52678",
+   "id": "d723ad36",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -794,7 +806,7 @@
   },
   {
    "cell_type": "code",
-   "id": "7325880c",
+   "id": "29b52678",
    "metadata": {
     "lines_to_next_cell": 2
    },

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -130,6 +130,7 @@ class COCOEvalCallback(Callback):
         self._output_widget: Any = None  # ipywidgets.Output, created lazily
         self._keypoint_mode: bool = False
         self._use_segm_metrics: bool = segmentation
+        self._train_segm_skip_warned: bool = False
         self._keypoint_oks_metrics: dict[str, MetricKeypointOKS] = {}
         self._keypoint_oks_sigmas = keypoint_oks_sigmas
         self._in_notebook: bool = False
@@ -298,8 +299,14 @@ class COCOEvalCallback(Callback):
         preds: list[dict[str, torch.Tensor]] = self._convert_preds(outputs["results"])
         targets = self._convert_targets(outputs["targets"])
         # In training mode pred_masks is a sparse dict, excluded from postprocess inputs, so
-        # preds have no masks key. torchmetrics requires it when iou_type includes "segm" → skip.
+        # preds have no masks key.  torchmetrics requires it when iou_type includes "segm" → skip.
         if self._use_segm_metrics and preds and "masks" not in preds[0]:
+            if not self._train_segm_skip_warned:
+                logger.info(
+                    "Train-split segmentation mAP skipped: pred_masks is a sparse dict during training "
+                    "(sparse_forward).  Only val/test segm mAP is available."
+                )
+                self._train_segm_skip_warned = True
             return
         self.map_metric_train.update(preds, targets)
 
@@ -1006,7 +1013,14 @@ class COCOEvalCallback(Callback):
             return
 
         console = _get_rich_console(trainer)
-        title_pfx = split.capitalize()
+        current_epoch = int(getattr(trainer, "current_epoch", 0)) + 1
+        max_epochs = getattr(trainer, "max_epochs", None)
+        epoch_sfx = (
+            f" (Epoch {current_epoch}/{max_epochs})"
+            if isinstance(max_epochs, int) and max_epochs > 0
+            else f" (Epoch {current_epoch})"
+        )
+        title_pfx = split.capitalize() + epoch_sfx
         overall_rendered = _render_overall_merged(title_pfx, overall, self._max_dets)
 
         if self._in_notebook:
@@ -1027,6 +1041,15 @@ class COCOEvalCallback(Callback):
                 with self._output_widget:
                     _render_summary_tables(console, title_pfx, overall_rendered, per_class)
                 return
+
+            # ipywidgets not installed — fall back to IPython cell-level clear so
+            # tables replace each other instead of accumulating across epochs.
+            with contextlib.suppress(ImportError):
+                from IPython.display import clear_output
+
+                clear_output(wait=True)
+            _render_summary_tables(console, title_pfx, overall_rendered, per_class)
+            return
 
         # Print directly through the console.  A second rich.live.Live on the same
         # console as RichProgressBar would silently nest (Live._nested=True) and

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -297,6 +297,10 @@ class COCOEvalCallback(Callback):
 
         preds: list[dict[str, torch.Tensor]] = self._convert_preds(outputs["results"])
         targets = self._convert_targets(outputs["targets"])
+        # In training mode pred_masks is a sparse dict, excluded from postprocess inputs, so
+        # preds have no masks key. torchmetrics requires it when iou_type includes "segm" → skip.
+        if self._use_segm_metrics and preds and "masks" not in preds[0]:
+            return
         self.map_metric_train.update(preds, targets)
 
         iou_type = "segm" if self._use_segm_metrics else "bbox"

--- a/src/rfdetr/training/module_data.py
+++ b/src/rfdetr/training/module_data.py
@@ -386,7 +386,9 @@ class RFDETRDataModule(LightningDataModule):
                 inches. When omitted, the size is derived from the grid shape.
 
         Returns:
-            Matplotlib figure containing the annotated sample grid.
+            Matplotlib figure containing the annotated sample grid. When the
+            dataset includes instance masks, they are rendered as coloured
+            overlays before bounding boxes and labels.
 
         Raises:
             ValueError: If ``count`` or ``columns`` is not positive.

--- a/src/rfdetr/training/module_data.py
+++ b/src/rfdetr/training/module_data.py
@@ -452,11 +452,19 @@ class RFDETRDataModule(LightningDataModule):
                 scale = torch.tensor([width, height, width, height], dtype=torch.float32)
                 xyxy = box_cxcywh_to_xyxy(boxes.detach().cpu()) * scale
                 class_ids = labels.detach().cpu().numpy().astype(int)
-                detections = sv.Detections(xyxy=xyxy.numpy().astype(np.float32), class_id=class_ids)
+                masks_tensor = target.get("masks")
+                mask_array = (
+                    masks_tensor.detach().cpu().numpy()
+                    if masks_tensor is not None and masks_tensor.numel() > 0
+                    else None
+                )
+                detections = sv.Detections(xyxy=xyxy.numpy().astype(np.float32), class_id=class_ids, mask=mask_array)
                 labels_text = [
                     class_names[class_id] if class_names is not None and class_id < len(class_names) else str(class_id)
                     for class_id in class_ids
                 ]
+                if mask_array is not None:
+                    scene = sv.MaskAnnotator().annotate(scene=scene, detections=detections)
                 scene = sv.BoxAnnotator(thickness=1).annotate(scene=scene, detections=detections)
                 scene = sv.LabelAnnotator(text_scale=0.4, text_padding=2).annotate(
                     scene=scene,

--- a/tests/training/test_coco_eval_callback.py
+++ b/tests/training/test_coco_eval_callback.py
@@ -334,6 +334,55 @@ class TestOnTrainBatchEnd:
         cb.map_metric.reset.assert_called_once()
         cb.map_metric_train.reset.assert_not_called()
 
+    def test_train_batch_end_segm_without_masks_skips_metric_update(self) -> None:
+        """Segm callback skips map_metric_train.update when preds lack a masks key."""
+        cb = COCOEvalCallback(segmentation=True)
+        cb.setup(_make_trainer(), _make_pl_module(), stage="fit")
+        cb.map_metric_train = MagicMock(name="map_metric_train")
+        module = _make_pl_module()
+        module.train_config = SimpleNamespace(compute_train_metrics=True)
+        # _detection_preds returns preds without "masks" — mimics sparse_forward training mode
+        outputs = {"results": _detection_preds(1), "targets": _detection_targets()}
+
+        cb.on_train_batch_end(_make_trainer(), module, outputs, None, 0)
+
+        cb.map_metric_train.update.assert_not_called()
+
+    def test_train_batch_end_segm_with_masks_calls_metric_update(self) -> None:
+        """Segm callback calls map_metric_train.update when preds include a masks key."""
+        cb = COCOEvalCallback(segmentation=True)
+        cb.setup(_make_trainer(), _make_pl_module(), stage="fit")
+        cb.map_metric_train = MagicMock(name="map_metric_train")
+        module = _make_pl_module()
+        module.train_config = SimpleNamespace(compute_train_metrics=True)
+        preds_with_masks = [
+            {
+                "boxes": torch.zeros(1, 4),
+                "scores": torch.zeros(1),
+                "labels": torch.zeros(1, dtype=torch.long),
+                "masks": torch.zeros(1, 16, 16, dtype=torch.bool),
+            }
+        ]
+        outputs = {"results": preds_with_masks, "targets": _detection_targets()}
+
+        cb.on_train_batch_end(_make_trainer(), module, outputs, None, 0)
+
+        cb.map_metric_train.update.assert_called_once()
+
+    def test_train_batch_end_segm_empty_preds_falls_through(self) -> None:
+        """Segm callback with empty preds list falls through guard and calls update."""
+        cb = COCOEvalCallback(segmentation=True)
+        cb.setup(_make_trainer(), _make_pl_module(), stage="fit")
+        cb.map_metric_train = MagicMock(name="map_metric_train")
+        module = _make_pl_module()
+        module.train_config = SimpleNamespace(compute_train_metrics=True)
+        # Empty preds: `preds and ...` short-circuits to False → no early return → update called
+        outputs = {"results": [], "targets": _detection_targets()}
+
+        cb.on_train_batch_end(_make_trainer(), module, outputs, None, 0)
+
+        cb.map_metric_train.update.assert_called_once()
+
 
 class TestMetricsTablePrinting:
     """Metric table terminal/notebook rendering behavior.
@@ -369,7 +418,8 @@ class TestMetricsTablePrinting:
 
         assert render_tables.call_count == 2
         assert render_tables.call_args_list[0].args[0] is console
-        assert render_tables.call_args_list[0].args[1] == title_pfx
+        assert render_tables.call_args_list[0].args[1].startswith(title_pfx)
+        assert "(Epoch" in render_tables.call_args_list[0].args[1]
         assert render_tables.call_args_list[0].args[2] == "overall-1"
 
     def test_missing_rich_warns_once_and_skips_metric_tables(self) -> None:

--- a/tests/training/test_module_data.py
+++ b/tests/training/test_module_data.py
@@ -297,6 +297,98 @@ class TestPrivateShowSamples:
         with pytest.raises(ImportError, match=r"rfdetr\[visual\]"):
             dm._show_samples(1)
 
+    def test_private_show_samples_returns_figure_for_segmentation_targets(self, build_datamodule, monkeypatch):
+        """_show_samples renders mask overlays when dataset targets include instance masks."""
+        import matplotlib
+        import numpy as np
+
+        matplotlib.use("Agg", force=True)
+        from unittest.mock import MagicMock
+        from unittest.mock import patch as _patch
+
+        from matplotlib import pyplot as plt
+        from matplotlib.figure import Figure
+
+        class _SegDataset(torch.utils.data.Dataset):
+            def __len__(self) -> int:
+                return 1
+
+            def __getitem__(self, idx: int):
+                return (
+                    torch.full((3, 16, 16), 0.5, dtype=torch.float32),
+                    {
+                        "boxes": torch.tensor([[0.5, 0.5, 0.5, 0.5]], dtype=torch.float32),
+                        "labels": torch.tensor([0], dtype=torch.int64),
+                        "masks": torch.ones((1, 16, 16), dtype=torch.bool),
+                        "size": torch.tensor([16, 16], dtype=torch.int64),
+                    },
+                )
+
+        dm = build_datamodule()
+        monkeypatch.setattr(dm, "_get_dataset_for_visualization", lambda split: _SegDataset())
+
+        mock_instance = MagicMock()
+        mock_instance.annotate.return_value = np.zeros((16, 16, 3), dtype=np.uint8)
+
+        with _patch("supervision.MaskAnnotator", return_value=mock_instance) as mock_mask_ann:
+            figure = dm._show_samples(1, split="train", columns=1)
+
+        assert isinstance(figure, Figure)
+        mock_mask_ann.assert_called_once()
+        mock_instance.annotate.assert_called_once()
+        plt.close(figure)
+
+    def test_private_show_samples_detection_only_does_not_call_mask_annotator(self, build_datamodule, monkeypatch):
+        """_show_samples skips MaskAnnotator when dataset targets have no masks key."""
+        from unittest.mock import patch as _patch
+
+        import matplotlib
+        from matplotlib import pyplot as plt
+
+        matplotlib.use("Agg", force=True)
+
+        dm = build_datamodule()
+        monkeypatch.setattr(dm, "_get_dataset_for_visualization", lambda split: _VisualDataset())
+
+        with _patch("supervision.MaskAnnotator") as mock_mask_ann:
+            figure = dm._show_samples(1, split="train", columns=1)
+
+        mock_mask_ann.assert_not_called()
+        plt.close(figure)
+
+    def test_private_show_samples_empty_masks_skips_mask_annotator(self, build_datamodule, monkeypatch):
+        """_show_samples skips MaskAnnotator when masks tensor has zero instances (0, H, W)."""
+        from unittest.mock import patch as _patch
+
+        import matplotlib
+        from matplotlib import pyplot as plt
+
+        matplotlib.use("Agg", force=True)
+
+        class _EmptyMasksDataset(torch.utils.data.Dataset):
+            def __len__(self) -> int:
+                return 1
+
+            def __getitem__(self, idx: int):
+                return (
+                    torch.full((3, 16, 16), 0.5, dtype=torch.float32),
+                    {
+                        "boxes": torch.tensor([[0.5, 0.5, 0.5, 0.5]], dtype=torch.float32),
+                        "labels": torch.tensor([0], dtype=torch.int64),
+                        "masks": torch.zeros((0, 16, 16), dtype=torch.bool),
+                        "size": torch.tensor([16, 16], dtype=torch.int64),
+                    },
+                )
+
+        dm = build_datamodule()
+        monkeypatch.setattr(dm, "_get_dataset_for_visualization", lambda split: _EmptyMasksDataset())
+
+        with _patch("supervision.MaskAnnotator") as mock_mask_ann:
+            figure = dm._show_samples(1, split="train", columns=1)
+
+        mock_mask_ann.assert_not_called()
+        plt.close(figure)
+
 
 class TestSetup:
     """Setup(stage) builds the correct dataset(s) for each PTL stage."""


### PR DESCRIPTION
- Add fine-tune_segmentation.ipynb: 4 datasets (crack, cattle, fruits, field), RFDETRSegSmall, SegmentationTrainConfig, mask+bbox metric plots, inference with MaskAnnotator
- Register card in cards.yaml: labels TRAINING, PYTORCH LIGHTNING, SEGMENTATION, INFERENCE, v1.8.1
- Update NOTES.md current-notebooks table (add segmentation + latency benchmark rows)
