### PR TITLE
fix(inference): disable antialias in `predict()` resize to match training

### DIFF
--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -1949,7 +1949,9 @@ class RFDETR:
             processed_images.append(img_tensor.to(self.model.device))
 
         resize_to = list(shape) if shape is not None else [self.model.resolution, self.model.resolution]
-        batch_tensor = torch.stack([F.resize(t, resize_to) for t in processed_images])
+        # antialias=False matches the antialias-free bilinear resize (cv2.INTER_LINEAR)
+        # used by Albumentations during training — see issue #1203.
+        batch_tensor = torch.stack([F.resize(t, resize_to, antialias=False) for t in processed_images])
         batch_tensor = F.normalize(batch_tensor, self.means, self.stds)
 
         if self._is_optimized_for_inference:

--- a/tests/inference/test_predict.py
+++ b/tests/inference/test_predict.py
@@ -457,6 +457,38 @@ class TestPredictShape:
             model.predict(img, shape=bad_shape)  # type: ignore[arg-type]
 
 
+class TestPredictResizeMatchesTrainingInterpolation:
+    """Verify ``predict()`` resize matches the training-time interpolation.
+
+    Regression test for https://github.com/roboflow/rf-detr/issues/1203.
+
+    Training/validation uses Albumentations ``Resize`` (cv2 bilinear, no
+    antialiasing). torchvision's ``F.resize`` defaults to antialiased
+    bilinear, which drifts bbox/confidence values relative to the
+    pretrained checkpoints' reference preprocessing. ``predict()`` must
+    disable antialiasing to match the training resize.
+    """
+
+    def test_predict_resize_disables_antialias(self) -> None:
+        """``predict()`` calls ``F.resize`` with ``antialias=False``."""
+        from unittest.mock import patch
+
+        import torchvision.transforms.functional as F  # noqa: N812
+
+        model = _DummyRFDETR()
+        img = PIL.Image.new("RGB", (100, 80), color=(64, 64, 64))
+
+        with patch("rfdetr.detr.F.resize", wraps=F.resize) as mock_resize:
+            model.predict(img)
+
+        assert mock_resize.call_args.kwargs.get("antialias") is False, (
+            "predict() must resize with antialias=False to match the antialias-free "
+            "bilinear resize (cv2.INTER_LINEAR) used during training. Antialiasing "
+            "on drifts bbox/confidence values away from the pretrained checkpoints' "
+            "reference preprocessing."
+        )
+
+
 class TestPredictPatchSize:
     """Predict() patch_size resolution and validation tests."""
 


### PR DESCRIPTION
This pull request ensures that the image resizing behavior during inference matches the interpolation used during training, addressing a regression issue that caused discrepancies in bounding box and confidence values. The update disables antialiasing in the resize operation and adds a regression test to verify this behavior.

**Inference preprocessing consistency:**

* Updated `src/rfdetr/detr.py` so that `F.resize` in the `predict()` method is called with `antialias=False`, matching the antialias-free bilinear resize (cv2.INTER_LINEAR) used by Albumentations during training. This prevents drift in bounding box and confidence values relative to pretrained checkpoints.

**Testing:**

* Added a new test class `TestPredictResizeMatchesTrainingInterpolation` in `tests/inference/test_predict.py` to verify that `predict()` disables antialiasing during resize, ensuring inference preprocessing matches training-time interpolation.

---

resolves #1203