### PR TITLE
refactor: drop_schedule and models.math with mypy-compliant typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -310,7 +310,6 @@ overrides = [
     "rfdetr.models.heads.detection",
     "rfdetr.models.heads.segmentation",
     "rfdetr.models.lwdetr",
-    "rfdetr.models.math",
     "rfdetr.models.matcher",
     "rfdetr.models.ops.functions.ms_deform_attn_func",
     "rfdetr.models.ops.modules.ms_deform_attn",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -326,7 +326,6 @@ overrides = [
     "rfdetr.training.callbacks.drop_schedule",
     "rfdetr.training.callbacks.ema",
     "rfdetr.training.cli",
-    "rfdetr.training.drop_schedule",
     "rfdetr.training.model_ema",
     "rfdetr.training.module_data",
     "rfdetr.training.module_model",

--- a/src/rfdetr/models/math.py
+++ b/src/rfdetr/models/math.py
@@ -9,8 +9,6 @@
 # ------------------------------------------------------------------------
 """Mathematical building blocks: MLP, inverse_sigmoid, accuracy, interpolate."""
 
-from typing import List, Optional, Tuple
-
 import torch
 import torch.nn.functional as F  # noqa: N812
 import torchvision
@@ -21,31 +19,31 @@ if float(torchvision.__version__.split(".")[1]) < 7.0:
     from torchvision.ops.misc import _output_size
 
 
-@torch.no_grad()
-def accuracy(output: torch.Tensor, target: torch.Tensor, topk: Tuple[int, ...] = (1,)) -> List[torch.Tensor]:
+def accuracy(output: torch.Tensor, target: torch.Tensor, topk: tuple[int, ...] = (1,)) -> list[torch.Tensor]:
     """Computes the precision@k for the specified values of k."""
-    if target.numel() == 0:
-        return [torch.zeros([], device=output.device)]
-    maxk = max(topk)
-    batch_size = target.size(0)
+    with torch.no_grad():
+        if target.numel() == 0:
+            return [torch.zeros([], device=output.device)]
+        maxk = max(topk)
+        batch_size = target.size(0)
 
-    _, pred = output.topk(maxk, 1, True, True)
-    pred = pred.t()
-    correct = pred.eq(target.view(1, -1).expand_as(pred))
+        _, pred = output.topk(maxk, 1, True, True)
+        pred = pred.t()
+        correct = pred.eq(target.view(1, -1).expand_as(pred))
 
-    res = []
-    for k in topk:
-        correct_k = correct[:k].view(-1).float().sum(0)
-        res.append(correct_k.mul_(100.0 / batch_size))
-    return res
+        res = []
+        for k in topk:
+            correct_k = correct[:k].view(-1).float().sum(0)
+            res.append(correct_k.mul_(100.0 / batch_size))
+        return res
 
 
 def interpolate(
     input: Tensor,
-    size: Optional[List[int]] = None,
-    scale_factor: Optional[float] = None,
+    size: list[int] | None = None,
+    scale_factor: float | None = None,
     mode: str = "nearest",
-    align_corners: Optional[bool] = None,
+    align_corners: bool | None = None,
 ) -> Tensor:
     """Equivalent to nn.functional.interpolate, but with support for empty batch sizes."""
     if float(torchvision.__version__.split(".")[1]) < 7.0:
@@ -69,13 +67,13 @@ def inverse_sigmoid(x: torch.Tensor, eps: float = 1e-5) -> torch.Tensor:
 class MLP(nn.Module):
     """Very simple multi-layer perceptron (also called FFN)"""
 
-    def __init__(self, input_dim, hidden_dim, output_dim, num_layers):
+    def __init__(self, input_dim: int, hidden_dim: int, output_dim: int, num_layers: int) -> None:
         super().__init__()
         self.num_layers = num_layers
         h = [hidden_dim] * (num_layers - 1)
         self.layers = nn.ModuleList(nn.Linear(n, k) for n, k in zip([input_dim] + h, h + [output_dim]))
 
-    def forward(self, x):
+    def forward(self, x: Tensor) -> Tensor:
         for i, layer in enumerate(self.layers):
             x = F.relu(layer(x)) if i < self.num_layers - 1 else layer(x)
         return x

--- a/src/rfdetr/models/math.py
+++ b/src/rfdetr/models/math.py
@@ -23,6 +23,7 @@ if float(torchvision.__version__.split(".")[1]) < 7.0:
 
 def accuracy(output: torch.Tensor, target: torch.Tensor, topk: tuple[int, ...] = (1,)) -> list[torch.Tensor]:
     """Computes the precision@k for the specified values of k."""
+    # Context manager avoids mypy untyped-decorator on @torch.no_grad()
     with torch.no_grad():
         if target.numel() == 0:
             return [torch.zeros([], device=output.device)]

--- a/src/rfdetr/models/math.py
+++ b/src/rfdetr/models/math.py
@@ -9,8 +9,6 @@
 # ------------------------------------------------------------------------
 """Mathematical building blocks: MLP, inverse_sigmoid, accuracy, interpolate."""
 
-from typing import cast
-
 import torch
 import torch.nn.functional as F  # noqa: N812
 import torchvision
@@ -52,13 +50,16 @@ def interpolate(
     """Equivalent to nn.functional.interpolate, but with support for empty batch sizes."""
     if float(torchvision.__version__.split(".")[1]) < 7.0:
         if input.numel() > 0:
-            return torch.nn.functional.interpolate(input, size, scale_factor, mode, align_corners)
+            interpolated: Tensor = torch.nn.functional.interpolate(input, size, scale_factor, mode, align_corners)
+            return interpolated
 
         output_shape = _output_size(2, input, size, scale_factor)
         output_shape = list(input.shape[:-2]) + list(output_shape)
-        return cast(Tensor, _new_empty_tensor(input, output_shape))
+        empty_output: Tensor = _new_empty_tensor(input, output_shape)
+        return empty_output
     else:
-        return cast(Tensor, torchvision.ops.misc.interpolate(input, size, scale_factor, mode, align_corners))
+        torchvision_output: Tensor = torchvision.ops.misc.interpolate(input, size, scale_factor, mode, align_corners)
+        return torchvision_output
 
 
 def inverse_sigmoid(x: torch.Tensor, eps: float = 1e-5) -> torch.Tensor:

--- a/src/rfdetr/models/math.py
+++ b/src/rfdetr/models/math.py
@@ -24,6 +24,7 @@ if float(torchvision.__version__.split(".")[1]) < 7.0:
 def accuracy(output: torch.Tensor, target: torch.Tensor, topk: tuple[int, ...] = (1,)) -> list[torch.Tensor]:
     """Computes the precision@k for the specified values of k."""
     # Context manager avoids mypy untyped-decorator on @torch.no_grad()
+    # Revert to decorator once torch floor >= 2.10 (pytorch/pytorch#166413)
     with torch.no_grad():
         if target.numel() == 0:
             return [torch.zeros([], device=output.device)]
@@ -36,7 +37,7 @@ def accuracy(output: torch.Tensor, target: torch.Tensor, topk: tuple[int, ...] =
 
         res = []
         for k in topk:
-            correct_k = correct[:k].view(-1).float().sum(0)
+            correct_k = correct[:k].reshape(-1).float().sum(0)
             res.append(correct_k.mul_(100.0 / batch_size))
         return res
 
@@ -51,7 +52,7 @@ def interpolate(
     """Equivalent to nn.functional.interpolate, but with support for empty batch sizes."""
     if float(torchvision.__version__.split(".")[1]) < 7.0:
         if input.numel() > 0:
-            return torch.nn.functional.interpolate(input, size, scale_factor, mode, align_corners)
+            return cast(Tensor, torch.nn.functional.interpolate(input, size, scale_factor, mode, align_corners))
 
         output_shape = _output_size(2, input, size, scale_factor)
         output_shape = list(input.shape[:-2]) + list(output_shape)
@@ -61,6 +62,19 @@ def interpolate(
 
 
 def inverse_sigmoid(x: torch.Tensor, eps: float = 1e-5) -> torch.Tensor:
+    """Compute element-wise logit (inverse sigmoid) of a tensor.
+
+    Clamps input to ``[0, 1]``, then returns ``log(x / (1 - x))`` with
+    numerical stability guarded by ``eps``.
+
+    Args:
+        x: Input tensor with values in the range ``[0, 1]``.
+        eps: Minimum clamp value applied to ``x`` and ``1 - x`` before the
+            log operation. Guards against ``log(0)``.
+
+    Returns:
+        Tensor of the same shape as ``x`` containing the logit values.
+    """
     x = x.clamp(min=0, max=1)
     x1 = x.clamp(min=eps)
     x2 = (1 - x).clamp(min=eps)
@@ -77,6 +91,14 @@ class MLP(nn.Module):
         self.layers = nn.ModuleList(nn.Linear(n, k) for n, k in zip([input_dim] + h, h + [output_dim]))
 
     def forward(self, x: Tensor) -> Tensor:
+        """Apply the MLP: ReLU on all layers except the last.
+
+        Args:
+            x: Input tensor of shape ``(..., input_dim)``.
+
+        Returns:
+            Output tensor of shape ``(..., output_dim)``.
+        """
         for i, layer in enumerate(self.layers):
             x = F.relu(layer(x)) if i < self.num_layers - 1 else layer(x)
         return x

--- a/src/rfdetr/models/math.py
+++ b/src/rfdetr/models/math.py
@@ -9,6 +9,8 @@
 # ------------------------------------------------------------------------
 """Mathematical building blocks: MLP, inverse_sigmoid, accuracy, interpolate."""
 
+from typing import cast
+
 import torch
 import torch.nn.functional as F  # noqa: N812
 import torchvision
@@ -52,9 +54,9 @@ def interpolate(
 
         output_shape = _output_size(2, input, size, scale_factor)
         output_shape = list(input.shape[:-2]) + list(output_shape)
-        return _new_empty_tensor(input, output_shape)
+        return cast(Tensor, _new_empty_tensor(input, output_shape))
     else:
-        return torchvision.ops.misc.interpolate(input, size, scale_factor, mode, align_corners)
+        return cast(Tensor, torchvision.ops.misc.interpolate(input, size, scale_factor, mode, align_corners))
 
 
 def inverse_sigmoid(x: torch.Tensor, eps: float = 1e-5) -> torch.Tensor:

--- a/src/rfdetr/models/math.py
+++ b/src/rfdetr/models/math.py
@@ -52,7 +52,7 @@ def interpolate(
     """Equivalent to nn.functional.interpolate, but with support for empty batch sizes."""
     if float(torchvision.__version__.split(".")[1]) < 7.0:
         if input.numel() > 0:
-            return cast(Tensor, torch.nn.functional.interpolate(input, size, scale_factor, mode, align_corners))
+            return torch.nn.functional.interpolate(input, size, scale_factor, mode, align_corners)
 
         output_shape = _output_size(2, input, size, scale_factor)
         output_shape = list(input.shape[:-2]) + list(output_shape)

--- a/src/rfdetr/training/drop_schedule.py
+++ b/src/rfdetr/training/drop_schedule.py
@@ -22,7 +22,26 @@ def drop_scheduler(
     mode: Literal["standard", "early", "late"] = "standard",
     schedule: Literal["constant", "linear"] = "constant",
 ) -> np.ndarray:
-    """Drop scheduler."""
+    """Build a per-iteration drop-path or dropout rate schedule.
+
+    ``"standard"`` mode: every iteration uses the same ``drop_rate``; ignored ``cutoff_epoch``, ``schedule``.
+    ``"early"`` mode: drop rate applies during the first ``cutoff_epoch`` epochs; remaining epochs use zero drop rate.
+        optional: schedule ``linear`` decay to zero over the first ``cutoff_epoch`` epochs.
+    ``"late"`` mode: the first ``cutoff_epoch`` epochs use zero drop rate; remaining epochs use ``drop_rate``.
+
+    Args:
+        drop_rate: Target drop probability.
+        epochs: Total number of training epochs.
+        niter_per_ep: Number of optimizer steps per epoch.
+        cutoff_epoch: Number of epochs in the initial schedule phase. Phases split at cutoff_epoch * niter_per_ep steps
+            Ignored when ``mode`` is ``"standard"``.
+        mode: Scheduling strategy: ``"standard"``, ``"early"``, or ``"late"``.
+        schedule: Shape of the initial schedule phase in ``"early"`` mode: ``"constant"`` or ``"linear"``.
+            Ignored when ``mode`` is ``"standard"`` or ``"late"``.
+
+    Returns:
+        One-dimensional array of length ``epochs * niter_per_ep`` containing the drop rate per iteration.
+    """
     assert mode in ["standard", "early", "late"]
     if mode == "standard":
         return np.full(epochs * niter_per_ep, drop_rate)

--- a/src/rfdetr/training/drop_schedule.py
+++ b/src/rfdetr/training/drop_schedule.py
@@ -43,23 +43,21 @@ def drop_scheduler(
         One-dimensional array of length ``epochs * niter_per_ep`` containing the drop rate per iteration.
     """
     assert mode in ["standard", "early", "late"]
+    total_iters = epochs * niter_per_ep
     if mode == "standard":
-        return np.full(epochs * niter_per_ep, drop_rate)
+        return np.full(total_iters, drop_rate)
 
     early_iters = cutoff_epoch * niter_per_ep
-    late_iters = (epochs - cutoff_epoch) * niter_per_ep
+    result = np.zeros(total_iters, dtype=np.float64)
 
     if mode == "early":
         assert schedule in ["constant", "linear"]
         if schedule == "constant":
-            early_schedule = np.full(early_iters, drop_rate)
-        elif schedule == "linear":
-            early_schedule = np.linspace(drop_rate, 0, early_iters)
-        final_schedule = np.concatenate((early_schedule, np.full(late_iters, 0)))
+            result[:early_iters] = drop_rate
+        else:
+            result[:early_iters] = np.linspace(drop_rate, 0, early_iters)
     elif mode == "late":
         assert schedule in ["constant"]
-        early_schedule = np.full(early_iters, 0)
-        final_schedule = np.concatenate((early_schedule, np.full(late_iters, drop_rate)))
+        result[early_iters:] = drop_rate
 
-    assert len(final_schedule) == epochs * niter_per_ep
-    return final_schedule
+    return result

--- a/src/rfdetr/training/drop_schedule.py
+++ b/src/rfdetr/training/drop_schedule.py
@@ -37,12 +37,24 @@ def drop_scheduler(
             Ignored when ``mode`` is ``"standard"``.
         mode: Scheduling strategy: ``"standard"``, ``"early"``, or ``"late"``.
         schedule: Shape of the initial schedule phase in ``"early"`` mode: ``"constant"`` or ``"linear"``.
-            Ignored when ``mode`` is ``"standard"`` or ``"late"``.
+            Ignored when ``mode`` is ``"standard"``; only ``"constant"`` is accepted for ``"late"`` mode.
 
     Returns:
         One-dimensional array of length ``epochs * niter_per_ep`` containing the drop rate per iteration.
+
+    Raises:
+        ValueError: If ``mode`` is not ``"standard"``, ``"early"``, or ``"late"``.
+        ValueError: If ``epochs`` or ``niter_per_ep`` is less than ``1``.
+        ValueError: If ``cutoff_epoch`` is not in the range ``[0, epochs]``.
+        ValueError: If ``schedule`` is not ``"constant"`` or ``"linear"`` in ``"early"`` mode.
+        NotImplementedError: If ``schedule`` is not ``"constant"`` in ``"late"`` mode.
     """
-    assert mode in ["standard", "early", "late"]
+    if mode not in ("standard", "early", "late"):
+        raise ValueError(f"mode must be 'standard', 'early', or 'late', got {mode!r}")
+    if epochs < 1:
+        raise ValueError(f"epochs must be >= 1, got {epochs}")
+    if niter_per_ep < 1:
+        raise ValueError(f"niter_per_ep must be >= 1, got {niter_per_ep}")
     total_iters = epochs * niter_per_ep
     if mode == "standard":
         return np.full(total_iters, drop_rate)
@@ -52,13 +64,17 @@ def drop_scheduler(
     result = np.zeros(total_iters, dtype=np.float64)
 
     if mode == "early":
-        assert schedule in ["constant", "linear"]
+        if schedule not in ("constant", "linear"):
+            raise ValueError(f"schedule must be 'constant' or 'linear', got {schedule!r}")
         if schedule == "constant":
             result[:early_iters] = drop_rate
         else:
             result[:early_iters] = np.linspace(drop_rate, 0, early_iters)
     elif mode == "late":
-        assert schedule in ["constant"]
+        if schedule != "constant":
+            raise NotImplementedError(
+                f"schedule={schedule!r} is not supported for mode='late'; only 'constant' is implemented"
+            )
         result[early_iters:] = drop_rate
 
     return result

--- a/src/rfdetr/training/drop_schedule.py
+++ b/src/rfdetr/training/drop_schedule.py
@@ -33,7 +33,7 @@ def drop_scheduler(
         drop_rate: Target drop probability.
         epochs: Total number of training epochs.
         niter_per_ep: Number of optimizer steps per epoch.
-        cutoff_epoch: Number of epochs in the initial schedule phase. Phases split at cutoff_epoch * niter_per_ep steps
+        cutoff_epoch: Number of epochs in the initial schedule phase. Phases split at cutoff_epoch * niter_per_ep steps.
             Ignored when ``mode`` is ``"standard"``.
         mode: Scheduling strategy: ``"standard"``, ``"early"``, or ``"late"``.
         schedule: Shape of the initial schedule phase in ``"early"`` mode: ``"constant"`` or ``"linear"``.
@@ -46,7 +46,8 @@ def drop_scheduler(
     total_iters = epochs * niter_per_ep
     if mode == "standard":
         return np.full(total_iters, drop_rate)
-
+    if not 0 <= cutoff_epoch <= epochs:
+        raise ValueError(f"cutoff_epoch must be in [0, {epochs}], but got {cutoff_epoch}")
     early_iters = cutoff_epoch * niter_per_ep
     result = np.zeros(total_iters, dtype=np.float64)
 

--- a/tests/models/test_math.py
+++ b/tests/models/test_math.py
@@ -1,0 +1,82 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Unit tests for rfdetr.models.math utility functions."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from rfdetr.models.math import accuracy, inverse_sigmoid
+
+
+class TestAccuracy:
+    """Verify accuracy() computes precision@k correctly."""
+
+    def test_top1_perfect_batch(self) -> None:
+        """All predictions correct returns top-1 accuracy of 100.0."""
+        output = torch.tensor([[0.0, 10.0], [10.0, 0.0], [0.0, 10.0]])
+        target = torch.tensor([1, 0, 1])
+        result = accuracy(output, target, topk=(1,))
+        assert len(result) == 1
+        assert result[0].item() == pytest.approx(100.0)
+
+    def test_top1_zero_accuracy(self) -> None:
+        """All predictions wrong returns top-1 accuracy of 0.0."""
+        output = torch.tensor([[10.0, 0.0], [0.0, 10.0]])
+        target = torch.tensor([1, 0])
+        result = accuracy(output, target, topk=(1,))
+        assert result[0].item() == pytest.approx(0.0)
+
+    def test_topk_returns_list_of_correct_length(self) -> None:
+        """Topk=(1, 5) returns a list of length 2."""
+        output = torch.randn(10, 10)
+        target = torch.zeros(10, dtype=torch.long)
+        result = accuracy(output, target, topk=(1, 5))
+        assert len(result) == 2
+
+    def test_empty_target_returns_single_zero_regardless_of_topk(self) -> None:
+        """Empty target returns list of length 1 with value 0 regardless of topk length."""
+        output = torch.zeros(0, 5)
+        target = torch.zeros(0, dtype=torch.long)
+        result = accuracy(output, target, topk=(1, 5))
+        assert len(result) == 1
+        assert result[0].item() == pytest.approx(0.0)
+
+
+class TestInverseSigmoid:
+    """Verify inverse_sigmoid() computes the logit function correctly."""
+
+    def test_identity_at_half(self) -> None:
+        """inverse_sigmoid(0.5) equals 0.0 since sigmoid(0.0) = 0.5."""
+        x = torch.tensor([0.5])
+        result = inverse_sigmoid(x)
+        assert result.item() == pytest.approx(0.0, abs=1e-5)
+
+    def test_clamping_at_zero_is_finite(self) -> None:
+        """inverse_sigmoid(0.0) is finite due to eps clamping."""
+        x = torch.tensor([0.0])
+        result = inverse_sigmoid(x)
+        assert torch.isfinite(result).all()
+
+    def test_clamping_at_one_is_finite(self) -> None:
+        """inverse_sigmoid(1.0) is finite due to eps clamping."""
+        x = torch.tensor([1.0])
+        result = inverse_sigmoid(x)
+        assert torch.isfinite(result).all()
+
+    def test_output_shape_matches_input(self) -> None:
+        """Output shape matches input shape for a multi-dimensional tensor."""
+        x = torch.rand(3, 4)
+        result = inverse_sigmoid(x)
+        assert result.shape == x.shape
+
+    def test_gradient_flows_for_non_saturated_input(self) -> None:
+        """Gradients are non-zero for a non-saturated input value."""
+        x = torch.tensor([0.3], requires_grad=True)
+        inverse_sigmoid(x).sum().backward()
+        assert x.grad is not None
+        assert x.grad.abs().item() > 0.0

--- a/tests/training/callbacks/test_drop_path_callback.py
+++ b/tests/training/callbacks/test_drop_path_callback.py
@@ -193,3 +193,101 @@ class TestOnTrainBatchStart:
 
         assert cb._dp_schedule is not None
         pl_module.model.update_drop_path.assert_called_once_with(cb._dp_schedule[step], 6)
+
+
+# ---------------------------------------------------------------------------
+# TestDropSchedulerValidation
+# ---------------------------------------------------------------------------
+
+
+class TestDropSchedulerValidation:
+    """Verify drop_scheduler raises for invalid inputs."""
+
+    @pytest.mark.parametrize(
+        "cutoff_epoch",
+        [
+            pytest.param(6, id="above_epochs"),
+            pytest.param(-1, id="negative"),
+        ],
+    )
+    def test_raises_for_invalid_cutoff_epoch(self, cutoff_epoch: int) -> None:
+        """drop_scheduler raises ValueError when cutoff_epoch is outside [0, epochs]."""
+        with pytest.raises(ValueError, match="cutoff_epoch must be in"):
+            drop_scheduler(0.3, 5, 10, cutoff_epoch=cutoff_epoch, mode="early")
+
+    @pytest.mark.parametrize(
+        ("epochs", "niter_per_ep", "match"),
+        [
+            pytest.param(0, 10, "epochs must be >= 1", id="epochs_zero"),
+            pytest.param(5, 0, "niter_per_ep must be >= 1", id="niter_per_ep_zero"),
+        ],
+    )
+    def test_raises_for_invalid_epoch_counts(self, epochs: int, niter_per_ep: int, match: str) -> None:
+        """drop_scheduler raises ValueError when epochs or niter_per_ep is less than 1."""
+        with pytest.raises(ValueError, match=match):
+            drop_scheduler(0.3, epochs, niter_per_ep)
+
+
+# ---------------------------------------------------------------------------
+# TestDropSchedulerBoundary
+# ---------------------------------------------------------------------------
+
+
+class TestDropSchedulerBoundary:
+    """Verify drop_scheduler with cutoff_epoch at the inclusive boundaries 0 and epochs."""
+
+    @pytest.mark.parametrize(
+        ("cutoff_epoch", "mode", "expected_first", "expected_last"),
+        [
+            pytest.param(0, "early", 0.0, 0.0, id="early_cutoff_zero_all_zeros"),
+            pytest.param(5, "early", 0.3, 0.3, id="early_cutoff_full_all_rate"),
+            pytest.param(0, "late", 0.3, 0.3, id="late_cutoff_zero_all_rate"),
+            pytest.param(5, "late", 0.0, 0.0, id="late_cutoff_full_all_zeros"),
+        ],
+    )
+    def test_boundary_cutoff_epoch(
+        self,
+        cutoff_epoch: int,
+        mode: str,
+        expected_first: float,
+        expected_last: float,
+    ) -> None:
+        """Boundary cutoff_epoch values (0 and epochs) produce correct first and last rates."""
+        schedule = drop_scheduler(0.3, 5, 10, cutoff_epoch=cutoff_epoch, mode=mode)
+        assert schedule[0] == expected_first
+        assert schedule[-1] == expected_last
+
+
+# ---------------------------------------------------------------------------
+# TestDropSchedulerLinear
+# ---------------------------------------------------------------------------
+
+
+class TestDropSchedulerLinear:
+    """Verify drop_scheduler with schedule='linear' in early mode."""
+
+    def test_linear_early_starts_at_drop_rate(self) -> None:
+        """Linear early schedule first value equals drop_rate."""
+        schedule = drop_scheduler(0.3, 5, 10, cutoff_epoch=2, mode="early", schedule="linear")
+        assert schedule[0] == pytest.approx(0.3, abs=1e-9)
+
+    def test_linear_early_ends_early_phase_at_zero(self) -> None:
+        """Linear early schedule last value of the early phase equals 0."""
+        schedule = drop_scheduler(0.3, 5, 10, cutoff_epoch=2, mode="early", schedule="linear")
+        assert schedule[19] == pytest.approx(0.0, abs=1e-9)
+
+    def test_linear_early_late_phase_is_zero(self) -> None:
+        """Linear early schedule: all values after cutoff_epoch are zero."""
+        schedule = drop_scheduler(0.3, 5, 10, cutoff_epoch=2, mode="early", schedule="linear")
+        np.testing.assert_array_equal(schedule[20:], 0.0)
+
+    def test_linear_early_decreases_monotonically(self) -> None:
+        """Linear early schedule values decrease monotonically during the early phase."""
+        schedule = drop_scheduler(0.3, 5, 10, cutoff_epoch=2, mode="early", schedule="linear")
+        assert np.all(np.diff(schedule[:20]) <= 0)
+
+    def test_linear_same_shape_as_constant(self) -> None:
+        """Schedule='linear' output has the same length as schedule='constant'."""
+        linear = drop_scheduler(0.3, 5, 10, cutoff_epoch=2, mode="early", schedule="linear")
+        constant = drop_scheduler(0.3, 5, 10, cutoff_epoch=2, mode="early", schedule="constant")
+        assert linear.shape == constant.shape


### PR DESCRIPTION
## What does this PR do?

drop_schedule: Graduates the module off the mypy ignore list and expands the Google-style docstring. Refactors early/late schedule construction (np.zeros + slice assignment instead of np.concatenate) so strict mypy can verify the np.ndarray return type. No intended behavior change.

models.math: Adds MLP annotations and modernizes builtins per PEP 585/604. Replaces @torch.no_grad() with with torch.no_grad(): in accuracy() to satisfy strict mypy across our torch>=2.2.0 range without a `# type: ignore[untyped-decorator]` (fixed upstream in PyTorch 2.10.0, pytorch/pytorch#166413). Add `cast()` on `interpolate()` to satisfy mypy strict `no-any-return`.

**Related Issue(s):** #564 

## Type of Change

- Refactoring (no functional changes)

## Testing

- `uv run --no-sync pytest src/ tests/ -n 1 -m "not gpu" --ignore=tests/run_smoke_all_models.py --timeout=240 --durations=50` — **2635 passed**, 40 skipped (~7m)
- `uv run --no-sync mypy src/rfdetr/ --no-error-summary` — clean (matches `ci-typing.yml`; validates `drop_schedule` and `math` off the mypy ignore list)

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change (existing tests pass)

**Test details:**
- No new tests added; existing `tests/training/callbacks/test_drop_path_callback.py` covers `drop_scheduler` behavior (standard / early / late modes and multi-step rates)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

`@torch.no_grad()` decorator in math can also be made compliant with strict mypy via `# type: ignore[untyped-decorator]`, however this would then need to be removed if/when torch updated to torch>=2.10.0; context manager is a more robust fix across a broader range of torch versions.