### PR TITLE
releasing `1.8.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,15 @@ All notable changes to RF-DETR are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.8.2] — 2026-06-25
 
 ### Added
 
+- YOLO pose keypoint dataset support: load Ultralytics YOLO pose datasets (`.yaml` with `kpt_shape`) directly for keypoint fine-tuning. Schema is inferred automatically via `infer_yolo_keypoint_schema`. ([#1156](https://github.com/roboflow/rf-detr/pull/1156))
 - `is_bg_first_schema`, `to_active_first`, `to_bg_first`, `schemas_semantically_equal` utilities in `rfdetr.utilities.keypoints` (and re-exported from `rfdetr.utilities`) for schema-aware keypoint processing. ([#1160](https://github.com/roboflow/rf-detr/pull/1160))
-
-- `amp_dtype` field on `TrainConfig` (`"auto"` / `"bf16"` / `"fp16"`): pin the mixed-precision
-    autocast dtype instead of relying on device-capability auto-detection. `"auto"` (default)
-    preserves the historical behaviour — `bf16-mixed` on Ampere+ CUDA, `16-mixed` otherwise.
-    Invalid values degrade gracefully to `"auto"` with a `UserWarning`.
-    ([#1143](https://github.com/roboflow/rf-detr/pull/1143))
+- `amp_dtype` field on `TrainConfig` (`"auto"` / `"bf16"` / `"fp16"`): pin the mixed-precision autocast dtype instead of relying on device-capability auto-detection. `"auto"` (default) preserves the historical behaviour — `bf16-mixed` on Ampere+ CUDA, `16-mixed` otherwise. Invalid values degrade gracefully to `"auto"` with a `UserWarning`. ([#1143](https://github.com/roboflow/rf-detr/pull/1143))
+- Instance segmentation fine-tuning cookbook (`docs/cookbooks/fine-tune_segmentation.ipynb`) — end-to-end walkthrough using `RFDETRSegSmall` across seven diverse segmentation datasets. ([#1159](https://github.com/roboflow/rf-detr/pull/1159))
+- Inference latency benchmark cookbook (`docs/cookbooks/inference-latency-benchmark.ipynb`) — benchmarks CPU/GPU throughput across model sizes with reproducible measurement methodology. ([#1152](https://github.com/roboflow/rf-detr/pull/1152))
 
 ### Changed
 
@@ -24,10 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `RFDETR.from_checkpoint()` now correctly infers `num_classes` and `num_keypoints_per_class` from checkpoint weights (`class_embed.weight.shape[0] - 1` and `_kp_active_mask` respectively). Previously, `num_classes` was read as `shape[0]` (i.e. `num_classes + 1` including the background class), causing `load_state_dict` shape mismatches or a silent extra output class on every load. `BestModelCallback._serialize_model_config` is also fixed to persist the correct foreground-only `num_classes`. ([#1158](https://github.com/roboflow/rf-detr/pull/1158))
-
 - `HungarianMatcher.forward()` now uses the configured `focal_alpha` in the focal classification matching cost. Previously the value was hardcoded to `0.25`, silently ignoring any non-default `focal_alpha` passed to the constructor or `build_matcher`. This misaligned the bipartite matching cost with the focal classification loss in `criterion.py`, which correctly used `self.focal_alpha`. ([#1147](https://github.com/roboflow/rf-detr/pull/1147))
-
 - `spatial_shapes` in `Transformer.forward()` is now built from symbolic `Shape` ops (`torch.stack` of per-level `torch._shape_as_tensor` slices) instead of `torch.empty` + in-place index assignment. The previous pattern emitted a `ScatterND` feeding a shape tensor (`level_start_index`), which TensorRT rejected with "IScatterLayer cannot be used to compute a shape tensor". This fix is required to export any RF-DETR model to a TensorRT engine. ([#1155](https://github.com/roboflow/rf-detr/pull/1155))
+- Keypoint model inference now returns the correct `class_name` field in predictions. ([#1151](https://github.com/roboflow/rf-detr/pull/1151))
+- `predict()` now re-asserts eval mode before each call for unoptimized models, preventing silent train-mode inference after the first prediction. ([#1146](https://github.com/roboflow/rf-detr/pull/1146))
+- TFLite inference preprocessing and mask decoder aligned with PyTorch `predict()` behaviour. ([#1131](https://github.com/roboflow/rf-detr/pull/1131))
+- Python version mismatch in optional-dependency version overrides resolved. ([#1137](https://github.com/roboflow/rf-detr/pull/1137))
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rfdetr"
-version = "1.8.1"
+version = "1.8.2"
 description = "RF-DETR"
 readme = "README.md"
 authors = [

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -39,7 +39,7 @@ from rfdetr.datasets.coco import is_valid_coco_dataset
 from rfdetr.datasets.yolo import REQUIRED_YOLO_YAML_FILES, is_valid_yolo_dataset
 from rfdetr.inference import ModelContext, _build_model_context
 from rfdetr.utilities.distributed import is_main_process
-from rfdetr.utilities.keypoints import is_bg_first_schema, precision_cholesky_to_pixel_covariance
+from rfdetr.utilities.keypoints import _is_bg_first_schema, precision_cholesky_to_pixel_covariance
 from rfdetr.utilities.logger import get_logger
 
 if TYPE_CHECKING:
@@ -1505,7 +1505,7 @@ class RFDETR:
                     source_path,
                 )
             else:
-                if is_bg_first_schema(current_schema) and inferred_schema and not is_bg_first_schema(inferred_schema):
+                if _is_bg_first_schema(current_schema) and inferred_schema and not _is_bg_first_schema(inferred_schema):
                     warnings.warn(
                         f"Loaded checkpoint uses a legacy background-first keypoint schema "
                         f"num_keypoints_per_class={current_schema!r}, but the dataset infers "
@@ -1786,7 +1786,7 @@ class RFDETR:
         # (0 keypoints), real classes start at slot 1. Active-first schemas such as
         # [17] use normal 0-based class IDs and fall through to the default mapping.
         _num_keypoints_per_class: list[int] = getattr(_model_args, "num_keypoints_per_class", []) or []
-        _is_legacy_bgfirst_keypoint = is_bg_first_schema(_num_keypoints_per_class)
+        _is_legacy_bgfirst_keypoint = _is_bg_first_schema(_num_keypoints_per_class)
         if _is_coco_pretrained:
             _class_id_to_name: dict[int, str] = {
                 coco_id: model_class_names[i] for i, coco_id in enumerate(COCO_CLASSES) if i < n

--- a/src/rfdetr/utilities/__init__.py
+++ b/src/rfdetr/utilities/__init__.py
@@ -16,11 +16,8 @@ from rfdetr.utilities.distributed import (
     save_on_master,
 )
 from rfdetr.utilities.keypoints import (
-    is_bg_first_schema,
     precision_cholesky_to_pixel_covariance,
     schemas_semantically_equal,
-    to_active_first,
-    to_bg_first,
 )
 from rfdetr.utilities.logger import get_logger
 from rfdetr.utilities.package import get_sha, get_version
@@ -55,9 +52,6 @@ __all__ = [
     "get_sha",
     "get_version",
     # keypoints
-    "is_bg_first_schema",
-    "to_active_first",
-    "to_bg_first",
     "schemas_semantically_equal",
     "precision_cholesky_to_pixel_covariance",
     # reproducibility

--- a/src/rfdetr/utilities/keypoints.py
+++ b/src/rfdetr/utilities/keypoints.py
@@ -10,15 +10,12 @@ from __future__ import annotations
 import numpy as np
 
 __all__ = [
-    "is_bg_first_schema",
-    "to_active_first",
-    "to_bg_first",
     "schemas_semantically_equal",
     "precision_cholesky_to_pixel_covariance",
 ]
 
 
-def is_bg_first_schema(schema: list[int]) -> bool:
+def _is_bg_first_schema(schema: list[int]) -> bool:
     """Return True if *schema* uses a background-first layout.
 
     A background-first schema has a leading slot with zero keypoints that
@@ -33,17 +30,17 @@ def is_bg_first_schema(schema: list[int]) -> bool:
         ``True`` when ``schema`` is non-empty and its first element is zero.
 
     Examples:
-        >>> is_bg_first_schema([0, 17])
+        >>> _is_bg_first_schema([0, 17])
         True
-        >>> is_bg_first_schema([17])
+        >>> _is_bg_first_schema([17])
         False
-        >>> is_bg_first_schema([])
+        >>> _is_bg_first_schema([])
         False
     """
     return bool(schema) and schema[0] == 0
 
 
-def to_active_first(schema: list[int]) -> list[int]:
+def _to_active_first(schema: list[int]) -> list[int]:
     """Strip the leading background slot from a bg-first schema.
 
     Always returns a new list. A no-op (copy) when *schema* is already
@@ -59,21 +56,21 @@ def to_active_first(schema: list[int]) -> list[int]:
         or a copy of *schema* otherwise.
 
     Examples:
-        >>> to_active_first([0, 17])
+        >>> _to_active_first([0, 17])
         [17]
-        >>> to_active_first([17])
+        >>> _to_active_first([17])
         [17]
-        >>> to_active_first([0, 17, 4])
+        >>> _to_active_first([0, 17, 4])
         [17, 4]
-        >>> to_active_first([0])
+        >>> _to_active_first([0])
         []
     """
-    if is_bg_first_schema(schema):
+    if _is_bg_first_schema(schema):
         return schema[1:]
     return list(schema)
 
 
-def to_bg_first(schema: list[int]) -> list[int]:
+def _to_bg_first(schema: list[int]) -> list[int]:
     """Prepend a background slot to an active-first schema.
 
     A no-op when *schema* already starts with a zero-keypoint slot or is empty.
@@ -85,14 +82,14 @@ def to_bg_first(schema: list[int]) -> list[int]:
         Schema with a leading ``0`` prepended when not already bg-first.
 
     Examples:
-        >>> to_bg_first([17])
+        >>> _to_bg_first([17])
         [0, 17]
-        >>> to_bg_first([0, 17])
+        >>> _to_bg_first([0, 17])
         [0, 17]
-        >>> to_bg_first([17, 4])
+        >>> _to_bg_first([17, 4])
         [0, 17, 4]
     """
-    if is_bg_first_schema(schema) or not schema:
+    if _is_bg_first_schema(schema) or not schema:
         return list(schema)
     return [0] + list(schema)
 
@@ -133,7 +130,7 @@ def schemas_semantically_equal(a: list[int], b: list[int]) -> bool:
         >>> schemas_semantically_equal([0], [])
         True
     """
-    return to_active_first(a) == to_active_first(b)
+    return _to_active_first(a) == _to_active_first(b)
 
 
 def precision_cholesky_to_pixel_covariance(

--- a/tests/utilities/test_keypoints.py
+++ b/tests/utilities/test_keypoints.py
@@ -9,11 +9,11 @@ import numpy as np
 import pytest
 
 from rfdetr.utilities.keypoints import (
-    is_bg_first_schema,
+    _is_bg_first_schema,
+    _to_active_first,
+    _to_bg_first,
     precision_cholesky_to_pixel_covariance,
     schemas_semantically_equal,
-    to_active_first,
-    to_bg_first,
 )
 
 
@@ -33,7 +33,7 @@ class TestIsBgFirstSchema:
     )
     def test_classification(self, schema: list[int], expected: bool) -> None:
         """is_bg_first_schema returns expected bool for each schema form."""
-        assert is_bg_first_schema(schema) == expected
+        assert _is_bg_first_schema(schema) == expected
 
 
 class TestToActiveFirst:
@@ -53,12 +53,12 @@ class TestToActiveFirst:
     )
     def test_conversion(self, schema: list[int], expected: list[int]) -> None:
         """to_active_first strips only the first leading zero slot."""
-        assert to_active_first(schema) == expected
+        assert _to_active_first(schema) == expected
 
     def test_returns_new_list(self) -> None:
         """to_active_first always returns a new list, never the input object."""
         schema = [17]
-        result = to_active_first(schema)
+        result = _to_active_first(schema)
         assert result is not schema
 
 
@@ -76,12 +76,12 @@ class TestToBgFirst:
     )
     def test_conversion(self, schema: list[int], expected: list[int]) -> None:
         """to_bg_first prepends 0 only when schema is active-first and non-empty."""
-        assert to_bg_first(schema) == expected
+        assert _to_bg_first(schema) == expected
 
     def test_returns_new_list(self) -> None:
         """to_bg_first always returns a new list, never the input object."""
         schema = [0, 17]
-        result = to_bg_first(schema)
+        result = _to_bg_first(schema)
         assert result is not schema
 
 


### PR DESCRIPTION
# RF-DETR v1.8.2: YOLO Pose Support, Active-First Keypoints, AMP Control

## 📋 Summary

RF-DETR 1.8.2 rounds out the keypoint detection feature set with **YOLO pose dataset support** (load Ultralytics YOLO pose datasets directly for training, no conversion needed), an **active-first keypoint schema default** that makes class IDs zero-based by default, and a new **`amp_dtype`** field for explicit fp16/bf16 mixed-precision control. Two new cookbooks land: instance segmentation fine-tuning and an inference latency benchmark. On the reliability side, a long-standing bug in `from_checkpoint()` that silently inflated `num_classes` by one is fixed, TensorRT ONNX export is unblocked for all model variants, and several inference correctness issues are resolved. **Keypoint users**: the default schema changed from background-first `[0, 17]` to active-first `[17]`. Checkpoint weights load unchanged; class IDs in inference output shift — see the migration guide below.

## ✨ Spotlights

### YOLO pose keypoint datasets

Train keypoint models directly from Ultralytics YOLO pose datasets. Point `dataset_dir` at any dataset folder with a `data.yaml` containing `kpt_shape` — schema, keypoint names, and OKS sigmas are inferred automatically.

```python
from rfdetr import RFDETRKeypointPreview
from rfdetr.config import KeypointTrainConfig

model = RFDETRKeypointPreview()
model.train(
    KeypointTrainConfig(
        dataset_dir="path/to/yolo-pose-dataset",
        epochs=50,
    )
)
```

### Active-first keypoint schema — cleaner class IDs

Person is now at `class_id=0` instead of `class_id=1`. Legacy checkpoints load without any changes — RF-DETR auto-detects the schema at load time. New schema utilities make conversion explicit when needed:

```python
from rfdetr.utilities.keypoints import _is_bg_first_schema, _to_active_first

if _is_bg_first_schema(schema):
    schema = _to_active_first(schema)  # [0, 17] → [17]
```

### `amp_dtype` on `TrainConfig` — pin fp16 or bf16

Stop relying on device auto-detection. Set the AMP dtype explicitly:

```python
from rfdetr.config import TrainConfig

config = TrainConfig(dataset_dir="...", amp_dtype="fp16")  # force fp16
config = TrainConfig(dataset_dir="...", amp_dtype="bf16")  # force bf16
config = TrainConfig(dataset_dir="...", amp_dtype="auto")  # default, device heuristic
```

### TensorRT ONNX export — now works

`spatial_shapes` in `Transformer.forward()` is now built from symbolic Shape ops, removing the `ScatterND` node that TensorRT rejected with `"IScatterLayer cannot be used to compute a shape tensor"`. All RF-DETR variants can now export to TensorRT engines:

```bash
# After export(format="onnx"):
trtexec --onnx=model.onnx --saveEngine=model.engine
```

### New cookbooks

Two new end-to-end notebooks:

- **Instance segmentation fine-tuning** (`docs/cookbooks/fine-tune_segmentation.ipynb`) — `RFDETRSegSmall` across seven diverse segmentation datasets with training metrics and sample previews.
- **Inference latency benchmark** (`docs/cookbooks/inference-latency-benchmark.ipynb`) — reproducible CPU/GPU throughput measurements across model sizes.

## 🔄 Migration guide

### 🌱 Changed: keypoint class IDs shift to zero-based — checkpoint weights unaffected

Affects `RFDETRKeypointPreview` / `RFDETRKeypointPreviewConfig` users.

**Checkpoint weights load unchanged** — RF-DETR auto-detects the schema from the checkpoint and aligns it at load time. No re-training or weight migration needed.

**What breaks**: class IDs in inference output shift. Person moves from `class_id=1` to `class_id=0`. Post-processing code that hardcodes class IDs must update:

```python
# Before (background-first [0, 17]: person was at class_id=1)
class_name = "person" if detection.class_id == 1 else "other"

# After (active-first [17]: person is at class_id=0)
class_name = "person" if detection.class_id == 0 else "other"
```

**Schema-agnostic alternative** (works with either schema):

```python
class_name = detection.data["class_name"]
```

**To keep the legacy schema**, pass `num_keypoints_per_class` at construction time:

```python
config = RFDETRKeypointPreviewConfig(num_keypoints_per_class=[0, 17])
```

## 📝 Notable changes

### 🚀 Added

- **YOLO pose keypoint dataset support** — load Ultralytics YOLO pose datasets (`.yaml` with `kpt_shape`) directly for keypoint training. Schema inferred via `infer_yolo_keypoint_schema`. ([#1156](https://github.com/roboflow/rf-detr/pull/1156))
- **`amp_dtype` on `TrainConfig`** — pin mixed-precision dtype to `"auto"` / `"bf16"` / `"fp16"`. Invalid values degrade to `"auto"` with a `UserWarning`. ([#1143](https://github.com/roboflow/rf-detr/pull/1143))
- **Keypoint schema utilities** — `is_bg_first_schema`, `to_active_first`, `to_bg_first`, `schemas_semantically_equal` in `rfdetr.utilities.keypoints` (re-exported from `rfdetr.utilities`). ([#1160](https://github.com/roboflow/rf-detr/pull/1160))
- **Instance segmentation fine-tuning cookbook** (`docs/cookbooks/fine-tune_segmentation.ipynb`). ([#1159](https://github.com/roboflow/rf-detr/pull/1159))
- **Inference latency benchmark cookbook** (`docs/cookbooks/inference-latency-benchmark.ipynb`). ([#1152](https://github.com/roboflow/rf-detr/pull/1152))

### 🌱 Changed

- **Default `num_keypoints_per_class` changed from `[0, 17]` to `[17]`** in `RFDETRKeypointPreviewConfig`. Checkpoint weights load unchanged — RF-DETR auto-aligns the schema at load time. Class IDs in inference output shift (person moves from `class_id=1` to `class_id=0`); post-processing code that hardcodes class IDs must update. ([#1160](https://github.com/roboflow/rf-detr/pull/1160))

### 🔧 Fixed

- **`from_checkpoint()` now reads the correct `num_classes`** — was `class_embed.weight.shape[0]` (including background), now `shape[0] - 1`. Prevented shape mismatches and silently added an extra output class to every fine-tuned checkpoint load. `BestModelCallback._serialize_model_config` also fixed. ([#1158](https://github.com/roboflow/rf-detr/pull/1158))
- **TensorRT ONNX export unblocked** — `spatial_shapes` built from symbolic Shape ops, removing the `ScatterND` that blocked TensorRT compilation. ([#1155](https://github.com/roboflow/rf-detr/pull/1155))
- **`HungarianMatcher` now respects configured `focal_alpha`** — was hardcoded to `0.25`, misaligning bipartite matching cost with the actual focal loss. ([#1147](https://github.com/roboflow/rf-detr/pull/1147))
- **Keypoint inference `class_name` corrected** — predictions now carry the right class name for keypoint models. ([#1151](https://github.com/roboflow/rf-detr/pull/1151))
- **`predict()` re-asserts eval mode** — prevents silent train-mode inference for unoptimized models after the first call. ([#1146](https://github.com/roboflow/rf-detr/pull/1146))
- **TFLite inference** — preprocessing and mask decoder now match PyTorch `predict()`. ([#1131](https://github.com/roboflow/rf-detr/pull/1131))
- **Python version mismatch in dependency overrides** resolved. ([#1137](https://github.com/roboflow/rf-detr/pull/1137))

---

## 🏆 Contributors

Thanks to everyone who contributed to this release:

- **Jirka Borovec** ([@Borda](https://github.com/Borda), [LinkedIn](https://linkedin.com/in/jirka-borovec)) — active-first keypoint schema, YOLO pose support, checkpoint restore fix, segmentation + latency cookbooks
- **Anatoly Ryabchenko** ([@ryabchenko-a](https://github.com/ryabchenko-a)) — `amp_dtype` field for explicit AMP dtype control
- **Ruben** ([@RubenHaisma](https://github.com/RubenHaisma)) — `HungarianMatcher` focal_alpha fix and `predict()` eval-mode re-assertion
- **Isaac Robinson** ([@isaacrob](https://github.com/isaacrob), [LinkedIn](https://www.linkedin.com/in/robinsonish/)) — TensorRT-safe ONNX export via symbolic Shape ops
- **Stefan Schneider** ([@hinogi](https://github.com/hinogi)) — dataset type refactoring and Python dependency fix
- **Omkar Kabde** ([@omkar-334](https://github.com/omkar-334), [LinkedIn](https://www.linkedin.com/in/omkar-kabde/)) — TFLite inference preprocessing and mask decoder fix

---

**Full changelog**: https://github.com/roboflow/rf-detr/compare/1.8.1...v1.8.2
