### PR TITLE
chore(deps): pin `torchvision` to `<0.26` in `ci-gpu-pin`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ plus = ["rfdetr_plus>=1.0.1, <2.0.0"]
 #   Does not affect users installing rfdetr from PyPI.
 ci-gpu-pin = [
     "torch<2.11",
+    "torchvision<0.26",
 ]
 
 build = [


### PR DESCRIPTION
This pull request introduces a small change to the `pyproject.toml` file, updating the `ci-gpu-pin` dependency group to include a version constraint for `torchvision`. This helps ensure compatibility in CI environments. 

* Added a version constraint for `torchvision` (`<0.26`) to the `ci-gpu-pin` dependency group in `pyproject.toml`.