### PR TITLE
fix(training): refresh `model.args` from real config after `train()`

### DIFF
--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -28,6 +28,7 @@ import torchvision.transforms.functional as F  # noqa: N812
 import yaml
 from PIL import Image
 
+from rfdetr._namespace import _namespace_from_configs
 from rfdetr.assets.coco_classes import COCO_CLASS_NAMES, COCO_CLASSES
 from rfdetr.assets.model_weights import download_pretrain_weights, get_model_cache_dir
 from rfdetr.config import ModelConfig, TrainConfig
@@ -877,6 +878,10 @@ class RFDETR:
 
         # Sync the trained weights back so predict() / export() see the updated model.
         self.model.model = module.model
+        # Rebuild model.args from the real training config (#1199): it was previously left as the
+        # construction-time snapshot built from a dummy TrainConfig, so overrides like lr/lr_encoder
+        # never appeared in model.model.__dict__['args'] even though the optimizer used them correctly.
+        self.model.args = _namespace_from_configs(self.model_config, config)
         # Mark this instance as trained so a subsequent train() call warns that it will
         # restart from pretrain_weights rather than continue from the in-memory state.
         self._has_been_trained = True

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -2216,7 +2216,7 @@ class RFDETR:
         """Write a Roboflow upload bundle (``weights.pt`` + ``class_names.txt``) into *output_dir*.
 
         This is the network-free core of :meth:`deploy_to_roboflow`: it serialises the model state and
-        training args into ``weights.pt``, always embedding ``class_names`` into a copy of the args so
+        a sanitized copy of the training args into ``weights.pt``, always embedding ``class_names`` so
         the bundle is self-contained, and writes the class labels to ``class_names.txt``.  The Roboflow
         SDK uses this format to adapt raw PyTorch-Lightning checkpoints into a deploy-ready bundle.
 
@@ -2243,11 +2243,12 @@ class RFDETR:
         with open(class_names_path, "w", encoding="utf-8", newline="\n") as f:
             f.write("\n".join(self.class_names))
 
-        # Embed class_names in a shallow copy of args so the saved bundle is
-        # self-contained (roboflow-python's second fallback reads args.class_names
-        # directly from the checkpoint).  Using a copy leaves self.model.args
-        # unmodified — each export call is independent regardless of call order.
+        # Serialize a sanitized copy so trained bundles do not expose the caller's
+        # filesystem layout.  Keep self.model.args unchanged for runtime consumers.
         args = copy(self.model.args)
+        args.dataset_dir = None
+        args.output_dir = "output"
+        args.resume = ""
         if not hasattr(args, "class_names") or args.class_names is None:
             args.class_names = self.class_names
 

--- a/tests/export/test_export_for_roboflow.py
+++ b/tests/export/test_export_for_roboflow.py
@@ -73,6 +73,23 @@ class TestExportForRoboflow:
         bundle = torch.load(tmp_path / "weights.pt", map_location="cpu", weights_only=False)
         assert bundle["args"].class_names == ["pre_existing"]
 
+    def test_sanitizes_training_paths_without_mutating_runtime_args(self, tmp_path: Path) -> None:
+        """Exported args hide local training paths while runtime args retain them."""
+        model = _make_stub_model(["cat", "dog"])
+        model.model.args.dataset_dir = "/private/training-dataset"
+        model.model.args.output_dir = "/private/training-output"
+        model.model.args.resume = "/private/checkpoints/last.ckpt"
+
+        model.export_for_roboflow(str(tmp_path))
+
+        bundle = torch.load(tmp_path / "weights.pt", map_location="cpu", weights_only=False)
+        assert bundle["args"].dataset_dir is None
+        assert bundle["args"].output_dir == "output"
+        assert bundle["args"].resume == ""
+        assert model.model.args.dataset_dir == "/private/training-dataset"
+        assert model.model.args.output_dir == "/private/training-output"
+        assert model.model.args.resume == "/private/checkpoints/last.ckpt"
+
     def test_empty_class_names_writes_empty_file(self, tmp_path: Path) -> None:
         """Empty class_names list produces an empty class_names.txt (no trailing newline)."""
         model = _make_stub_model([])

--- a/tests/training/test_auto_batch.py
+++ b/tests/training/test_auto_batch.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 
+from rfdetr.config import RFDETRBaseConfig, TrainConfig
 from rfdetr.detr import RFDETR
 from rfdetr.training import auto_batch
 from rfdetr.training.auto_batch import AutoBatchResult
@@ -153,6 +154,7 @@ def test_train_auto_batch_ensures_model_on_device_before_resolve(
     _mock_build_trainer: MagicMock,
     mock_resolve: MagicMock,
     _mock_is_main: MagicMock,
+    tmp_path,
 ) -> None:
     """Model weights must be moved before resolve_auto_batch_config when batch_size='auto'."""
     auto_result = SimpleNamespace(safe_micro_batch=4, recommended_grad_accum_steps=1, effective_batch_size=4)
@@ -168,16 +170,17 @@ def test_train_auto_batch_ensures_model_on_device_before_resolve(
     mock_move.side_effect = _move_side_effect
     mock_resolve.side_effect = _resolve_side_effect
 
-    train_config = SimpleNamespace(
+    # Real config objects: RFDETR.train() rebuilds self.model.args via _namespace_from_configs
+    # after trainer.fit() (#1199 fix), which requires genuine ModelConfig/TrainConfig instances.
+    train_config = TrainConfig(
+        dataset_dir=None,
+        output_dir=str(tmp_path / "out"),
         batch_size="auto",
         grad_accum_steps=99,
-        dataset_dir=None,
-        resume=None,
-        class_names=None,
-        save_dataset_grids=False,
+        tensorboard=False,
     )
     mock_self = MagicMock()
-    mock_self.model_config = SimpleNamespace(model_name=None)
+    mock_self.model_config = RFDETRBaseConfig(pretrain_weights=None, num_classes=3, device="cpu")
     mock_self.get_train_config.return_value = train_config
 
     RFDETR.train(mock_self)

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -256,6 +256,23 @@ class TestRFDETRTrainPTL:
 
         assert mock_self.model.class_names == []
 
+    def test_model_args_synced_from_train_config_after_training(self, tmp_path, patch_lit):
+        """self.model.args reflects the real TrainConfig's lr/lr_encoder after train().
+
+        Regression test for #1199: model.model.__dict__['args'] retained the construction-time defaults (lr=0.0001,
+        lr_encoder=0.00015) instead of the overrides passed to train(), because ``self.model.args`` was built once at
+        model-construction time from a dummy config and never refreshed after ``train()`` completed.
+        """
+        mock_self = _make_rfdetr_self(tmp_path, lr=5e-5, lr_encoder=1e-4)
+        mock_self.model.args = SimpleNamespace(lr=0.0001, lr_encoder=0.00015, resolution=560)
+        p_mod, p_dm, p_bt, *_ = patch_lit
+
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self)
+
+        assert mock_self.model.args.lr == 5e-5
+        assert mock_self.model.args.lr_encoder == 1e-4
+
     def test_device_kwarg_cpu_no_warning(self, tmp_path, patch_lit):
         """Device='cpu' is consumed without a DeprecationWarning."""
         mock_self = _make_rfdetr_self(tmp_path)

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -257,13 +257,14 @@ class TestRFDETRTrainPTL:
         assert mock_self.model.class_names == []
 
     def test_model_args_synced_from_train_config_after_training(self, tmp_path, patch_lit):
-        """self.model.args reflects the real TrainConfig's lr/lr_encoder after train().
+        """self.model.args reflects effective training and model config after train().
 
         Regression test for #1199: model.model.__dict__['args'] retained the construction-time defaults (lr=0.0001,
         lr_encoder=0.00015) instead of the overrides passed to train(), because ``self.model.args`` was built once at
         model-construction time from a dummy config and never refreshed after ``train()`` completed.
         """
-        mock_self = _make_rfdetr_self(tmp_path, lr=5e-5, lr_encoder=1e-4)
+        mock_self = _make_rfdetr_self(tmp_path, lr=5e-5, lr_encoder=1e-4, batch_size=7)
+        mock_self.model_config.num_classes = 7
         mock_self.model.args = SimpleNamespace(lr=0.0001, lr_encoder=0.00015, resolution=560)
         p_mod, p_dm, p_bt, *_ = patch_lit
 
@@ -272,6 +273,10 @@ class TestRFDETRTrainPTL:
 
         assert mock_self.model.args.lr == 5e-5
         assert mock_self.model.args.lr_encoder == 1e-4
+        assert mock_self.model.args.batch_size == 7
+        assert mock_self.model.args.num_classes == 7
+        assert mock_self.model.args.dataset_dir == str(tmp_path / "ds")
+        assert mock_self.model.args.output_dir == str(tmp_path / "out")
 
     def test_device_kwarg_cpu_no_warning(self, tmp_path, patch_lit):
         """Device='cpu' is consumed without a DeprecationWarning."""


### PR DESCRIPTION
This pull request addresses an important regression where model training overrides (like `lr` and `lr_encoder`) were not correctly reflected in the model's `args` after training. The update ensures that `self.model.args` is rebuilt from the actual training configuration, so any parameter overrides are accurately captured. Additionally, the test suite is updated to use real config objects and includes a regression test for this fix.

**Bug fix: Model argument synchronization after training**
- [`src/rfdetr/detr.py`](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86R881-R884): After training, `self.model.args` is now rebuilt from the real training config using `_namespace_from_configs`, ensuring that parameter overrides (e.g., `lr`, `lr_encoder`) are reflected in the model's state.

**Testing improvements**
- [`tests/training/test_auto_batch.py`](diffhunk://#diff-64aba6a805871780a386184b8777c9ec1b1c7497c2616aee142775f7a0e77b22L171-R183): Tests now use real `TrainConfig` and `RFDETRBaseConfig` objects instead of `SimpleNamespace`, aligning with the updated logic in `RFDETR.train()`.
- [`tests/training/test_auto_batch.py`](diffhunk://#diff-64aba6a805871780a386184b8777c9ec1b1c7497c2616aee142775f7a0e77b22R157): The `test_train_auto_batch_ensures_model_on_device_before_resolve` test is updated to accept `tmp_path` for proper temporary directory handling.
- [`tests/training/test_detr_shim.py`](diffhunk://#diff-6b1d80c3cb1bad19362f3974e085ec0eec262356a56dfbac555707b8b0cc0cb8R259-R275): Adds a regression test to verify that `self.model.args` reflects the real training config's `lr` and `lr_encoder` after training, preventing a repeat of issue #1199.

**Imports and dependencies**
- `src/rfdetr/detr.py`, `tests/training/test_auto_batch.py`: Updated imports to include `_namespace_from_configs`, `RFDETRBaseConfig`, and `TrainConfig` where needed for the new logic and tests. [[1]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86R31) [[2]](diffhunk://#diff-64aba6a805871780a386184b8777c9ec1b1c7497c2616aee142775f7a0e77b22R13)

---

resolves #1199