### PR TITLE
fix(security,export,backbone): fix all 22 HIGH findings

### DIFF
--- a/.github/workflows/ci-tests-cpu.yml
+++ b/.github/workflows/ci-tests-cpu.yml
@@ -57,7 +57,7 @@ jobs:
       - name: 🧪 Run the Test
         run: |
           uv run --no-sync pytest src/ tests/ \
-            -n 2 -m "not gpu" \
+            -n 2 -m "not gpu and not coco17" \
             --ignore=tests/run_smoke_all_models.py \
             --cov=rfdetr --cov-report=xml \
             --timeout=420 \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `trust_checkpoint: bool = False` keyword-only parameter on `RFDETR.from_checkpoint()` to opt into full pickle deserialization for trusted checkpoint files.
 - `optimize_for_inference(inplace=True)` — new keyword-only argument on `RFDETR.optimize_for_inference()`; skips the deep-copy of the base model for memory-constrained inference-only deployments (~0.5× model-weight peak memory reduction). Requires `compile=False`. After inplace optimization, `export()` raises `RuntimeError` and `remove_optimized_model()` issues a `UserWarning` and returns cleanly instead of silently clearing state. New `RFDETR.is_optimized_inplace` property returns `True` after a successful inplace optimization. ([#1089](https://github.com/roboflow/rf-detr/pull/1089))
 - `CocoKeypointSchema.keypoint_flip_pairs` and `YoloKeypointSchema.keypoint_flip_pairs` fields — horizontal-flip swap pairs inferred automatically from keypoint names (left/right naming convention) for COCO schemas, and from `flip_idx` permutation for YOLO schemas. Auto-populated by `infer_coco_keypoint_schema` and `infer_yolo_keypoint_schema` respectively. ([#1164](https://github.com/roboflow/rf-detr/pull/1164))
 - `infer_coco_keypoint_schema` and `infer_yolo_keypoint_schema` re-exported from `rfdetr.datasets` (previously only accessible from `rfdetr.datasets._keypoint_schema`). ([#1164](https://github.com/roboflow/rf-detr/pull/1164))
 
 ### Changed
 
+- `RFDETR.from_checkpoint()` now uses safe deserialization by default (`weights_only=True`). Checkpoints containing custom Python objects beyond `argparse.Namespace` or `types.SimpleNamespace` must pass `trust_checkpoint=True`. Previously, full pickle deserialization was always used.
 - Horizontal flip detection in `AlbumentationsWrapper` now uses Albumentations `ReplayCompose` replay metadata instead of heuristic bbox-center mirroring; eliminates false positives on non-flip transforms that shift box centers. Falls back to `alb.Compose` with a `UserWarning` when `albumentations <1.3` is detected. ([#1164](https://github.com/roboflow/rf-detr/pull/1164))
 - Keypoint schema inference now supports native COCO format (`dataset_file="coco"`) in addition to `"roboflow"` and `"yolo"`. ([#1164](https://github.com/roboflow/rf-detr/pull/1164))
 - `_keypoint_schema_cache` key changed from `dataset_dir` (string) to `(dataset_file, dataset_dir)` tuple to prevent cross-format cache collisions when the same directory is used with different dataset formats. ([#1164](https://github.com/roboflow/rf-detr/pull/1164))

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -426,11 +426,13 @@ class RFDETR:
         # are reloaded with the correct class instead of falling through to the
         # substring matcher (which would wrongly pick RFDETRLarge and fail with a
         # pydantic literal_error on encoder / projector_scale fields).
-        # Reference the class symbol directly (rfdetr_variants is imported above)
-        # rather than a string key: if RFDETRLargeDeprecated is ever renamed, this
-        # raises AttributeError loudly instead of silently dropping the mapping.
-        _large_deprecated_cls = rfdetr_variants.RFDETRLargeDeprecated
-        _name_map[_large_deprecated_cls.__name__] = _large_deprecated_cls
+        # Note: RFDETRLargeDeprecated is a _DeprecatedProxy (pyDeprecate) and has no
+        # __name__; look it up by the string key it was registered under, then inject
+        # into _name_map so checkpoint matching resolves directly without the substring
+        # fallback.  Tests assert this mapping exists (see tests/inference/test_from_checkpoint.py).
+        _large_deprecated_cls = _variant_name_to_class.get("RFDETRLargeDeprecated")
+        if _large_deprecated_cls is not None:
+            _name_map["RFDETRLargeDeprecated"] = _large_deprecated_cls
         saved_model_name = ckpt.get("model_name")
         model_cls: type[RFDETR] | None = None
         if isinstance(saved_model_name, str):

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -426,9 +426,11 @@ class RFDETR:
         # are reloaded with the correct class instead of falling through to the
         # substring matcher (which would wrongly pick RFDETRLarge and fail with a
         # pydantic literal_error on encoder / projector_scale fields).
-        _large_deprecated_cls = _variant_name_to_class.get("RFDETRLargeDeprecated")
-        if _large_deprecated_cls is not None:
-            _name_map["RFDETRLargeDeprecated"] = _large_deprecated_cls
+        # Reference the class symbol directly (rfdetr_variants is imported above)
+        # rather than a string key: if RFDETRLargeDeprecated is ever renamed, this
+        # raises AttributeError loudly instead of silently dropping the mapping.
+        _large_deprecated_cls = rfdetr_variants.RFDETRLargeDeprecated
+        _name_map[_large_deprecated_cls.__name__] = _large_deprecated_cls
         saved_model_name = ckpt.get("model_name")
         model_cls: type[RFDETR] | None = None
         if isinstance(saved_model_name, str):
@@ -1877,7 +1879,7 @@ class RFDETR:
                 # standard detector API contract: callers passing a file path or
                 # a PIL image should not have to pre-convert; for tensor inputs
                 # the channel dimension is the caller's responsibility.
-                if isinstance(img, Image.Image):
+                if isinstance(img, Image.Image) and img.mode != "RGB":
                     img = img.convert("RGB")
                 if include_source_image:
                     src = np.array(img)

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -290,7 +290,7 @@ class RFDETR:
         return self._model_config_class(**kwargs)
 
     @classmethod
-    def from_checkpoint(cls, path: str | os.PathLike[str], **kwargs: Any) -> RFDETR:
+    def from_checkpoint(cls, path: str | os.PathLike[str], *, trust_checkpoint: bool = False, **kwargs: Any) -> RFDETR:
         """Load an RF-DETR model from a training checkpoint, automatically inferring the model class.
 
         The correct subclass is resolved in order of preference:
@@ -312,6 +312,10 @@ class RFDETR:
 
         Args:
             path: Path to a checkpoint file (e.g. ``checkpoint_best_total.pth``).
+            trust_checkpoint: When ``True``, fall back to ``weights_only=False``
+                (full pickle) if safe deserialization fails.  Only set this for
+                checkpoints from fully trusted sources; the default ``False``
+                keeps the safe loading path and raises if it cannot succeed.
             **kwargs: Additional keyword arguments forwarded to the model
                 constructor (e.g. ``accept_platform_model_license=True`` for XLarge / 2XLarge models).
 
@@ -336,8 +340,10 @@ class RFDETR:
             An instance of the appropriate :class:`RFDETR` subclass loaded from the checkpoint.
 
         Warning:
-            This method calls ``torch.load`` with ``weights_only=False``, which
-            unpickles arbitrary Python objects. Only load checkpoints from trusted sources.
+            By default this method attempts safe deserialization
+            (``weights_only=True``).  Pass ``trust_checkpoint=True`` only for
+            checkpoints from fully trusted sources, as it enables full pickle
+            deserialization which can execute arbitrary code.
 
         Raises:
             FileNotFoundError: If *path* does not exist.
@@ -373,10 +379,12 @@ class RFDETR:
                 if ex.name not in {"rfdetr_plus", "rfdetr_plus.models"}:
                     raise
 
-        # weights_only=False is required because legacy checkpoints embed
-        # argparse.Namespace objects that cannot be deserialised with
-        # weights_only=True.
-        ckpt: dict[str, Any] = torch.load(path, map_location="cpu", weights_only=False)
+        # Use the safe-load helper which tries weights_only=True first (with
+        # legacy argparse.Namespace safe globals), falling back to full pickle
+        # only when the caller explicitly passes trust_checkpoint=True.
+        from rfdetr.util.io import _safe_torch_load
+
+        ckpt: dict[str, Any] = _safe_torch_load(path, trust=trust_checkpoint)
         args = ckpt["args"]
 
         _variant_name_to_class: dict[str, type[RFDETR]] = {
@@ -412,6 +420,15 @@ class RFDETR:
         # Plus-model classes are resolved only when rfdetr_plus is installed.
         if _plus_available:
             _name_map.update(_plus_symbols)
+        # RFDETRLargeDeprecated is excluded from _CHECKPOINT_MODEL_NAME_CLASS_SYMBOLS
+        # (so forward name-map lookups always reach RFDETRLarge), but it must be
+        # in _name_map so that checkpoints carrying model_name="RFDETRLargeDeprecated"
+        # are reloaded with the correct class instead of falling through to the
+        # substring matcher (which would wrongly pick RFDETRLarge and fail with a
+        # pydantic literal_error on encoder / projector_scale fields).
+        _large_deprecated_cls = _variant_name_to_class.get("RFDETRLargeDeprecated")
+        if _large_deprecated_cls is not None:
+            _name_map["RFDETRLargeDeprecated"] = _large_deprecated_cls
         saved_model_name = ckpt.get("model_name")
         model_cls: type[RFDETR] | None = None
         if isinstance(saved_model_name, str):
@@ -1855,6 +1872,13 @@ class RFDETR:
                 img = Image.open(img)
 
             if not isinstance(img, torch.Tensor):
+                # Auto-convert PIL images from any colour mode (L, LA, RGBA, P,
+                # etc.) to RGB before converting to tensor.  This matches the
+                # standard detector API contract: callers passing a file path or
+                # a PIL image should not have to pre-convert; for tensor inputs
+                # the channel dimension is the caller's responsibility.
+                if isinstance(img, Image.Image):
+                    img = img.convert("RGB")
                 if include_source_image:
                     src = np.array(img)
                     if src.dtype != np.uint8:
@@ -1876,7 +1900,8 @@ class RFDETR:
                 raise ValueError(
                     "Invalid tensor image shape. Tensor inputs to `predict()` must be in (C, H, W) format "
                     f"with C matching the model configuration ({self.model_config.num_channels} channels). "
-                    f"Received tensor with shape {tuple(img.shape)}."
+                    f"Received tensor with shape {tuple(img.shape)}. "
+                    "For automatic RGB conversion, pass a PIL Image or a file path instead of a tensor."
                 )
             img_tensor = img
 

--- a/src/rfdetr/export/_tensorrt.py
+++ b/src/rfdetr/export/_tensorrt.py
@@ -19,11 +19,30 @@ from rfdetr.utilities.logger import get_logger
 logger = get_logger()
 
 
-def run_command_shell(command: str, dry_run: bool = False) -> "subprocess.CompletedProcess[str]":
+def run_command_shell(command: list[str], dry_run: bool = False) -> "subprocess.CompletedProcess[str]":
+    """Run *command* as a subprocess, optionally in dry-run mode.
+
+    Args:
+        command: Argument list (``argv``).  Must be a list — never a shell
+            string — so that paths containing spaces or shell metacharacters
+            are passed verbatim to the OS without interpretation.
+        dry_run: When ``True``, log the command that *would* run and return a
+            synthetic :class:`subprocess.CompletedProcess` with ``returncode=0``
+            without actually executing anything.
+
+    Returns:
+        A :class:`subprocess.CompletedProcess` instance.
+
+    Raises:
+        subprocess.CalledProcessError: If the command exits with a non-zero
+            return code (``check=True``).
+    """
     if dry_run:
-        logger.info(f"\nCUDA_VISIBLE_DEVICES={os.getenv('CUDA_VISIBLE_DEVICES', '')} {command}\n")
+        display = " ".join(command)
+        logger.info(f"\nCUDA_VISIBLE_DEVICES={os.getenv('CUDA_VISIBLE_DEVICES', '')} {display}\n")
+        return subprocess.CompletedProcess(args=command, returncode=0, stdout="", stderr="")
     try:
-        result = subprocess.run(command, shell=True, capture_output=True, text=True, check=True)
+        result = subprocess.run(command, shell=False, capture_output=True, text=True, check=True)
         return result
     except subprocess.CalledProcessError as e:
         logger.error(f"Command failed with exit code {e.returncode}")
@@ -31,36 +50,65 @@ def run_command_shell(command: str, dry_run: bool = False) -> "subprocess.Comple
         raise
 
 
-def trtexec(onnx_dir: str, args: argparse.Namespace) -> None:
+def trtexec(onnx_dir: str, args: argparse.Namespace) -> str:
+    """Convert an ONNX model to a TensorRT engine using ``trtexec``.
+
+    Args:
+        onnx_dir: Path to the source ``.onnx`` file.
+        args: Parsed CLI arguments.  Consumed attributes: ``profile``,
+            ``verbose``, ``dry_run``.
+
+    Returns:
+        Path to the generated ``.engine`` file.
+    """
     engine_dir = onnx_dir.replace(".onnx", ".engine")
 
-    # Base trtexec command
-    trt_command = " ".join(
-        [
-            "trtexec",
-            f"--onnx={onnx_dir}",
-            f"--saveEngine={engine_dir}",
-            "--memPoolSize=workspace:4096 --fp16",
-            "--useCudaGraph --useSpinWait --warmUp=500 --avgRuns=1000 --duration=10",
-            f"{'--verbose' if args.verbose else ''}",
-        ]
-    )
+    # Build trtexec argv — list form prevents shell-injection via paths.
+    trt_argv: list[str] = [
+        "trtexec",
+        f"--onnx={onnx_dir}",
+        f"--saveEngine={engine_dir}",
+        "--memPoolSize=workspace:4096",
+        "--fp16",
+        "--useCudaGraph",
+        "--useSpinWait",
+        "--warmUp=500",
+        "--avgRuns=1000",
+        "--duration=10",
+    ]
+    if args.verbose:
+        trt_argv.append("--verbose")
 
     if args.profile:
         profile_dir = onnx_dir.replace(".onnx", ".nsys-rep")
-        # Wrap with nsys profile command
-        command = " ".join(
-            ["nsys profile", f"--output={profile_dir}", "--trace=cuda,nvtx", "--force-overwrite true", trt_command]
-        )
+        # Wrap with nsys profile — also argv, not a shell string.
+        argv: list[str] = [
+            "nsys",
+            "profile",
+            f"--output={profile_dir}",
+            "--trace=cuda,nvtx",
+            "--force-overwrite",
+            "true",
+            *trt_argv,
+        ]
         logger.info(f"Profile data will be saved to: {profile_dir}")
     else:
-        command = trt_command
+        argv = trt_argv
 
-    output = run_command_shell(command, args.dry_run)
+    output = run_command_shell(argv, args.dry_run)
     parse_trtexec_output(output.stdout)
+    return engine_dir
 
 
 def parse_trtexec_output(output_text: str) -> dict[str, Any]:
+    """Parse latency / throughput statistics from ``trtexec`` stdout.
+
+    Args:
+        output_text: Raw stdout from a ``trtexec`` run.
+
+    Returns:
+        Dictionary with timing statistics extracted from the output.
+    """
     logger.info(output_text)
     # Common patterns in trtexec output
     gpu_compute_pattern = (

--- a/src/rfdetr/export/_tensorrt.py
+++ b/src/rfdetr/export/_tensorrt.py
@@ -12,7 +12,6 @@ import argparse
 import os
 import re
 import subprocess
-from typing import Any
 
 from rfdetr.utilities.logger import get_logger
 
@@ -21,6 +20,9 @@ logger = get_logger()
 
 def run_command_shell(command: list[str], dry_run: bool = False) -> "subprocess.CompletedProcess[str]":
     """Run *command* as a subprocess, optionally in dry-run mode.
+
+    Note: Despite the legacy name, this function always uses ``shell=False`` —
+    command must be an argv list, never a shell string.
 
     Args:
         command: Argument list (``argv``).  Must be a list — never a shell
@@ -60,6 +62,10 @@ def trtexec(onnx_dir: str, args: argparse.Namespace) -> str:
 
     Returns:
         Path to the generated ``.engine`` file.
+
+    Raises:
+        subprocess.CalledProcessError: If ``trtexec`` (or ``nsys profile``) exits
+            with a non-zero return code.
     """
     engine_dir = onnx_dir.replace(".onnx", ".engine")
 
@@ -100,14 +106,15 @@ def trtexec(onnx_dir: str, args: argparse.Namespace) -> str:
     return engine_dir
 
 
-def parse_trtexec_output(output_text: str) -> dict[str, Any]:
+def parse_trtexec_output(output_text: str) -> dict[str, float]:
     """Parse latency / throughput statistics from ``trtexec`` stdout.
 
     Args:
         output_text: Raw stdout from a ``trtexec`` run.
 
     Returns:
-        Dictionary with timing statistics extracted from the output.
+        Dictionary mapping statistic names to float values. Empty dict if no
+        patterns matched.
     """
     logger.info(output_text)
     # Common patterns in trtexec output
@@ -119,7 +126,7 @@ def parse_trtexec_output(output_text: str) -> dict[str, Any]:
     latency_pattern = r"Latency: min = (\d+\.\d+) ms, max = (\d+\.\d+) ms, mean = (\d+\.\d+) ms"
     throughput_pattern = r"Throughput: (\d+\.\d+) qps"
 
-    stats: dict[str, Any] = {}
+    stats: dict[str, float] = {}
 
     # Extract compute times
     if match := re.search(gpu_compute_pattern, output_text):

--- a/src/rfdetr/export/benchmark.py
+++ b/src/rfdetr/export/benchmark.py
@@ -25,7 +25,7 @@ from PIL import Image
 from tqdm.auto import tqdm
 
 try:
-    import _tensorrt as trt
+    import tensorrt as trt
 except ImportError:
     trt = None
 

--- a/src/rfdetr/export/main.py
+++ b/src/rfdetr/export/main.py
@@ -10,6 +10,7 @@
 
 import os
 import random
+import warnings
 
 import numpy as np
 import torch
@@ -113,12 +114,28 @@ def main(args):
     n_transformer_parameters = sum(p.numel() for p in model.transformer.parameters())
     logger.info(f"number of transformer parameters: {n_transformer_parameters}")
     if args.resume:
-        # trust=True: --resume is a developer/ops flag pointing at RF-DETR-produced
-        # checkpoints that may contain argparse.Namespace objects.  Users loading
-        # third-party checkpoints via this flag accept the associated risk.
+        # --resume points at RF-DETR-produced checkpoints that may embed
+        # argparse.Namespace objects requiring full-pickle deserialization.
+        # Mirror RFDETR.from_checkpoint(trust_checkpoint=...): honour an optional
+        # `trust_checkpoint` attribute on args (default True for backward
+        # compatibility, since --resume is a developer/ops flag).  Setting
+        # args.trust_checkpoint=False enforces safe-tensors-only loading and
+        # raises if the checkpoint needs pickle.
         from rfdetr.util.io import _safe_torch_load
 
-        checkpoint = _safe_torch_load(args.resume, trust=True)
+        trust_checkpoint = getattr(args, "trust_checkpoint", True)
+        if trust_checkpoint:
+            # Explicit pre-load warning: --resume has no CLI opt-in gate, so make
+            # the pickle-deserialization risk (CWE-502) visible before loading.
+            warnings.warn(
+                f"Loading --resume checkpoint {args.resume!r} with full pickle "
+                "deserialization (weights_only=False fallback). This can execute "
+                "arbitrary code if the checkpoint comes from an untrusted source. "
+                "Set args.trust_checkpoint=False to require safe-tensors-only loading.",
+                UserWarning,
+                stacklevel=2,
+            )
+        checkpoint = _safe_torch_load(args.resume, trust=trust_checkpoint)
         result = model.load_state_dict(checkpoint["model"], strict=False)
         if result.missing_keys or result.unexpected_keys:
             logger.warning(

--- a/src/rfdetr/export/main.py
+++ b/src/rfdetr/export/main.py
@@ -113,8 +113,12 @@ def main(args):
     n_transformer_parameters = sum(p.numel() for p in model.transformer.parameters())
     logger.info(f"number of transformer parameters: {n_transformer_parameters}")
     if args.resume:
-        # weights_only=False: legacy checkpoints may contain non-tensor objects (argparse.Namespace).
-        checkpoint = torch.load(args.resume, map_location="cpu", weights_only=False)
+        # trust=True: --resume is a developer/ops flag pointing at RF-DETR-produced
+        # checkpoints that may contain argparse.Namespace objects.  Users loading
+        # third-party checkpoints via this flag accept the associated risk.
+        from rfdetr.util.io import _safe_torch_load
+
+        checkpoint = _safe_torch_load(args.resume, trust=True)
         result = model.load_state_dict(checkpoint["model"], strict=False)
         if result.missing_keys or result.unexpected_keys:
             logger.warning(
@@ -141,9 +145,16 @@ def main(args):
         dynamic_axes = {name: {0: "batch"} for name in input_names + output_names}
     else:
         dynamic_axes = None
-    # Run model inference in pytorch mode
-    model.eval().to("cuda")
-    input_tensors = input_tensors.to("cuda")
+    # Run model inference in pytorch mode.
+    # Use the export device (args.device) — not a hard-coded "cuda" — so that
+    # CPU-only export paths work correctly.  Fall back to CPU when CUDA was
+    # requested but is not available (e.g. in a CPU-only CI environment).
+    run_device = torch.device(args.device)
+    if run_device.type == "cuda" and not torch.cuda.is_available():
+        logger.warning("CUDA requested but not available; falling back to CPU for sanity forward pass.")
+        run_device = torch.device("cpu")
+    model.eval().to(run_device)
+    input_tensors = input_tensors.to(run_device)
     with torch.no_grad():
         if args.backbone_only:
             features = model(input_tensors)

--- a/src/rfdetr/models/backbone/dinov2_with_windowed_attn.py
+++ b/src/rfdetr/models/backbone/dinov2_with_windowed_attn.py
@@ -973,7 +973,13 @@ class WindowedDinov2WithRegistersModel(WindowedDinov2WithRegistersPreTrainedMode
             )
         self.config._attn_implementation = attn_implementation
         for layer in self.encoder.layer:
-            layer.attention = DINOV2_WITH_REGISTERS_ATTENTION_CLASSES[attn_implementation](self.config)
+            new_attn = DINOV2_WITH_REGISTERS_ATTENTION_CLASSES[attn_implementation](self.config)
+            # Transfer trained weights: eager and sdpa variants share identical parameter keys
+            # (both contain attention.{query,key,value,dropout} and output.{dense,dropout}).
+            # strict=True is intentional — a key mismatch would indicate a structural divergence
+            # that should be caught and fixed rather than silently skipped.
+            new_attn.load_state_dict(layer.attention.state_dict())
+            layer.attention = new_attn
 
     @add_start_docstrings_to_model_forward(DINOV2_WITH_REGISTERS_BASE_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=BaseModelOutputWithPooling, config_class=_CONFIG_FOR_DOC)

--- a/src/rfdetr/models/position_encoding.py
+++ b/src/rfdetr/models/position_encoding.py
@@ -135,14 +135,42 @@ class PositionEmbeddingLearned(nn.Module):
         return pos
 
 
-def build_position_encoding(hidden_dim, position_embedding):
+def build_position_encoding(hidden_dim: int, position_embedding: str) -> nn.Module:
+    """Build a positional encoding module.
+
+    Args:
+        hidden_dim: Transformer hidden dimension. Half of this value is used as the number
+            of positional feature dimensions for the sine encoding.
+        position_embedding: Encoding variant to construct.  Supported values:
+            ``"sine"`` / ``"v2"`` — standard sine/cosine positional encoding (recommended).
+            The aliases ``"learned"`` / ``"v3"`` are **not supported** and raise
+            :exc:`ValueError`; their implementation had two bugs (wrong ``forward`` signature
+            and wrong shape unpacking) and are rejected early rather than silently producing
+            incorrect results.
+
+    Returns:
+        Positional encoding module.
+
+    Raises:
+        ValueError: If *position_embedding* is not a recognised and supported variant.
+
+    Examples:
+        >>> import torch
+        >>> from rfdetr.models.position_encoding import build_position_encoding
+        >>> enc = build_position_encoding(256, "sine")
+        >>> enc  # doctest: +ELLIPSIS
+        PositionEmbeddingSine(...)
+    """
     num_steps = hidden_dim // 2
     if position_embedding in ("v2", "sine"):
         # TODO find a better way of exposing other arguments
-        position_embedding = PositionEmbeddingSine(num_steps, normalize=True)
-    elif position_embedding in ("v3", "learned"):
-        position_embedding = PositionEmbeddingLearned(num_steps)
-    else:
-        raise ValueError(f"not supported {position_embedding}")
-
-    return position_embedding
+        return PositionEmbeddingSine(num_steps, normalize=True)
+    if position_embedding in ("v3", "learned"):
+        raise ValueError(
+            f"position_embedding={position_embedding!r} is not supported. "
+            "The 'learned'/'v3' implementation has two bugs: the forward() signature "
+            "is incompatible with Joiner.forward(), and the shape unpacking uses "
+            "x.shape[:2] (batch, channels) instead of x.shape[-2:] (height, width). "
+            "Use 'sine' or 'v2' instead."
+        )
+    raise ValueError(f"position_embedding={position_embedding!r} is not supported. Supported values: 'sine', 'v2'.")

--- a/src/rfdetr/models/weights.py
+++ b/src/rfdetr/models/weights.py
@@ -300,22 +300,24 @@ def load_pretrain_weights(
         return []
     class_names: List[str] = []
 
+    from rfdetr.util.io import _safe_torch_load
+
     # Download first (no-op if already present and hash is valid).
     download_pretrain_weights(pretrain_weights)
     # If the first download attempt didn't produce the file (e.g. stale MD5
-    # caused an earlier ValueError that was silently swallowed), retry with
-    # MD5 validation disabled so a stale registry hash can't block training.
+    # caused an earlier ValueError that was silently swallowed), retry once.
+    # MD5 validation is kept on the retry — if it fails again the error is real.
     if not os.path.isfile(pretrain_weights):
-        logger.warning("Pretrain weights not found after initial download; retrying without MD5 validation.")
-        download_pretrain_weights(pretrain_weights, redownload=True, validate_md5=False)
+        logger.warning("Pretrain weights not found after initial download; retrying.")
+        download_pretrain_weights(pretrain_weights, redownload=True)
     validate_pretrain_weights(pretrain_weights, strict=False)
 
     try:
-        checkpoint = torch.load(pretrain_weights, map_location="cpu", weights_only=False)
+        checkpoint = _safe_torch_load(pretrain_weights)
     except Exception:
         logger.info("Failed to load pretrain weights, re-downloading")
-        download_pretrain_weights(pretrain_weights, redownload=True, validate_md5=False)
-        checkpoint = torch.load(pretrain_weights, map_location="cpu", weights_only=False)
+        download_pretrain_weights(pretrain_weights, redownload=True)
+        checkpoint = _safe_torch_load(pretrain_weights)
 
     # Normalize PyTorch Lightning native .ckpt format to the expected {"model": {...}}
     # structure.  PTL stores model weights in "state_dict" with keys prefixed by

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -548,6 +548,7 @@ class BestModelCallback(ModelCheckpoint):
                 # Load best weights before test — mirrors legacy main.py:602-609.
                 # trust=True: checkpoint_best_total.pth is produced locally; allow pickle fallback if needed.
                 from rfdetr.util.io import _safe_torch_load
+
                 ckpt = _safe_torch_load(total_path, trust=True)
                 # Checkpoints always store plain keys; load into the unwrapped module
                 # so compiled (OptimizedModule) and non-compiled models both work.

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -546,9 +546,9 @@ class BestModelCallback(ModelCheckpoint):
                     )
                     return
                 # Load best weights before test — mirrors legacy main.py:602-609.
-                # weights_only=True is safe: best-checkpoint files are produced by
-                # BestModelCallback and contain only a plain {"model": state_dict}.
-                ckpt = torch.load(total_path, map_location="cpu", weights_only=True)
+                # trust=True: checkpoint_best_total.pth is produced locally; allow pickle fallback if needed.
+                from rfdetr.util.io import _safe_torch_load
+                ckpt = _safe_torch_load(total_path, trust=True)
                 # Checkpoints always store plain keys; load into the unwrapped module
                 # so compiled (OptimizedModule) and non-compiled models both work.
                 _orig = getattr(pl_module.model, "_orig_mod", None)

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -546,7 +546,9 @@ class BestModelCallback(ModelCheckpoint):
                     )
                     return
                 # Load best weights before test — mirrors legacy main.py:602-609.
-                ckpt = torch.load(total_path, map_location="cpu", weights_only=False)
+                # weights_only=True is safe: best-checkpoint files are produced by
+                # BestModelCallback and contain only a plain {"model": state_dict}.
+                ckpt = torch.load(total_path, map_location="cpu", weights_only=True)
                 # Checkpoints always store plain keys; load into the unwrapped module
                 # so compiled (OptimizedModule) and non-compiled models both work.
                 _orig = getattr(pl_module.model, "_orig_mod", None)

--- a/src/rfdetr/training/checkpoint.py
+++ b/src/rfdetr/training/checkpoint.py
@@ -45,7 +45,7 @@ def convert_legacy_checkpoint(old_path: str, new_path: str) -> None:
         new_path: Destination path for the converted ``.ckpt`` file.
     """
     # trust=True: this function converts internally-produced legacy .pth files;
-    # they may contain argparse.Namespace objects not covered by safe globals.
+    # allow pickle fallback if safe deserialization fails due to non-tensor/custom objects.
     from rfdetr.util.io import _safe_torch_load
 
     old: dict[str, Any] = _safe_torch_load(old_path, trust=True)

--- a/src/rfdetr/training/checkpoint.py
+++ b/src/rfdetr/training/checkpoint.py
@@ -44,7 +44,11 @@ def convert_legacy_checkpoint(old_path: str, new_path: str) -> None:
         old_path: Path to the source legacy ``.pth`` checkpoint.
         new_path: Destination path for the converted ``.ckpt`` file.
     """
-    old: dict[str, Any] = torch.load(old_path, map_location="cpu", weights_only=False)
+    # trust=True: this function converts internally-produced legacy .pth files;
+    # they may contain argparse.Namespace objects not covered by safe globals.
+    from rfdetr.util.io import _safe_torch_load
+
+    old: dict[str, Any] = _safe_torch_load(old_path, trust=True)
 
     if "model" not in old:
         raise ValueError(

--- a/src/rfdetr/util/io.py
+++ b/src/rfdetr/util/io.py
@@ -68,7 +68,7 @@ def _safe_torch_load(path: str | Path, *, trust: bool = False) -> Any:
     # ── Attempt 1: strict safe load ──────────────────────────────────────
     try:
         return torch.load(path, map_location="cpu", weights_only=True)
-    except (RuntimeError, pickle.UnpicklingError, Exception):
+    except (RuntimeError, pickle.UnpicklingError):
         pass
 
     # ── Attempt 2: add well-known legacy safe globals ─────────────────────
@@ -78,7 +78,7 @@ def _safe_torch_load(path: str | Path, *, trust: bool = False) -> Any:
     try:
         torch.serialization.add_safe_globals([argparse.Namespace, types.SimpleNamespace])
         return torch.load(path, map_location="cpu", weights_only=True)
-    except (RuntimeError, pickle.UnpicklingError, Exception):
+    except (RuntimeError, pickle.UnpicklingError):
         pass
 
     # ── Attempt 3 (opt-in): full pickle ───────────────────────────────────

--- a/src/rfdetr/util/io.py
+++ b/src/rfdetr/util/io.py
@@ -20,7 +20,9 @@ from typing import Any
 
 import torch
 
-__all__ = ["_safe_torch_load"]
+# No public API: _safe_torch_load is an underscore-private, security-sensitive
+# helper imported directly by trusted internal callers, not for ad-hoc external use.
+__all__: list[str] = []
 
 
 def _safe_torch_load(path: str | Path, *, trust: bool = False) -> Any:
@@ -31,9 +33,11 @@ def _safe_torch_load(path: str | Path, *, trust: bool = False) -> Any:
     1. ``weights_only=True`` (strict — only tensors and a small set of
        built-in scalars).
     2. Same as 1, but with ``argparse.Namespace`` and
-       ``types.SimpleNamespace`` registered as safe globals so that legacy
+       ``types.SimpleNamespace`` temporarily allowed via the
+       :func:`torch.serialization.safe_globals` context manager so that legacy
        RF-DETR checkpoints that embed an ``args`` namespace can be loaded
-       without falling back to pickle.
+       without falling back to pickle.  The allow-list is scoped to this call
+       and does **not** permanently mutate global deserialization state.
     3. ``weights_only=False`` (full pickle) — allowed **only** when
        ``trust=True``, with a loud :class:`UserWarning`.  Never used for
        checkpoints received from external sources.
@@ -51,9 +55,9 @@ def _safe_torch_load(path: str | Path, *, trust: bool = False) -> Any:
 
     Raises:
         RuntimeError: When all safe loading strategies fail and
-            ``trust=False``.  The error message suggests passing
-            ``trust_checkpoint=True`` so the caller can make an informed
-            decision.
+            ``trust=False``.  The error message suggests passing ``trust=True``
+            (or ``trust_checkpoint=True`` at the ``RFDETR.from_checkpoint()``
+            level) so the caller can make an informed decision.
 
     Examples:
         >>> import torch, tempfile, os
@@ -71,13 +75,16 @@ def _safe_torch_load(path: str | Path, *, trust: bool = False) -> Any:
     except (RuntimeError, pickle.UnpicklingError):
         pass
 
-    # ── Attempt 2: add well-known legacy safe globals ─────────────────────
+    # ── Attempt 2: scoped safe globals (no permanent process-global mutation) ─
     # argparse.Namespace and types.SimpleNamespace appear in RF-DETR checkpoints
-    # saved by the pre-PTL engine.py training loop.  Registering them as safe
-    # globals is semantically safe because they contain only primitive values.
+    # saved by the pre-PTL engine.py training loop.  Allowing them is semantically
+    # safe because they contain only primitive values.  Using the
+    # ``safe_globals`` context manager scopes the allow-list to this single load
+    # (instead of the process-global ``add_safe_globals``) and folds the retry
+    # into one ``torch.load`` call rather than a separate double-load.
     try:
-        torch.serialization.add_safe_globals([argparse.Namespace, types.SimpleNamespace])
-        return torch.load(path, map_location="cpu", weights_only=True)
+        with torch.serialization.safe_globals([argparse.Namespace, types.SimpleNamespace]):
+            return torch.load(path, map_location="cpu", weights_only=True)
     except (RuntimeError, pickle.UnpicklingError):
         pass
 
@@ -98,6 +105,6 @@ def _safe_torch_load(path: str | Path, *, trust: bool = False) -> Any:
         f"Failed to safely load checkpoint {str(path)!r}. "
         "The file likely contains custom Python objects that cannot be "
         "deserialized with weights_only=True. "
-        "If you fully trust this checkpoint source, pass trust_checkpoint=True "
-        "to the loading function."
+        "If you fully trust this checkpoint source, pass trust=True to "
+        "_safe_torch_load() or trust_checkpoint=True to RFDETR.from_checkpoint()."
     )

--- a/src/rfdetr/util/io.py
+++ b/src/rfdetr/util/io.py
@@ -1,0 +1,103 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Safe checkpoint loading helpers.
+
+This module provides :func:`_safe_torch_load`, a defense-in-depth wrapper around :func:`torch.load` that prevents
+pickle-based remote code execution (CWE-502) when loading checkpoints from external or user-supplied sources.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pickle
+import types
+import warnings
+from pathlib import Path
+from typing import Any
+
+import torch
+
+__all__ = ["_safe_torch_load"]
+
+
+def _safe_torch_load(path: str | Path, *, trust: bool = False) -> Any:
+    """Load a PyTorch checkpoint as safely as possible.
+
+    Tries progressively less restrictive deserialization strategies:
+
+    1. ``weights_only=True`` (strict — only tensors and a small set of
+       built-in scalars).
+    2. Same as 1, but with ``argparse.Namespace`` and
+       ``types.SimpleNamespace`` registered as safe globals so that legacy
+       RF-DETR checkpoints that embed an ``args`` namespace can be loaded
+       without falling back to pickle.
+    3. ``weights_only=False`` (full pickle) — allowed **only** when
+       ``trust=True``, with a loud :class:`UserWarning`.  Never used for
+       checkpoints received from external sources.
+
+    Args:
+        path: Path to the checkpoint file.
+        trust: When ``True``, allow pickle deserialization as a last-resort
+            fallback and emit a :class:`UserWarning`.  Set this only for
+            checkpoint files produced by RF-DETR itself (e.g. during legacy
+            checkpoint conversion) that may contain non-tensor Python
+            objects that are not covered by the safe-globals list.
+
+    Returns:
+        The loaded checkpoint (usually a :class:`dict`).
+
+    Raises:
+        RuntimeError: When all safe loading strategies fail and
+            ``trust=False``.  The error message suggests passing
+            ``trust_checkpoint=True`` so the caller can make an informed
+            decision.
+
+    Examples:
+        >>> import torch, tempfile, os
+        >>> with tempfile.NamedTemporaryFile(suffix=".pth", delete=False) as fh:
+        ...     path = fh.name
+        >>> torch.save({"model": {"weight": torch.tensor([1.0])}}, path)
+        >>> ckpt = _safe_torch_load(path)
+        >>> list(ckpt.keys())
+        ['model']
+        >>> os.unlink(path)
+    """
+    # ── Attempt 1: strict safe load ──────────────────────────────────────
+    try:
+        return torch.load(path, map_location="cpu", weights_only=True)
+    except (RuntimeError, pickle.UnpicklingError, Exception):
+        pass
+
+    # ── Attempt 2: add well-known legacy safe globals ─────────────────────
+    # argparse.Namespace and types.SimpleNamespace appear in RF-DETR checkpoints
+    # saved by the pre-PTL engine.py training loop.  Registering them as safe
+    # globals is semantically safe because they contain only primitive values.
+    try:
+        torch.serialization.add_safe_globals([argparse.Namespace, types.SimpleNamespace])
+        return torch.load(path, map_location="cpu", weights_only=True)
+    except (RuntimeError, pickle.UnpicklingError, Exception):
+        pass
+
+    # ── Attempt 3 (opt-in): full pickle ───────────────────────────────────
+    if trust:
+        warnings.warn(
+            f"Loading checkpoint {str(path)!r} with weights_only=False. "
+            "This allows arbitrary Python objects to be deserialized from the "
+            "checkpoint file, which can execute malicious code if the file "
+            "comes from an untrusted source. "
+            "Only use trust=True for checkpoint files produced by RF-DETR itself.",
+            UserWarning,
+            stacklevel=3,
+        )
+        return torch.load(path, map_location="cpu", weights_only=False)
+
+    raise RuntimeError(
+        f"Failed to safely load checkpoint {str(path)!r}. "
+        "The file likely contains custom Python objects that cannot be "
+        "deserialized with weights_only=True. "
+        "If you fully trust this checkpoint source, pass trust_checkpoint=True "
+        "to the loading function."
+    )

--- a/src/rfdetr/utilities/state_dict.py
+++ b/src/rfdetr/utilities/state_dict.py
@@ -147,11 +147,14 @@ def strip_checkpoint(checkpoint: str | os.PathLike[str]) -> None:
     """
     import torch
 
+    from rfdetr.util.io import _safe_torch_load
+
     # `checkpoint_best_total.pth` is produced by local RF-DETR training and can
     # contain non-tensor metadata under "args" (e.g. `types.SimpleNamespace`).
     # PyTorch 2.6 changed `torch.load` default `weights_only=True`, which rejects
-    # these objects. This utility intentionally operates on trusted checkpoints.
-    state_dict = torch.load(checkpoint, map_location="cpu", weights_only=False)
+    # these objects. This utility intentionally operates on trusted, locally
+    # produced checkpoints, so trust=True permits the full-pickle fallback.
+    state_dict = _safe_torch_load(checkpoint, trust=True)
     new_state_dict = {
         "model": state_dict["model"],
         "args": state_dict["args"],

--- a/tests/assets/test_downloads.py
+++ b/tests/assets/test_downloads.py
@@ -48,18 +48,24 @@ class TestDownloadPretrainWeights:
 
     @pytest.mark.skipif(not _IS_RFDETR_PLUS_AVAILABLE, reason="rf-detr-plus not installed - skip priority test")
     def test_download_from_rfdetr_plus_when_available(self, mock_file_operations):
-        """Test that rf-detr-plus models are prioritized when available.
+        """Test that rf-detr-plus URL is used for models absent from local ModelWeights.
 
-        Note: This test only runs if rf-detr-plus is actually installed.
-        The priority logic is also tested in the fallback test.
+        Verifies the priority contract: a model not registered in local ModelWeights but
+        present in rf-detr-plus triggers _download_file with the plus URL, not a fallback
+        or silent no-op.
         """
-        # This test validates the real rf-detr-plus integration
-        # If rf-detr-plus is installed, verify it's checked first
-        download_pretrain_weights("some-model.pth")
+        plus_url = "https://plus.example.com/plus-only-model.pth"
+        plus_asset = ModelWeightAsset(filename="plus-only-model.pth", url=plus_url, md5_hash=None)
 
-        # Should attempt download (whether from plus or local)
-        # The important part is that the function doesn't crash
-        assert mock_file_operations["download"].called or not mock_file_operations["exists"].return_value
+        with (
+            patch("rfdetr.assets.model_weights.ModelWeights.from_filename", return_value=None),
+            patch("rfdetr_plus.assets.ModelWeights.from_filename", return_value=plus_asset),
+        ):
+            download_pretrain_weights("plus-only-model.pth")
+
+        mock_file_operations["download"].assert_called_once()
+        call_kwargs = mock_file_operations["download"].call_args[1]
+        assert call_kwargs["url"] == plus_url
 
     def test_download_from_platform_models_fallback(self, mock_file_operations):
         """Test falling back to PLATFORM_MODELS when model not in ModelWeights."""

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -38,6 +38,9 @@ def download_coco_val() -> tuple[Path, Path]:
     Returns:
         Tuple containing the images root directory and annotations file path.
     """
+    if not _is_online(_COCO_HOST, _COCO_PORT):
+        pytest.skip("Offline environment, skipping COCO val2017 benchmark tests.")
+
     images_root = _DATA_DIR / "val2017"
     annotations_path = _DATA_DIR / "annotations" / "instances_val2017.json"
 

--- a/tests/benchmarks/test_inference_coco.py
+++ b/tests/benchmarks/test_inference_coco.py
@@ -65,6 +65,9 @@ from rfdetr.evaluation.matching import (
 )
 from rfdetr.training import RFDETRDataModule, RFDETRModelModule, build_trainer
 
+# All tests in this file download COCO val2017 (~1 GB); exclude from CPU CI with -m "not coco17".
+pytestmark = pytest.mark.coco17
+
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------

--- a/tests/export/test_export.py
+++ b/tests/export/test_export.py
@@ -473,6 +473,70 @@ class TestCliExportMain:
             f"expected keys {expected_names}, got {set(dynamic_axes.keys())}"
         )
 
+    @pytest.mark.parametrize(
+        "device",
+        [
+            pytest.param("cpu", id="cpu"),
+            pytest.param("cuda", id="cuda"),
+        ],
+    )
+    def test_model_moved_to_correct_device(self, output_dir: str, device: str, monkeypatch) -> None:
+        """model.to() and input_tensors.to() must use args.device, not a hard-coded 'cuda'.
+
+        Before the fix, export/main.py line 145 called model.eval().to('cuda') unconditionally, which crashed when
+        CUDA_VISIBLE_DEVICES was blank (CPU export).
+        """
+        import torch
+
+        to_calls = []
+
+        mock_model = MagicMock()
+        mock_model.parameters.return_value = []
+        mock_model.backbone.parameters.return_value = []
+        mock_model.backbone.__getitem__.return_value.projector.parameters.return_value = []
+        mock_model.backbone.__getitem__.return_value.encoder.parameters.return_value = []
+        mock_model.transformer.parameters.return_value = []
+
+        # Capture .to() calls
+        def _record_to(dev):
+            to_calls.append(str(dev))
+            return mock_model
+
+        mock_model.to.side_effect = _record_to
+        mock_model.cpu.return_value = mock_model
+        mock_model.eval.return_value = mock_model
+        mock_model.return_value = {"pred_boxes": torch.zeros(1, 300, 4), "pred_logits": torch.zeros(1, 300, 90)}
+
+        mock_tensor = MagicMock()
+        tensor_to_calls = []
+
+        def _tensor_to(dev):
+            tensor_to_calls.append(str(dev))
+            return mock_tensor
+
+        mock_tensor.to.side_effect = _tensor_to
+        mock_tensor.cpu.return_value = mock_tensor
+
+        # When testing "cuda" path, pretend CUDA is not available so the
+        # fallback-to-cpu branch fires and we can verify the warning without
+        # needing a GPU in CI.
+        monkeypatch.setattr(torch, "cuda", MagicMock(is_available=MagicMock(return_value=False)))
+
+        args = self._make_args(output_dir=output_dir)
+        args.device = device
+
+        with (
+            patch.object(_cli_export_module, "build_model", return_value=(mock_model, MagicMock(), MagicMock())),
+            patch.object(_cli_export_module, "make_infer_image", return_value=mock_tensor),
+            patch.object(_cli_export_module, "export_onnx", return_value=str(output_dir) + "/m.onnx"),
+            patch.object(_cli_export_module, "get_rank", return_value=0),
+        ):
+            _cli_export_module.main(args)
+
+        # The model must NOT have been moved to a hard-coded "cuda" device when
+        # device="cpu" — verify the fallback CPU path was taken.
+        assert "cuda" not in to_calls, f"model was moved to 'cuda' unexpectedly: {to_calls}"
+
 
 class TestExportPatchSize:
     """RFDETR.export() patch_size validation and shape-divisibility tests."""

--- a/tests/export/test_tensorrt_export.py
+++ b/tests/export/test_tensorrt_export.py
@@ -5,7 +5,10 @@
 # ------------------------------------------------------------------------
 """Tests for TensorRT export helpers."""
 
+import argparse
 import subprocess
+
+import pytest
 
 from rfdetr.export import _tensorrt as tensorrt_export
 
@@ -14,14 +17,101 @@ def test_run_command_shell_dry_run_handles_missing_cuda_visible_devices(monkeypa
     """Dry-run logging should not crash when CUDA_VISIBLE_DEVICES is unset."""
     monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
 
-    def _fake_run(command, shell, capture_output, text, check):
-        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
-
-    monkeypatch.setattr(tensorrt_export.subprocess, "run", _fake_run)
     logged_messages = []
     monkeypatch.setattr(tensorrt_export.logger, "info", logged_messages.append)
 
-    result = tensorrt_export.run_command_shell("trtexec --help", dry_run=True)
+    result = tensorrt_export.run_command_shell(["trtexec", "--help"], dry_run=True)
 
     assert result.returncode == 0
     assert any("CUDA_VISIBLE_DEVICES=" in message for message in logged_messages)
+
+
+def test_run_command_shell_uses_list_not_string(monkeypatch) -> None:
+    """subprocess.run must be called with a list (shell=False) to prevent injection."""
+    captured = {}
+
+    def _fake_run(command, shell, capture_output, text, check):
+        captured["command"] = command
+        captured["shell"] = shell
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(tensorrt_export.subprocess, "run", _fake_run)
+
+    tensorrt_export.run_command_shell(["trtexec", "--onnx=/some/model.onnx"], dry_run=False)
+
+    assert isinstance(captured["command"], list), "command must be a list, not a string"
+    assert captured["shell"] is False, "shell=False is required to prevent injection"
+
+
+def test_run_command_shell_dry_run_does_not_invoke_subprocess(monkeypatch) -> None:
+    """Dry-run must return early without calling subprocess.run."""
+    was_called = []
+
+    def _should_not_run(*args, **kwargs):
+        was_called.append(True)
+        return subprocess.CompletedProcess([], 0)
+
+    monkeypatch.setattr(tensorrt_export.subprocess, "run", _should_not_run)
+    monkeypatch.setattr(tensorrt_export.logger, "info", lambda _: None)
+
+    result = tensorrt_export.run_command_shell(["trtexec", "--help"], dry_run=True)
+
+    assert not was_called, "subprocess.run must not be called during dry_run"
+    assert result.returncode == 0
+
+
+def test_trtexec_returns_engine_path(monkeypatch) -> None:
+    """Trtexec() must return the .engine path, not None."""
+    captured_argv = []
+
+    def _fake_run(command, **kwargs):
+        captured_argv.extend(command)
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(tensorrt_export.subprocess, "run", _fake_run)
+    monkeypatch.setattr(tensorrt_export, "parse_trtexec_output", lambda _: {})
+
+    args = argparse.Namespace(profile=False, verbose=False, dry_run=False)
+    result = tensorrt_export.trtexec("/tmp/model.onnx", args)
+
+    assert result == "/tmp/model.engine"
+
+
+def test_trtexec_dry_run_returns_engine_path(monkeypatch) -> None:
+    """Trtexec() with dry_run=True must still return the engine path."""
+    monkeypatch.setattr(tensorrt_export.logger, "info", lambda _: None)
+    monkeypatch.setattr(tensorrt_export, "parse_trtexec_output", lambda _: {})
+
+    args = argparse.Namespace(profile=False, verbose=False, dry_run=True)
+    result = tensorrt_export.trtexec("/tmp/model.onnx", args)
+
+    assert result == "/tmp/model.engine"
+
+
+@pytest.mark.parametrize(
+    ("onnx_path", "expected_engine"),
+    [
+        pytest.param("/output/rfdetr.onnx", "/output/rfdetr.engine", id="plain-path"),
+        pytest.param("/path with spaces/model.onnx", "/path with spaces/model.engine", id="path-with-spaces"),
+    ],
+)
+def test_trtexec_argv_contains_no_shell_string(monkeypatch, onnx_path: str, expected_engine: str) -> None:
+    """Trtexec builds an argv list; no shell string concatenation of user paths."""
+    captured = {}
+
+    def _fake_run(command, shell, **kwargs):
+        captured["command"] = command
+        captured["shell"] = shell
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(tensorrt_export.subprocess, "run", _fake_run)
+    monkeypatch.setattr(tensorrt_export, "parse_trtexec_output", lambda _: {})
+
+    args = argparse.Namespace(profile=False, verbose=False, dry_run=False)
+    result = tensorrt_export.trtexec(onnx_path, args)
+
+    assert result == expected_engine
+    assert isinstance(captured["command"], list), "argv must be a list"
+    assert captured["shell"] is False, "shell=False required"
+    # Verify the ONNX path appears as a standalone argument element
+    assert any(onnx_path in arg for arg in captured["command"])

--- a/tests/export/test_tensorrt_export.py
+++ b/tests/export/test_tensorrt_export.py
@@ -93,6 +93,7 @@ def test_trtexec_dry_run_returns_engine_path(monkeypatch) -> None:
     [
         pytest.param("/output/rfdetr.onnx", "/output/rfdetr.engine", id="plain-path"),
         pytest.param("/path with spaces/model.onnx", "/path with spaces/model.engine", id="path-with-spaces"),
+        pytest.param("/model;rm -rf /.onnx", "/model;rm -rf /.engine", id="shell-metachar"),
     ],
 )
 def test_trtexec_argv_contains_no_shell_string(monkeypatch, onnx_path: str, expected_engine: str) -> None:
@@ -113,5 +114,116 @@ def test_trtexec_argv_contains_no_shell_string(monkeypatch, onnx_path: str, expe
     assert result == expected_engine
     assert isinstance(captured["command"], list), "argv must be a list"
     assert captured["shell"] is False, "shell=False required"
-    # Verify the ONNX path appears as a standalone argument element
+    # Verify the ONNX path appears as a standalone argument element (not shell-expanded)
     assert any(onnx_path in arg for arg in captured["command"])
+
+
+# ---------------------------------------------------------------------------
+# parse_trtexec_output (#1)
+# ---------------------------------------------------------------------------
+
+_FULL_TRTEXEC_STDOUT = """\
+[I] GPU Compute Time: min = 1.23 ms, max = 4.56 ms, mean = 2.34 ms, median = 2.10 ms
+[I] Host to Device Transfer Time: min = 0.10 ms, max = 0.20 ms, mean = 0.15 ms
+[I] Device to Host Transfer Time: min = 0.05 ms, max = 0.08 ms, mean = 0.06 ms
+[I] Latency: min = 1.40 ms, max = 4.80 ms, mean = 2.55 ms
+[I] Throughput: 391.22 qps
+"""
+
+_PARTIAL_TRTEXEC_STDOUT = """\
+[I] GPU Compute Time: min = 1.00 ms, max = 2.00 ms, mean = 1.50 ms, median = 1.45 ms
+[I] Throughput: 100.00 qps
+"""
+
+
+@pytest.mark.parametrize(
+    ("output_text", "expected"),
+    [
+        pytest.param(
+            _FULL_TRTEXEC_STDOUT,
+            {
+                "compute_min_ms": 1.23,
+                "compute_max_ms": 4.56,
+                "compute_mean_ms": 2.34,
+                "compute_median_ms": 2.10,
+                "h2d_min_ms": 0.10,
+                "h2d_max_ms": 0.20,
+                "h2d_mean_ms": 0.15,
+                "d2h_min_ms": 0.05,
+                "d2h_max_ms": 0.08,
+                "d2h_mean_ms": 0.06,
+                "latency_min_ms": 1.40,
+                "latency_max_ms": 4.80,
+                "latency_mean_ms": 2.55,
+                "throughput_qps": 391.22,
+            },
+            id="all-5-patterns",
+        ),
+        pytest.param(
+            "",
+            {},
+            id="empty-stdout",
+        ),
+        pytest.param(
+            _PARTIAL_TRTEXEC_STDOUT,
+            {
+                "compute_min_ms": 1.00,
+                "compute_max_ms": 2.00,
+                "compute_mean_ms": 1.50,
+                "compute_median_ms": 1.45,
+                "throughput_qps": 100.00,
+            },
+            id="partial-stdout",
+        ),
+    ],
+)
+def test_parse_trtexec_output(output_text: str, expected: dict) -> None:
+    """parse_trtexec_output extracts timing statistics from trtexec stdout."""
+    result = tensorrt_export.parse_trtexec_output(output_text)
+    assert result == pytest.approx(expected, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# CalledProcessError logging path (#15)
+# ---------------------------------------------------------------------------
+
+
+def test_run_command_shell_called_process_error_is_reraised(monkeypatch) -> None:
+    """CalledProcessError from subprocess.run is re-raised after logging."""
+    error_messages = []
+
+    def _fake_run(command, **kwargs):
+        raise subprocess.CalledProcessError(returncode=1, cmd=["trtexec"], stderr="engine build failed")
+
+    monkeypatch.setattr(tensorrt_export.subprocess, "run", _fake_run)
+    monkeypatch.setattr(tensorrt_export.logger, "error", error_messages.append)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        tensorrt_export.run_command_shell(["trtexec", "--onnx=/tmp/model.onnx"], dry_run=False)
+
+    assert error_messages, "logger.error must be called when CalledProcessError is raised"
+
+
+# ---------------------------------------------------------------------------
+# profile=True argv path (#17)
+# ---------------------------------------------------------------------------
+
+
+def test_trtexec_profile_true_wraps_with_nsys(monkeypatch) -> None:
+    """Profile=True wraps trtexec with 'nsys profile …' and the output flag is present."""
+    captured_argv: list[str] = []
+
+    def _fake_run(command, **kwargs):
+        captured_argv.extend(command)
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(tensorrt_export.subprocess, "run", _fake_run)
+    monkeypatch.setattr(tensorrt_export, "parse_trtexec_output", lambda _: {})
+    monkeypatch.setattr(tensorrt_export.logger, "info", lambda _: None)
+
+    args = argparse.Namespace(profile=True, verbose=False, dry_run=False)
+    tensorrt_export.trtexec("/tmp/model.onnx", args)
+
+    assert captured_argv[0] == "nsys", "profile=True must wrap with nsys as argv[0]"
+    argv_str = " ".join(captured_argv)
+    assert "--output=" in argv_str, "nsys profile must include --output= flag"

--- a/tests/inference/test_from_checkpoint.py
+++ b/tests/inference/test_from_checkpoint.py
@@ -435,6 +435,25 @@ class TestFromCheckpointModelName:
             model = RFDETR.from_checkpoint(tmp_path / "ckpt.pth")
         assert model.__class__.__name__ == expected_class
 
+    def test_large_deprecated_model_name_resolves_to_deprecated_class(self, tmp_path: Path) -> None:
+        """Checkpoints saved with model_name='RFDETRLargeDeprecated' must load as RFDETRLargeDeprecated.
+
+        Before the fix, RFDETRLargeDeprecated was absent from _name_map; the substring matcher would pick RFDETRLarge,
+        which fails with a pydantic literal_error when the saved model_config carries encoder='dinov2_windowed_base'
+        (only valid for the deprecated Large configuration).
+        """
+        ckpt = {
+            "args": {"pretrain_weights": "rf-detr-large.pth", "num_classes": 80},
+            "model_name": "RFDETRLargeDeprecated",
+            "model_config": {
+                "encoder": "dinov2_windowed_base",
+                "projector_scale": "P4",
+            },
+        }
+        result, mock_cls = _call_from_checkpoint(ckpt, tmp_path / "ckpt.pth", "rfdetr.variants.RFDETRLargeDeprecated")
+        mock_cls.assert_called_once()
+        assert result is mock_cls.return_value
+
     @pytest.mark.skipif(_IS_RFDETR_PLUS_AVAILABLE, reason="rfdetr_plus is installed — guard not active")
     @pytest.mark.parametrize("model_name", ["RFDETRXLarge", "RFDETR2XLarge"])
     def test_plus_model_name_without_plus_raises_import_error(self, tmp_path: Path, model_name: str) -> None:

--- a/tests/inference/test_from_checkpoint.py
+++ b/tests/inference/test_from_checkpoint.py
@@ -25,6 +25,14 @@ from rfdetr.platform import _IS_RFDETR_PLUS_AVAILABLE
 from rfdetr.variants import RFDETRSmall
 
 
+class _CustomObj:
+    """Module-level class that weights_only=True rejects (not in safe globals).
+
+    Must be at module scope so pickle can resolve the fully-qualified name during torch.save.  Local/nested classes
+    cannot be pickled.
+    """
+
+
 def _ns(pretrain_weights: str, num_classes: int = 80) -> dict:
     """Fake legacy checkpoint with argparse.Namespace args."""
     return {"args": argparse.Namespace(pretrain_weights=pretrain_weights, num_classes=num_classes)}
@@ -277,6 +285,18 @@ class TestFromCheckpointEdgeCases:
             with patch("rfdetr.detr.torch.load", return_value=ckpt):
                 with pytest.raises(ImportError):
                     RFDETR.from_checkpoint(tmp_path / "ckpt.pth")
+
+    def test_trust_gate_rejects_custom_class_by_default(self, tmp_path: Path) -> None:
+        """from_checkpoint raises RuntimeError for custom-class checkpoints without trust_checkpoint=True.
+
+        Scenario: user calls from_checkpoint on a file containing an unrecognised Python class.
+        The default trust_checkpoint=False must reject it to prevent arbitrary code execution.
+        """
+        ckpt_path = tmp_path / "custom_obj.pth"
+        torch.save({"model": {}, "args": _CustomObj(), "model_name": "RFDETRSmall"}, ckpt_path)
+
+        with pytest.raises(RuntimeError, match="trust_checkpoint=True"):
+            RFDETR.from_checkpoint(ckpt_path)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/inference/test_predict.py
+++ b/tests/inference/test_predict.py
@@ -952,3 +952,55 @@ class TestPredictKeypointClassNameMapping:
         assert detections.data["class_name"][0] == "cat", (
             f"Detection model: class_id=0 must map to 'cat', got '{detections.data['class_name'][0]}'"
         )
+
+
+# ---------------------------------------------------------------------------
+# Fix F — non-RGB PIL / file-path inputs are auto-converted to RGB
+# ---------------------------------------------------------------------------
+
+
+class TestPredictNonRGBAutoConvert:
+    """Predict() must silently convert non-RGB PIL images and file paths to RGB.
+
+    Standard detector contract: callers pass images in any PIL mode (L, LA,
+    RGBA, P …) and expect detection results, not opaque tensor-shape errors.
+    Tensor inputs with wrong channel count are still the caller's error.
+    """
+
+    @pytest.mark.parametrize(
+        "pil_mode",
+        [
+            pytest.param("L", id="grayscale-L"),
+            pytest.param("LA", id="grayscale-with-alpha-LA"),
+            pytest.param("RGBA", id="rgba"),
+            pytest.param("P", id="palette-P"),
+        ],
+    )
+    def test_non_rgb_pil_image_succeeds(self, pil_mode: str) -> None:
+        """PIL images in any mode are auto-converted to RGB and return sv.Detections."""
+        import supervision as sv
+
+        img = PIL.Image.new(pil_mode, (28, 28))
+        model = _DummyRFDETR()
+        detections = model.predict(img)
+        assert isinstance(detections, sv.Detections)
+
+    def test_grayscale_file_path_succeeds(self, tmp_path) -> None:
+        """Grayscale image opened from a file path is auto-converted and returns sv.Detections."""
+        import supervision as sv
+
+        img_path = tmp_path / "gray.png"
+        PIL.Image.new("L", (28, 28)).save(str(img_path))
+        model = _DummyRFDETR()
+        detections = model.predict(str(img_path))
+        assert isinstance(detections, sv.Detections)
+
+    def test_wrong_channel_tensor_still_raises(self) -> None:
+        """Tensor inputs with wrong channel count must still raise ValueError with helpful message."""
+        import torch
+
+        # 1-channel tensor — caller is responsible for correct shape
+        tensor = torch.rand(1, 28, 28)
+        model = _DummyRFDETR()
+        with pytest.raises(ValueError, match="PIL Image or a file path"):
+            model.predict(tensor)

--- a/tests/inference/test_predict.py
+++ b/tests/inference/test_predict.py
@@ -974,6 +974,7 @@ class TestPredictNonRGBAutoConvert:
             pytest.param("LA", id="grayscale-with-alpha-LA"),
             pytest.param("RGBA", id="rgba"),
             pytest.param("P", id="palette-P"),
+            pytest.param("CMYK", id="cmyk"),
         ],
     )
     def test_non_rgb_pil_image_succeeds(self, pil_mode: str) -> None:

--- a/tests/models/backbone/test_windowed_dino.py
+++ b/tests/models/backbone/test_windowed_dino.py
@@ -444,3 +444,101 @@ def test_forward_validates_spatial_dims(h: int, w: int, num_windows: int, should
             model(pixel_values)
     else:
         model(pixel_values)  # must not raise
+
+
+def _make_small_model() -> WindowedDinov2WithRegistersModel:
+    """Return the smallest valid WindowedDinov2WithRegistersModel for unit tests."""
+    config = WindowedDinov2WithRegistersConfig(
+        hidden_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        image_size=32,
+        patch_size=16,
+        num_register_tokens=2,
+    )
+    return WindowedDinov2WithRegistersModel(config)
+
+
+class TestSetAttnImplementationPreservesWeights:
+    """set_attn_implementation must transfer trained weights to the new attention module.
+
+    Before the fix the method replaced each layer's attention with a freshly constructed (randomly initialised) module,
+    silently discarding all trained q/k/v/output weights.
+    """
+
+    @pytest.mark.parametrize(
+        "from_impl, to_impl",
+        [
+            pytest.param("sdpa", "eager", id="sdpa_to_eager"),
+            pytest.param("eager", "sdpa", id="eager_to_sdpa"),
+        ],
+    )
+    def test_query_weight_preserved_after_switch(self, from_impl: str, to_impl: str) -> None:
+        """After switching implementation the query weight tensor must be unchanged."""
+        model = _make_small_model()
+        model.set_attn_implementation(from_impl)
+
+        # Record the query weights of every layer before switching.
+        before = [layer.attention.attention.query.weight.clone() for layer in model.encoder.layer]
+
+        model.set_attn_implementation(to_impl)
+
+        after = [layer.attention.attention.query.weight for layer in model.encoder.layer]
+        for layer_idx, (w_before, w_after) in enumerate(zip(before, after)):
+            assert torch.equal(w_before, w_after), (
+                f"Layer {layer_idx}: query weight changed after set_attn_implementation({from_impl!r} → {to_impl!r})"
+            )
+
+    def test_key_and_value_weights_preserved(self) -> None:
+        """Key and value weights must also survive the implementation switch."""
+        model = _make_small_model()
+        model.set_attn_implementation("sdpa")
+
+        key_before = [layer.attention.attention.key.weight.clone() for layer in model.encoder.layer]
+        val_before = [layer.attention.attention.value.weight.clone() for layer in model.encoder.layer]
+
+        model.set_attn_implementation("eager")
+
+        for layer_idx, layer in enumerate(model.encoder.layer):
+            assert torch.equal(key_before[layer_idx], layer.attention.attention.key.weight), (
+                f"Layer {layer_idx}: key weight changed after implementation switch"
+            )
+            assert torch.equal(val_before[layer_idx], layer.attention.attention.value.weight), (
+                f"Layer {layer_idx}: value weight changed after implementation switch"
+            )
+
+    def test_output_dense_weight_preserved(self) -> None:
+        """The output projection (dense) weight must survive the implementation switch."""
+        model = _make_small_model()
+        model.set_attn_implementation("sdpa")
+
+        dense_before = [layer.attention.output.dense.weight.clone() for layer in model.encoder.layer]
+
+        model.set_attn_implementation("eager")
+
+        for layer_idx, layer in enumerate(model.encoder.layer):
+            assert torch.equal(dense_before[layer_idx], layer.attention.output.dense.weight), (
+                f"Layer {layer_idx}: output dense weight changed after implementation switch"
+            )
+
+    def test_config_updated_after_switch(self) -> None:
+        """config._attn_implementation must reflect the new implementation after switching."""
+        model = _make_small_model()
+        model.set_attn_implementation("eager")
+        assert model.config._attn_implementation == "eager"
+        model.set_attn_implementation("sdpa")
+        assert model.config._attn_implementation == "sdpa"
+
+    def test_attention_module_type_after_switch(self) -> None:
+        """After switching to eager, every layer must hold a non-SDPA attention class."""
+        model = _make_small_model()
+        model.set_attn_implementation("eager")
+        for layer in model.encoder.layer:
+            assert isinstance(layer.attention, Dinov2WithRegistersAttention)
+            assert not isinstance(layer.attention, Dinov2WithRegistersSdpaAttention)
+
+    def test_invalid_implementation_raises_value_error(self) -> None:
+        """An unknown implementation name must raise ValueError before touching any layer."""
+        model = _make_small_model()
+        with pytest.raises(ValueError, match="Unknown attn_implementation"):
+            model.set_attn_implementation("flash_attn")

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -4,3 +4,21 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 """Shared fixtures for the models test suite."""
+
+import pytest
+import torch
+
+
+@pytest.fixture(autouse=True)
+def reset_torch_safe_globals():
+    """Reset torch serialization safe globals after each test.
+
+    Prevents cross-test state contamination caused by ``_safe_torch_load``'s Attempt 2 path, which calls
+    ``torch.serialization.add_safe_globals``. Without this reset, globals registered by one test bleed into subsequent
+    tests and can mask trust-gate failures.
+    """
+    yield
+    try:
+        torch.serialization.clear_safe_globals()
+    except AttributeError:
+        pass  # torch <2.4 does not have clear_safe_globals

--- a/tests/models/test_position_encoding.py
+++ b/tests/models/test_position_encoding.py
@@ -1,0 +1,88 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Tests for rfdetr.models.position_encoding.build_position_encoding.
+
+Covers:
+- Supported aliases ``"sine"`` / ``"v2"`` return a ``PositionEmbeddingSine`` instance.
+- Unsupported but previously accepted aliases ``"learned"`` / ``"v3"`` now raise
+  ``ValueError`` with a message that names supported alternatives.
+- Fully unsupported values raise ``ValueError`` with the same pattern.
+"""
+
+import pytest
+
+from rfdetr.models.position_encoding import (
+    PositionEmbeddingSine,
+    build_position_encoding,
+)
+
+
+class TestBuildPositionEncodingSupportedValues:
+    """build_position_encoding returns valid modules for supported aliases."""
+
+    @pytest.mark.parametrize(
+        "alias",
+        [
+            pytest.param("sine", id="sine"),
+            pytest.param("v2", id="v2"),
+        ],
+    )
+    def test_returns_sine_embedding(self, alias: str) -> None:
+        """Supported aliases produce a PositionEmbeddingSine with normalized=True."""
+        enc = build_position_encoding(hidden_dim=256, position_embedding=alias)
+        assert isinstance(enc, PositionEmbeddingSine)
+        assert enc.normalize is True
+
+    @pytest.mark.parametrize(
+        "hidden_dim, expected_num_pos_feats",
+        [
+            pytest.param(256, 128, id="dim256"),
+            pytest.param(512, 256, id="dim512"),
+        ],
+    )
+    def test_num_pos_feats_is_half_hidden_dim(self, hidden_dim: int, expected_num_pos_feats: int) -> None:
+        """The sine encoding uses hidden_dim // 2 positional feature dimensions."""
+        enc = build_position_encoding(hidden_dim=hidden_dim, position_embedding="sine")
+        assert enc.num_pos_feats == expected_num_pos_feats
+
+
+class TestBuildPositionEncodingUnsupportedValues:
+    """build_position_encoding raises ValueError for broken or unknown aliases."""
+
+    @pytest.mark.parametrize(
+        "alias",
+        [
+            pytest.param("learned", id="learned"),
+            pytest.param("v3", id="v3"),
+        ],
+    )
+    def test_learned_raises_value_error(self, alias: str) -> None:
+        """'learned' and 'v3' are doubly broken and must raise ValueError immediately.
+
+        The PositionEmbeddingLearned class has two bugs:
+        1. forward() signature is incompatible with Joiner.forward() (no align_dim_orders param).
+        2. h, w = x.shape[:2] unpacks batch and channels instead of height and width.
+        Rejecting them at build time is preferable to a silent or confusing runtime failure.
+        """
+        with pytest.raises(ValueError, match="not supported"):
+            build_position_encoding(hidden_dim=256, position_embedding=alias)
+
+    def test_unknown_value_raises_value_error(self) -> None:
+        """A fully unknown alias raises ValueError naming the supported alternatives."""
+        with pytest.raises(ValueError, match="not supported"):
+            build_position_encoding(hidden_dim=256, position_embedding="unknown_variant")
+
+    @pytest.mark.parametrize(
+        "alias",
+        [
+            pytest.param("learned", id="learned"),
+            pytest.param("v3", id="v3"),
+        ],
+    )
+    def test_error_message_mentions_supported_alternatives(self, alias: str) -> None:
+        """Error message for 'learned'/'v3' mentions at least one supported alternative."""
+        with pytest.raises(ValueError, match="sine"):
+            build_position_encoding(hidden_dim=256, position_embedding=alias)

--- a/tests/models/test_safe_torch_load.py
+++ b/tests/models/test_safe_torch_load.py
@@ -1,0 +1,167 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Tests for the ``_safe_torch_load`` helper in ``rfdetr.util.io``.
+
+Covers the three-stage safe-load strategy: strict weights_only, safe-globals fallback, and opt-in pickle fallback.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from rfdetr.util.io import _safe_torch_load
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_tensor_only_checkpoint(path: Path) -> None:
+    """Save a checkpoint containing only tensors and plain dicts to *path*."""
+    ckpt = {"model": {"weight": torch.tensor([1.0, 2.0]), "bias": torch.tensor([0.0])}}
+    torch.save(ckpt, path)
+
+
+def _write_namespace_checkpoint(path: Path) -> None:
+    """Save a checkpoint with an ``argparse.Namespace`` args value to *path*.
+
+    Legacy RF-DETR engine.py checkpoints embed a Namespace; strict ``weights_only=True`` (without safe globals) would
+    reject these.
+    """
+    ckpt = {
+        "model": {"weight": torch.tensor([1.0])},
+        "args": argparse.Namespace(pretrain_weights="rf-detr-small.pth", num_classes=80),
+    }
+    torch.save(ckpt, path)
+
+
+def _write_simple_namespace_checkpoint(path: Path) -> None:
+    """Save a checkpoint with a ``types.SimpleNamespace`` to *path*."""
+    ckpt = {
+        "model": {"weight": torch.tensor([1.0])},
+        "args": SimpleNamespace(pretrain_weights="rf-detr-small.pth"),
+    }
+    torch.save(ckpt, path)
+
+
+class _ArbitraryObject:
+    """Module-level object that torch.save can pickle but weights_only=True rejects.
+
+    Must be defined at module scope so pickle can resolve its fully-qualified name during serialisation (local/nested
+    classes cannot be pickled by torch.save).
+    """
+
+    value = 42
+
+
+def _write_arbitrary_pickle_checkpoint(path: Path) -> None:
+    """Save a checkpoint that embeds an arbitrary class (requires pickle)."""
+    ckpt = {"model": {"weight": torch.tensor([1.0])}, "extra": _ArbitraryObject()}
+    torch.save(ckpt, path)
+
+
+# ---------------------------------------------------------------------------
+# Safe path (weights_only=True)
+# ---------------------------------------------------------------------------
+
+
+class TestSafeTorchLoadSafePath:
+    """Tensor-only checkpoints load without trust=True."""
+
+    def test_tensor_only_checkpoint_loads(self, tmp_path: Path) -> None:
+        """Pure-tensor checkpoint succeeds on the first safe-load attempt."""
+        ckpt_path = tmp_path / "ckpt.pth"
+        _write_tensor_only_checkpoint(ckpt_path)
+
+        result = _safe_torch_load(ckpt_path)
+
+        assert "model" in result
+        assert torch.allclose(result["model"]["weight"], torch.tensor([1.0, 2.0]))
+
+    def test_accepts_pathlib_path(self, tmp_path: Path) -> None:
+        """Helper accepts a :class:`pathlib.Path` argument without error."""
+        ckpt_path = tmp_path / "ckpt.pth"
+        _write_tensor_only_checkpoint(ckpt_path)
+
+        result = _safe_torch_load(ckpt_path)
+
+        assert "model" in result
+
+    def test_accepts_string_path(self, tmp_path: Path) -> None:
+        """Helper accepts a :class:`str` path argument without error."""
+        ckpt_path = tmp_path / "ckpt.pth"
+        _write_tensor_only_checkpoint(ckpt_path)
+
+        result = _safe_torch_load(str(ckpt_path))
+
+        assert "model" in result
+
+
+# ---------------------------------------------------------------------------
+# Safe-globals fallback (legacy Namespace checkpoints)
+# ---------------------------------------------------------------------------
+
+
+class TestSafeTorchLoadSafeGlobals:
+    """Checkpoints with argparse.Namespace / SimpleNamespace load without trust=True."""
+
+    def test_argparse_namespace_loads_without_trust(self, tmp_path: Path) -> None:
+        """argparse.Namespace checkpoint succeeds via the safe-globals retry."""
+        ckpt_path = tmp_path / "ckpt.pth"
+        _write_namespace_checkpoint(ckpt_path)
+
+        result = _safe_torch_load(ckpt_path)
+
+        assert isinstance(result["args"], argparse.Namespace)
+        assert result["args"].num_classes == 80
+
+    def test_simple_namespace_loads_without_trust(self, tmp_path: Path) -> None:
+        """SimpleNamespace checkpoint succeeds via the safe-globals retry."""
+        ckpt_path = tmp_path / "ckpt.pth"
+        _write_simple_namespace_checkpoint(ckpt_path)
+
+        result = _safe_torch_load(ckpt_path)
+
+        assert isinstance(result["args"], SimpleNamespace)
+
+
+# ---------------------------------------------------------------------------
+# Arbitrary pickle — trust=False must raise, trust=True must succeed
+# ---------------------------------------------------------------------------
+
+
+class TestSafeTorchLoadTrustGate:
+    """Arbitrary-pickle checkpoints require explicit trust=True."""
+
+    def test_arbitrary_pickle_raises_without_trust(self, tmp_path: Path) -> None:
+        """Checkpoint with unknown Python object raises RuntimeError when trust=False."""
+        ckpt_path = tmp_path / "ckpt.pth"
+        _write_arbitrary_pickle_checkpoint(ckpt_path)
+
+        with pytest.raises(RuntimeError, match="trust_checkpoint=True"):
+            _safe_torch_load(ckpt_path, trust=False)
+
+    def test_arbitrary_pickle_succeeds_with_trust(self, tmp_path: Path) -> None:
+        """Checkpoint with unknown Python object loads when trust=True."""
+        ckpt_path = tmp_path / "ckpt.pth"
+        _write_arbitrary_pickle_checkpoint(ckpt_path)
+
+        result = _safe_torch_load(ckpt_path, trust=True)
+
+        assert "model" in result
+
+    def test_trust_true_emits_warning(self, tmp_path: Path) -> None:
+        """Trust=True triggers a UserWarning about unsafe loading."""
+        ckpt_path = tmp_path / "ckpt.pth"
+        _write_arbitrary_pickle_checkpoint(ckpt_path)
+
+        with pytest.warns(UserWarning, match="weights_only=False"):
+            _safe_torch_load(ckpt_path, trust=True)

--- a/tests/models/test_safe_torch_load.py
+++ b/tests/models/test_safe_torch_load.py
@@ -149,6 +149,14 @@ class TestSafeTorchLoadTrustGate:
         with pytest.raises(RuntimeError, match="trust_checkpoint=True"):
             _safe_torch_load(ckpt_path, trust=False)
 
+    def test_arbitrary_pickle_raises_by_default(self, tmp_path: Path) -> None:
+        """Checkpoint with unknown Python object raises RuntimeError when trust omitted (default=False)."""
+        ckpt_path = tmp_path / "ckpt.pth"
+        _write_arbitrary_pickle_checkpoint(ckpt_path)
+
+        with pytest.raises(RuntimeError, match="trust_checkpoint=True"):
+            _safe_torch_load(ckpt_path)
+
     def test_arbitrary_pickle_succeeds_with_trust(self, tmp_path: Path) -> None:
         """Checkpoint with unknown Python object loads when trust=True."""
         ckpt_path = tmp_path / "ckpt.pth"

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -396,19 +396,21 @@ class TestLoadPretrainWeights:
 
         load_calls = [0]
 
-        def fake_torch_load(*args, **kwargs):
+        def fake_safe_load(*args, **kwargs):
             load_calls[0] += 1
             if load_calls[0] == 1:
                 raise RuntimeError("corrupted file")
             return checkpoint
 
-        with patch("rfdetr.models.weights.torch.load", side_effect=fake_torch_load):
+        # Patch at the definition site in util.io (_safe_torch_load is a deferred import in
+        # weights.py so it is not a module-level name there). MD5 validation is intentionally
+        # kept on the retry (validate_md5=False was removed in favour of rejecting
+        # hash-mismatched files rather than silently accepting them).
+        with patch("rfdetr.util.io._safe_torch_load", side_effect=fake_safe_load):
             load_pretrain_weights(module.model, module.model_config)
 
-        # Verify a redownload with validate_md5=False was triggered after load failure.
         redownload_calls = [c for c in mock_download.call_args_list if c.kwargs.get("redownload") is True]
         assert len(redownload_calls) >= 1
-        assert all(c.kwargs.get("validate_md5") is False for c in redownload_calls)
         assert load_calls[0] == 2
 
     @patch("rfdetr.models.weights.os.path.isfile", return_value=False)


### PR DESCRIPTION
## Security:
- add _safe_torch_load helper (src/rfdetr/util/io.py): tries weights_only=True with safe_globals for legacy Namespace checkpoints, falls back to weights_only=False only behind explicit trust_checkpoint=True; replaces unsafe torch.load at 5 sites (detr.py, weights.py, checkpoint.py, export/main.py, best_model.py)
- fix shell injection in trtexec wrapper: argv list + shell=False; fix dry_run early-return; trtexec() now returns engine_dir
- fix CPU export: sanity inference now runs on args.device instead of unconditional .to("cuda")
- fix dead TensorRT import: _tensorrt → tensorrt

## Backbone:
- set_attn_implementation now transfers state_dict before swapping attention module, preserving trained q/k/v weights
- position_embedding="learned"/"v3" now raises clear ValueError instead of crashing or silently producing wrong encodings
- from_checkpoint: extend _should_fallback_to_deprecated_config to catch pydantic literal_error on encoder/projector_scale, fixing opaque failure for RFDETRLargeDeprecated checkpoints

## detr.py / predict:
- add .convert("RGB") for PIL and path inputs so grayscale/RGBA/palette images work instead of hitting a misleading tensor-shape error

## Tests / CI:
- add non-RGB predict tests (L/LA/RGBA/P modes + grayscale file path)
- fix tautological assertion in test_downloads.py: assert plus URL called
- add coco17 marker to unmarked COCO benchmark tests; add _is_online guard to download_coco_val fixture
- exclude coco17 from CPU CI workflow to stop downloading 1GB per matrix job
- add tests for safe-load helper, set_attn weight preservation, position_encoding ValueError, CPU export device handling, TRT benchmark import, from_checkpoint deprecated-Large path, shell-injection-free trtexec
