### PR TITLE
fix(postprocess): clamp predicted boxes to image bounds

### DIFF
--- a/src/rfdetr/models/postprocess.py
+++ b/src/rfdetr/models/postprocess.py
@@ -132,7 +132,9 @@ class PostProcess(nn.Module):
         boxes = torch.gather(boxes, 1, topk_boxes.unsqueeze(-1).repeat(1, 1, 4))
         img_h, img_w = target_sizes.unbind(1)
         scale_fct = torch.stack([img_w, img_h, img_w, img_h], dim=1)
-        return boxes * scale_fct[:, None, :]
+        boxes = boxes * scale_fct[:, None, :]
+        boxes = boxes.clamp(min=torch.zeros_like(scale_fct[:, None, :]), max=scale_fct[:, None, :])
+        return boxes
 
     @staticmethod
     def _postprocess_masks(

--- a/src/rfdetr/models/postprocess.py
+++ b/src/rfdetr/models/postprocess.py
@@ -46,9 +46,9 @@ class PostProcess(nn.Module):
                 original image size so normalized boxes and keypoints are returned in source-image pixel coordinates.
 
         Returns:
-            One dictionary per image. Every dictionary contains ``scores``, ``labels``, and ``boxes``. Segmentation
-            outputs also contain ``masks``. Keypoint outputs also contain ``keypoints`` and
-            ``keypoint_precision_cholesky``.
+            One dictionary per image. Every dictionary contains ``scores``, ``labels``, and ``boxes`` in absolute
+            pixel coordinates clamped to the respective image dimensions. Segmentation outputs also contain
+            ``masks``. Keypoint outputs also contain ``keypoints`` and ``keypoint_precision_cholesky``.
         """
         out_logits, out_bbox = outputs["pred_logits"], outputs["pred_boxes"]
         out_masks = outputs.get("pred_masks", None)
@@ -126,14 +126,16 @@ class PostProcess(nn.Module):
             target_sizes: Per-image ``(height, width)`` tensor.
 
         Returns:
-            Absolute ``xyxy`` boxes with shape ``(B, K, 4)`` in pixel units.
+            Absolute ``xyxy`` boxes with shape ``(B, K, 4)`` in pixel units,
+            clamped to ``[0, width]`` for x-coordinates and ``[0, height]`` for y-coordinates.
         """
         boxes = box_ops.box_cxcywh_to_xyxy(out_bbox)
         boxes = torch.gather(boxes, 1, topk_boxes.unsqueeze(-1).repeat(1, 1, 4))
         img_h, img_w = target_sizes.unbind(1)
-        scale_fct = torch.stack([img_w, img_h, img_w, img_h], dim=1)
+        scale_fct = torch.stack([img_w, img_h, img_w, img_h], dim=1).to(boxes.dtype)
         boxes = boxes * scale_fct[:, None, :]
-        boxes = boxes.clamp(min=torch.zeros_like(scale_fct[:, None, :]), max=scale_fct[:, None, :])
+        # Model regression is unbounded; clamp to valid pixel range before returning.
+        boxes = boxes.clamp_min(0.0).clamp(max=scale_fct[:, None, :])
         return boxes
 
     @staticmethod

--- a/tests/inference/test_predict.py
+++ b/tests/inference/test_predict.py
@@ -39,7 +39,7 @@ class TestPredictReturnTypes:
     def test_detection_returns_sv_detections(self) -> None:
         """Detection model returns a list of ``sv.Detections``."""
         img = PIL.Image.new("RGB", (640, 640), color=(128, 128, 128))
-        model = RFDETRNano()
+        model = RFDETRNano(pretrain_weights=None)
         detections = model.predict([img, img], threshold=0.3)
         assert isinstance(detections, list), "predict() must return a list for multiple inputs"
         assert all(isinstance(d, sv.Detections) for d in detections), "Each result must be sv.Detections"
@@ -47,7 +47,7 @@ class TestPredictReturnTypes:
     def test_segmentation_returns_sv_detections_with_masks(self) -> None:
         """Segmentation model returns ``sv.Detections`` with the mask field always set."""
         img = PIL.Image.new("RGB", (640, 640), color=(128, 128, 128))
-        model = RFDETRSegNano()
+        model = RFDETRSegNano(pretrain_weights=None)
         detections = model.predict([img, img], threshold=0.3)
         assert isinstance(detections, list), "predict() must return a list for multiple inputs"
         assert all(isinstance(d, sv.Detections) for d in detections), "Each result must be sv.Detections"

--- a/tests/models/test_postprocess.py
+++ b/tests/models/test_postprocess.py
@@ -14,8 +14,8 @@ class TestGatherAndScaleBoxes:
     """Tests for :meth:`PostProcess._gather_and_scale_boxes`."""
 
     def test_clamps_boxes_to_image_bounds(self):
-        """Boxes that extrapolate beyond [0, 1] in normalized space are
-        clamped to pixel-space image dimensions after scaling."""
+        """Boxes that extrapolate beyond [0, 1] in normalized space are clamped to pixel-space image dimensions after
+        scaling."""
         # Three synthetic boxes in cxcywh normalized coords:
         #   [0] cx=0.01, w=0.10 → x1 = (0.01 - 0.05) * 640 = -25.6  ← negative
         #   [1] cx=0.99, w=0.10 → x2 = (0.99 + 0.05) * 640 = 665.6  ← overflow

--- a/tests/models/test_postprocess.py
+++ b/tests/models/test_postprocess.py
@@ -1,0 +1,112 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Tests for PostProcess box clamping behaviour."""
+
+import torch
+
+from rfdetr.models.postprocess import PostProcess
+
+
+class TestGatherAndScaleBoxes:
+    """Tests for :meth:`PostProcess._gather_and_scale_boxes`."""
+
+    def test_clamps_boxes_to_image_bounds(self):
+        """Boxes that extrapolate beyond [0, 1] in normalized space are
+        clamped to pixel-space image dimensions after scaling."""
+        # Three synthetic boxes in cxcywh normalized coords:
+        #   [0] cx=0.01, w=0.10 → x1 = (0.01 - 0.05) * 640 = -25.6  ← negative
+        #   [1] cx=0.99, w=0.10 → x2 = (0.99 + 0.05) * 640 = 665.6  ← overflow
+        #   [2] cx=0.50, w=0.20 → fully in-bounds
+        out_bbox = torch.tensor(
+            [
+                [
+                    [0.01, 0.01, 0.10, 0.10],  # negative x1, y1 after scale
+                    [0.99, 0.99, 0.10, 0.10],  # x2 > img_w, y2 > img_h after scale
+                    [0.50, 0.50, 0.20, 0.20],  # in-bounds control
+                ]
+            ]
+        )  # shape (B=1, Q=3, 4)
+
+        topk_boxes = torch.tensor([[0, 1, 2]])  # select all three
+        target_sizes = torch.tensor([[480, 640]])  # (h, w)
+
+        boxes = PostProcess._gather_and_scale_boxes(out_bbox, topk_boxes, target_sizes)
+
+        img_h, img_w = 480, 640
+
+        # All coords must be >= 0
+        assert (boxes >= 0).all(), f"Negative coords present: {boxes[boxes < 0]}"
+        # x1, x2 must be <= image width
+        assert (boxes[..., 0] <= img_w).all()
+        assert (boxes[..., 2] <= img_w).all()
+        # y1, y2 must be <= image height
+        assert (boxes[..., 1] <= img_h).all()
+        assert (boxes[..., 3] <= img_h).all()
+
+    def test_in_bounds_boxes_unchanged(self):
+        """Boxes already within image bounds are not altered by clamping."""
+        out_bbox = torch.tensor(
+            [
+                [
+                    [0.30, 0.30, 0.20, 0.20],
+                    [0.70, 0.60, 0.30, 0.40],
+                ]
+            ]
+        )
+
+        topk_boxes = torch.tensor([[0, 1]])
+        target_sizes = torch.tensor([[480, 640]])
+
+        boxes = PostProcess._gather_and_scale_boxes(out_bbox, topk_boxes, target_sizes)
+
+        # Manually computed expected values (no clamping needed)
+        expected = torch.tensor(
+            [
+                [
+                    [128.0, 96.0, 256.0, 192.0],  # cx=0.30,cy=0.30,w=0.20,h=0.20
+                    [352.0, 192.0, 544.0, 384.0],  # cx=0.70,cy=0.60,w=0.30,h=0.40
+                ]
+            ]
+        )
+
+        assert torch.allclose(boxes, expected, atol=1e-4), (
+            f"In-bounds boxes were altered.\nExpected:\n{expected}\nGot:\n{boxes}"
+        )
+
+    def test_multiple_images_in_batch(self):
+        """Clamping works correctly across a batch of mixed image sizes."""
+        out_bbox = torch.tensor(
+            [
+                [
+                    [0.01, 0.50, 0.10, 0.20],  # image 0: negative x1
+                ],
+                [
+                    [0.99, 0.50, 0.10, 0.20],  # image 1: x2 overflow
+                ],
+            ]
+        )
+
+        topk_boxes = torch.tensor([[0], [0]])
+        target_sizes = torch.tensor(
+            [
+                [300, 400],  # image 0: 400×300
+                [600, 800],  # image 1: 800×600
+            ]
+        )
+
+        boxes = PostProcess._gather_and_scale_boxes(out_bbox, topk_boxes, target_sizes)
+
+        # Image 0: all coords must be in [0, 400]×[0, 300]
+        assert (boxes[0, :, 0] >= 0).all() and (boxes[0, :, 0] <= 400).all()
+        assert (boxes[0, :, 1] >= 0).all() and (boxes[0, :, 1] <= 300).all()
+        assert (boxes[0, :, 2] >= 0).all() and (boxes[0, :, 2] <= 400).all()
+        assert (boxes[0, :, 3] >= 0).all() and (boxes[0, :, 3] <= 300).all()
+
+        # Image 1: all coords must be in [0, 800]×[0, 600]
+        assert (boxes[1, :, 0] >= 0).all() and (boxes[1, :, 0] <= 800).all()
+        assert (boxes[1, :, 1] >= 0).all() and (boxes[1, :, 1] <= 600).all()
+        assert (boxes[1, :, 2] >= 0).all() and (boxes[1, :, 2] <= 800).all()
+        assert (boxes[1, :, 3] >= 0).all() and (boxes[1, :, 3] <= 600).all()

--- a/tests/models/test_postprocess.py
+++ b/tests/models/test_postprocess.py
@@ -5,6 +5,7 @@
 # ------------------------------------------------------------------------
 """Tests for PostProcess box clamping behaviour."""
 
+import pytest
 import torch
 
 from rfdetr.models.postprocess import PostProcess
@@ -45,6 +46,14 @@ class TestGatherAndScaleBoxes:
         # y1, y2 must be <= image height
         assert (boxes[..., 1] <= img_h).all()
         assert (boxes[..., 3] <= img_h).all()
+
+        # Exact clamped values — bounds-only check cannot catch a clamp returning e.g. 1.0 instead of 0.0
+        # box [0]: x1_raw=-25.6, y1_raw=-19.2 → clamped to 0.0
+        assert boxes[0, 0, 0].item() == pytest.approx(0.0), "x1 of underflowing box must clamp to 0"
+        assert boxes[0, 0, 1].item() == pytest.approx(0.0), "y1 of underflowing box must clamp to 0"
+        # box [1]: x2_raw=665.6 → clamped to img_w=640.0; y2_raw=499.2 → clamped to img_h=480.0
+        assert boxes[0, 1, 2].item() == pytest.approx(640.0), "x2 of overflowing box must clamp to img_w"
+        assert boxes[0, 1, 3].item() == pytest.approx(480.0), "y2 of overflowing box must clamp to img_h"
 
     def test_in_bounds_boxes_unchanged(self):
         """Boxes already within image bounds are not altered by clamping."""
@@ -100,13 +109,41 @@ class TestGatherAndScaleBoxes:
         boxes = PostProcess._gather_and_scale_boxes(out_bbox, topk_boxes, target_sizes)
 
         # Image 0: all coords must be in [0, 400]×[0, 300]
-        assert (boxes[0, :, 0] >= 0).all() and (boxes[0, :, 0] <= 400).all()
-        assert (boxes[0, :, 1] >= 0).all() and (boxes[0, :, 1] <= 300).all()
-        assert (boxes[0, :, 2] >= 0).all() and (boxes[0, :, 2] <= 400).all()
-        assert (boxes[0, :, 3] >= 0).all() and (boxes[0, :, 3] <= 300).all()
+        assert (boxes[0, :, 0] >= 0).all(), "img0 x1: expected >= 0"
+        assert (boxes[0, :, 0] <= 400).all(), "img0 x1: expected <= img_w (400)"
+        assert (boxes[0, :, 1] >= 0).all(), "img0 y1: expected >= 0"
+        assert (boxes[0, :, 1] <= 300).all(), "img0 y1: expected <= img_h (300)"
+        assert (boxes[0, :, 2] >= 0).all(), "img0 x2: expected >= 0"
+        assert (boxes[0, :, 2] <= 400).all(), "img0 x2: expected <= img_w (400)"
+        assert (boxes[0, :, 3] >= 0).all(), "img0 y2: expected >= 0"
+        assert (boxes[0, :, 3] <= 300).all(), "img0 y2: expected <= img_h (300)"
 
         # Image 1: all coords must be in [0, 800]×[0, 600]
-        assert (boxes[1, :, 0] >= 0).all() and (boxes[1, :, 0] <= 800).all()
-        assert (boxes[1, :, 1] >= 0).all() and (boxes[1, :, 1] <= 600).all()
-        assert (boxes[1, :, 2] >= 0).all() and (boxes[1, :, 2] <= 800).all()
-        assert (boxes[1, :, 3] >= 0).all() and (boxes[1, :, 3] <= 600).all()
+        assert (boxes[1, :, 0] >= 0).all(), "img1 x1: expected >= 0"
+        assert (boxes[1, :, 0] <= 800).all(), "img1 x1: expected <= img_w (800)"
+        assert (boxes[1, :, 1] >= 0).all(), "img1 y1: expected >= 0"
+        assert (boxes[1, :, 1] <= 600).all(), "img1 y1: expected <= img_h (600)"
+        assert (boxes[1, :, 2] >= 0).all(), "img1 x2: expected >= 0"
+        assert (boxes[1, :, 2] <= 800).all(), "img1 x2: expected <= img_w (800)"
+        assert (boxes[1, :, 3] >= 0).all(), "img1 y2: expected >= 0"
+        assert (boxes[1, :, 3] <= 600).all(), "img1 y2: expected <= img_h (600)"
+
+
+class TestPostProcessForward:
+    """Integration tests for :meth:`PostProcess.forward`."""
+
+    def test_forward_clamps_edge_boxes_to_bounds(self):
+        """PostProcess.forward returns non-negative in-bounds boxes for edge-hugging predictions."""
+        postprocess = PostProcess(num_select=2)
+        outputs = {
+            "pred_logits": torch.tensor([[[10.0, -10.0], [9.0, -10.0]]]),
+            "pred_boxes": torch.tensor([[[0.01, 0.01, 0.10, 0.10], [0.99, 0.99, 0.10, 0.10]]]),
+        }
+        target_sizes = torch.tensor([[480, 640]])
+        results = postprocess(outputs, target_sizes)
+        boxes = results[0]["boxes"]
+        assert (boxes >= 0).all(), f"Negative coords present: {boxes[boxes < 0]}"
+        assert (boxes[..., 0] <= 640).all(), "x1 exceeds img_w (640)"
+        assert (boxes[..., 2] <= 640).all(), "x2 exceeds img_w (640)"
+        assert (boxes[..., 1] <= 480).all(), "y1 exceeds img_h (480)"
+        assert (boxes[..., 3] <= 480).all(), "y2 exceeds img_h (480)"


### PR DESCRIPTION
Boxes for objects near image edges can extrapolate beyond the visible region, producing negative x1/y1 or x2/y2 > image dims. Clamp to target image dimensions after cxcywh→xyxy→scale.

## What does this PR do?

Clamp predicted bounding box coordinates to image dimensions after
scaling from normalized space. Boxes for objects near image edges
can extrapolate beyond the visible region — producing negative x1/y1
or x2/y2 values exceeding the image width/height.

- **`src/rfdetr/models/postprocess.py`**: Added `.clamp()` call in
  `_gather_and_scale_boxes` to bound scaled xyxy coordinates to
  `[0, image_dimension]` per image in the batch.

- **`tests/models/test_postprocess.py`**: Three new tests covering:
  - mixed input (negative, overflow, and in-bounds boxes in one batch)
  - in-bounds boxes pass through unchanged
  - batches with images of different sizes

**Related Issue(s):** Fixes #1167 

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->

- [X] I have tested this change locally
- [X] I have added/updated tests for this change

**Test details:**
I verified the TDD flow by temporarily reverting the fix. Here's the analysis against the contribution guidelines:
| Test | Without fix | With fix |
|:-:|:-:|:-:|
| test_clamps_boxes_to_image_bounds | ❌ Fails: negative coords [-25.6, -19.2] | ✅ Passes |
| test_in_bounds_boxes_unchanged | ✅ Passes (expected) | ✅ Passes |
| test_multiple_images_in_batch  | ❌ Fails: negative coord [-16.0] | ✅ Passes |

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code where necessary, particularly in hard-to-understand areas
- [X] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->

I have read the CLA Document and I sign the CLA.
