### PR TITLE
fix(core): inference-mode grads, EMA swap, kwargs

### DIFF
--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -642,7 +642,10 @@ class TrainConfig(BaseConfig):
           This avoids silently changing behavior when scaling from single-GPU to multi-GPU training.
     """
 
-    model_config: ClassVar[ConfigDict] = ConfigDict(extra="ignore", validate_assignment=True)
+    # extra="forbid" arms BaseConfig.catch_typo_kwargs so typo'd train() kwargs (e.g. ``epoch`` instead of
+    # ``epochs``) raise with a helpful message instead of being silently ignored.  Legacy kwargs handled by
+    # RFDETR.train() (resolution/device/callbacks/start_epoch/do_benchmark) are popped before construction.
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid", validate_assignment=True)
 
     lr: float = 1e-4
     lr_encoder: float = 1.5e-4

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -203,7 +203,13 @@ def _move_model_context_to_device(model_ctx: Any) -> None:
         target = torch.device(target)
     first_param = next(inner.parameters(), None)
     if first_param is not None and first_param.device != target:
-        model_ctx.model = inner.to(target)
+        # ``predict()`` stacks ``@torch.inference_mode()`` on top of ``@_ensure_model_on_device``, so the deferred
+        # move can run while inference mode is active.  Tensors materialised by ``.to()`` under inference mode become
+        # *inference tensors*: they can never require gradients, so a later ``train()`` or auto-batch probe would
+        # silently produce no gradients.  Disable inference mode for the move so deferred device placement is safe
+        # regardless of decorator order.
+        with torch.inference_mode(False):
+            model_ctx.model = inner.to(target)
 
 
 def _ensure_model_on_device(method: Callable[Concatenate[Any, _P], _R]) -> Callable[Concatenate[Any, _P], _R]:
@@ -1670,8 +1676,8 @@ class RFDETR:
                         f"num_keypoints_per_class={current_schema!r}, but the dataset infers "
                         f"active-first {inferred_schema!r}. Training will shift person from slot 1 "
                         f"to slot 0; checkpoint head weights are now misaligned. "
-                        f"Pass num_keypoints_per_class={current_schema!r} to train() to keep the "
-                        f"legacy schema.",
+                        f"Pass num_keypoints_per_class={current_schema!r} to the model constructor "
+                        f"to keep the legacy schema.",
                         UserWarning,
                         stacklevel=2,
                     )
@@ -2115,7 +2121,15 @@ class RFDETR:
         if self.size is None and size is None:
             raise ValueError("Must set size for custom architectures")
 
-        size = self.size or size
+        if size is not None and self.size is not None and size != self.size:
+            warnings.warn(
+                f"deploy_to_roboflow(size={size!r}) overrides this model's own size {self.size!r}; "
+                f"deploying as {size!r}. Omit size to deploy with the model's own size.",
+                UserWarning,
+                stacklevel=2,
+            )
+        # Explicit user argument wins; fall back to the trained model's size (documented behaviour).
+        size = size or self.size
         with tempfile.TemporaryDirectory(prefix="roboflow_upload_") as tmp_out_dir:
             self.export_for_roboflow(tmp_out_dir)
             project = workspace.project(project_id)

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -2129,7 +2129,7 @@ class RFDETR:
                 stacklevel=2,
             )
         # Explicit user argument wins; fall back to the trained model's size (documented behaviour).
-        size = size or self.size
+        size = self.size if size is None else size
         with tempfile.TemporaryDirectory(prefix="roboflow_upload_") as tmp_out_dir:
             self.export_for_roboflow(tmp_out_dir)
             project = workspace.project(project_id)

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -20,6 +20,7 @@ from pytorch_lightning import LightningModule, Trainer
 from pytorch_lightning import __version__ as ptl_version
 from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint
 
+from rfdetr.training.callbacks.ema import RFDETREMACallback
 from rfdetr.utilities.logger import get_logger
 from rfdetr.utilities.package import get_version
 from rfdetr.utilities.state_dict import _make_fit_loop_state, strip_checkpoint
@@ -552,7 +553,17 @@ class BestModelCallback(ModelCheckpoint):
                 raw = _orig if isinstance(_orig, torch.nn.Module) else pl_module.model
                 raw.load_state_dict(ckpt["model"], strict=True)
                 logger.info("Loaded best weights from %s for test evaluation.", total_path)
-                trainer.test(pl_module, datamodule=trainer.datamodule, verbose=False)
+                # The EMA callback swaps final-EMA weights in for test epochs, which would silently overwrite the
+                # just-loaded best weights — suppress its swap for this run only, restoring the default afterwards
+                # so standalone trainer.test() calls keep evaluating EMA weights.
+                ema_callbacks = [cb for cb in trainer.callbacks if isinstance(cb, RFDETREMACallback)]
+                for ema_callback in ema_callbacks:
+                    ema_callback.suppress_test_swap = True
+                try:
+                    trainer.test(pl_module, datamodule=trainer.datamodule, verbose=False)
+                finally:
+                    for ema_callback in ema_callbacks:
+                        ema_callback.suppress_test_swap = False
 
 
 class RFDETREarlyStopping(EarlyStopping):

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -557,13 +557,14 @@ class BestModelCallback(ModelCheckpoint):
                 # just-loaded best weights — suppress its swap for this run only, restoring the default afterwards
                 # so standalone trainer.test() calls keep evaluating EMA weights.
                 ema_callbacks = [cb for cb in trainer.callbacks if isinstance(cb, RFDETREMACallback)]
+                prior_flags = [cb.suppress_test_swap for cb in ema_callbacks]
                 for ema_callback in ema_callbacks:
                     ema_callback.suppress_test_swap = True
                 try:
                     trainer.test(pl_module, datamodule=trainer.datamodule, verbose=False)
                 finally:
-                    for ema_callback in ema_callbacks:
-                        ema_callback.suppress_test_swap = False
+                    for ema_callback, prior in zip(ema_callbacks, prior_flags):
+                        ema_callback.suppress_test_swap = prior
 
 
 class RFDETREarlyStopping(EarlyStopping):

--- a/src/rfdetr/training/callbacks/ema.py
+++ b/src/rfdetr/training/callbacks/ema.py
@@ -31,6 +31,13 @@ class RFDETREMACallback(Callback):
             ``TrainConfig.ema_tau``.
         use_buffers: Whether buffers are averaged in addition to parameters.
         update_interval_steps: Update EMA every N optimizer steps.
+
+    Attributes:
+        suppress_test_swap: When ``True`` the test-epoch hooks skip the EMA weight swap.  Set (and restored) by
+            :class:`~rfdetr.training.callbacks.best_model.BestModelCallback` around its fit-end ``trainer.test()``
+            run, which has already loaded the best checkpoint weights into the module — swapping in the final EMA
+            weights there would make the reported ``test/*`` metrics reflect the wrong model.  Standalone
+            ``trainer.test()`` runs keep the default ``False`` and evaluate EMA weights as before.
     """
 
     def __init__(
@@ -45,6 +52,7 @@ class RFDETREMACallback(Callback):
         self._tau = tau
         self._use_buffers = use_buffers
         self._update_interval_steps = max(1, int(update_interval_steps))
+        self.suppress_test_swap = False
 
         self._average_model: Optional[AveragedModel] = None
         self._latest_update_step = 0
@@ -177,11 +185,15 @@ class RFDETREMACallback(Callback):
             self._latest_update_epoch = trainer.current_epoch
 
     def on_test_epoch_start(self, trainer: Trainer, pl_module: LightningModule) -> None:
-        """Evaluate tests using averaged EMA weights."""
+        """Evaluate tests using averaged EMA weights unless the swap is suppressed."""
+        if self.suppress_test_swap:
+            return
         self._swap_models(pl_module)
 
     def on_test_epoch_end(self, trainer: Trainer, pl_module: LightningModule) -> None:
-        """Restore live weights after test evaluation."""
+        """Restore live weights after test evaluation unless the swap is suppressed."""
+        if self.suppress_test_swap:
+            return
         self._swap_models(pl_module)
 
     def on_train_end(self, trainer: Trainer, pl_module: LightningModule) -> None:

--- a/tests/inference/test_model_device_move.py
+++ b/tests/inference/test_model_device_move.py
@@ -1,0 +1,68 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Tests for the lazy device move running under ``torch.inference_mode()``.
+
+``predict()`` stacks ``@torch.inference_mode()`` on top of ``@_ensure_model_on_device``, so the deferred CPU-to-
+accelerator move happens while inference mode is active.  Tensors materialised under inference mode are *inference
+tensors*: they can never require gradients, so a later ``train()`` / auto-batch probe silently produces no gradients.
+The move itself must therefore always run with inference mode disabled.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+from torch import nn
+
+from rfdetr.detr import _move_model_context_to_device
+
+
+class _RecordingModule(nn.Module):
+    """Module whose ``to()`` records whether inference mode was active at move time."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = nn.Linear(2, 2)
+        self.inference_mode_at_move: bool | None = None
+
+    def to(self, *args: Any, **kwargs: Any) -> "_RecordingModule":
+        """Record the inference-mode state instead of performing a real device move."""
+        self.inference_mode_at_move = torch.is_inference_mode_enabled()
+        return self
+
+
+class TestMoveModelContextUnderInferenceMode:
+    """The deferred device move must never materialise parameters as inference tensors."""
+
+    def test_moved_params_are_not_inference_tensors(self) -> None:
+        """A real ``.to()`` move inside ``torch.inference_mode()`` must not create inference-tensor parameters."""
+        ctx = SimpleNamespace(device=torch.device("meta"), model=nn.Linear(2, 2))
+
+        with torch.inference_mode():
+            _move_model_context_to_device(ctx)
+
+        assert not any(p.is_inference() for p in ctx.model.parameters())
+
+    def test_move_still_materializes_on_target_device(self) -> None:
+        """The inference-mode guard must not suppress the device move itself."""
+        ctx = SimpleNamespace(device=torch.device("meta"), model=nn.Linear(2, 2))
+
+        with torch.inference_mode():
+            _move_model_context_to_device(ctx)
+
+        assert all(p.device.type == "meta" for p in ctx.model.parameters())
+
+    def test_move_runs_with_inference_mode_disabled(self) -> None:
+        """The ``.to()`` call itself must observe inference mode as disabled."""
+        module = _RecordingModule()
+        ctx = SimpleNamespace(device=torch.device("meta"), model=module)
+
+        with torch.inference_mode():
+            _move_model_context_to_device(ctx)
+
+        assert module.inference_mode_at_move is False

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -208,6 +208,42 @@ class TestSegmentationTrainConfigNumSelect:
         assert config_class().num_select == expected_num_select
 
 
+class TestTrainConfigRejectsUnknownKwargs:
+    """TrainConfig must raise on unknown/typo'd kwargs instead of silently ignoring them (extra='forbid')."""
+
+    def test_typo_kwarg_raises_with_helpful_message(self, tmp_path) -> None:
+        """A typo'd kwarg (epoch instead of epochs) raises listing the unknown and available parameters."""
+        with pytest.raises(ValidationError, match=r"Unknown parameter\(s\): 'epoch'"):
+            TrainConfig(dataset_dir=str(tmp_path), output_dir=str(tmp_path), epoch=5)
+
+    def test_typo_error_lists_available_parameters(self, tmp_path) -> None:
+        """The rejection message includes the available parameter list so the typo is easy to fix."""
+        with pytest.raises(ValidationError, match=r"Available parameter\(s\):.*epochs"):
+            TrainConfig(dataset_dir=str(tmp_path), output_dir=str(tmp_path), epoch=5)
+
+    @pytest.mark.parametrize(
+        "config_class",
+        [
+            pytest.param(SegmentationTrainConfig, id="segmentation"),
+            pytest.param(KeypointTrainConfig, id="keypoint"),
+        ],
+    )
+    def test_subclasses_reject_unknown_kwargs(self, tmp_path, config_class) -> None:
+        """TrainConfig subclasses inherit the forbid behaviour."""
+        with pytest.raises(ValidationError, match=r"Unknown parameter\(s\): 'epoch'"):
+            config_class(dataset_dir=str(tmp_path), output_dir=str(tmp_path), epoch=5)
+
+    def test_get_train_config_raises_for_typo_kwarg(self, tmp_path) -> None:
+        """The public RFDETR.get_train_config path surfaces the typo instead of swallowing it."""
+        from types import SimpleNamespace
+
+        from rfdetr.detr import RFDETR
+
+        stub = SimpleNamespace(_train_config_class=TrainConfig)
+        with pytest.raises(ValidationError, match=r"Unknown parameter\(s\): 'epoch'"):
+            RFDETR.get_train_config(stub, dataset_dir=str(tmp_path), output_dir=str(tmp_path), epoch=5)
+
+
 class TestTrainConfigT42PromotedFields:
     """T4-2: Promoted fields exist with correct defaults; device field is absent."""
 
@@ -222,11 +258,10 @@ class TestTrainConfigT42PromotedFields:
         """Device must not appear in TrainConfig.model_fields (PTL auto-detects accelerator)."""
         assert "device" not in TrainConfig.model_fields
 
-    def test_device_kwarg_silently_ignored(self, tmp_path):
-        """Passing device= to TrainConfig is silently ignored (extra='ignore'); PTL absorbs it."""
-        # TrainConfig uses Pydantic default extra='ignore', so unknown kwargs don't raise.
-        tc = self._tc(tmp_path, device="cpu")
-        assert not hasattr(tc, "device")  # field not set on the instance
+    def test_device_kwarg_rejected(self, tmp_path):
+        """Passing device= directly to TrainConfig raises (extra='forbid'); RFDETR.train() pops it beforehand."""
+        with pytest.raises(ValidationError, match=r"Unknown parameter\(s\): 'device'"):
+            self._tc(tmp_path, device="cpu")
 
     # --- promoted fields: defaults ---
 

--- a/tests/models/test_config_keypoints.py
+++ b/tests/models/test_config_keypoints.py
@@ -102,12 +102,11 @@ def test_unknown_keypoint_fields_are_not_public_config_fields() -> None:
     with pytest.raises(ValueError, match="Unknown parameter"):
         RFDETRBaseConfig(num_classes=1, keypoint_private_hidden_dim=256)
 
-    # KeypointTrainConfig (a TrainConfig subclass) uses extra="ignore" for Lightning
-    # compatibility, so unknown kwargs are silently dropped rather than raising.
-    kc = KeypointTrainConfig(
-        dataset_dir="/tmp",
-        keypoint_private_hidden_dim=256,
-        keypoint_private_loss_coef=1.0,
-    )
-    assert not hasattr(kc, "keypoint_private_hidden_dim")
-    assert not hasattr(kc, "keypoint_private_loss_coef")
+    # KeypointTrainConfig (a TrainConfig subclass) uses extra="forbid", so unknown
+    # kwargs raise with a helpful message rather than being silently dropped.
+    with pytest.raises(ValueError, match="Unknown parameter"):
+        KeypointTrainConfig(
+            dataset_dir="/tmp",
+            keypoint_private_hidden_dim=256,
+            keypoint_private_loss_coef=1.0,
+        )

--- a/tests/training/callbacks/test_best_model_callback.py
+++ b/tests/training/callbacks/test_best_model_callback.py
@@ -19,6 +19,7 @@ from torch.utils.data import DataLoader, TensorDataset
 
 from rfdetr.config import RFDETRLargeDeprecatedConfig, RFDETRMediumConfig
 from rfdetr.training.callbacks.best_model import BestModelCallback, RFDETREarlyStopping
+from rfdetr.training.callbacks.ema import RFDETREMACallback
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1992,3 +1993,105 @@ class TestSerializeModelConfig:
         result = BestModelCallback._serialize_model_config(pl_module)
 
         assert result is raw
+
+
+# ---------------------------------------------------------------------------
+# TestOnFitEndEMASwapSuppression
+# ---------------------------------------------------------------------------
+
+
+class _TestStepLinearModule(LightningModule):
+    """Real module with ``test_step`` and a tiny linear model for weight-identity assertions."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.model = torch.nn.Linear(1, 1, bias=False)
+        self.train_config = {"lr": 0.001}
+
+    def test_step(self, batch: object, batch_idx: int) -> None:
+        """No-op test step so BestModelCallback.on_fit_end runs trainer.test()."""
+
+
+def _fill_module_weight(pl_module: LightningModule, value: float) -> None:
+    """Set the single linear weight of *pl_module* to *value* in-place."""
+    with torch.no_grad():
+        pl_module.model.weight.fill_(value)
+
+
+class TestOnFitEndEMASwapSuppression:
+    """The fit-end test run must evaluate the best checkpoint, not the final EMA weights.
+
+    Regression tests: ``BestModelCallback.on_fit_end`` loads ``checkpoint_best_total.pth`` into the module and then
+    calls ``trainer.test()`` — but ``RFDETREMACallback.on_test_epoch_start`` used to swap in the final EMA weights,
+    silently overwriting the just-loaded best weights for the whole test run.
+    """
+
+    @staticmethod
+    def _build_fit_end_scenario(
+        tmp_path: Path,
+    ) -> tuple[BestModelCallback, RFDETREMACallback, LightningModule, MagicMock, list[torch.Tensor]]:
+        """Arrange best=3.0 checkpoint, EMA=5.0 average model, live=7.0 weights, and a hook-simulating trainer."""
+        from torch.optim.swa_utils import AveragedModel
+
+        pl_module = _TestStepLinearModule()
+        cb = BestModelCallback(output_dir=str(tmp_path), run_test=True)
+        ema_cb = RFDETREMACallback()
+
+        # Best checkpoint saved at weight 3.0.
+        _fill_module_weight(pl_module, 3.0)
+        trainer = _make_trainer({"val/mAP_50_95": 0.5})
+        cb.on_validation_end(trainer, pl_module)
+
+        # EMA average model captured at weight 5.0.
+        _fill_module_weight(pl_module, 5.0)
+        ema_cb._average_model = AveragedModel(
+            model=pl_module,
+            use_buffers=True,
+            avg_fn=ema_cb._avg_fn,
+        )
+        ema_cb._average_model.eval()
+
+        # Final live weights end training at 7.0.
+        _fill_module_weight(pl_module, 7.0)
+
+        trainer.callbacks = [ema_cb, cb]
+        observed_weights: list[torch.Tensor] = []
+
+        def _fake_test(module: object, datamodule: object = None, verbose: bool = False) -> None:
+            # Simulate the PTL test loop invoking the EMA callback's test hooks.
+            ema_cb.on_test_epoch_start(trainer, pl_module)
+            observed_weights.append(pl_module.model.weight.detach().clone())
+            ema_cb.on_test_epoch_end(trainer, pl_module)
+
+        trainer.test = MagicMock(side_effect=_fake_test)
+        return cb, ema_cb, pl_module, trainer, observed_weights
+
+    def test_fit_end_test_runs_on_best_weights_not_ema(self, tmp_path: Path) -> None:
+        """During the fit-end test run the module must hold the best checkpoint weights (3.0), not EMA (5.0)."""
+        cb, _ema_cb, pl_module, trainer, observed_weights = self._build_fit_end_scenario(tmp_path)
+
+        cb.on_fit_end(trainer, pl_module)
+
+        assert observed_weights, "trainer.test() must have been invoked"
+        expected = torch.full_like(observed_weights[0], 3.0)
+        assert torch.allclose(observed_weights[0], expected), (
+            f"test ran with weight {observed_weights[0].item():.1f}; expected best-checkpoint weight 3.0"
+        )
+
+    def test_ema_swap_suppression_cleared_after_fit_end(self, tmp_path: Path) -> None:
+        """After on_fit_end the EMA callback must swap again for standalone trainer.test() runs."""
+        cb, ema_cb, pl_module, trainer, _observed = self._build_fit_end_scenario(tmp_path)
+
+        cb.on_fit_end(trainer, pl_module)
+
+        assert ema_cb.suppress_test_swap is False
+
+    def test_ema_swap_suppression_cleared_when_test_raises(self, tmp_path: Path) -> None:
+        """Suppression must be lifted even when trainer.test() raises."""
+        cb, ema_cb, pl_module, trainer, _observed = self._build_fit_end_scenario(tmp_path)
+        trainer.test = MagicMock(side_effect=RuntimeError("boom"))
+
+        with pytest.raises(RuntimeError, match="boom"):
+            cb.on_fit_end(trainer, pl_module)
+
+        assert ema_cb.suppress_test_swap is False

--- a/tests/training/callbacks/test_ema_callback.py
+++ b/tests/training/callbacks/test_ema_callback.py
@@ -202,3 +202,59 @@ class TestLegacyEMAResume:
         for key, expected in legacy_ema_state.items():
             assert torch.allclose(restored[key], expected)
         assert not hasattr(pl_module, "_pending_legacy_ema_state")
+
+
+class TestSuppressTestSwap:
+    """suppress_test_swap must disable the test-time EMA weight swap while leaving defaults unchanged."""
+
+    @staticmethod
+    def _make_swap_scenario() -> tuple[RFDETREMACallback, _EMAContainerModule]:
+        """Build a module at weight 7.0 with an EMA average model captured at weight 5.0."""
+        cb = RFDETREMACallback()
+        pl_module = _EMAContainerModule()
+        with torch.no_grad():
+            for p in pl_module.parameters():
+                p.fill_(5.0)
+        cb._average_model = AveragedModel(model=pl_module, use_buffers=True, avg_fn=cb._avg_fn)
+        with torch.no_grad():
+            for p in pl_module.parameters():
+                p.fill_(7.0)
+        return cb, pl_module
+
+    def test_default_flag_is_false(self) -> None:
+        """The suppression flag defaults to False so standalone trainer.test() keeps EMA evaluation."""
+        cb = RFDETREMACallback()
+        assert cb.suppress_test_swap is False
+
+    def test_on_test_epoch_start_swaps_by_default(self) -> None:
+        """Without suppression, the test hooks swap live weights (7.0) for EMA weights (5.0)."""
+        cb, pl_module = self._make_swap_scenario()
+        trainer = MagicMock()
+
+        cb.on_test_epoch_start(trainer, pl_module)
+
+        weight = pl_module.model.weight.detach()
+        assert torch.allclose(weight, torch.full_like(weight, 5.0))
+
+    def test_on_test_epoch_start_suppressed_keeps_live_weights(self) -> None:
+        """With suppress_test_swap=True the live weights (7.0) must stay in place during test."""
+        cb, pl_module = self._make_swap_scenario()
+        cb.suppress_test_swap = True
+        trainer = MagicMock()
+
+        cb.on_test_epoch_start(trainer, pl_module)
+
+        weight = pl_module.model.weight.detach()
+        assert torch.allclose(weight, torch.full_like(weight, 7.0))
+
+    def test_on_test_epoch_end_suppressed_does_not_swap(self) -> None:
+        """With suppression active, on_test_epoch_end must not swap EMA weights in unpaired."""
+        cb, pl_module = self._make_swap_scenario()
+        cb.suppress_test_swap = True
+        trainer = MagicMock()
+
+        cb.on_test_epoch_start(trainer, pl_module)
+        cb.on_test_epoch_end(trainer, pl_module)
+
+        weight = pl_module.model.weight.detach()
+        assert torch.allclose(weight, torch.full_like(weight, 7.0))

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -1681,6 +1681,58 @@ class TestDeployToRoboflow:
         assert not deployed_paths[0].exists(), "Temporary upload dir must be removed even after a failed deploy"
         assert not (tmp_path / ".roboflow_temp_upload").exists(), "Fixed-name temp dir must not be created"
 
+    @staticmethod
+    def _deploy(mock_self, size=None):
+        """Call deploy_to_roboflow with a mocked Roboflow client; return the captured deploy mock."""
+        mock_rf = MagicMock()
+        deploy_mock = mock_rf.workspace.return_value.project.return_value.version.return_value.deploy
+        kwargs = {} if size is None else {"size": size}
+        with patch("roboflow.Roboflow", return_value=mock_rf):
+            RFDETR.deploy_to_roboflow(
+                mock_self,
+                workspace="test-workspace",
+                project_id="test-project",
+                version=1,
+                api_key="dummy-key",
+                **kwargs,
+            )
+        return deploy_mock
+
+    def test_explicit_size_overrides_model_size(self, tmp_path, monkeypatch, mock_self, patch_lit):
+        """An explicitly passed size must win over self.size (documented precedence).
+
+        Regression: ``size = self.size or size`` inverted the precedence, silently ignoring the user's argument.
+        """
+        monkeypatch.chdir(tmp_path)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            deploy_mock = self._deploy(mock_self, size="rfdetr-medium")
+
+        assert deploy_mock.call_args.kwargs["model_type"] == "rfdetr-medium"
+
+    def test_size_defaults_to_model_size_when_not_provided(self, tmp_path, monkeypatch, mock_self, patch_lit):
+        """Without an explicit size the model's own size is deployed."""
+        monkeypatch.chdir(tmp_path)
+        deploy_mock = self._deploy(mock_self)
+
+        assert deploy_mock.call_args.kwargs["model_type"] == "rfdetr-small"
+
+    def test_warns_when_explicit_size_differs_from_model_size(self, tmp_path, monkeypatch, mock_self, patch_lit):
+        """A UserWarning is emitted when the explicit size conflicts with the model's own size."""
+        monkeypatch.chdir(tmp_path)
+        with pytest.warns(UserWarning, match="rfdetr-medium.*rfdetr-small"):
+            self._deploy(mock_self, size="rfdetr-medium")
+
+    def test_no_warning_when_explicit_size_matches_model_size(self, tmp_path, monkeypatch, mock_self, patch_lit):
+        """No size-conflict warning is emitted when the explicit size equals the model's own size."""
+        monkeypatch.chdir(tmp_path)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            self._deploy(mock_self, size="rfdetr-small")
+
+        conflict_warnings = [w for w in caught if "deploy_to_roboflow" in str(w.message)]
+        assert not conflict_warnings
+
 
 # ---------------------------------------------------------------------------
 # TestSaveTrainingConfig


### PR DESCRIPTION
## What does this PR do?

- escape torch.inference_mode() in the lazy device move so the first predict() on CUDA/MPS no longer turns parameters into inference tensors; previously any subsequent backward produced no grads and optimizer steps were silent no-ops, also corrupting batch_size="auto" probing
- TrainConfig now uses extra="forbid": unknown train() kwargs raise a ValueError with typo suggestions instead of silently training with defaults; legacy keypoint-schema warning now correctly points at the model constructor instead of train()
- suppress the EMA weight swap during the fit-end best-checkpoint trainer.test() run so reported test metrics reflect the shipped best checkpoint, not the final EMA model; standalone trainer.test() behavior unchanged
- deploy_to_roboflow: explicit size argument now takes precedence over the model default as documented, with a warning when both are set and differ
- add regression tests for all four behaviors (new tests/inference/test_model_device_move.py; extended config, EMA/best-model callback, and detr shim suites)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
