### PR TITLE
fix(export): freeze backbone position embeddings before ONNX trace

### DIFF
--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -39,6 +39,7 @@ from rfdetr.datasets._keypoint_schema import (
 from rfdetr.datasets.coco import is_valid_coco_dataset
 from rfdetr.datasets.yolo import REQUIRED_YOLO_YAML_FILES, is_valid_yolo_dataset
 from rfdetr.inference import ModelContext, _build_model_context
+from rfdetr.models.backbone.dinov2 import DinoV2
 from rfdetr.utilities.distributed import is_main_process
 from rfdetr.utilities.keypoints import _is_bg_first_schema, precision_cholesky_to_pixel_covariance
 from rfdetr.utilities.logger import get_logger
@@ -1285,6 +1286,15 @@ class RFDETR:
                     )
             else:
                 shape = _validate_shape_dims(shape, block_size, patch_size, num_windows)
+
+            # Freeze the backbone's position embeddings to the export shape before tracing. Without this, a
+            # `shape` that differs from the model's native resolution forces the traced forward pass through
+            # DINOv2's antialiased bicubic interpolation, which has no ONNX symbolic (`aten::_upsample_bicubic2d_aa`
+            # is unsupported). Precomputing here (outside the trace) keeps that op out of the traced graph.
+            for backbone_module in model.modules():
+                if isinstance(backbone_module, DinoV2):
+                    backbone_module.shape = shape
+                    backbone_module.export()
 
             input_tensors = make_infer_image(
                 infer_dir, shape, batch_size, device, num_channels=self.model_config.num_channels

--- a/src/rfdetr/models/backbone/dinov2.py
+++ b/src/rfdetr/models/backbone/dinov2.py
@@ -206,7 +206,8 @@ class DinoV2(nn.Module):
         def new_interpolate_pos_encoding(self_mod: Any, embeddings: Tensor, height: int, width: int) -> Tensor:
             num_patches = embeddings.shape[1] - 1
             num_positions = self_mod.position_embeddings.shape[1] - 1
-            if num_patches == num_positions and height == width:
+            # The precomputed table is valid only for this exact static export grid.
+            if num_patches == num_positions and (height, width) == shape:
                 return cast(Tensor, self_mod.position_embeddings)
             return cast(Tensor, old_interpolate_pos_encoding(embeddings, height, width))
 

--- a/tests/export/test_export.py
+++ b/tests/export/test_export.py
@@ -27,7 +27,7 @@ import pytest
 import torch
 from torch.jit import TracerWarning
 
-from rfdetr import RFDETRSegNano
+from rfdetr import RFDETRNano, RFDETRSegNano
 from rfdetr import detr as _detr_module
 from rfdetr.export import main as _cli_export_module
 
@@ -60,6 +60,9 @@ class _DummyCoreModel:
 
     def cpu(self):
         return self
+
+    def modules(self):
+        return iter(())
 
     def __call__(self, *_args, **_kwargs):
         out = {"pred_boxes": torch.zeros(1, 1, 4), "pred_logits": torch.zeros(1, 1, 2)}
@@ -114,6 +117,27 @@ def test_segmentation_model_export_no_crash(tmp_path: Path) -> None:
         model.export(output_dir=str(tmp_path), verbose=False)
 
     # Verify export produced output files
+    onnx_files = list(tmp_path.glob("*.onnx"))
+    assert len(onnx_files) > 0, "Export should produce ONNX file(s)"
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for export test")
+@pytest.mark.skipif(not _IS_ONNX_INSTALLED, reason="onnx not installed, run: pip install rfdetr[onnx]")
+def test_export_with_shape_different_from_resolution_no_crash(tmp_path: Path) -> None:
+    """Integration test: exporting with a `shape` different from the model's native resolution should not crash.
+
+    A mismatched shape forces the DINOv2 backbone to interpolate its position embeddings for the new grid size. This
+    must not trace an antialiased bicubic resize (``aten::_upsample_bicubic2d_aa``), which has no ONNX opset-17
+    symbolic function.
+    """
+    model = RFDETRNano()
+    export_shape = (608, 608)
+    assert export_shape != (model.model.resolution, model.model.resolution)
+
+    with ignore_tracer_warnings():
+        model.export(output_dir=str(tmp_path), shape=export_shape, verbose=False)
+
     onnx_files = list(tmp_path.glob("*.onnx"))
     assert len(onnx_files) > 0, "Export should produce ONNX file(s)"
 

--- a/tests/export/test_export.py
+++ b/tests/export/test_export.py
@@ -30,6 +30,7 @@ from torch.jit import TracerWarning
 from rfdetr import RFDETRNano, RFDETRSegNano
 from rfdetr import detr as _detr_module
 from rfdetr.export import main as _cli_export_module
+from rfdetr.models.backbone.dinov2 import DinoV2
 
 _IS_ONNX_INSTALLED = importlib.util.find_spec("onnx") is not None
 
@@ -124,22 +125,65 @@ def test_segmentation_model_export_no_crash(tmp_path: Path) -> None:
 @pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for export test")
 @pytest.mark.skipif(not _IS_ONNX_INSTALLED, reason="onnx not installed, run: pip install rfdetr[onnx]")
-def test_export_with_shape_different_from_resolution_no_crash(tmp_path: Path) -> None:
-    """Integration test: exporting with a `shape` different from the model's native resolution should not crash.
+def test_export_with_rectangular_shape_different_from_resolution_no_crash(tmp_path: Path) -> None:
+    """Integration test: exporting with a valid rectangular shape should not crash.
 
     A mismatched shape forces the DINOv2 backbone to interpolate its position embeddings for the new grid size. This
     must not trace an antialiased bicubic resize (``aten::_upsample_bicubic2d_aa``), which has no ONNX opset-17
     symbolic function.
     """
     model = RFDETRNano()
-    export_shape = (608, 608)
-    assert export_shape != (model.model.resolution, model.model.resolution)
+    block_size = model.model_config.patch_size * model.model_config.num_windows
+    native_resolution = model.model.resolution
+    export_shape = (native_resolution, native_resolution + block_size)
+    assert all(dimension % block_size == 0 for dimension in export_shape)
+    assert export_shape != (native_resolution, native_resolution)
 
     with ignore_tracer_warnings():
         model.export(output_dir=str(tmp_path), shape=export_shape, verbose=False)
 
     onnx_files = list(tmp_path.glob("*.onnx"))
     assert len(onnx_files) > 0, "Export should produce ONNX file(s)"
+
+
+def test_dinov2_export_uses_precomputed_positions_for_exact_rectangular_grid() -> None:
+    """DINOv2 export must bypass interpolation only for its precomputed rectangular grid."""
+    patch_size = 8
+    export_shape = (32, 48)
+    source_positions = torch.nn.Parameter(torch.randn(1, 17, 2))
+    original_calls: list[tuple[int, int]] = []
+    fallback_positions = torch.randn(1, 1, 2)
+
+    def original_interpolate_pos_encoding(_embeddings: torch.Tensor, height: int, width: int) -> torch.Tensor:
+        """Record fallback interpolation calls made by the exported backbone."""
+        original_calls.append((height, width))
+        return fallback_positions
+
+    backbone = DinoV2.__new__(DinoV2)
+    torch.nn.Module.__init__(backbone)
+    backbone.shape = export_shape
+    backbone._export = False
+    backbone.encoder = types.SimpleNamespace(
+        config=types.SimpleNamespace(patch_size=patch_size),
+        embeddings=types.SimpleNamespace(
+            position_embeddings=source_positions,
+            interpolate_pos_encoding=original_interpolate_pos_encoding,
+        ),
+    )
+
+    backbone.export()
+    patch_count = (export_shape[0] // patch_size) * (export_shape[1] // patch_size)
+    embeddings = torch.randn(1, patch_count + 1, 2)
+
+    fixed_positions = backbone.encoder.embeddings.interpolate_pos_encoding(embeddings, *export_shape)
+    assert fixed_positions is backbone.encoder.embeddings.position_embeddings
+    assert original_calls == []
+
+    transposed_positions = backbone.encoder.embeddings.interpolate_pos_encoding(
+        embeddings, export_shape[1], export_shape[0]
+    )
+    assert transposed_positions is fallback_positions
+    assert original_calls == [(export_shape[1], export_shape[0])]
 
 
 @pytest.mark.gpu


### PR DESCRIPTION
This pull request improves the export functionality for models using the DINOv2 backbone, ensuring compatibility with ONNX export when the export shape differs from the model's native resolution. It also adds a new integration test to prevent regressions in this area.

**Export compatibility and DINOv2 backbone handling:**

* In `src/rfdetr/detr.py`, the export logic now freezes the DINOv2 backbone's position embeddings to the export shape before tracing. This avoids tracing through DINOv2's antialiased bicubic interpolation, which is unsupported by ONNX, by precomputing the embeddings outside the traced graph. [[1]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86R42) [[2]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86R1290-R1298)

**Testing enhancements:**

* Added an integration test in `tests/export/test_export.py` to verify that exporting with a shape different from the model's native resolution does not crash and produces ONNX files as expected. This ensures that the fix for DINOv2 export compatibility is maintained.
* Updated the test model stub to implement the `modules` method, supporting the new export logic that iterates over submodules.
* Imported `RFDETRNano` in the test file to support the new integration test.

---

resolving #1204