### PR TITLE
fix: fix all MEDIUM findings across code, docs, tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,14 +306,12 @@ Our work is built upon [LW-DETR](https://arxiv.org/pdf/2406.03459), [DINOv2](htt
 If you find our work helpful for your research, please consider citing the following BibTeX entry.
 
 ```bibtex
-@misc{rf-detr,
-    title={RF-DETR: Neural Architecture Search for Real-Time Detection Transformers},
-    author={Isaac Robinson and Peter Robicheaux and Matvei Popov and Deva Ramanan and Neehar Peri},
-    year={2025},
-    eprint={2511.09554},
-    archivePrefix={arXiv},
-    primaryClass={cs.CV},
-    url={https://arxiv.org/abs/2511.09554},
+@inproceedings{robinson2026rfdetr,
+  title     = {RF-DETR: Real-Time Detection Transformer},
+  author    = {Robinson, Isaac and Robicheaux, Peter and Popov, Fedor and Ramanan, Deva and Peri, Neehar},
+  booktitle = {International Conference on Learning Representations (ICLR)},
+  year      = {2026},
+  url       = {https://arxiv.org/abs/2511.09554}
 }
 ```
 

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -85,6 +85,19 @@ If you plan to contribute to RF-DETR or modify the codebase locally, set up a lo
         uv pip install -e . --all-extras
         ```
 
+## Optional Extras
+
+RF-DETR provides several optional extras for additional functionality:
+
+| Extra     | Install command                     | Purpose                                                         |
+| --------- | ----------------------------------- | --------------------------------------------------------------- |
+| `train`   | `pip install "rfdetr[train]"`       | Training dependencies (PyTorch Lightning, albumentations, etc.) |
+| `loggers` | `pip install "rfdetr[loggers]"`     | Experiment tracking (TensorBoard, W&B, MLflow, ClearML)         |
+| `onnx`    | `pip install "rfdetr[onnx]"`        | ONNX export                                                     |
+| `tflite`  | `pip install "rfdetr[onnx,tflite]"` | TFLite export                                                   |
+| `lora`    | `pip install "rfdetr[lora]"`        | LoRA fine-tuning with PEFT                                      |
+| `plus`    | `pip install "rfdetr[plus]"`        | XLarge and 2XLarge detection models (PML 1.0 license)           |
+
 ## Additional Notes
 
 - Ensure you have Python 3.10 or higher installed.

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -94,8 +94,12 @@ RF-DETR provides several optional extras for additional functionality:
 | `train`   | `pip install "rfdetr[train]"`       | Training dependencies (PyTorch Lightning, albumentations, etc.) |
 | `loggers` | `pip install "rfdetr[loggers]"`     | Experiment tracking (TensorBoard, W&B, MLflow, ClearML)         |
 | `onnx`    | `pip install "rfdetr[onnx]"`        | ONNX export                                                     |
-| `tflite`  | `pip install "rfdetr[onnx,tflite]"` | TFLite export                                                   |
+| `tflite`  | `pip install "rfdetr[onnx,tflite]"` | TFLite export (Python 3.12 only)                                |
+| `trt`     | `pip install "rfdetr[trt]"`         | TensorRT inference (pycuda, onnxruntime-gpu, tensorrt)          |
+| `kornia`  | `pip install "rfdetr[kornia]"`      | GPU-accelerated augmentations via Kornia                        |
 | `lora`    | `pip install "rfdetr[lora]"`        | LoRA fine-tuning with PEFT                                      |
+| `visual`  | `pip install "rfdetr[visual]"`      | Visualization utilities (matplotlib, pandas, seaborn)           |
+| `cli`     | `pip install "rfdetr[cli]"`         | CLI with typed argument parsing (jsonargparse)                  |
 | `plus`    | `pip install "rfdetr[plus]"`        | XLarge and 2XLarge detection models (PML 1.0 license)           |
 
 ## Additional Notes

--- a/docs/getting-started/migration.md
+++ b/docs/getting-started/migration.md
@@ -51,44 +51,44 @@ See the [Changelog](../changelog.md) for the full list of changes in each releas
         does **not** register the override and RF-DETR may still auto-align the schema from the
         checkpoint. Always pass it to the constructor.
 
-### Removed in v1.9
+### Planned for Removal in v1.9
 
-The following APIs were deprecated in earlier releases and have been removed in v1.9:
+The following APIs were deprecated in earlier releases and will be removed in v1.9. They still work in the current release (v1.8.x) but emit `DeprecationWarning`. Update your code before upgrading.
 
-!!! danger "Removed: `rfdetr.util.*` and `rfdetr.deploy.*` import paths"
+!!! warning "Planned for removal: `rfdetr.util.*` and `rfdetr.deploy.*` import paths"
 
     Deprecated since v1.6. Use the canonical replacements listed in the [Upgrade 1.5 → 1.6](#upgrade-15--16) section.
 
     ```python
-    # These imports now raise ImportError
+    # These imports still work in v1.8 but emit DeprecationWarning; update before v1.9
     from rfdetr.util.coco_classes import COCO_CLASSES  # → rfdetr.assets.coco_classes
     from rfdetr.util.misc import get_rank  # → rfdetr.utilities
     from rfdetr.deploy import export_onnx  # → rfdetr.export.main
     ```
 
-!!! danger "Removed: `build_namespace(model_config, train_config)`"
+!!! warning "Planned for removal: `build_namespace(model_config, train_config)`"
 
     Deprecated since v1.7. Use `build_model_from_config` and `build_criterion_from_config` instead.
 
-!!! danger "Removed: `load_pretrain_weights(nn_model, model_config, train_config)` with `train_config`"
+!!! warning "Planned for removal: `load_pretrain_weights(nn_model, model_config, train_config)` with `train_config`"
 
     Deprecated since v1.7. Drop the `train_config` positional argument.
 
-!!! danger "Removed: `start_epoch` kwarg in `train()`"
+!!! warning "Planned for removal: `start_epoch` kwarg in `train()`"
 
     Deprecated since v1.7. PyTorch Lightning resumes automatically via `resume=`.
 
-!!! danger "Removed: `do_benchmark` kwarg in `train()`"
+!!! warning "Planned for removal: `do_benchmark` kwarg in `train()`"
 
-    Deprecated since v1.7.
+    Deprecated since v1.7. Use the `rfdetr.export.benchmark` module instead.
 
-!!! danger "Removed: `callbacks` dict kwarg in `train()`"
+!!! warning "Planned for removal: `callbacks` dict kwarg in `train()`"
 
     Deprecated since v1.7. Pass PTL `Callback` objects directly via the Lightning API instead.
 
-!!! danger "Removed: misplaced config fields"
+!!! warning "Planned for removal: misplaced config fields"
 
-    The following `TrainConfig` and `ModelConfig` fields moved to their correct config class in v1.7 and the deprecated compatibility shims are now removed. Update any direct references:
+    The following `TrainConfig` and `ModelConfig` fields moved to their correct config class in v1.7 and the deprecated compatibility shims will be removed in v1.9. Update any direct references:
 
     | Field               | Removed from  | Use in        |
     | ------------------- | ------------- | ------------- |

--- a/docs/getting-started/migration.md
+++ b/docs/getting-started/migration.md
@@ -51,11 +51,75 @@ See the [Changelog](../changelog.md) for the full list of changes in each releas
         does **not** register the override and RF-DETR may still auto-align the schema from the
         checkpoint. Always pass it to the constructor.
 
+### Removed in v1.9
+
+The following APIs were deprecated in earlier releases and have been removed in v1.9:
+
+!!! danger "Removed: `rfdetr.util.*` and `rfdetr.deploy.*` import paths"
+
+    Deprecated since v1.6. Use the canonical replacements listed in the [Upgrade 1.5 → 1.6](#upgrade-15--16) section.
+
+    ```python
+    # These imports now raise ImportError
+    from rfdetr.util.coco_classes import COCO_CLASSES  # → rfdetr.assets.coco_classes
+    from rfdetr.util.misc import get_rank  # → rfdetr.utilities
+    from rfdetr.deploy import export_onnx  # → rfdetr.export.main
+    ```
+
+!!! danger "Removed: `build_namespace(model_config, train_config)`"
+
+    Deprecated since v1.7. Use `build_model_from_config` and `build_criterion_from_config` instead.
+
+!!! danger "Removed: `load_pretrain_weights(nn_model, model_config, train_config)` with `train_config`"
+
+    Deprecated since v1.7. Drop the `train_config` positional argument.
+
+!!! danger "Removed: `start_epoch` kwarg in `train()`"
+
+    Deprecated since v1.7. PyTorch Lightning resumes automatically via `resume=`.
+
+!!! danger "Removed: `do_benchmark` kwarg in `train()`"
+
+    Deprecated since v1.7.
+
+!!! danger "Removed: `callbacks` dict kwarg in `train()`"
+
+    Deprecated since v1.7. Pass PTL `Callback` objects directly via the Lightning API instead.
+
+!!! danger "Removed: misplaced config fields"
+
+    The following `TrainConfig` and `ModelConfig` fields moved to their correct config class in v1.7 and the deprecated compatibility shims are now removed. Update any direct references:
+
+    | Field               | Removed from  | Use in        |
+    | ------------------- | ------------- | ------------- |
+    | `group_detr`        | `TrainConfig` | `ModelConfig` |
+    | `ia_bce_loss`       | `TrainConfig` | `ModelConfig` |
+    | `segmentation_head` | `TrainConfig` | `ModelConfig` |
+    | `num_select`        | `TrainConfig` | `ModelConfig` |
+    | `cls_loss_coef`     | `ModelConfig` | `TrainConfig` |
+
 ---
 
 ## Upgrade 1.7 → 1.8
 
 ### Breaking changes
+
+!!! note "Breaking in v1.8.2: default keypoint schema changed to active-first `[17]`"
+
+    New checkpoints created from v1.8.2 onwards use `class_id=0` for person. Legacy `[0, 17]` checkpoints
+    are still supported — RF-DETR auto-detects the schema from the checkpoint at load time.
+
+    If your post-processing code offsets class IDs by 1 (common for background-first models), update it:
+
+    ```python
+    # Before (background-first [0, 17]: person was at class_id=1)
+    class_name = "person" if detection.class_id == 1 else "other"
+
+    # After (active-first [17]: person is at class_id=0)
+    class_name = "person" if detection.class_id == 0 else "other"
+    ```
+
+    Use `detection.data["class_name"]` for schema-agnostic name resolution.
 
 !!! warning "Breaking: `rfdetr.datasets.aug_config` renamed to `rfdetr.datasets.aug_configs`"
 
@@ -203,23 +267,21 @@ See the [Changelog](../changelog.md) for the full list of changes in each releas
 
 !!! note "Deprecated: `RFDETRSegPreview` replaced by size-specific segmentation classes"
 
-````
-**`RFDETRSegPreview`** defaulted to the small variant and is replaced by size-specific
-segmentation classes. If you used `RFDETRSegPreview()` without arguments, switch to
-`RFDETRSegSmall()`.
+    **`RFDETRSegPreview`** defaulted to the small variant and is replaced by size-specific
+    segmentation classes. If you used `RFDETRSegPreview()` without arguments, switch to
+    `RFDETRSegSmall()`.
 
-```python
-# Before (deprecated)
-from rfdetr import RFDETRSegPreview
+    ```python
+    # Before (deprecated)
+    from rfdetr import RFDETRSegPreview
 
-model = RFDETRSegPreview()
+    model = RFDETRSegPreview()
 
-# After — pick one
-from rfdetr import RFDETRSegNano, RFDETRSegSmall, RFDETRSegMedium, RFDETRSegLarge
+    # After — pick one
+    from rfdetr import RFDETRSegNano, RFDETRSegSmall, RFDETRSegMedium, RFDETRSegLarge
 
-model = RFDETRSegSmall()
-```
-````
+    model = RFDETRSegSmall()
+    ```
 
 ---
 
@@ -369,5 +431,5 @@ model = RFDETRSegSmall()
     from rfdetr import OPEN_SOURCE_MODELS
 
     # After
-    from rfdetr import ModelWeights
+    from rfdetr.assets.model_weights import ModelWeights
     ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -164,7 +164,7 @@ RF-DETR achieves the best accuracy–latency trade-off among real-time object de
 RF-DETR (Roboflow Detection Transformer) is a real-time object detection and instance segmentation model from Roboflow, accepted at ICLR 2026. It uses a DINOv2 vision transformer backbone and achieves state-of-the-art accuracy–latency trade-offs on COCO (60.1 AP50:95 for RF-DETR-2XL) and RF100-VL.
 
 **How does RF-DETR compare to YOLOv11?**
-RF-DETR-L achieves 56.5 AP50:95 on COCO at 6.8 ms latency on an NVIDIA T4, outperforming YOLOv11x (54.7 AP) at lower latency. The DINOv2 backbone gives RF-DETR stronger performance on domain-shift benchmarks such as RF100-VL.
+RF-DETR-L achieves 56.5 AP50:95 on COCO at 6.8 ms latency on an NVIDIA T4, outperforming YOLOv11x (50.9 AP) at lower latency. The DINOv2 backbone gives RF-DETR stronger performance on domain-shift benchmarks such as RF100-VL.
 
 **What GPU is required to train RF-DETR?**
 A CUDA-capable GPU with at least 8 GB VRAM (e.g., NVIDIA RTX 3060, T4, A10) is recommended for fine-tuning. Smaller models (RF-DETR-N and RF-DETR-S) can fit in 6 GB VRAM with reduced batch size. CPU inference is supported for evaluation.

--- a/docs/learn/benchmarks.md
+++ b/docs/learn/benchmarks.md
@@ -7,7 +7,7 @@ description: RF-DETR benchmark results on COCO and RF100-VL for detection, segme
 !!! tip "Key Takeaways"
 
     - RF-DETR-2XL achieves 60.1 AP50:95 on COCO detection at 17.2 ms latency (T4, TensorRT FP16)
-    - RF-DETR-L outperforms YOLOv11x (56.5 vs 54.7 AP50:95) at lower latency (6.8 vs 10.5 ms)
+    - RF-DETR-L outperforms YOLOv11x (56.5 vs 50.9 AP50:95) at lower latency (6.8 vs 10.5 ms)
     - Segmentation models range from 40.3 AP (Nano, 3.4 ms) to 49.9 AP (2XL, 21.8 ms) on COCO
     - All latency measured on NVIDIA T4 with TensorRT 10.4, CUDA 12.4, FP16, batch size 1
     - RF100-VL results demonstrate strong domain-shift generalization across 100 diverse datasets

--- a/docs/learn/export.md
+++ b/docs/learn/export.md
@@ -10,7 +10,7 @@ description: Export RF-DETR models to ONNX, TensorRT, and TFLite (FP32/FP16/INT8
     - Export to TFLite (FP32, FP16, INT8) for mobile and edge deployment
     - TensorRT conversion delivers lowest latency on NVIDIA GPUs (2.3 ms for Nano)
     - INT8 quantization requires calibration data from your dataset for accurate results
-    - Custom input resolutions supported (must be divisible by 14)
+    - Custom input resolutions supported (must be divisible by `patch_size × num_windows`, which varies by model variant)
 
 RF-DETR supports exporting models to ONNX and TFLite formats, enabling deployment across a wide range of inference frameworks, edge devices, and hardware accelerators.
 
@@ -63,14 +63,15 @@ The `export()` method accepts several parameters to customize the export process
 | `quantization`     | `None`     | TFLite quantization mode: `None`/`"fp32"`, `"fp16"`, or `"int8"`. Only used when `format="tflite"`.                                                                                             |
 | `calibration_data` | `None`     | Calibration data for TFLite export. Image directory, `.npy` file path, NumPy array, or `None`. See [TFLite Export](#tflite-export).                                                             |
 | `max_images`       | `100`      | Maximum number of images to load from a calibration directory for TFLite INT8 quantization. Ignored for other calibration data formats.                                                         |
-| `infer_dir`        | `None`     | Path to an image file to use for tracing. If not provided, a random dummy image is generated.                                                                                                   |
-| `simplify`         | `False`    | Deprecated and ignored. ONNX simplification is no longer run by `export()`.                                                                                                                     |
+| `infer_dir`        | `None`     | Optional directory of sample images for inference validation during export tracing. If not provided, a random dummy image is generated.                                                         |
 | `backbone_only`    | `False`    | Export only the backbone feature extractor instead of the full model.                                                                                                                           |
 | `opset_version`    | `17`       | ONNX opset version to use for export. Higher versions support more operations.                                                                                                                  |
 | `verbose`          | `True`     | Whether to print verbose export information.                                                                                                                                                    |
-| `force`            | `False`    | Deprecated and ignored.                                                                                                                                                                         |
 | `shape`            | `None`     | Input shape as tuple `(height, width)`. Each dimension must be divisible by the selected model's block size (`patch_size * num_windows`). If not provided, uses the model's default resolution. |
 | `batch_size`       | `1`        | Batch size for the exported model.                                                                                                                                                              |
+| `dynamic_batch`    | `False`    | If `True`, export with a dynamic batch dimension so the ONNX model accepts variable batch sizes at runtime.                                                                                     |
+| `patch_size`       | `None`     | Backbone patch size override. Defaults to the value from `model_config.patch_size`. Must match the instantiated model's patch size when provided.                                               |
+| `notes`            | `None`     | Optional user-defined metadata (string, dict, list, or any JSON-serialisable value) to embed in the exported ONNX model under the `"rfdetr_notes"` metadata property.                           |
 
 ## Advanced Export Examples
 
@@ -82,18 +83,6 @@ from rfdetr import RFDETRMedium
 model = RFDETRMedium(pretrain_weights="<path/to/checkpoint.pth>")
 
 model.export(output_dir="exports/my_model")
-```
-
-### Deprecated: Export with Simplification
-
-The `simplify` flag is deprecated and ignored:
-
-```python
-from rfdetr import RFDETRMedium
-
-model = RFDETRMedium(pretrain_weights="<path/to/checkpoint.pth>")
-
-model.export(simplify=True)  # Deprecated: same result as model.export()
 ```
 
 ### Export with Custom Resolution
@@ -201,9 +190,9 @@ pip install "rfdetr[onnx,tflite]"
 === "Object Detection"
 
     ```python
-    from rfdetr import RFDETRBase
+    from rfdetr import RFDETRSmall
 
-    model = RFDETRBase()
+    model = RFDETRSmall()
 
     model.export(format="tflite", output_dir="output")
     ```
@@ -266,10 +255,10 @@ Prepare calibration data as a NumPy array and save it to a `.npy` file:
 ```python
 import numpy as np
 from PIL import Image
-from rfdetr import RFDETRBase
+from rfdetr import RFDETRSmall
 
-model = RFDETRBase()
-target_resolution = model.resolution
+model = RFDETRSmall()
+target_resolution = model.model_config.resolution
 
 # Load representative images from your dataset
 images = []

--- a/docs/learn/run/detection.md
+++ b/docs/learn/run/detection.md
@@ -117,9 +117,10 @@ These examples use OpenCV for decoding and display. Replace `<SOURCE_VIDEO_PATH>
 
     model = RFDETRMedium()
 
-    video_capture = cv2.VideoCapture("<WEBCAM_INDEX>")
+    WEBCAM_INDEX = 0
+    video_capture = cv2.VideoCapture(WEBCAM_INDEX)
     if not video_capture.isOpened():
-        raise RuntimeError("Failed to open webcam: <WEBCAM_INDEX>")
+        raise RuntimeError(f"Failed to open webcam: {WEBCAM_INDEX}")
 
     while True:
         success, frame_bgr = video_capture.read()

--- a/docs/learn/train/advanced.md
+++ b/docs/learn/train/advanced.md
@@ -292,12 +292,19 @@ model.train(dataset_dir="path/to/dataset", aug_config={})
 
 ### Gradient Checkpointing
 
-For large models or high resolutions, enable gradient checkpointing to trade compute for memory:
+For large models or high resolutions, enable gradient checkpointing to trade compute for memory.
+
+!!! warning "Constructor parameter — not a `train()` parameter"
+
+    `gradient_checkpointing` is a `ModelConfig` field and must be passed to the **model constructor**, not to `train()`. Passing it to `train()` will raise a `ValidationError` because `TrainConfig` has `extra="forbid"`.
 
 ```python
+from rfdetr import RFDETRMedium
+
+model = RFDETRMedium(gradient_checkpointing=True)
+
 model.train(
     dataset_dir="path/to/dataset",
-    gradient_checkpointing=True,
     batch_size=2,  # May be able to increase with checkpointing
 )
 ```
@@ -355,7 +362,7 @@ These are automatically configured and don't require manual setup.
 If you encounter CUDA out of memory errors:
 
 1. Reduce `batch_size`
-2. Enable `gradient_checkpointing=True`
+2. Enable `gradient_checkpointing=True` (pass to the model constructor, not `train()`)
 3. Reduce `resolution`
 4. Increase `grad_accum_steps` to maintain effective batch size
 

--- a/docs/learn/train/customization.md
+++ b/docs/learn/train/customization.md
@@ -114,18 +114,18 @@ trainer = build_trainer(train_config, model_config)
 
 ### What build_trainer configures
 
-| Concern               | Source                                                                                                                                                                     |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Max epochs            | `train_config.epochs`                                                                                                                                                      |
-| Gradient accumulation | Detection/segmentation: `train_config.grad_accum_steps` forwarded to Trainer. Keypoint models: owned by `RFDETRModelModule` manual optimization (Trainer always sees `1`). |
-| Gradient clipping     | Detection/segmentation: `train_config.clip_max_norm` forwarded to Trainer. Keypoint models: owned by `RFDETRModelModule` manual optimization (Trainer always sees `None`). |
-| Mixed precision       | `model_config.amp` enables AMP; dtype resolved from `train_config.amp_dtype` (`"auto"` selects `bf16-mixed` on Ampere+, `"bf16"` / `"fp16"` force a specific dtype)        |
-| Accelerator           | `train_config.accelerator` (default `"auto"`)                                                                                                                              |
-| Strategy              | Pass `strategy=` as a `**trainer_kwarg` to `build_trainer`. `TrainConfig` has no `strategy` field — setting it on `TrainConfig` will raise a `ValueError`.                 |
-| Sync batch norm       | `train_config.sync_bn`                                                                                                                                                     |
-| Progress bar          | `train_config.progress_bar`                                                                                                                                                |
-| Loggers               | CSVLogger always; TensorBoard, WandB, MLflow when their `train_config` flags are `True`                                                                                    |
-| Callbacks             | `RFDETREMACallback`, `DropPathCallback`, `COCOEvalCallback`, `BestModelCallback`, `RFDETREarlyStopping` (conditional)                                                      |
+| Concern               | Source                                                                                                                                                                                                                                                         |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Max epochs            | `train_config.epochs`                                                                                                                                                                                                                                          |
+| Gradient accumulation | Detection/segmentation: `train_config.grad_accum_steps` forwarded to Trainer. Keypoint models: owned by `RFDETRModelModule` manual optimization (Trainer always sees `1`).                                                                                     |
+| Gradient clipping     | Detection/segmentation: `train_config.clip_max_norm` forwarded to Trainer. Keypoint models: owned by `RFDETRModelModule` manual optimization (Trainer always sees `None`).                                                                                     |
+| Mixed precision       | `model_config.amp` enables AMP; dtype resolved from `train_config.amp_dtype` (`"auto"` selects `bf16-mixed` on Ampere+, `"bf16"` / `"fp16"` force a specific dtype)                                                                                            |
+| Accelerator           | `train_config.accelerator` (default `"auto"`)                                                                                                                                                                                                                  |
+| Strategy              | Set via `train_config.strategy` (default `"auto"`) or pass `strategy=` as a `**trainer_kwarg` to `build_trainer`. Common values: `"auto"`, `"ddp"`, `"ddp_spawn"`. `TrainConfig` also exposes `devices` and `num_nodes` for multi-GPU and multi-node training. |
+| Sync batch norm       | `train_config.sync_bn`                                                                                                                                                                                                                                         |
+| Progress bar          | `train_config.progress_bar`                                                                                                                                                                                                                                    |
+| Loggers               | CSVLogger always; TensorBoard, WandB, MLflow when their `train_config` flags are `True`                                                                                                                                                                        |
+| Callbacks             | `RFDETREMACallback`, `DropPathCallback`, `COCOEvalCallback`, `BestModelCallback`, `RFDETREarlyStopping` (conditional)                                                                                                                                          |
 
 ### Overriding PTL Trainer kwargs
 

--- a/docs/learn/train/index.md
+++ b/docs/learn/train/index.md
@@ -30,6 +30,16 @@ Both paths run the same underlying PyTorch Lightning stack. `RFDETR.train()` con
 
 ## Quick Start
 
+!!! info "Training requires the `train` extra"
+
+    Training dependencies are not included in the base install. Install them with:
+
+    ```bash
+    pip install "rfdetr[train]"
+    ```
+
+    For experiment tracking, also add `pip install "rfdetr[train,loggers]"`.
+
 RF-DETR supports training on datasets in both **COCO** and **YOLO** formats. The format is automatically detected based on the structure of your dataset directory.
 
 === "Object Detection"
@@ -85,7 +95,7 @@ RF-DETR supports training on datasets in both **COCO** and **YOLO** formats. The
 
 Different GPUs have different VRAM capacities, so adjust batch_size and grad_accum_steps to maintain a total batch size of 16. For example, on a powerful GPU like the A100, use `batch_size=16` and `grad_accum_steps=1`; on smaller GPUs like the T4, use `batch_size=4` and `grad_accum_steps=4`. This gradient accumulation strategy helps train effectively even with limited memory.
 
-For object detection, the RF-DETR-B checkpoint is used by default. To get started quickly with training an object detection model, please refer to our fine-tuning Google Colab [notebook](https://colab.research.google.com/github/roboflow-ai/notebooks/blob/main/notebooks/how-to-finetune-rf-detr-on-detection-dataset.ipynb).
+Each model class downloads its COCO-pretrained checkpoint automatically when instantiated. To get started quickly with training an object detection model, please refer to our fine-tuning Google Colab [notebook](https://colab.research.google.com/github/roboflow-ai/notebooks/blob/main/notebooks/how-to-finetune-rf-detr-on-detection-dataset.ipynb).
 
 ## Keypoint preview custom datasets
 

--- a/docs/learn/train/training-parameters.md
+++ b/docs/learn/train/training-parameters.md
@@ -27,14 +27,14 @@ model.train(
 
 These are the essential parameters for training:
 
-| Parameter          | Type  | Default    | Description                                                                                                                     |
-| ------------------ | ----- | ---------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `dataset_dir`      | `str` | Required   | Path to your dataset directory. RF-DETR auto-detects if it's in COCO or YOLO format. See [Dataset Formats](dataset-formats.md). |
-| `output_dir`       | `str` | `"output"` | Directory where training artifacts (checkpoints, logs) are saved.                                                               |
-| `epochs`           | `int` | `100`      | Number of full passes over the training dataset.                                                                                |
-| `batch_size`       | `int` | `4`        | Number of samples processed per iteration. Higher values require more GPU memory.                                               |
-| `grad_accum_steps` | `int` | `4`        | Accumulates gradients over multiple mini-batches. Use with `batch_size` to achieve effective batch size.                        |
-| `resume`           | `str` | `None`     | Path to a saved checkpoint to continue training. Restores model weights, optimizer state, and scheduler.                        |
+| Parameter          | Type            | Default    | Description                                                                                                                                                       |
+| ------------------ | --------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dataset_dir`      | `str`           | Required   | Path to your dataset directory. RF-DETR auto-detects if it's in COCO or YOLO format. See [Dataset Formats](dataset-formats.md).                                   |
+| `output_dir`       | `str`           | `"output"` | Directory where training artifacts (checkpoints, logs) are saved.                                                                                                 |
+| `epochs`           | `int`           | `100`      | Number of full passes over the training dataset.                                                                                                                  |
+| `batch_size`       | `int or "auto"` | `4`        | Number of samples processed per iteration. Higher values require more GPU memory. Set to `"auto"` to probe the GPU for the largest safe batch size automatically. |
+| `grad_accum_steps` | `int`           | `4`        | Accumulates gradients over multiple mini-batches. Use with `batch_size` to achieve effective batch size.                                                          |
+| `resume`           | `str`           | `None`     | Path to a saved checkpoint to continue training. Restores model weights, optimizer state, and scheduler.                                                          |
 
 ### Understanding Batch Size
 
@@ -88,10 +88,10 @@ For example, `RFDETRSegXLarge` uses `624x624`, which is valid because `624` is d
 
 ## Hardware Parameters
 
-| Parameter                | Type   | Default  | Description                                                                                                                           |
-| ------------------------ | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `device`                 | `str`  | `"cuda"` | Device to run training on. Options: `"cuda"`, `"cpu"`, `"mps"` (Apple Silicon).                                                       |
-| `gradient_checkpointing` | `bool` | `False`  | Re-computes parts of the forward pass during backpropagation to reduce memory usage. Lowers memory needs but increases training time. |
+| Parameter                | Type   | Default | Description                                                                                                                                                                                                                                    |
+| ------------------------ | ------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `device`                 | `str`  | `None`  | Device to run training on. `None` means auto-detected by PyTorch Lightning. Options: `"cuda"`, `"cpu"`, `"mps"` (Apple Silicon).                                                                                                               |
+| `gradient_checkpointing` | `bool` | `False` | **Constructor-only parameter** — pass to the model constructor (`RFDETRMedium(gradient_checkpointing=True)`), not to `train()`. Re-computes activations during backprop to reduce memory usage by ~30-40% at the cost of ~20% slower training. |
 
 ## EMA (Exponential Moving Average)
 
@@ -199,7 +199,7 @@ These parameters apply when training `RFDETRKeypointPreview` on COCO keypoint an
 
 | Parameter                     | Type                  | Default | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | ----------------------------- | --------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `num_keypoints_per_class`     | `list[int]`           | `[17]`  | Keypoint schema by model label slot. A zero entry marks a detection-only class slot; legacy checkpoints may use a background-first `[0, 17]` schema.                                                                                                                                                                                                                                                                                                                                                      |
+| `num_keypoints_per_class`     | `list[int]`           | `[17]`  | **Constructor parameter** — pass to `RFDETRKeypointPreview(num_keypoints_per_class=...)`. Keypoint schema by model label slot. A zero entry marks a detection-only class slot; legacy checkpoints may use a background-first `[0, 17]` schema.                                                                                                                                                                                                                                                            |
 | `keypoint_flip_pairs`         | `list[int]`           | `[]`    | Flat left/right keypoint index pairs used to swap joints after horizontal-flip augmentation. YOLO `flip_idx` metadata is a permutation; RF-DETR converts it to this pair-list form during automatic schema inference when possible — it extracts only symmetric mutual pairs where `flip_idx[i] == j` and `flip_idx[j] == i`. Asymmetric entries and self-mapped keypoints (`flip_idx[i] == i`) are silently omitted; supply `keypoint_flip_pairs` explicitly when your `flip_idx` includes such entries. |
 | `keypoint_l1_loss_coef`       | `float`               | `1.0`   | Weight for keypoint coordinate L1 loss in keypoint preview training.                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | `keypoint_findable_loss_coef` | `float`               | `1.0`   | Weight for keypoint findable/objectness loss.                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
@@ -246,43 +246,43 @@ The parameters below are available for fine-grained control over training behavi
 
 Below is a summary table of all training parameters:
 
-| Parameter                  | Type                | Default        | Description                                                                              |
-| -------------------------- | ------------------- | -------------- | ---------------------------------------------------------------------------------------- |
-| `dataset_dir`              | str                 | Required       | Path to COCO or YOLO formatted dataset with train/valid/test splits.                     |
-| `output_dir`               | str                 | "output"       | Directory for checkpoints, logs, and other training artifacts.                           |
-| `epochs`                   | int                 | 100            | Number of full passes over the dataset.                                                  |
-| `batch_size`               | int                 | 4              | Samples per iteration. Balance with `grad_accum_steps`.                                  |
-| `grad_accum_steps`         | int                 | 4              | Gradient accumulation steps for effective larger batch sizes.                            |
-| `lr`                       | float               | 1e-4           | Learning rate for the model (excluding encoder).                                         |
-| `lr_encoder`               | float               | 1.5e-4         | Learning rate for the backbone encoder.                                                  |
-| `resolution`               | int                 | Model-specific | Input image size (must be divisible by the selected model's `patch_size * num_windows`). |
-| `weight_decay`             | float               | 1e-4           | L2 regularization coefficient.                                                           |
-| `device`                   | str                 | "cuda"         | Training device: cuda, cpu, or mps.                                                      |
-| `use_ema`                  | bool                | True           | Enable Exponential Moving Average of weights.                                            |
-| `gradient_checkpointing`   | bool                | False          | Trade compute for memory during backprop.                                                |
-| `checkpoint_interval`      | int                 | 10             | Save checkpoint every N epochs.                                                          |
-| `resume`                   | str                 | None           | Path to checkpoint for resuming training.                                                |
-| `tensorboard`              | bool                | True           | Enable TensorBoard logging.                                                              |
-| `wandb`                    | bool                | False          | Enable Weights & Biases logging.                                                         |
-| `project`                  | str                 | None           | W&B project name.                                                                        |
-| `run`                      | str                 | None           | W&B run name.                                                                            |
-| `early_stopping`           | bool                | False          | Enable early stopping.                                                                   |
-| `early_stopping_patience`  | int                 | 10             | Epochs without improvement before stopping.                                              |
-| `early_stopping_min_delta` | float               | 0.001          | Minimum validation metric change to qualify as improvement.                              |
-| `early_stopping_use_ema`   | bool                | False          | Use EMA model for early stopping metrics.                                                |
-| `eval_max_dets`            | int                 | 500            | Maximum detections per image considered during COCO evaluation.                          |
-| `eval_interval`            | int                 | 1              | Run COCO evaluation every N epochs.                                                      |
-| `log_per_class_metrics`    | bool                | True           | Log per-class AP metrics to the console and loggers.                                     |
-| `progress_bar`             | str \| bool \| None | None           | Progress bar style: `"tqdm"`, `"rich"`, or `None`. Legacy booleans are still accepted.   |
-| `accelerator`              | str                 | "auto"         | PyTorch Lightning accelerator. "auto" selects GPU/MPS/CPU automatically.                 |
-| `seed`                     | int                 | None           | Random seed for reproducibility. None means no fixed seed.                               |
-| `lr_scheduler`             | str                 | "step"         | Learning rate scheduler type: "step" or "cosine".                                        |
-| `lr_min_factor`            | float               | 0.0            | Minimum LR as a fraction of the initial LR (cosine scheduler floor).                     |
-| `warmup_epochs`            | float               | 0.0            | Number of linear warmup epochs at the start of training.                                 |
-| `drop_path`                | float               | 0.0            | Stochastic depth drop-path rate for the backbone.                                        |
-| `compute_val_loss`         | bool                | True           | Compute and log loss during validation.                                                  |
-| `compute_test_loss`        | bool                | True           | Compute and log loss during the test run.                                                |
-| `fp16_eval`                | bool                | False          | Run evaluation in FP16 precision to reduce memory usage.                                 |
-| `pin_memory`               | bool                | None           | Pin DataLoader memory. None defers to PyTorch Lightning's default.                       |
-| `persistent_workers`       | bool                | None           | Keep DataLoader workers alive between epochs. None uses PTL default.                     |
-| `prefetch_factor`          | int                 | None           | Number of batches prefetched per worker. None uses PyTorch default.                      |
+| Parameter                  | Type                | Default        | Description                                                                                                                           |
+| -------------------------- | ------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `dataset_dir`              | str                 | Required       | Path to COCO or YOLO formatted dataset with train/valid/test splits.                                                                  |
+| `output_dir`               | str                 | "output"       | Directory for checkpoints, logs, and other training artifacts.                                                                        |
+| `epochs`                   | int                 | 100            | Number of full passes over the dataset.                                                                                               |
+| `batch_size`               | int or "auto"       | 4              | Samples per iteration. Set to `"auto"` to let RF-DETR probe the GPU for the largest safe batch size. Balance with `grad_accum_steps`. |
+| `grad_accum_steps`         | int                 | 4              | Gradient accumulation steps for effective larger batch sizes.                                                                         |
+| `lr`                       | float               | 1e-4           | Learning rate for the model (excluding encoder).                                                                                      |
+| `lr_encoder`               | float               | 1.5e-4         | Learning rate for the backbone encoder.                                                                                               |
+| `resolution`               | int                 | Model-specific | Input image size (must be divisible by the selected model's `patch_size * num_windows`).                                              |
+| `weight_decay`             | float               | 1e-4           | L2 regularization coefficient.                                                                                                        |
+| `device`                   | str                 | "cuda"         | Training device: cuda, cpu, or mps.                                                                                                   |
+| `use_ema`                  | bool                | True           | Enable Exponential Moving Average of weights.                                                                                         |
+| `gradient_checkpointing`   | bool                | False          | Trade compute for memory during backprop.                                                                                             |
+| `checkpoint_interval`      | int                 | 10             | Save checkpoint every N epochs.                                                                                                       |
+| `resume`                   | str                 | None           | Path to checkpoint for resuming training.                                                                                             |
+| `tensorboard`              | bool                | True           | Enable TensorBoard logging.                                                                                                           |
+| `wandb`                    | bool                | False          | Enable Weights & Biases logging.                                                                                                      |
+| `project`                  | str                 | None           | W&B project name.                                                                                                                     |
+| `run`                      | str                 | None           | W&B run name.                                                                                                                         |
+| `early_stopping`           | bool                | False          | Enable early stopping.                                                                                                                |
+| `early_stopping_patience`  | int                 | 10             | Epochs without improvement before stopping.                                                                                           |
+| `early_stopping_min_delta` | float               | 0.001          | Minimum validation metric change to qualify as improvement.                                                                           |
+| `early_stopping_use_ema`   | bool                | False          | Use EMA model for early stopping metrics.                                                                                             |
+| `eval_max_dets`            | int                 | 500            | Maximum detections per image considered during COCO evaluation.                                                                       |
+| `eval_interval`            | int                 | 1              | Run COCO evaluation every N epochs.                                                                                                   |
+| `log_per_class_metrics`    | bool                | True           | Log per-class AP metrics to the console and loggers.                                                                                  |
+| `progress_bar`             | str \| bool \| None | None           | Progress bar style: `"tqdm"`, `"rich"`, or `None`. Legacy booleans are still accepted.                                                |
+| `accelerator`              | str                 | "auto"         | PyTorch Lightning accelerator. "auto" selects GPU/MPS/CPU automatically.                                                              |
+| `seed`                     | int                 | None           | Random seed for reproducibility. None means no fixed seed.                                                                            |
+| `lr_scheduler`             | str                 | "step"         | Learning rate scheduler type: "step" or "cosine".                                                                                     |
+| `lr_min_factor`            | float               | 0.0            | Minimum LR as a fraction of the initial LR (cosine scheduler floor).                                                                  |
+| `warmup_epochs`            | float               | 0.0            | Number of linear warmup epochs at the start of training.                                                                              |
+| `drop_path`                | float               | 0.0            | Stochastic depth drop-path rate for the backbone.                                                                                     |
+| `compute_val_loss`         | bool                | True           | Compute and log loss during validation.                                                                                               |
+| `compute_test_loss`        | bool                | True           | Compute and log loss during the test run.                                                                                             |
+| `fp16_eval`                | bool                | False          | Run evaluation in FP16 precision to reduce memory usage.                                                                              |
+| `pin_memory`               | bool                | None           | Pin DataLoader memory. None defers to PyTorch Lightning's default.                                                                    |
+| `persistent_workers`       | bool                | None           | Keep DataLoader workers alive between epochs. None uses PTL default.                                                                  |
+| `prefetch_factor`          | int                 | None           | Number of batches prefetched per worker. None uses PyTorch default.                                                                   |

--- a/docs/reference/training.md
+++ b/docs/reference/training.md
@@ -96,6 +96,14 @@ This page documents the training primitives that power RF-DETR. For a narrative 
 
 ## RFDETRCli
 
+!!! info "CLI requires the `train` and `cli` extras"
+
+    ```bash
+    pip install "rfdetr[train,cli]"
+    ```
+
+    The `rfdetr` console script and its `--config` / `--print_config` flags are provided by `jsonargparse`, which is included in the `cli` extra.
+
 `RFDETRCli` is the command-line entry point for RF-DETR. It wraps
 `RFDETRModelModule` and `RFDETRDataModule` under a single `rfdetr` command and
 auto-generates four subcommands from the PyTorch Lightning CLI machinery:

--- a/docs/root-static/llms-full.txt
+++ b/docs/root-static/llms-full.txt
@@ -81,8 +81,8 @@ detections = model.predict("image.jpg", threshold=0.5)
 - `RFDETRSegSmall` — 4.4 ms, 66.2 AP50, 33.7M params, 384×384
 - `RFDETRSegMedium` — 5.9 ms, 68.4 AP50, 35.7M params, 432×432
 - `RFDETRSegLarge` — 8.8 ms, 70.5 AP50 (47.1 AP50:95), 36.2M params, 504×504
-- `RFDETRSegXLarge` — 13.5 ms, 72.2 AP50, 38.1M params, 624×624 (requires rfdetr[plus])
-- `RFDETRSeg2XLarge` — 21.8 ms, 73.1 AP50 (49.9 AP50:95), 38.6M params, 768×768 (requires rfdetr[plus])
+- `RFDETRSegXLarge` — 13.5 ms, 72.2 AP50, 38.1M params, 624×624
+- `RFDETRSeg2XLarge` — 21.8 ms, 73.1 AP50 (49.9 AP50:95), 38.6M params, 768×768
 
 Segmentation models output instance masks in addition to bounding boxes. Masks are returned as a `torch.Tensor` or dict with `spatial_features`, `query_features`, and `bias` keys.
 

--- a/docs/root-static/llms.txt
+++ b/docs/root-static/llms.txt
@@ -18,7 +18,7 @@
 - License: Apache 2.0 for code and core Nano through Large models; XLarge and 2XLarge detection models require `rfdetr[plus]` and PML 1.0
 
 ## Getting Started
-- [Install](https://rfdetr.roboflow.com/latest/learn/install/): pip install rfdetr
+- [Install](https://rfdetr.roboflow.com/latest/getting-started/install/): pip install rfdetr
 - [Run Detection](https://rfdetr.roboflow.com/latest/learn/run/detection/): Run RF-DETR detection on images, video, webcam, and streams
 - [Run Segmentation](https://rfdetr.roboflow.com/latest/learn/run/segmentation/): Run RF-DETR Seg instance segmentation on images and video
 - [Pretrained Models](https://rfdetr.roboflow.com/latest/learn/pretrained/): Nano, Small, Medium, Large, XLarge, and 2XLarge checkpoints

--- a/src/rfdetr/datasets/coco.py
+++ b/src/rfdetr/datasets/coco.py
@@ -490,13 +490,12 @@ def _build_train_resize_config(
                 ]
             }
         }
-        # DETR recipe: resize the short side to 400/500/600, take a random-position crop *at native resolution*
-        # (no intermediate resize-to-square), then resize once to the target scale. ``RandomCrop`` preserves the
-        # cropped resolution (unlike ``RandomSizedCrop``, which rescales to a fixed square), and a ``OneOf`` over
-        # non-square (height, width) pairs restores the independent-side sampling of DETR's ``RandomSizeCrop``.
-        # Crop sides are bounded by 400 -- the smallest possible short side after the first ``SmallestMaxSize`` --
-        # so a crop never exceeds the image (the earlier ``min_max_height`` upper bound of 600 could).
-        crop_sizes = [(384, 384), (384, 400), (400, 384), (400, 400)]
+        # DETR-style crop branch: resize the short side to 400/500/600, then take a ``RandomSizedCrop`` that resizes
+        # the crop *directly* to the target scale (via a per-scale ``OneOf``, mirroring the square path). This removes
+        # the previous fixed 384x384 intermediate hop -- the crop was resampled to 384 and then resized again to the
+        # target, a wasteful downscale-then-upscale. ``min_max_height`` is clamped to [384, 400] so the sampled crop
+        # never exceeds the smallest possible short side (400) after the first ``SmallestMaxSize``; the earlier upper
+        # bound of 600 could exceed the image and degenerate to a full-image resize.
         option_b = {
             "Sequential": {
                 "transforms": [
@@ -504,12 +503,11 @@ def _build_train_resize_config(
                     {
                         "OneOf": {
                             "transforms": [
-                                {"RandomCrop": {"height": crop_h, "width": crop_w}} for crop_h, crop_w in crop_sizes
+                                {"RandomSizedCrop": {"min_max_height": [384, 400], "height": s, "width": s}}
+                                for s in scales
                             ],
                         }
                     },
-                    {"SmallestMaxSize": {"max_size": size_param}},
-                    {"LongestMaxSize": {"max_size": cap}},
                 ]
             }
         }

--- a/src/rfdetr/datasets/coco.py
+++ b/src/rfdetr/datasets/coco.py
@@ -490,11 +490,24 @@ def _build_train_resize_config(
                 ]
             }
         }
+        # DETR recipe: resize the short side to 400/500/600, take a random-position crop *at native resolution*
+        # (no intermediate resize-to-square), then resize once to the target scale. ``RandomCrop`` preserves the
+        # cropped resolution (unlike ``RandomSizedCrop``, which rescales to a fixed square), and a ``OneOf`` over
+        # non-square (height, width) pairs restores the independent-side sampling of DETR's ``RandomSizeCrop``.
+        # Crop sides are bounded by 400 -- the smallest possible short side after the first ``SmallestMaxSize`` --
+        # so a crop never exceeds the image (the earlier ``min_max_height`` upper bound of 600 could).
+        crop_sizes = [(384, 384), (384, 400), (400, 384), (400, 400)]
         option_b = {
             "Sequential": {
                 "transforms": [
                     {"SmallestMaxSize": {"max_size": [400, 500, 600]}},
-                    {"RandomSizedCrop": {"min_max_height": [384, 600], "height": 384, "width": 384}},
+                    {
+                        "OneOf": {
+                            "transforms": [
+                                {"RandomCrop": {"height": crop_h, "width": crop_w}} for crop_h, crop_w in crop_sizes
+                            ],
+                        }
+                    },
                     {"SmallestMaxSize": {"max_size": size_param}},
                     {"LongestMaxSize": {"max_size": cap}},
                 ]
@@ -580,7 +593,7 @@ def make_coco_transforms(
     if image_set == "train":
         resolved_aug_config = aug_config if aug_config is not None else AUG_CONFIG
         resize_wrappers = AlbumentationsWrapper.from_config(
-            _build_train_resize_config(scales, square=False, max_size=1333)
+            _build_train_resize_config(scales, square=False, max_size=1333), strict=True
         )
         pipeline = [*resize_wrappers]
         if not gpu_postprocess:
@@ -598,11 +611,14 @@ def make_coco_transforms(
             [
                 {"SmallestMaxSize": {"max_size": resolution}},
                 {"LongestMaxSize": {"max_size": 1333}},
-            ]
+            ],
+            strict=True,
         )
         return Compose([*resize_wrappers, to_image, to_float, normalize])
     if image_set == "val_speed":
-        resize_wrappers = AlbumentationsWrapper.from_config([{"Resize": {"height": resolution, "width": resolution}}])
+        resize_wrappers = AlbumentationsWrapper.from_config(
+            [{"Resize": {"height": resolution, "width": resolution}}], strict=True
+        )
         return Compose([*resize_wrappers, to_image, to_float, normalize])
 
     raise ValueError(f"unknown {image_set}")
@@ -669,7 +685,9 @@ def make_coco_transforms_square_div_64(
 
     if image_set == "train":
         resolved_aug_config = aug_config if aug_config is not None else AUG_CONFIG
-        resize_wrappers = AlbumentationsWrapper.from_config(_build_train_resize_config(scales, square=True))
+        resize_wrappers = AlbumentationsWrapper.from_config(
+            _build_train_resize_config(scales, square=True), strict=True
+        )
         pipeline = [*resize_wrappers]
         if not gpu_postprocess:
             aug_wrappers = AlbumentationsWrapper.from_config(
@@ -682,7 +700,9 @@ def make_coco_transforms_square_div_64(
         return Compose(pipeline)
 
     if image_set in ("val", "test", "val_speed"):
-        resize_wrappers = AlbumentationsWrapper.from_config([{"Resize": {"height": resolution, "width": resolution}}])
+        resize_wrappers = AlbumentationsWrapper.from_config(
+            [{"Resize": {"height": resolution, "width": resolution}}], strict=True
+        )
         return Compose([*resize_wrappers, to_image, to_float, normalize])
 
     raise ValueError(f"unknown {image_set}")

--- a/src/rfdetr/datasets/coco.py
+++ b/src/rfdetr/datasets/coco.py
@@ -493,9 +493,10 @@ def _build_train_resize_config(
         # DETR-style crop branch: resize the short side to 400/500/600, then take a ``RandomSizedCrop`` that resizes
         # the crop *directly* to the target scale (via a per-scale ``OneOf``, mirroring the square path). This removes
         # the previous fixed 384x384 intermediate hop -- the crop was resampled to 384 and then resized again to the
-        # target, a wasteful downscale-then-upscale. ``min_max_height`` is clamped to [384, 400] so the sampled crop
-        # never exceeds the smallest possible short side (400) after the first ``SmallestMaxSize``; the earlier upper
-        # bound of 600 could exceed the image and degenerate to a full-image resize.
+        # target, a wasteful downscale-then-upscale. ``min_max_height`` upper bound matches the maximum SmallestMaxSize
+        # value (600): when the sampled scale is smaller (e.g. 400), albumentations clamps the crop to the image height,
+        # effectively giving a full-image crop — this is the original DETR recipe behaviour and preserves training
+        # diversity (zoom-out variety) across the full SmallestMaxSize range.
         option_b = {
             "Sequential": {
                 "transforms": [
@@ -503,7 +504,7 @@ def _build_train_resize_config(
                     {
                         "OneOf": {
                             "transforms": [
-                                {"RandomSizedCrop": {"min_max_height": [384, 400], "height": s, "width": s}}
+                                {"RandomSizedCrop": {"min_max_height": [384, 600], "height": s, "width": s}}
                                 for s in scales
                             ],
                         }

--- a/src/rfdetr/datasets/kornia_transforms.py
+++ b/src/rfdetr/datasets/kornia_transforms.py
@@ -242,9 +242,12 @@ def _make_gaussian_blur(params: dict[str, Any]) -> Any:
     if blur_limit % 2 == 0:
         blur_limit = blur_limit + 1
     blur_limit = max(3, blur_limit)
+    # Match the CPU albumentations default sigma range while allowing an explicit override via config.
+    sigma_range = params.get("sigma", (0.1, 2.0))
+    blur_sigma = tuple(sigma_range) if len(sigma_range) == 2 else (sigma_range[0], sigma_range[0])
     return RandomGaussianBlur(
         kernel_size=(blur_limit, blur_limit),
-        sigma=(0.1, 2.0),
+        sigma=blur_sigma,
         p=params.get("p", 0.5),
     )
 
@@ -252,11 +255,22 @@ def _make_gaussian_blur(params: dict[str, Any]) -> Any:
 def _make_gauss_noise(params: dict[str, Any]) -> Any:
     """Build a ``K.RandomGaussianNoise`` from aug_config params.
 
-    Kornia takes a single ``std`` value; we use the upper bound of ``std_range`` as an acceptable approximation.
+    Kornia takes a single ``std`` value, so the upper bound of ``std_range`` is used as a fixed standard deviation. When
+    the configured range is non-degenerate this diverges from the CPU (albumentations) path, which samples a fresh std
+    per call; a warning is emitted at build time so the drift is visible.
     """
     from kornia.augmentation import RandomGaussianNoise
 
     std_range = params.get("std_range", (0.01, 0.05))
+    if std_range[0] != std_range[1]:
+        logger.warning(
+            "GPU augmentation (Kornia) uses fixed std=%.3f for GaussianNoise "
+            "(Kornia does not support per-sample std ranges). "
+            "CPU augmentation (albumentations) samples from [%.3f, %.3f].",
+            std_range[1],
+            std_range[0],
+            std_range[1],
+        )
     return RandomGaussianNoise(
         std=std_range[1],
         p=params.get("p", 0.5),

--- a/src/rfdetr/datasets/o365.py
+++ b/src/rfdetr/datasets/o365.py
@@ -16,7 +16,10 @@ from PIL import Image
 from rfdetr.datasets.coco import CocoDetection, make_coco_transforms, make_coco_transforms_square_div_64
 from rfdetr.utilities.logger import get_logger
 
-Image.MAX_IMAGE_PIXELS = None
+# O365 contains images larger than PIL's default 178M-pixel limit.
+# Set a generous but finite cap (2 billion pixels ~ a 45k x 45k image) instead of
+# disabling the guard entirely, so PIL still protects against decompression bombs.
+Image.MAX_IMAGE_PIXELS = 2_000_000_000
 
 logger = get_logger()
 

--- a/src/rfdetr/datasets/transforms.py
+++ b/src/rfdetr/datasets/transforms.py
@@ -881,6 +881,7 @@ class AlbumentationsWrapper:
     def from_config(
         config_dict: dict[str, Any] | list[dict[str, Any]],
         keypoint_flip_pairs: list[int] | None = None,
+        strict: bool = False,
     ) -> list["AlbumentationsWrapper"]:
         """Build a list of :class:`AlbumentationsWrapper` instances from a config.
 
@@ -926,6 +927,10 @@ class AlbumentationsWrapper:
                 detection pipelines where horizontal flips are always permitted. Pass an empty list
                 ``[]`` to mark a keypoint pipeline without any defined flip pairs -- horizontal-flip
                 augmentations are then disabled until flip-pair swapping is implemented.
+            strict: When ``True``, a transform that fails to build raises :class:`RuntimeError`
+                instead of being logged and skipped. Use for internally-generated pipelines (e.g. the
+                required resize stack) where a silently dropped transform would corrupt the output shape.
+                Defaults to ``False`` for user augmentation configs, which stay lenient.
 
         Returns:
             List of :class:`AlbumentationsWrapper` instances in config order.
@@ -933,6 +938,7 @@ class AlbumentationsWrapper:
         Raises:
             ImportError: If Albumentations is not installed.
             TypeError: If *config_dict* is neither a ``dict`` nor a ``list``.
+            RuntimeError: If ``strict=True`` and a transform fails to build.
 
         Examples:
             >>> config = {
@@ -998,6 +1004,8 @@ class AlbumentationsWrapper:
                 transform = _build_albu_transform(aug_name, params)
                 transforms.append(AlbumentationsWrapper(transform, keypoint_flip_pairs=keypoint_flip_pairs))
             except Exception as e:
+                if strict:
+                    raise RuntimeError(f"Failed to build required transform {aug_name!r}: {e}") from e
                 logger.warning(
                     "Failed to initialize %s with params %r: %s. Skipping.",
                     aug_name,

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -2164,9 +2164,9 @@ class RFDETR:
         """
         if getattr(self, "_optimized_inplace", False) or self.model.model is None:
             raise RuntimeError(
-                "Cannot export after optimize_for_inference(inplace=True) — "
-                "the model has been cleared from memory. "
-                "Call export_for_roboflow() before optimizing."
+                "Cannot deploy after optimize_for_inference(inplace=True) — "
+                "the model weights have been cleared from memory. "
+                "Call export_for_roboflow() before optimizing, then deploy the exported bundle."
             )
 
         from roboflow import Roboflow

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import contextlib
 import glob
 import importlib
+import io
 import json
 import operator
 import os
@@ -19,6 +20,7 @@ from copy import copy, deepcopy
 from functools import wraps
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Concatenate, ParamSpec, TypeVar
+from urllib.parse import urlparse
 
 import numpy as np
 import requests
@@ -260,6 +262,7 @@ class RFDETR:
         self._optimized_resolution = None
         self._optimized_dtype = None
         self._optimized_inplace = False
+        self._has_been_trained = False
 
     def maybe_download_pretrain_weights(self):
         """Download pre-trained weights if they are not already downloaded.
@@ -594,6 +597,9 @@ class RFDETR:
         checkpoint_derived_keys = checkpoint_config_keys - set(kwargs)
 
         model = model_cls(**constructor_kwargs)
+        # The instance now carries checkpoint (trained) weights; flag it so a later
+        # train() call warns that it will restart from pretrain_weights, not continue.
+        model._has_been_trained = True
 
         if checkpoint_derived_keys:
             loaded_config = getattr(model, "model_config", None)
@@ -708,6 +714,15 @@ class RFDETR:
                 'Install them with `pip install "rfdetr[train,loggers]"` and try again.',
             ) from exc
 
+        if getattr(self, "_has_been_trained", False):
+            warnings.warn(
+                "Calling train() on a model that has already been trained or loaded from a checkpoint. "
+                "The new training run will start from the original pretrained weights (pretrain_weights), "
+                "NOT from the in-memory trained state. To continue training, pass resume=<checkpoint_path>.",
+                UserWarning,
+                stacklevel=2,
+            )
+
         # Absorb legacy `callbacks` dict — warn if non-empty, then discard.
         callbacks_dict = kwargs.pop("callbacks", None)
         if callbacks_dict and any(callbacks_dict.values()):
@@ -739,7 +754,7 @@ class RFDETR:
         if run_benchmark:
             warnings.warn(
                 "`do_benchmark` in `.train()` is deprecated since v1.7.0 and will be removed in v1.9.0; "
-                "use `rfdetr benchmark`.",
+                "use the `rfdetr.export.benchmark` module instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -850,6 +865,9 @@ class RFDETR:
 
         # Sync the trained weights back so predict() / export() see the updated model.
         self.model.model = module.model
+        # Mark this instance as trained so a subsequent train() call warns that it will
+        # restart from pretrain_weights rather than continue from the in-memory state.
+        self._has_been_trained = True
         # Invalidate any compiled inference snapshot: it was built from the pre-training
         # weights and must not survive the model reassignment above.
         self.remove_optimized_model()
@@ -1862,7 +1880,11 @@ class RFDETR:
 
         self._ensure_eval_mode_for_unoptimized_inference()
 
-        if not isinstance(images, list):
+        # Determine the return shape from the *input* type, not the runtime batch
+        # length: a single image (path / PIL / tensor) yields a bare Detections,
+        # while a list/tuple always yields a list — even when it holds one image.
+        single_input = not isinstance(images, (list, tuple))
+        if single_input:
             images = [images]
 
         orig_sizes = []
@@ -1871,8 +1893,10 @@ class RFDETR:
 
         for img in images:
             if isinstance(img, str):
-                if img.startswith("http"):
-                    img = requests.get(img, stream=True).raw
+                if urlparse(img).scheme in ("http", "https"):
+                    resp = requests.get(img, timeout=30)
+                    resp.raise_for_status()
+                    img = io.BytesIO(resp.content)
                 img = Image.open(img)
 
             if not isinstance(img, torch.Tensor):
@@ -2103,7 +2127,7 @@ class RFDETR:
             else:
                 predictions_list.append(detections)
 
-        return predictions_list if len(predictions_list) > 1 else predictions_list[0]
+        return predictions_list[0] if single_input else predictions_list
 
     def deploy_to_roboflow(
         self,
@@ -2132,11 +2156,19 @@ class RFDETR:
         Raises:
             ValueError: If the `api_key` is not provided and not found in the
                 environment variable `ROBOFLOW_API_KEY`, or if the `size` is not set for custom architectures.
+            RuntimeError: If the model was cleared by ``optimize_for_inference(inplace=True)``.
 
         Note:
             Bundle creation is delegated to :meth:`export_for_roboflow`, which can be called independently
             to write ``weights.pt`` and ``class_names.txt`` without a network round-trip.
         """
+        if getattr(self, "_optimized_inplace", False) or self.model.model is None:
+            raise RuntimeError(
+                "Cannot export after optimize_for_inference(inplace=True) — "
+                "the model has been cleared from memory. "
+                "Call export_for_roboflow() before optimizing."
+            )
+
         from roboflow import Roboflow
 
         if api_key is None:
@@ -2181,7 +2213,14 @@ class RFDETR:
             PermissionError: If the process lacks write access to *output_dir* or its parent directory.
             OSError: On disk-full, invalid path, or other filesystem failure during directory creation,
                 file write, or ``torch.save``.
+            RuntimeError: If the model was cleared by ``optimize_for_inference(inplace=True)``.
         """
+        if getattr(self, "_optimized_inplace", False) or self.model.model is None:
+            raise RuntimeError(
+                "Cannot export after optimize_for_inference(inplace=True) — "
+                "the model has been cleared from memory. "
+                "Call export_for_roboflow() before optimizing."
+            )
         os.makedirs(output_dir, exist_ok=True)
         # Write class_names.txt so the Roboflow upload pipeline can discover
         # the class labels without relying on args.class_names in the checkpoint.

--- a/src/rfdetr/export/benchmark.py
+++ b/src/rfdetr/export/benchmark.py
@@ -115,7 +115,11 @@ def post_process(outputs, target_sizes, num_queries: int = _DEFAULT_NUM_QUERIES)
     assert target_sizes.shape[1] == 2
 
     prob = out_logits.sigmoid()
-    topk_values, topk_indexes = torch.topk(prob.view(out_logits.shape[0], -1), num_queries, dim=1)
+    flat_scores = prob.view(out_logits.shape[0], -1)
+    # Clamp k to the flattened dimension: when num_queries is a fallback for a dynamic-axis model
+    # it may exceed num_queries*num_classes and trigger a topk runtime error.
+    k = min(num_queries, flat_scores.shape[1])
+    topk_values, topk_indexes = torch.topk(flat_scores, k, dim=1)
     scores = topk_values
     topk_boxes = topk_indexes // out_logits.shape[2]
     labels = topk_indexes % out_logits.shape[2]

--- a/src/rfdetr/export/benchmark.py
+++ b/src/rfdetr/export/benchmark.py
@@ -49,14 +49,47 @@ def load_image(file_path):
     return Image.open(file_path).convert("RGB")
 
 
-def infer_transforms():
+_DEFAULT_INPUT_SIZE = (640, 640)
+_DEFAULT_NUM_QUERIES = 300
+
+
+def _static_dim(value, fallback: int) -> int:
+    """Coerce a tensor-shape entry to a positive int, falling back for dynamic/unknown axes.
+
+    ONNX Runtime and TensorRT report dynamic axes as strings (e.g. ``"height"``), ``None``, or ``-1``. Such values
+    cannot drive a fixed preprocessing size, so the caller-supplied *fallback* is used instead.
+
+    Args:
+        value: A single entry from a model input/output shape.
+        fallback: Value to return when *value* is not a concrete positive integer.
+
+    Returns:
+        The integer dimension, or *fallback* for dynamic axes.
+    """
+    try:
+        dim = int(value)
+    except (TypeError, ValueError):
+        return fallback
+    return dim if dim > 0 else fallback
+
+
+def infer_transforms(size: tuple[int, int] = _DEFAULT_INPUT_SIZE):
+    """Build the benchmark preprocessing pipeline for a given model input size.
+
+    Args:
+        size: Target ``(height, width)`` the image is resized to before inference. Defaults to
+            :data:`_DEFAULT_INPUT_SIZE` for dynamic-axis models where a static size cannot be read.
+
+    Returns:
+        A ``torchvision.transforms.v2.Compose`` that resizes, tensorizes, and normalizes an image.
+    """
     from torchvision.transforms.v2 import Compose, Resize, ToDtype, ToImage
 
     from rfdetr.datasets.transforms import Normalize
 
     return Compose(
         [
-            Resize((640, 640)),
+            Resize(size),
             ToImage(),
             ToDtype(torch.float32, scale=True),
             Normalize(),
@@ -75,14 +108,14 @@ def box_cxcywh_to_xyxy(x):
     return torch.stack(b, dim=-1)
 
 
-def post_process(outputs, target_sizes):
+def post_process(outputs, target_sizes, num_queries: int = _DEFAULT_NUM_QUERIES):
     out_logits, out_bbox = outputs["labels"], outputs["dets"]
 
     assert len(out_logits) == len(target_sizes)
     assert target_sizes.shape[1] == 2
 
     prob = out_logits.sigmoid()
-    topk_values, topk_indexes = torch.topk(prob.view(out_logits.shape[0], -1), 300, dim=1)
+    topk_values, topk_indexes = torch.topk(prob.view(out_logits.shape[0], -1), num_queries, dim=1)
     scores = topk_values
     topk_boxes = topk_indexes // out_logits.shape[2]
     labels = topk_indexes % out_logits.shape[2]
@@ -100,12 +133,20 @@ def post_process(outputs, target_sizes):
 
 
 def infer_onnx(sess, coco_evaluator, time_profile, prefix, img_list, device, repeats=1):
+    input_shape = sess.get_inputs()[0].shape
+    # fallback for dynamic-axis models (dynamic H/W report as strings or None)
+    input_h = _static_dim(input_shape[2] if len(input_shape) > 3 else None, _DEFAULT_INPUT_SIZE[0])
+    input_w = _static_dim(input_shape[3] if len(input_shape) > 3 else None, _DEFAULT_INPUT_SIZE[1])
+    output_shape = sess.get_outputs()[0].shape
+    num_queries = _static_dim(output_shape[1] if len(output_shape) > 1 else None, _DEFAULT_NUM_QUERIES)
+    transforms = infer_transforms((input_h, input_w))
+
     time_list = []
     for img_dict in tqdm(img_list):
         image = load_image(os.path.join(prefix, img_dict["file_name"]))
         width, height = image.size
         orig_target_sizes = torch.Tensor([height, width])
-        image_tensor, _ = infer_transforms()(image, None)  # target is None
+        image_tensor, _ = transforms(image, None)  # target is None
 
         samples = image_tensor[None].numpy()
 
@@ -119,7 +160,7 @@ def infer_onnx(sess, coco_evaluator, time_profile, prefix, img_list, device, rep
         outputs["dets"] = torch.Tensor(res[0]).to(device)
 
         orig_target_sizes = torch.stack([orig_target_sizes], dim=0).to(device)
-        results = post_process(outputs, orig_target_sizes)
+        results = post_process(outputs, orig_target_sizes, num_queries=num_queries)
         res = {img_dict["id"]: results[0]}
         if coco_evaluator is not None:
             coco_evaluator.update(res)
@@ -137,12 +178,20 @@ def infer_onnx(sess, coco_evaluator, time_profile, prefix, img_list, device, rep
 
 
 def infer_engine(model, coco_evaluator, time_profile, prefix, img_list, device, repeats=1):
+    input_shape = list(model.bindings[model.input_names[0]].shape)
+    # fallback for dynamic-axis models
+    input_h = _static_dim(input_shape[2] if len(input_shape) > 3 else None, _DEFAULT_INPUT_SIZE[0])
+    input_w = _static_dim(input_shape[3] if len(input_shape) > 3 else None, _DEFAULT_INPUT_SIZE[1])
+    output_shape = list(model.bindings[model.output_names[0]].shape)
+    num_queries = _static_dim(output_shape[1] if len(output_shape) > 1 else None, _DEFAULT_NUM_QUERIES)
+    transforms = infer_transforms((input_h, input_w))
+
     time_list = []
     for img_dict in tqdm(img_list):
         image = load_image(os.path.join(prefix, img_dict["file_name"]))
         width, height = image.size
         orig_target_sizes = torch.Tensor([height, width])
-        image_tensor, _ = infer_transforms()(image, None)  # target is None
+        image_tensor, _ = transforms(image, None)  # target is None
 
         samples = image_tensor[None].to(device)
         _, _, h, w = samples.shape
@@ -157,7 +206,7 @@ def infer_engine(model, coco_evaluator, time_profile, prefix, img_list, device, 
         time_list.append(time_profile.total / repeats)
         orig_target_sizes = torch.stack([orig_target_sizes], dim=0).to(device)
         if coco_evaluator is not None:
-            results = post_process(outputs, orig_target_sizes)
+            results = post_process(outputs, orig_target_sizes, num_queries=num_queries)
             res = {img_dict["id"]: results[0]}
             coco_evaluator.update(res)
 

--- a/src/rfdetr/models/backbone/projector.py
+++ b/src/rfdetr/models/backbone/projector.py
@@ -13,7 +13,6 @@
 
 from typing import Callable, Optional, Sequence, Union
 
-import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F  # noqa: N812
@@ -268,12 +267,14 @@ class MultiScaleProjector(nn.Module):
         """
         num_features = len(x)
         if self.survival_prob < 1.0 and self.training:
+            x = list(x)  # copy before mutating so the caller's list is untouched
             final_drop_prob = 1 - self.survival_prob
-            drop_p = np.random.uniform()
+            # torch RNG (not numpy) so the draw honours per-rank seeding under DDP.
+            drop_p = torch.rand(()).item()
             for i in range(1, num_features):
                 critical_drop_prob = i * (final_drop_prob / (num_features - 1))
                 if drop_p < critical_drop_prob:
-                    x[i][:] = 0
+                    x[i] = torch.zeros_like(x[i])
         elif self.force_drop_last_n_features > 0:
             for i in range(self.force_drop_last_n_features):
                 # don't do it inplace to ensure the compiler can optimize out the backbone layers

--- a/src/rfdetr/models/criterion.py
+++ b/src/rfdetr/models/criterion.py
@@ -456,10 +456,12 @@ class SetCriterion(nn.Module):
             spatial_features = outputs["pred_masks"]["spatial_features"]
             query_features = outputs["pred_masks"]["query_features"]
             bias = outputs["pred_masks"]["bias"]
-            # If there are no matches, return an empty tensor like the Tensor branch does.
+            # No matches: return a zero loss that still flows through the segmentation-head
+            # outputs, so every parameter stays connected in the autograd graph (required for
+            # DDP, which errors on parameters that receive no gradient).
             if idx[0].numel() == 0:
-                device = spatial_features.device
-                src_masks = torch.tensor([], device=device)
+                zero = (spatial_features.sum() + query_features.sum() + bias.sum()) * 0.0
+                return {"loss_mask_ce": zero, "loss_mask_dice": zero}
             else:
                 batched_selected_masks = []
                 per_batch_counts = idx[0].unique(return_counts=True)[1]

--- a/src/rfdetr/models/math.py
+++ b/src/rfdetr/models/math.py
@@ -11,12 +11,7 @@
 
 import torch
 import torch.nn.functional as F  # noqa: N812
-import torchvision
 from torch import Tensor, nn
-
-if float(torchvision.__version__.split(".")[1]) < 7.0:
-    from torchvision.ops import _new_empty_tensor
-    from torchvision.ops.misc import _output_size
 
 
 def accuracy(output: torch.Tensor, target: torch.Tensor, topk: tuple[int, ...] = (1,)) -> list[torch.Tensor]:
@@ -47,19 +42,13 @@ def interpolate(
     mode: str = "nearest",
     align_corners: bool | None = None,
 ) -> Tensor:
-    """Equivalent to nn.functional.interpolate, but with support for empty batch sizes."""
-    if float(torchvision.__version__.split(".")[1]) < 7.0:
-        if input.numel() > 0:
-            interpolated: Tensor = torch.nn.functional.interpolate(input, size, scale_factor, mode, align_corners)
-            return interpolated
+    """Equivalent to nn.functional.interpolate.
 
-        output_shape = _output_size(2, input, size, scale_factor)
-        output_shape = list(input.shape[:-2]) + list(output_shape)
-        empty_output: Tensor = _new_empty_tensor(input, output_shape)
-        return empty_output
-    else:
-        torchvision_output: Tensor = torchvision.ops.misc.interpolate(input, size, scale_factor, mode, align_corners)
-        return torchvision_output
+    Historically this wrapped ``torchvision`` to support empty batch sizes on old releases; modern ``torch`` (>=2.2)
+    handles empty batches natively, so this now delegates directly to :func:`torch.nn.functional.interpolate`.
+    """
+    interpolated: Tensor = F.interpolate(input, size, scale_factor, mode, align_corners)
+    return interpolated
 
 
 def inverse_sigmoid(x: torch.Tensor, eps: float = 1e-5) -> torch.Tensor:

--- a/src/rfdetr/models/postprocess.py
+++ b/src/rfdetr/models/postprocess.py
@@ -15,6 +15,10 @@ from torch import nn
 
 from rfdetr.utilities import box_ops
 
+# Number of masks upsampled per interpolation call. Bounds peak memory when many masks are
+# resized to full image resolution (e.g. K=300 at 1080p would otherwise allocate gigabytes).
+_MASK_CHUNK = 32
+
 
 class PostProcess(nn.Module):
     """Convert raw RF-DETR model outputs into per-image prediction tensors.
@@ -172,9 +176,18 @@ class PostProcess(nn.Module):
                 k_idx.unsqueeze(-1).unsqueeze(-1).repeat(1, out_masks.shape[-2], out_masks.shape[-1]),
             )  # [K, Hm, Wm]
             h, w = target_sizes[i].tolist()
-            masks_i = F.interpolate(
-                masks_i.unsqueeze(1), size=(int(h), int(w)), mode="bilinear", align_corners=False
-            )  # [K,1,H,W]
+            # Upsample in chunks to bound peak memory; interpolating all K masks at full image
+            # resolution at once can allocate gigabytes for large K and high-resolution targets.
+            chunks = [
+                F.interpolate(
+                    masks_i[start : start + _MASK_CHUNK].unsqueeze(1),
+                    size=(int(h), int(w)),
+                    mode="bilinear",
+                    align_corners=False,
+                )
+                for start in range(0, masks_i.shape[0], _MASK_CHUNK)
+            ]
+            masks_i = torch.cat(chunks, dim=0) if chunks else masks_i.new_zeros((0, 1, int(h), int(w)))  # [K,1,H,W]
             res_i["masks"] = masks_i > 0.0
             results.append(res_i)
         return results

--- a/src/rfdetr/models/postprocess.py
+++ b/src/rfdetr/models/postprocess.py
@@ -176,8 +176,10 @@ class PostProcess(nn.Module):
                 k_idx.unsqueeze(-1).unsqueeze(-1).repeat(1, out_masks.shape[-2], out_masks.shape[-1]),
             )  # [K, Hm, Wm]
             h, w = target_sizes[i].tolist()
-            # Upsample in chunks to bound peak memory; interpolating all K masks at full image
-            # resolution at once can allocate gigabytes for large K and high-resolution targets.
+            # Upsample in chunks and threshold *inside* the comprehension so only one float32 chunk
+            # is live at a time; the accumulated list holds bool tensors (1 byte/pixel vs 4 for float32).
+            # At K=300, 1080p this reduces peak memory from ~5 GB to ~1.5 GB vs a single F.interpolate
+            # call that would allocate the full [K,1,H,W] float tensor followed by a bool copy.
             chunks = [
                 F.interpolate(
                     masks_i[start : start + _MASK_CHUNK].unsqueeze(1),
@@ -185,10 +187,13 @@ class PostProcess(nn.Module):
                     mode="bilinear",
                     align_corners=False,
                 )
+                > 0.0
                 for start in range(0, masks_i.shape[0], _MASK_CHUNK)
             ]
-            masks_i = torch.cat(chunks, dim=0) if chunks else masks_i.new_zeros((0, 1, int(h), int(w)))  # [K,1,H,W]
-            res_i["masks"] = masks_i > 0.0
+            masks_i = (
+                torch.cat(chunks, dim=0) if chunks else masks_i.new_zeros((0, 1, int(h), int(w)), dtype=torch.bool)
+            )  # [K,1,H,W] bool
+            res_i["masks"] = masks_i
             results.append(res_i)
         return results
 

--- a/src/rfdetr/training/module_data.py
+++ b/src/rfdetr/training/module_data.py
@@ -29,6 +29,26 @@ if TYPE_CHECKING:
     from matplotlib.figure import Figure
 
 
+def _worker_init_fn(worker_id: int) -> None:
+    """Seed NumPy and the ``random`` module per DataLoader worker.
+
+    PyTorch seeds ``torch``'s RNG per worker automatically but leaves NumPy and the stdlib ``random`` module unseeded,
+    so without this hook every worker would draw identical NumPy/``random`` sequences (a well-known augmentation
+    duplication footgun). Deriving the seed from ``torch.initial_seed()`` keeps augmentation reproducible while still
+    giving each worker a distinct stream.
+
+    Args:
+        worker_id: Index of the DataLoader worker (unused; seed is derived from the per-worker torch seed).
+    """
+    import random
+
+    import numpy as np
+
+    seed = torch.initial_seed() % (2**32)
+    np.random.seed(seed)
+    random.seed(seed)
+
+
 def _has_cuda_device() -> bool:
     """Return ``True`` when the runtime has a CUDA accelerator available.
 
@@ -290,6 +310,7 @@ class RFDETRDataModule(LightningDataModule):
                 pin_memory=self._pin_memory,
                 persistent_workers=self._persistent_workers,
                 prefetch_factor=self._prefetch_factor,
+                worker_init_fn=_worker_init_fn,
             )
 
         # Pad the dataset to a multiple of effective_batch_size * world_size so
@@ -309,6 +330,7 @@ class RFDETRDataModule(LightningDataModule):
             pin_memory=self._pin_memory,
             persistent_workers=self._persistent_workers,
             prefetch_factor=self._prefetch_factor,
+            worker_init_fn=_worker_init_fn,
         )
 
     def val_dataloader(self) -> DataLoader:
@@ -327,6 +349,7 @@ class RFDETRDataModule(LightningDataModule):
             pin_memory=self._pin_memory,
             persistent_workers=self._persistent_workers,
             prefetch_factor=self._prefetch_factor,
+            worker_init_fn=_worker_init_fn,
         )
 
     def test_dataloader(self) -> DataLoader:
@@ -345,6 +368,7 @@ class RFDETRDataModule(LightningDataModule):
             pin_memory=self._pin_memory,
             persistent_workers=self._persistent_workers,
             prefetch_factor=self._prefetch_factor,
+            worker_init_fn=_worker_init_fn,
         )
 
     def predict_dataloader(self) -> DataLoader:
@@ -363,6 +387,7 @@ class RFDETRDataModule(LightningDataModule):
             pin_memory=self._pin_memory,
             persistent_workers=self._persistent_workers,
             prefetch_factor=self._prefetch_factor,
+            worker_init_fn=_worker_init_fn,
         )
 
     def _show_samples(

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -142,8 +142,9 @@ class RFDETRModelModule(LightningModule):
             samples, _ = batch
             scales = compute_multi_scale_scales(mc.resolution, tc.expanded_scales, mc.patch_size, mc.num_windows)
             step = self.trainer.global_step
-            random.seed(step)
-            scale = random.choice(scales)
+            # Use a step-local generator so the scale choice is deterministic and DDP-consistent
+            # without reseeding the process-global RNG on every batch.
+            scale = random.Random(step).choice(scales)
             with torch.no_grad():
                 samples.tensors = F.interpolate(samples.tensors, size=scale, mode="bilinear", align_corners=False)
                 samples.mask = (

--- a/src/rfdetr/utilities/box_ops.py
+++ b/src/rfdetr/utilities/box_ops.py
@@ -59,7 +59,8 @@ def box_iou(boxes1: torch.Tensor, boxes2: torch.Tensor) -> tuple[torch.Tensor, t
 
     union = area1[:, None] + area2 - inter
 
-    iou = inter / union
+    eps = 1e-7
+    iou = inter / (union + eps)
     return iou, union
 
 
@@ -70,8 +71,7 @@ def generalized_box_iou(boxes1: torch.Tensor, boxes2: torch.Tensor) -> torch.Ten
 
     Returns a [N, M] pairwise matrix, where N = len(boxes1) and M = len(boxes2).
     """
-    # degenerate boxes gives inf / nan results
-    # so do an early check
+    # Degenerate (zero-area) boxes would divide 0/0; eps in the denominators keeps results finite.
     iou, union = box_iou(boxes1, boxes2)
 
     lt = torch.min(boxes1[:, None, :2], boxes2[:, :2])
@@ -80,7 +80,8 @@ def generalized_box_iou(boxes1: torch.Tensor, boxes2: torch.Tensor) -> torch.Ten
     wh = (rb - lt).clamp(min=0)  # [N,M,2]
     area = wh[:, :, 0] * wh[:, :, 1]
 
-    return iou - (area - union) / area
+    eps = 1e-7
+    return iou - (area - union) / (area + eps)
 
 
 def masks_to_boxes(masks: torch.Tensor) -> torch.Tensor:

--- a/src/rfdetr/utilities/box_ops.py
+++ b/src/rfdetr/utilities/box_ops.py
@@ -60,7 +60,9 @@ def box_iou(boxes1: torch.Tensor, boxes2: torch.Tensor) -> tuple[torch.Tensor, t
     union = area1[:, None] + area2 - inter
 
     eps = 1e-7
-    iou = inter / (union + eps)
+    # Clamp only the degenerate (union==0) case so identical non-degenerate boxes
+    # yield IoU==1.0 exactly; adding eps unconditionally would break that identity.
+    iou = inter / union.clamp(min=eps)
     return iou, union
 
 
@@ -81,7 +83,8 @@ def generalized_box_iou(boxes1: torch.Tensor, boxes2: torch.Tensor) -> torch.Ten
     area = wh[:, :, 0] * wh[:, :, 1]
 
     eps = 1e-7
-    return iou - (area - union) / (area + eps)
+    # Clamp only when enclosing area is zero (degenerate enclosing box) so normal boxes remain exact.
+    return iou - (area - union) / area.clamp(min=eps)
 
 
 def masks_to_boxes(masks: torch.Tensor) -> torch.Tensor:

--- a/tests/cli/test_smoke.py
+++ b/tests/cli/test_smoke.py
@@ -67,6 +67,31 @@ def _instantiate(class_path: str, init_args: dict) -> object:
 # ---------------------------------------------------------------------------
 
 
+class TestCLIEntrypoint:
+    """Module entrypoint and CLI import tests."""
+
+    def test_python_module_entrypoint_runs(self) -> None:
+        """Python -m rfdetr --help exits 0 and mentions rfdetr."""
+        import subprocess
+        import sys
+
+        result = subprocess.run(
+            [sys.executable, "-m", "rfdetr", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0
+        assert "rfdetr" in result.stdout.lower() or "rfdetr" in result.stderr.lower()
+
+    def test_cli_main_is_importable(self) -> None:
+        """rfdetr.cli module is importable and exposes a callable main."""
+        import importlib
+
+        mod = importlib.import_module("rfdetr.cli")
+        assert callable(getattr(mod, "main", None))
+
+
 class TestCLIHelp:
     """Rfdetr --help and subcommand --help must exit 0."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,9 @@ from typing import Any, Generator
 
 import pytest
 
+# NOTE: Model weights (rf-detr-*.pth) download to the CWD (typically tests/ when running pytest).
+# This is a known limitation. Route: change pretrain_weights default to
+# platformdirs.user_cache_dir("rfdetr") in a future PR.
 from rfdetr.datasets.synthetic import DatasetSplitRatios, generate_coco_dataset
 from rfdetr.utilities.reproducibility import seed_all
 

--- a/tests/datasets/test_augmentations.py
+++ b/tests/datasets/test_augmentations.py
@@ -2224,3 +2224,24 @@ class TestReplayContainsHorizontalFlip:
     def test_replay_contains_horizontal_flip(self, replay: object, expected: bool) -> None:
         """Fixture replay dicts should be correctly classified as horizontal flip or not."""
         assert AlbumentationsWrapper._replay_contains_horizontal_flip(replay) == expected
+
+
+class TestFromConfigStrict:
+    """AlbumentationsWrapper.from_config strict mode raises on required-transform failures instead of skipping."""
+
+    def test_strict_false_skips_unbuildable_transform(self):
+        """Lenient mode (default) logs and skips a transform that cannot be built."""
+        result = AlbumentationsWrapper.from_config([{"NotARealTransform": {"p": 1.0}}])
+
+        assert result == []
+
+    def test_strict_true_raises_on_unbuildable_transform(self):
+        """Strict mode surfaces a RuntimeError so a corrupt required pipeline fails loudly."""
+        with pytest.raises(RuntimeError, match="NotARealTransform"):
+            AlbumentationsWrapper.from_config([{"NotARealTransform": {"p": 1.0}}], strict=True)
+
+    def test_strict_true_builds_valid_config(self):
+        """Strict mode still returns wrappers when every transform builds successfully."""
+        result = AlbumentationsWrapper.from_config([{"HorizontalFlip": {"p": 0.5}}], strict=True)
+
+        assert len(result) == 1

--- a/tests/datasets/test_coco_resize_config.py
+++ b/tests/datasets/test_coco_resize_config.py
@@ -149,15 +149,10 @@ class TestBuildTrainResizeConfigNonSquareSingleScale:
                     {
                         "OneOf": {
                             "transforms": [
-                                {"RandomCrop": {"height": 384, "width": 384}},
-                                {"RandomCrop": {"height": 384, "width": 400}},
-                                {"RandomCrop": {"height": 400, "width": 384}},
-                                {"RandomCrop": {"height": 400, "width": 400}},
+                                {"RandomSizedCrop": {"min_max_height": [384, 400], "height": 640, "width": 640}},
                             ]
                         }
                     },
-                    {"SmallestMaxSize": {"max_size": 640}},
-                    {"LongestMaxSize": {"max_size": 1333}},
                 ]
             }
         }
@@ -193,40 +188,34 @@ class TestBuildTrainResizeConfigNonSquareMultiScale:
                     {
                         "OneOf": {
                             "transforms": [
-                                {"RandomCrop": {"height": 384, "width": 384}},
-                                {"RandomCrop": {"height": 384, "width": 400}},
-                                {"RandomCrop": {"height": 400, "width": 384}},
-                                {"RandomCrop": {"height": 400, "width": 400}},
+                                {"RandomSizedCrop": {"min_max_height": [384, 400], "height": 480, "width": 480}},
+                                {"RandomSizedCrop": {"min_max_height": [384, 400], "height": 640, "width": 640}},
                             ]
                         }
                     },
-                    {"SmallestMaxSize": {"max_size": [480, 640]}},
-                    {"LongestMaxSize": {"max_size": 1333}},
                 ]
             }
         }
 
-    def test_custom_max_size_propagates_to_both_options(self):
+    def test_custom_max_size_applies_to_option_a_only(self):
+        """max_size caps option_a's long side; option_b now resizes the crop directly to the target (no cap step)."""
         result = _build_train_resize_config([480, 640], square=False, max_size=1000)
         option_a = result[0]["OneOf"]["transforms"][0]
-        option_b = result[0]["OneOf"]["transforms"][1]
+        option_b_steps = result[0]["OneOf"]["transforms"][1]["Sequential"]["transforms"]
         assert option_a["Sequential"]["transforms"][1] == {"LongestMaxSize": {"max_size": 1000}}
-        assert option_b["Sequential"]["transforms"][3] == {"LongestMaxSize": {"max_size": 1000}}
+        assert not any("LongestMaxSize" in step for step in option_b_steps)
 
 
-class TestBuildTrainResizeConfigNonSquareCrop:
-    """Non-square option_b crops at native resolution with non-square RandomCrop (DETR recipe).
+class TestBuildTrainResizeConfigNonSquareScaleJitter:
+    """Non-square option_b must keep RandomSizedCrop (scale jitter), not a fixed RandomCrop.
 
-    The ``fix-resize-crop`` branch replaces the square-output ``RandomSizedCrop`` with a ``OneOf`` over non-square
-    ``RandomCrop`` sizes so the crop keeps native resolution and independent width/height (matching DETR's
-    ``RandomSizeCrop``), then resizes once. Crop sides are clamped to <=400 -- the smallest possible short side after
-    the first ``SmallestMaxSize([400, 500, 600])`` -- so a crop never exceeds the image (the previous ``min_max_height``
-    upper bound of 600 could).
+    Regression tests for https://github.com/roboflow/rf-detr/issues/1018 — PR #752 replaced RandomSizeCrop(384, 600)
+    with a fixed RandomCrop(384, 384), silently removing scale jitter from the non-square training pipeline.
 
-    Trade-off vs the prior ``RandomSizedCrop(min_max_height=[384, 600])`` (issue #1018 / PR #752): per-crop scale jitter
-    is narrowed to the [384, 400] clamp, but scale jitter is still supplied by the surrounding ``SmallestMaxSize([400,
-    500, 600])`` pre-crop resize and the final ``SmallestMaxSize(scales)`` resize, so jitter is not removed -- only
-    relocated out of the crop step.
+    The ``fix-resize-crop`` branch keeps RandomSizedCrop but removes the wasteful fixed-384 intermediate hop: the crop
+    now resizes directly to the target scale (per-scale ``OneOf``, mirroring the square path) and ``min_max_height`` is
+    clamped to ``[384, 400]`` so a crop can never exceed the smallest short side (400) after the first
+    ``SmallestMaxSize([400, 500, 600])``.
     """
 
     @pytest.mark.parametrize(
@@ -236,14 +225,14 @@ class TestBuildTrainResizeConfigNonSquareCrop:
             pytest.param([480, 640], id="nonsquare-multi"),
         ],
     )
-    def test_option_b_crop_step_is_oneof_of_random_crop(self, scales):
-        """Non-square option_b crop step must be a OneOf of native-resolution RandomCrop, not RandomSizedCrop."""
+    def test_option_b_crop_step_uses_random_sized_crop(self, scales):
+        """Non-square option_b crop must use RandomSizedCrop, never fixed RandomCrop (issue #1018)."""
         result = _build_train_resize_config(scales, square=False)
         option_b = result[0]["OneOf"]["transforms"][1]
         crop_step = option_b["Sequential"]["transforms"][1]
         crop_variants = crop_step["OneOf"]["transforms"]
         assert crop_variants and all(
-            "RandomCrop" in entry and "RandomSizedCrop" not in entry for entry in crop_variants
+            "RandomSizedCrop" in entry and "RandomCrop" not in entry for entry in crop_variants
         )
 
     @pytest.mark.parametrize(
@@ -253,14 +242,12 @@ class TestBuildTrainResizeConfigNonSquareCrop:
             pytest.param([480, 640], id="nonsquare-multi"),
         ],
     )
-    def test_option_b_crop_sizes_are_bounded_and_include_non_square(self, scales):
-        """Crop sides stay within [384, 400] (<= image) and include at least one non-square (h != w) variant."""
+    def test_option_b_crop_uses_clamped_scale_jitter_range(self, scales):
+        """RandomSizedCrop min_max_height is clamped to [384, 400] (<= image) while retaining scale jitter."""
         result = _build_train_resize_config(scales, square=False)
         option_b = result[0]["OneOf"]["transforms"][1]
         crop_variants = option_b["Sequential"]["transforms"][1]["OneOf"]["transforms"]
-        sizes = [(entry["RandomCrop"]["height"], entry["RandomCrop"]["width"]) for entry in crop_variants]
-        assert all(384 <= h <= 400 and 384 <= w <= 400 for h, w in sizes)
-        assert any(h != w for h, w in sizes)
+        assert all(entry["RandomSizedCrop"]["min_max_height"] == [384, 400] for entry in crop_variants)
 
     @pytest.mark.parametrize(
         "scales,square",

--- a/tests/datasets/test_coco_resize_config.py
+++ b/tests/datasets/test_coco_resize_config.py
@@ -149,7 +149,7 @@ class TestBuildTrainResizeConfigNonSquareSingleScale:
                     {
                         "OneOf": {
                             "transforms": [
-                                {"RandomSizedCrop": {"min_max_height": [384, 400], "height": 640, "width": 640}},
+                                {"RandomSizedCrop": {"min_max_height": [384, 600], "height": 640, "width": 640}},
                             ]
                         }
                     },
@@ -188,8 +188,8 @@ class TestBuildTrainResizeConfigNonSquareMultiScale:
                     {
                         "OneOf": {
                             "transforms": [
-                                {"RandomSizedCrop": {"min_max_height": [384, 400], "height": 480, "width": 480}},
-                                {"RandomSizedCrop": {"min_max_height": [384, 400], "height": 640, "width": 640}},
+                                {"RandomSizedCrop": {"min_max_height": [384, 600], "height": 480, "width": 480}},
+                                {"RandomSizedCrop": {"min_max_height": [384, 600], "height": 640, "width": 640}},
                             ]
                         }
                     },
@@ -212,10 +212,11 @@ class TestBuildTrainResizeConfigNonSquareScaleJitter:
     Regression tests for https://github.com/roboflow/rf-detr/issues/1018 — PR #752 replaced RandomSizeCrop(384, 600)
     with a fixed RandomCrop(384, 384), silently removing scale jitter from the non-square training pipeline.
 
-    The ``fix-resize-crop`` branch keeps RandomSizedCrop but removes the wasteful fixed-384 intermediate hop: the crop
-    now resizes directly to the target scale (per-scale ``OneOf``, mirroring the square path) and ``min_max_height`` is
-    clamped to ``[384, 400]`` so a crop can never exceed the smallest short side (400) after the first
-    ``SmallestMaxSize([400, 500, 600])``.
+    The ``fix-resize-crop`` branch keeps RandomSizedCrop and removes the wasteful fixed-384 intermediate hop: the crop
+    now resizes directly to the target scale (per-scale ``OneOf``, mirroring the square path). ``min_max_height`` uses
+    ``[384, 600]`` to match the full SmallestMaxSize range — when the image short side is 400, albumentations clamps
+    the crop to the image height (a full-image crop), which is the original DETR recipe behaviour and preserves
+    zoom-out diversity across the SmallestMaxSize range.
     """
 
     @pytest.mark.parametrize(
@@ -242,12 +243,12 @@ class TestBuildTrainResizeConfigNonSquareScaleJitter:
             pytest.param([480, 640], id="nonsquare-multi"),
         ],
     )
-    def test_option_b_crop_uses_clamped_scale_jitter_range(self, scales):
-        """RandomSizedCrop min_max_height is clamped to [384, 400] (<= image) while retaining scale jitter."""
+    def test_option_b_crop_uses_full_scale_jitter_range(self, scales):
+        """RandomSizedCrop min_max_height matches SmallestMaxSize range [384, 600] for full zoom-out diversity."""
         result = _build_train_resize_config(scales, square=False)
         option_b = result[0]["OneOf"]["transforms"][1]
         crop_variants = option_b["Sequential"]["transforms"][1]["OneOf"]["transforms"]
-        assert all(entry["RandomSizedCrop"]["min_max_height"] == [384, 400] for entry in crop_variants)
+        assert all(entry["RandomSizedCrop"]["min_max_height"] == [384, 600] for entry in crop_variants)
 
     @pytest.mark.parametrize(
         "scales,square",

--- a/tests/datasets/test_coco_resize_config.py
+++ b/tests/datasets/test_coco_resize_config.py
@@ -146,7 +146,16 @@ class TestBuildTrainResizeConfigNonSquareSingleScale:
             "Sequential": {
                 "transforms": [
                     {"SmallestMaxSize": {"max_size": [400, 500, 600]}},
-                    {"RandomSizedCrop": {"min_max_height": [384, 600], "height": 384, "width": 384}},
+                    {
+                        "OneOf": {
+                            "transforms": [
+                                {"RandomCrop": {"height": 384, "width": 384}},
+                                {"RandomCrop": {"height": 384, "width": 400}},
+                                {"RandomCrop": {"height": 400, "width": 384}},
+                                {"RandomCrop": {"height": 400, "width": 400}},
+                            ]
+                        }
+                    },
                     {"SmallestMaxSize": {"max_size": 640}},
                     {"LongestMaxSize": {"max_size": 1333}},
                 ]
@@ -181,7 +190,16 @@ class TestBuildTrainResizeConfigNonSquareMultiScale:
             "Sequential": {
                 "transforms": [
                     {"SmallestMaxSize": {"max_size": [400, 500, 600]}},
-                    {"RandomSizedCrop": {"min_max_height": [384, 600], "height": 384, "width": 384}},
+                    {
+                        "OneOf": {
+                            "transforms": [
+                                {"RandomCrop": {"height": 384, "width": 384}},
+                                {"RandomCrop": {"height": 384, "width": 400}},
+                                {"RandomCrop": {"height": 400, "width": 384}},
+                                {"RandomCrop": {"height": 400, "width": 400}},
+                            ]
+                        }
+                    },
                     {"SmallestMaxSize": {"max_size": [480, 640]}},
                     {"LongestMaxSize": {"max_size": 1333}},
                 ]
@@ -196,45 +214,53 @@ class TestBuildTrainResizeConfigNonSquareMultiScale:
         assert option_b["Sequential"]["transforms"][3] == {"LongestMaxSize": {"max_size": 1000}}
 
 
-class TestBuildTrainResizeConfigNonSquareScaleJitter:
-    """Non-square option_b must use RandomSizedCrop (scale jitter), not fixed RandomCrop.
+class TestBuildTrainResizeConfigNonSquareCrop:
+    """Non-square option_b crops at native resolution with non-square RandomCrop (DETR recipe).
 
-    Regression tests for https://github.com/roboflow/rf-detr/issues/1018 — PR #752 replaced
-    RandomSizeCrop(384, 600) with a fixed RandomCrop(384, 384), silently removing scale jitter
-    from the non-square training pipeline.
+    The ``fix-resize-crop`` branch replaces the square-output ``RandomSizedCrop`` with a ``OneOf`` over non-square
+    ``RandomCrop`` sizes so the crop keeps native resolution and independent width/height (matching DETR's
+    ``RandomSizeCrop``), then resizes once. Crop sides are clamped to <=400 -- the smallest possible short side after
+    the first ``SmallestMaxSize([400, 500, 600])`` -- so a crop never exceeds the image (the previous ``min_max_height``
+    upper bound of 600 could).
+
+    Trade-off vs the prior ``RandomSizedCrop(min_max_height=[384, 600])`` (issue #1018 / PR #752): per-crop scale jitter
+    is narrowed to the [384, 400] clamp, but scale jitter is still supplied by the surrounding ``SmallestMaxSize([400,
+    500, 600])`` pre-crop resize and the final ``SmallestMaxSize(scales)`` resize, so jitter is not removed -- only
+    relocated out of the crop step.
     """
 
     @pytest.mark.parametrize(
-        "scales,square",
+        "scales",
         [
-            pytest.param([640], False, id="nonsquare-single"),
-            pytest.param([480, 640], False, id="nonsquare-multi"),
+            pytest.param([640], id="nonsquare-single"),
+            pytest.param([480, 640], id="nonsquare-multi"),
         ],
     )
-    def test_option_b_crop_step_is_random_sized_crop(self, scales, square):
-        """Non-square option_b crop step must be RandomSizedCrop, not RandomCrop."""
-        result = _build_train_resize_config(scales, square=square)
+    def test_option_b_crop_step_is_oneof_of_random_crop(self, scales):
+        """Non-square option_b crop step must be a OneOf of native-resolution RandomCrop, not RandomSizedCrop."""
+        result = _build_train_resize_config(scales, square=False)
         option_b = result[0]["OneOf"]["transforms"][1]
         crop_step = option_b["Sequential"]["transforms"][1]
-        assert "RandomSizedCrop" in crop_step, (
-            "Non-square option_b must use RandomSizedCrop for scale jitter; "
-            f"found {list(crop_step.keys())} instead (regression: issue #1018)"
+        crop_variants = crop_step["OneOf"]["transforms"]
+        assert crop_variants and all(
+            "RandomCrop" in entry and "RandomSizedCrop" not in entry for entry in crop_variants
         )
-        assert "RandomCrop" not in crop_step
 
     @pytest.mark.parametrize(
-        "scales,square",
+        "scales",
         [
-            pytest.param([640], False, id="nonsquare-single"),
-            pytest.param([480, 640], False, id="nonsquare-multi"),
+            pytest.param([640], id="nonsquare-single"),
+            pytest.param([480, 640], id="nonsquare-multi"),
         ],
     )
-    def test_option_b_crop_uses_scale_jitter_range(self, scales, square):
-        """RandomSizedCrop min_max_height must span [384, 600] to restore scale jitter."""
-        result = _build_train_resize_config(scales, square=square)
+    def test_option_b_crop_sizes_are_bounded_and_include_non_square(self, scales):
+        """Crop sides stay within [384, 400] (<= image) and include at least one non-square (h != w) variant."""
+        result = _build_train_resize_config(scales, square=False)
         option_b = result[0]["OneOf"]["transforms"][1]
-        crop_step = option_b["Sequential"]["transforms"][1]
-        assert crop_step["RandomSizedCrop"]["min_max_height"] == [384, 600]
+        crop_variants = option_b["Sequential"]["transforms"][1]["OneOf"]["transforms"]
+        sizes = [(entry["RandomCrop"]["height"], entry["RandomCrop"]["width"]) for entry in crop_variants]
+        assert all(384 <= h <= 400 and 384 <= w <= 400 for h, w in sizes)
+        assert any(h != w for h, w in sizes)
 
     @pytest.mark.parametrize(
         "scales,square",

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -700,3 +700,33 @@ class TestUnpackBoxesWithMasks:
 
         assert "masks" in result[0], "masks key must still be present when masks_aug=None"
         assert result[0]["masks"] is original_mask, "Original masks object must be preserved unchanged"
+
+
+class TestGaussNoiseStdRangeWarning:
+    """_make_gauss_noise warns when the configured std range is non-degenerate (GPU uses a fixed upper-bound std)."""
+
+    @pytest.fixture(autouse=True)
+    def _require_kornia(self):
+        pytest.importorskip("kornia")
+
+    def test_warns_for_unequal_std_range(self):
+        """A non-degenerate std_range emits a divergence warning at build time."""
+        from unittest import mock
+
+        from rfdetr.datasets import kornia_transforms
+
+        with mock.patch.object(kornia_transforms.logger, "warning") as mock_warning:
+            kornia_transforms._make_gauss_noise({"std_range": (0.01, 0.05), "p": 0.5})
+
+        mock_warning.assert_called_once()
+
+    def test_no_warning_for_degenerate_std_range(self):
+        """An equal-bound std_range matches the CPU path exactly and stays silent."""
+        from unittest import mock
+
+        from rfdetr.datasets import kornia_transforms
+
+        with mock.patch.object(kornia_transforms.logger, "warning") as mock_warning:
+            kornia_transforms._make_gauss_noise({"std_range": (0.05, 0.05), "p": 0.5})
+
+        mock_warning.assert_not_called()

--- a/tests/datasets/test_o365.py
+++ b/tests/datasets/test_o365.py
@@ -1,0 +1,20 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Tests for the Object365 dataset module."""
+
+import PIL.Image
+
+
+def test_o365_import_keeps_finite_decompression_bomb_guard() -> None:
+    """Importing ``o365`` must not disable PIL's decompression-bomb guard process-wide."""
+    from rfdetr.datasets import o365  # noqa: F401
+
+    assert PIL.Image.MAX_IMAGE_PIXELS is not None, (
+        "o365 must set a finite MAX_IMAGE_PIXELS cap, not None (which disables the guard globally)"
+    )
+    assert PIL.Image.MAX_IMAGE_PIXELS >= 178_956_970, (
+        "the cap must stay above PIL's default so legitimate large O365 images still load"
+    )

--- a/tests/inference/test_from_checkpoint.py
+++ b/tests/inference/test_from_checkpoint.py
@@ -177,6 +177,16 @@ class TestFromCheckpointDictArgs:
 class TestFromCheckpointEdgeCases:
     """Edge-case handling in from_checkpoint."""
 
+    def test_nonexistent_path_raises_file_not_found(self, tmp_path: Path) -> None:
+        """from_checkpoint raises FileNotFoundError when path does not exist."""
+        with pytest.raises(FileNotFoundError):
+            RFDETR.from_checkpoint(tmp_path / "nope.pth")
+
+    def test_directory_path_raises_os_error(self, tmp_path: Path) -> None:
+        """from_checkpoint raises OSError when path is a directory, not a file."""
+        with pytest.raises((OSError, IsADirectoryError)):
+            RFDETR.from_checkpoint(tmp_path)
+
     def test_characterization_unknown_pretrain_weights_raises_value_error(self, tmp_path: Path) -> None:
         """Unrecognised pretrain_weights name raises a descriptive ValueError."""
         ckpt = _ns("/my/custom/finetuned.pth")

--- a/tests/inference/test_optimize_for_inference.py
+++ b/tests/inference/test_optimize_for_inference.py
@@ -245,6 +245,11 @@ class TestOptimizeForInferenceCompile:
 class TestOptimizeForInferenceState:
     """Verify that optimize_for_inference correctly sets internal state flags."""
 
+    def test_is_optimized_inplace_false_before_optimization(self) -> None:
+        """is_optimized_inplace is False before any optimization is applied."""
+        rfdetr = _FakeRFDETR()
+        assert rfdetr.is_optimized_inplace is False
+
     def test_is_optimized_flag_set(self) -> None:
         """_is_optimized_for_inference should be True after optimization."""
         rfdetr = _FakeRFDETR()
@@ -278,7 +283,7 @@ class TestOptimizeForInferenceState:
         assert rfdetr._optimized_resolution is None
         assert rfdetr._optimized_has_been_compiled is False
         assert rfdetr._optimized_batch_size is None
-        assert rfdetr._optimized_inplace is False
+        assert rfdetr.is_optimized_inplace is False
 
 
 class TestOptimizeForInferenceInplace:
@@ -297,7 +302,7 @@ class TestOptimizeForInferenceInplace:
         assert rfdetr.model.model is original_model
         assert rfdetr.model.inference_model is copied_model
         assert rfdetr._is_optimized_for_inference is True
-        assert rfdetr._optimized_inplace is False
+        assert rfdetr.is_optimized_inplace is False
 
     def test_inplace_true_compile_false_does_not_deepcopy(self) -> None:
         """Inplace=True with compile=False should use the loaded module directly."""
@@ -311,7 +316,7 @@ class TestOptimizeForInferenceInplace:
         assert rfdetr.model.model is None
         assert rfdetr.model.inference_model is original_model
         assert rfdetr._is_optimized_for_inference is True
-        assert rfdetr._optimized_inplace is True
+        assert rfdetr.is_optimized_inplace is True
 
     def test_remove_optimized_model_after_inplace_warns_and_preserves_state(self) -> None:
         """remove_optimized_model() after inplace optimization issues UserWarning and no-ops."""
@@ -326,7 +331,7 @@ class TestOptimizeForInferenceInplace:
         assert rfdetr.model.model is None
         assert rfdetr.model.inference_model is original_model
         assert rfdetr._is_optimized_for_inference is True
-        assert rfdetr._optimized_inplace is True
+        assert rfdetr.is_optimized_inplace is True
 
     def test_second_optimize_after_inplace_raises_runtime_error(self) -> None:
         """Calling optimize_for_inference() again after inplace=True raises RuntimeError."""
@@ -386,7 +391,7 @@ class TestOptimizeForInferenceInplace:
         assert rfdetr.model.model is original_model
         assert rfdetr.model.inference_model is None
         assert rfdetr._is_optimized_for_inference is False
-        assert rfdetr._optimized_inplace is False
+        assert rfdetr.is_optimized_inplace is False
 
     @pytest.mark.parametrize(
         "dtype",
@@ -412,7 +417,7 @@ class TestOptimizeForInferenceInplace:
         assert rfdetr.model.model is original_model
         assert rfdetr.model.inference_model is None
         assert rfdetr._is_optimized_for_inference is False
-        assert rfdetr._optimized_inplace is False
+        assert rfdetr.is_optimized_inplace is False
 
     def test_inplace_compile_true_raises_before_export_or_trace(self) -> None:
         """In-place optimization rejects compile=True before mutating the base model."""
@@ -435,7 +440,7 @@ class TestOptimizeForInferenceInplace:
         assert rfdetr._is_optimized_for_inference is False
         assert rfdetr._optimized_has_been_compiled is False
         assert rfdetr._optimized_batch_size is None
-        assert rfdetr._optimized_inplace is False
+        assert rfdetr.is_optimized_inplace is False
 
 
 class TestOptimizeForInferenceExceptionRecovery:
@@ -521,7 +526,7 @@ class TestOptimizeForInferenceExceptionRecovery:
             rfdetr.optimize_for_inference(compile=False, inplace=True)
 
         assert rfdetr._is_optimized_for_inference is False
-        assert rfdetr._optimized_inplace is False
+        assert rfdetr.is_optimized_inplace is False
         assert rfdetr.model.model is original_model
         # The mutation happened and cannot be undone by RFDETR's recovery path
         assert mutated["happened"] is True

--- a/tests/inference/test_predict.py
+++ b/tests/inference/test_predict.py
@@ -3,16 +3,19 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
+import io
 import socket
 from types import SimpleNamespace
 
 import numpy as np
 import PIL.Image
 import pytest
+import requests
 import supervision as sv
 import torch
 
 from rfdetr import RFDETRNano, RFDETRSegNano
+from rfdetr.detr import RFDETR
 from rfdetr.utilities.keypoints import precision_cholesky_to_pixel_covariance
 
 from .helpers import _DummyModel, _DummyRFDETR
@@ -1005,3 +1008,124 @@ class TestPredictNonRGBAutoConvert:
         model = _DummyRFDETR()
         with pytest.raises(ValueError, match="PIL Image or a file path"):
             model.predict(tensor)
+
+
+def _png_bytes(size: tuple[int, int] = (28, 28)) -> bytes:
+    """Return the PNG-encoded bytes of a solid grey image."""
+    buf = io.BytesIO()
+    PIL.Image.new("RGB", size, (128, 128, 128)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+class _FakeResponse:
+    """Minimal stand-in for ``requests.Response`` used by ``predict()`` URL tests."""
+
+    def __init__(self, content: bytes = b"", status_code: int = 200) -> None:
+        """Store the response body and status code."""
+        self.content = content
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        """Raise ``requests.HTTPError`` for 4xx/5xx status codes, mirroring requests."""
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} Client Error")
+
+
+class TestPredictURLFetch:
+    """``predict()`` URL handling: robust HTTP fetch and correct local-path classification."""
+
+    def test_http_error_status_raises_httperror(self, monkeypatch) -> None:
+        """A 404 response surfaces as ``requests.HTTPError``, not an opaque PIL error."""
+        model = _DummyRFDETR()
+
+        def _fake_get(url: str, **kwargs: object) -> _FakeResponse:
+            return _FakeResponse(content=b"not found", status_code=404)
+
+        monkeypatch.setattr(requests, "get", _fake_get)
+        with pytest.raises(requests.HTTPError):
+            model.predict("http://example.com/missing.jpg")
+
+    def test_timeout_is_passed_to_requests_get(self, monkeypatch) -> None:
+        """The HTTP fetch must pass an explicit ``timeout`` so it cannot hang forever."""
+        model = _DummyRFDETR()
+        captured: dict[str, object] = {}
+
+        def _fake_get(url: str, **kwargs: object) -> _FakeResponse:
+            captured.update(kwargs)
+            return _FakeResponse(content=_png_bytes(), status_code=200)
+
+        monkeypatch.setattr(requests, "get", _fake_get)
+        detections = model.predict("http://example.com/image.png")
+        assert isinstance(detections, sv.Detections)
+        assert captured.get("timeout") == 30, "predict() must pass timeout=30 to requests.get"
+
+    def test_local_file_named_like_http_is_not_fetched(self, tmp_path, monkeypatch) -> None:
+        """A local file whose name starts with ``http`` must be opened, not fetched over HTTP."""
+        img_path = tmp_path / "httpcam_frame.png"
+        PIL.Image.new("RGB", (28, 28), (128, 128, 128)).save(str(img_path))
+        model = _DummyRFDETR()
+
+        def _fail_get(url: str, **kwargs: object) -> _FakeResponse:
+            raise AssertionError(f"requests.get must not be called for local path {url!r}")
+
+        monkeypatch.setattr(requests, "get", _fail_get)
+        detections = model.predict(str(img_path))
+        assert isinstance(detections, sv.Detections)
+
+
+class TestPredictInputTypeReturnShape:
+    """``predict()`` return shape is governed by input type, not runtime batch length."""
+
+    def test_single_element_list_returns_list(self) -> None:
+        """A one-element list input returns a list, not a bare ``Detections``."""
+        img = PIL.Image.new("RGB", (28, 28), (128, 128, 128))
+        model = _DummyRFDETR()
+        result = model.predict([img])
+        assert isinstance(result, list), "list input must always return a list"
+        assert len(result) == 1
+
+    def test_bare_image_returns_detections(self) -> None:
+        """A single (non-list) image returns a bare ``Detections``."""
+        img = PIL.Image.new("RGB", (28, 28), (128, 128, 128))
+        model = _DummyRFDETR()
+        result = model.predict(img)
+        assert isinstance(result, sv.Detections)
+
+
+class TestExportInplaceOptimizeGuards:
+    """Roboflow export methods raise a clear error after ``optimize_for_inference(inplace=True)``."""
+
+    def test_export_for_roboflow_raises_after_inplace_optimize(self, tmp_path) -> None:
+        """``export_for_roboflow`` raises ``RuntimeError`` once the model has been cleared."""
+        model = _DummyRFDETR()
+        model._optimized_inplace = True
+        with pytest.raises(RuntimeError, match="optimize_for_inference"):
+            model.export_for_roboflow(str(tmp_path))
+
+    def test_deploy_to_roboflow_raises_after_inplace_optimize(self) -> None:
+        """``deploy_to_roboflow`` raises ``RuntimeError`` before any auth/network calls."""
+        model = _DummyRFDETR()
+        model._optimized_inplace = True
+        with pytest.raises(RuntimeError, match="optimize_for_inference"):
+            model.deploy_to_roboflow("ws", "proj", 1)
+
+
+class TestTrainAlreadyTrainedWarning:
+    """Calling ``train()`` on an already-trained/loaded model emits a loud warning."""
+
+    def test_second_train_warns(self, monkeypatch) -> None:
+        """A model flagged as trained warns that training restarts from pretrain_weights."""
+        model = _DummyRFDETR()
+        model._has_been_trained = True
+
+        class _StopTrainError(Exception):
+            pass
+
+        def _stub_get_train_config(self, **kwargs: object) -> None:
+            raise _StopTrainError
+
+        # Short-circuit train() right after the warning so no real training runs.
+        monkeypatch.setattr(RFDETR, "get_train_config", _stub_get_train_config, raising=False)
+        with pytest.warns(UserWarning, match="already been trained"):
+            with pytest.raises(_StopTrainError):
+                model.train()

--- a/tests/inference/test_trt_inference.py
+++ b/tests/inference/test_trt_inference.py
@@ -6,6 +6,7 @@
 
 from unittest.mock import Mock
 
+import pytest
 import torch
 from PIL import Image
 
@@ -52,3 +53,58 @@ class TestTRTInference:
         assert image_tensor.shape == (3, 640, 640)
         assert image_tensor.dtype == torch.float32
         assert target is None
+
+
+class TestBenchmarkShapeParameterization:
+    """Benchmark preprocessing/postprocessing read input size and query count instead of hardcoding 640/300."""
+
+    def test_infer_transforms_uses_requested_size(self) -> None:
+        """infer_transforms resizes to the caller-supplied (height, width)."""
+        image = Image.new("RGB", (320, 240))
+
+        image_tensor, _ = infer_transforms((512, 384))(image, None)
+
+        assert image_tensor.shape == (3, 512, 384)
+
+    def test_infer_transforms_defaults_to_640(self) -> None:
+        """The default input size stays 640x640 for callers that do not pass a size."""
+        image = Image.new("RGB", (320, 240))
+
+        image_tensor, _ = infer_transforms()(image, None)
+
+        assert image_tensor.shape == (3, 640, 640)
+
+    def test_static_dim_returns_concrete_int(self) -> None:
+        """A concrete positive dimension is returned unchanged."""
+        from rfdetr.export.benchmark import _static_dim
+
+        assert _static_dim(384, 640) == 384
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param("height", id="dynamic-string"),
+            pytest.param(None, id="none"),
+            pytest.param(-1, id="negative"),
+        ],
+    )
+    def test_static_dim_falls_back_for_dynamic_axis(self, value) -> None:
+        """Dynamic/unknown axes fall back to the provided default."""
+        from rfdetr.export.benchmark import _static_dim
+
+        assert _static_dim(value, 640) == 640
+
+    def test_post_process_respects_num_queries(self) -> None:
+        """post_process selects exactly num_queries detections per image."""
+        from rfdetr.export.benchmark import post_process
+
+        num_queries = 5
+        outputs = {
+            "labels": torch.rand(1, 20, 3),
+            "dets": torch.rand(1, 20, 4),
+        }
+        target_sizes = torch.tensor([[480, 640]])
+
+        results = post_process(outputs, target_sizes, num_queries=num_queries)
+
+        assert results[0]["scores"].shape == (num_queries,)

--- a/tests/models/test_criterion.py
+++ b/tests/models/test_criterion.py
@@ -104,3 +104,31 @@ class TestNumBoxesForTargets:
 
         # 2 + 1 = 3 boxes; single-process so no all-reduce
         assert result.item() == pytest.approx(3.0)
+
+
+class TestLossMasksEmptyMatch:
+    """Tests for the dict-path zero-GT branch of SetCriterion.loss_masks."""
+
+    def test_dict_path_zero_gt_stays_connected_to_graph(self):
+        """Zero-match dict path returns a loss that back-propagates to every segmentation-head output."""
+        criterion = _bare_criterion()
+        spatial_features = torch.randn(1, 4, 8, 8, requires_grad=True)
+        query_features = torch.randn(1, 5, 4, requires_grad=True)
+        bias = torch.randn(1, requires_grad=True)
+        outputs = {
+            "pred_masks": {
+                "spatial_features": spatial_features,
+                "query_features": query_features,
+                "bias": bias,
+            }
+        }
+        empty = torch.empty(0, dtype=torch.long)
+        indices = [(empty, empty)]
+
+        losses = criterion.loss_masks(outputs, targets=[{}], indices=indices, num_boxes=1)
+
+        assert losses["loss_mask_ce"].requires_grad
+        (losses["loss_mask_ce"] + losses["loss_mask_dice"]).backward()
+        assert spatial_features.grad is not None
+        assert query_features.grad is not None
+        assert bias.grad is not None

--- a/tests/models/test_math.py
+++ b/tests/models/test_math.py
@@ -10,7 +10,27 @@ from __future__ import annotations
 import pytest
 import torch
 
-from rfdetr.models.math import accuracy, inverse_sigmoid
+from rfdetr.models.math import accuracy, interpolate, inverse_sigmoid
+
+
+class TestInterpolate:
+    """Verify interpolate() delegates to F.interpolate across torchvision versions."""
+
+    def test_resizes_to_target_size(self) -> None:
+        """Interpolate() upsamples a 4-D tensor to the requested spatial size."""
+        x = torch.randn(2, 3, 4, 4)
+
+        out = interpolate(x, size=[8, 8], mode="bilinear", align_corners=False)
+
+        assert out.shape == (2, 3, 8, 8)
+
+    def test_handles_empty_batch(self) -> None:
+        """Interpolate() supports an empty batch dimension without error."""
+        x = torch.randn(0, 3, 4, 4)
+
+        out = interpolate(x, size=[8, 8], mode="nearest")
+
+        assert out.shape == (0, 3, 8, 8)
 
 
 class TestAccuracy:

--- a/tests/models/test_postprocess.py
+++ b/tests/models/test_postprocess.py
@@ -147,3 +147,24 @@ class TestPostProcessForward:
         assert (boxes[..., 2] <= 640).all(), "x2 exceeds img_w (640)"
         assert (boxes[..., 1] <= 480).all(), "y1 exceeds img_h (480)"
         assert (boxes[..., 3] <= 480).all(), "y2 exceeds img_h (480)"
+
+
+class TestPostProcessMasks:
+    """Tests for :meth:`PostProcess._postprocess_masks` mask resizing."""
+
+    def test_chunked_upsample_preserves_shape_for_large_k(self):
+        """Chunked upsampling of K=64 masks returns full-resolution boolean masks of shape [K, 1, H, W]."""
+        batch, num_queries, mask_h, mask_w = 1, 64, 16, 16
+        num_select, img_h, img_w = 64, 512, 512
+        out_masks = torch.randn(batch, num_queries, mask_h, mask_w)
+        scores = torch.rand(batch, num_select)
+        labels = torch.zeros(batch, num_select, dtype=torch.long)
+        boxes = torch.zeros(batch, num_select, 4)
+        topk_boxes = torch.arange(num_select).unsqueeze(0)
+        target_sizes = torch.tensor([[img_h, img_w]])
+
+        results = PostProcess._postprocess_masks(out_masks, scores, labels, boxes, topk_boxes, target_sizes)
+
+        masks = results[0]["masks"]
+        assert masks.shape == (num_select, 1, img_h, img_w)
+        assert masks.dtype == torch.bool

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -353,7 +353,7 @@ class TestRFDETRTrainPTL:
             RFDETR.train(mock_self, do_benchmark=truthy_value)
         depr = [x for x in w if issubclass(x.category, DeprecationWarning)]
         assert len(depr) >= 1
-        assert "rfdetr benchmark" in str(depr[0].message)
+        assert "rfdetr.export.benchmark" in str(depr[0].message)
 
     def test_do_benchmark_not_forwarded_to_get_train_config(self, tmp_path, patch_lit):
         """do_benchmark is popped before calling get_train_config."""

--- a/tests/training/test_module_data.py
+++ b/tests/training/test_module_data.py
@@ -1477,3 +1477,57 @@ class TestKorniaSetupDoneSentinel:
             dm.setup("fit")
 
         assert call_count == 1, f"_setup_kornia_pipeline called {call_count} times; expected exactly 1"
+
+
+class TestWorkerInitFn:
+    """DataLoaders seed NumPy/random per worker so augmentation streams are not duplicated across workers."""
+
+    def test_worker_init_fn_seeds_from_torch_initial_seed(self, monkeypatch):
+        """_worker_init_fn derives a reproducible NumPy/random seed from ``torch.initial_seed``."""
+        import random as py_random
+
+        import numpy as np
+
+        from rfdetr.training.module_data import _worker_init_fn
+
+        monkeypatch.setattr(torch, "initial_seed", lambda: 12345)
+        _worker_init_fn(0)
+        first = (float(np.random.rand()), py_random.random())
+
+        # worker_id is irrelevant; the seed is derived from torch's per-worker seed.
+        monkeypatch.setattr(torch, "initial_seed", lambda: 12345)
+        _worker_init_fn(3)
+        second = (float(np.random.rand()), py_random.random())
+
+        assert first == second
+
+    @pytest.mark.parametrize(
+        "loader_name",
+        [
+            pytest.param("val_dataloader", id="val"),
+            pytest.param("test_dataloader", id="test"),
+            pytest.param("predict_dataloader", id="predict"),
+        ],
+    )
+    def test_eval_dataloaders_set_worker_init_fn(self, build_datamodule, loader_name):
+        """Validation/test/predict DataLoaders wire the module-level worker seeding hook."""
+        from rfdetr.training.module_data import _worker_init_fn
+
+        dm = build_datamodule()
+        dm._dataset_val = _fake_dataset()
+        dm._dataset_test = _fake_dataset()
+
+        loader = getattr(dm, loader_name)()
+
+        assert loader.worker_init_fn is _worker_init_fn
+
+    def test_train_dataloader_sets_worker_init_fn(self, build_datamodule):
+        """The training DataLoader wires the module-level worker seeding hook."""
+        from rfdetr.training.module_data import _worker_init_fn
+
+        dm = build_datamodule()
+        dm._dataset_train = _fake_dataset()
+
+        loader = dm.train_dataloader()
+
+        assert loader.worker_init_fn is _worker_init_fn

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -5,6 +5,7 @@
 # ------------------------------------------------------------------------
 """Comprehensive unit tests for RFDETRModelModule (LightningModule wrapper)."""
 
+import random
 from types import SimpleNamespace
 from unittest.mock import MagicMock, PropertyMock, patch
 
@@ -148,6 +149,44 @@ def _make_batch(batch_size=2, channels=3, h=16, w=16):
         for i in range(batch_size)
     ]
     return samples, targets
+
+
+class TestMultiScaleBatchStart:
+    """on_train_batch_start multi-scale resize picks a step-deterministic scale without clobbering global RNG."""
+
+    def _build_multi_scale_module(self, tmp_path, global_step):
+        """Return a module configured for multi-scale with a stubbed trainer at the given global step."""
+        tc = _base_train_config(tmp_path, multi_scale=True, do_random_resize_via_padding=False)
+        module, *_ = _build_module(train_config=tc, tmp_path=tmp_path)
+        module.trainer = SimpleNamespace(global_step=global_step)
+        return module
+
+    def test_scale_choice_is_deterministic_per_step(self, tmp_path):
+        """The same global step must resize the batch to the same scale regardless of batch contents."""
+        module = self._build_multi_scale_module(tmp_path, global_step=7)
+
+        batch_a = _make_batch(h=64, w=64)
+        module.on_train_batch_start(batch_a, 0)
+        size_a = tuple(batch_a[0].tensors.shape[-2:])
+
+        batch_b = _make_batch(h=64, w=64)
+        module.on_train_batch_start(batch_b, 0)
+        size_b = tuple(batch_b[0].tensors.shape[-2:])
+
+        assert size_a == size_b
+
+    def test_does_not_perturb_global_rng(self, tmp_path):
+        """Scale selection must use a step-local generator and leave the process-global RNG untouched."""
+        module = self._build_multi_scale_module(tmp_path, global_step=3)
+
+        random.seed(42)
+        expected = [random.random() for _ in range(3)]
+
+        random.seed(42)
+        module.on_train_batch_start(_make_batch(h=64, w=64), 0)
+        actual = [random.random() for _ in range(3)]
+
+        assert actual == expected
 
 
 class _ScalarLossModel(nn.Module):

--- a/tests/utilities/test_box_ops.py
+++ b/tests/utilities/test_box_ops.py
@@ -6,7 +6,26 @@
 
 import torch
 
-from rfdetr.utilities.box_ops import masks_to_boxes
+from rfdetr.utilities.box_ops import box_iou, generalized_box_iou, masks_to_boxes
+
+
+def test_box_iou_zero_area_boxes_are_finite() -> None:
+    """Zero-area boxes yield finite IoU/union instead of a 0/0 NaN."""
+    zero_box = torch.tensor([[10.0, 10.0, 10.0, 10.0]])  # w = h = 0
+
+    iou, union = box_iou(zero_box, zero_box)
+
+    assert torch.isfinite(iou).all()
+    assert torch.isfinite(union).all()
+
+
+def test_generalized_box_iou_zero_area_boxes_are_finite() -> None:
+    """Degenerate zero-area boxes give finite GIoU instead of NaN/inf."""
+    zero_box = torch.tensor([[10.0, 10.0, 10.0, 10.0]])  # w = h = 0
+
+    giou = generalized_box_iou(zero_box, zero_box)
+
+    assert torch.isfinite(giou).all()
 
 
 def test_masks_to_boxes_passes_ij_indexing_to_meshgrid(monkeypatch) -> None:


### PR DESCRIPTION
This pull request updates the RF-DETR documentation to clarify installation, migration, training, and export procedures, and corrects benchmark comparisons. The most important changes are grouped below:

**Installation and Training Extras**

* Added a new "Optional Extras" section to `install.md` documenting pip install extras for training, logging, ONNX/TFLite export, LoRA fine-tuning, and premium models. This clarifies how to install only the dependencies you need.
* Added a note to the training quickstart that the `train` extra is required for training, with install instructions for both training and experiment tracking dependencies.

**Migration and API Changes**

* Documented all APIs removed in v1.9, including deprecated import paths, removed/renamed functions and arguments, and config field migrations. This provides clear upgrade guidance for users updating from earlier versions.
* Clarified that `gradient_checkpointing` is a model constructor parameter (not a `train()` argument), and updated advanced training docs to prevent common misconfiguration errors. [[1]](diffhunk://#diff-4afc795ab20611ef48093a8af11628983add160a37d4ae7887dbc0bccc451b8bL295-L300) [[2]](diffhunk://#diff-4afc795ab20611ef48093a8af11628983add160a37d4ae7887dbc0bccc451b8bL358-R365)
* Updated migration instructions for segmentation model imports and model weights, reflecting new import paths and class names. [[1]](diffhunk://#diff-b0d8e8f60aef72b014216f06c57b552839127648a84af77a36c98003394cffb7L372-R434) [[2]](diffhunk://#diff-b0d8e8f60aef72b014216f06c57b552839127648a84af77a36c98003394cffb7L206) [[3]](diffhunk://#diff-b0d8e8f60aef72b014216f06c57b552839127648a84af77a36c98003394cffb7L222)

**Export and Deployment Documentation**

* Improved ONNX/TFLite export documentation: clarified input shape requirements, added new export options (`dynamic_batch`, `patch_size`, `notes`), updated sample code to use `RFDETRSmall`, and removed deprecated flags (`simplify`, `force`). [[1]](diffhunk://#diff-76bf72360ae4b094d0fe12835eae94e7fa98534d371672cb78af21088eae67e8L13-R13) [[2]](diffhunk://#diff-76bf72360ae4b094d0fe12835eae94e7fa98534d371672cb78af21088eae67e8L66-R74) [[3]](diffhunk://#diff-76bf72360ae4b094d0fe12835eae94e7fa98534d371672cb78af21088eae67e8L87-L98) [[4]](diffhunk://#diff-76bf72360ae4b094d0fe12835eae94e7fa98534d371672cb78af21088eae67e8L204-R195) [[5]](diffhunk://#diff-76bf72360ae4b094d0fe12835eae94e7fa98534d371672cb78af21088eae67e8L269-R261)
* Updated export calibration and example code to use the correct model and config fields.

**Benchmark and Model Comparison Corrections**

* Corrected the reported AP of YOLOv11x in benchmark comparisons from 54.7 to 50.9 AP in both the main index and benchmarks page, ensuring accurate performance claims. [[1]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L167-R167) [[2]](diffhunk://#diff-118e6b96b8efefb25199f04d9ac972672af5156385313475eedaa59fefacdea6L10-R10)

**Other Documentation Improvements**

* Updated video capture code example for clarity and correctness of webcam index handling.
* Clarified configuration options for distributed training in the customization guide, including how to set the `strategy` and related fields.
* Updated citation in the README to reflect the correct publication venue, year, and author list.