### PR TITLE
docs: correct citation author name to Matvei Popov

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ If you find our work helpful for your research, please consider citing the follo
 ```bibtex
 @inproceedings{robinson2026rfdetr,
   title     = {RF-DETR: Real-Time Detection Transformer},
-  author    = {Robinson, Isaac and Robicheaux, Peter and Popov, Fedor and Ramanan, Deva and Peri, Neehar},
+  author    = {Robinson, Isaac and Robicheaux, Peter and Popov, Matvei and Ramanan, Deva and Peri, Neehar},
   booktitle = {International Conference on Learning Representations (ICLR)},
   year      = {2026},
   url       = {https://arxiv.org/abs/2511.09554}

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,12 +10,12 @@ RF-DETR is a real-time transformer architecture for object detection, instance s
 
 RF-DETR uses a DINOv2 vision transformer backbone and supports object detection, instance segmentation, and keypoint detection (preview) in a single, consistent API. Core models (Nano through Large) and all code are released under the Apache 2.0 license; XL and 2XLarge detection models require `rfdetr[plus]` and are provided under PML 1.0.
 
-Developed by Isaac Robinson, Peter Robicheaux, Fedor Popov, Deva Ramanan (CMU), and Neehar Peri (CMU) at [Roboflow](https://roboflow.com). If you use RF-DETR in your research, please cite:
+Developed by Isaac Robinson, Peter Robicheaux, Matvei Popov, Deva Ramanan (CMU), and Neehar Peri (CMU) at [Roboflow](https://roboflow.com). If you use RF-DETR in your research, please cite:
 
 ```bibtex
 @inproceedings{robinson2026rfdetr,
   title     = {RF-DETR: Real-Time Detection Transformer},
-  author    = {Robinson, Isaac and Robicheaux, Peter and Popov, Fedor and Ramanan, Deva and Peri, Neehar},
+  author    = {Robinson, Isaac and Robicheaux, Peter and Popov, Matvei and Ramanan, Deva and Peri, Neehar},
   booktitle = {International Conference on Learning Representations (ICLR)},
   year      = {2026},
   url       = {https://arxiv.org/abs/2511.09554}


### PR DESCRIPTION
## Description

The README citation and docs homepage list the third RF-DETR author as **Fedor Popov**; the correct name is **Matvei Popov** (see [arXiv:2511.09554](https://arxiv.org/abs/2511.09554)). This fixes all three occurrences (README.md bibtex, docs/index.md prose + bibtex).

How the error got in:

- `545a932a` (Apr 25, 2026, "docs: update documentation with new authorship...") introduced the docs/index.md author list with "Fedor Popov" from the start.
- `42e05c8c` (#1180, Jul 3, 2026) rewrote the README bibtex, replacing the previously-correct "Matvei Popov" with the docs' incorrect "Popov, Fedor".

## Type of change

- [x] Documentation update

## How has this change been tested?

Docs-only change (no runtime surface). Verified locally:

- `grep -rn Fedor .` returns no matches after the change
- `pre-commit run mdformat/codespell --files README.md docs/index.md` — all pass
- Manual check: view the Citation section of the rendered README and the docs homepage intro; both should read "Matvei Popov" matching the arXiv author list

🤖 Generated with [Claude Code](https://claude.com/claude-code)