### PR TITLE
refactor(detr): `optimize_for_inference()` -> `inference()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to RF-DETR are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Deprecated
+
+- `RFDETR.optimize_for_inference()` renamed to `RFDETR.inference()` (same signature). The old name is kept as a deprecated alias that forwards to `inference()` and emits a `FutureWarning`. Deprecated since v1.9.0, will be removed in v1.11.0.
+
+---
+
 ## [1.8.3] — 2026-06-27
 
 ### Added

--- a/docs/cookbooks/inference-latency-benchmark.ipynb
+++ b/docs/cookbooks/inference-latency-benchmark.ipynb
@@ -26,7 +26,7 @@
     "| Config | Description |\n",
     "|--------|-------------|\n",
     "| **FP32** | `predict()` — unoptimized baseline |\n",
-    "| **FP16+JIT** | `optimize_for_inference(dtype=torch.float16)` |\n",
+    "| **FP16+JIT** | `inference(dtype=torch.float16)` |\n",
     "| **ONNX** | exported `.onnx` via `onnxruntime-gpu` |"
    ]
   },
@@ -199,7 +199,7 @@
     "Three inference paths are compared:\n",
     "\n",
     "- **FP32** — `predict()` as shipped.  Full 32-bit arithmetic on GPU.  Baseline.\n",
-    "- **FP16+JIT** — `optimize_for_inference(dtype=torch.float16)` fuses layers with `torch.jit.script` and\n",
+    "- **FP16+JIT** — `inference(dtype=torch.float16)` fuses layers with `torch.jit.script` and\n",
     "  halves the arithmetic precision.  Typically 1.5–2× faster than FP32 with negligible accuracy loss on\n",
     "  modern tensor cores.\n",
     "- **ONNX** — the model is exported to the Open Neural Network Exchange format and run through ONNX Runtime,\n",
@@ -226,8 +226,8 @@
     "\n",
     "\n",
     "def _predict_fp16(model: Any, image: Image.Image) -> BenchmarkResult:\n",
-    "    \"\"\"FP16+JIT latency — applies and removes optimize_for_inference.\"\"\"\n",
-    "    model.optimize_for_inference(dtype=torch.float16)\n",
+    "    \"\"\"FP16+JIT latency — applies and removes inference().\"\"\"\n",
+    "    model.inference(dtype=torch.float16)\n",
     "    mean, std = _measure(lambda: model.predict(image))\n",
     "    model.remove_optimized_model()\n",
     "    return BenchmarkResult(\"predict() FP16+JIT\", mean, std)\n",

--- a/docs/getting-started/migration.md
+++ b/docs/getting-started/migration.md
@@ -67,6 +67,21 @@ The following APIs were deprecated in earlier releases and will be removed in v1
     | `num_select`        | `TrainConfig` | `ModelConfig` |
     | `cls_loss_coef`     | `ModelConfig` | `TrainConfig` |
 
+### Deprecated in v1.9 → Remove in v1.11
+
+!!! note "Deprecated: `RFDETR.optimize_for_inference()` renamed to `RFDETR.inference()`"
+
+    **`optimize_for_inference(compile=..., batch_size=..., dtype=..., inplace=...)`** — renamed to
+    `inference()` with the same signature.
+
+    ```python
+    # Before (deprecated)
+    model.optimize_for_inference(dtype=torch.float16)
+
+    # After
+    model.inference(dtype=torch.float16)
+    ```
+
 ---
 
 ## Upgrade 1.7 → 1.8

--- a/docs/learn/run/detection.md
+++ b/docs/learn/run/detection.md
@@ -71,7 +71,7 @@ calling `predict()`. Pass `dtype="float16"` to halve weight memory in addition t
 This operation is irreversible — to restore the original model, create a new `RFDETR` instance:
 
 ```python
-model.optimize_for_inference(compile=False, inplace=True, dtype="float16")
+model.inference(compile=False, inplace=True, dtype="float16")
 ```
 
 ## Run on video, webcam, or RTSP stream

--- a/docs/learn/run/segmentation.md
+++ b/docs/learn/run/segmentation.md
@@ -63,7 +63,7 @@ calling `predict()`. Pass `dtype="float16"` to halve weight memory in addition t
 This operation is irreversible — to restore the original model, create a new `RFDETR` instance:
 
 ```python
-model.optimize_for_inference(compile=False, inplace=True, dtype="float16")
+model.inference(compile=False, inplace=True, dtype="float16")
 ```
 
 ## Run on video, webcam, or RTSP stream

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -26,6 +26,7 @@ import requests
 import torch
 import torchvision.transforms.functional as F  # noqa: N812
 import yaml
+from deprecate import deprecated
 from PIL import Image
 
 from rfdetr._namespace import _namespace_from_configs
@@ -916,7 +917,7 @@ class RFDETR:
                 logger.warning("Could not save training_config.json to %s: %s", config.output_dir, exc)
 
     @_ensure_model_on_device
-    def optimize_for_inference(
+    def inference(
         self,
         compile: bool = True,
         batch_size: int = 1,
@@ -990,7 +991,7 @@ class RFDETR:
             >>> model._optimized_dtype = None
             >>> model._optimized_inplace = False
             >>> # Standard (non-inplace) optimization — reversible:
-            >>> model.optimize_for_inference(compile=False)
+            >>> model.inference(compile=False)
             >>> model._is_optimized_for_inference
             True
             >>> model._optimized_inplace
@@ -999,7 +1000,7 @@ class RFDETR:
             >>> model._is_optimized_for_inference
             False
             >>> # Inplace optimization — destructive, cannot be reversed:
-            >>> model.optimize_for_inference(compile=False, dtype="float16", inplace=True)
+            >>> model.inference(compile=False, dtype="float16", inplace=True)
             >>> model._is_optimized_for_inference
             True
             >>> model._optimized_dtype
@@ -1018,7 +1019,7 @@ class RFDETR:
             raise ValueError(f"dtype must be a floating-point torch.dtype or string name of one, got {dtype}")
         if inplace and compile:
             raise ValueError(
-                "optimize_for_inference(inplace=True) requires compile=False. "
+                "inference(inplace=True) requires compile=False. "
                 "torch.jit.trace retains references to the original parameter storage in the returned "
                 "ScriptModule, so setting model.model=None would not free the weight tensors and "
                 "inplace=True would not reduce memory usage."
@@ -1077,10 +1078,33 @@ class RFDETR:
                 self.remove_optimized_model()
             raise
 
+    @deprecated(target=inference, deprecated_in="1.9.0", remove_in="1.11.0")
+    def optimize_for_inference(
+        self,
+        compile: bool = True,
+        batch_size: int = 1,
+        dtype: torch.dtype | str = torch.float32,
+        *,
+        inplace: bool = False,
+    ) -> None:
+        """Deprecated alias for :meth:`inference`.
+
+        .. deprecated:: 1.9.0
+            ``optimize_for_inference`` was renamed to :meth:`inference`. Deprecated since v1.9.0, will be
+            removed in v1.11.0. Use :meth:`inference` instead.
+
+        Args:
+            compile: See :meth:`inference`.
+            batch_size: See :meth:`inference`.
+            dtype: See :meth:`inference`.
+            inplace: See :meth:`inference`.
+        """
+        ...
+
     def remove_optimized_model(self) -> None:
         """Remove the optimized inference model and reset all optimization flags.
 
-        Clears ``model.inference_model`` and resets all internal state set by :meth:`optimize_for_inference`. Safe to
+        Clears ``model.inference_model`` and resets all internal state set by :meth:`inference`. Safe to
         call even if the model has not been optimized. When the model was optimized with ``inplace=True``, this method
         issues a :class:`UserWarning` and returns without modifying state — the original module cannot be restored
         because ``export()`` and dtype casting mutate it; create or reload a new ``RFDETR`` instance instead.
@@ -1112,7 +1136,7 @@ class RFDETR:
             >>> model._optimized_resolution = None
             >>> model._optimized_dtype = None
             >>> model._optimized_inplace = False
-            >>> model.optimize_for_inference(compile=False)
+            >>> model.inference(compile=False)
             >>> model.remove_optimized_model()
             >>> model._is_optimized_for_inference
             False
@@ -1138,7 +1162,7 @@ class RFDETR:
     def is_optimized_inplace(self) -> bool:
         """Whether the model was optimized with ``inplace=True``.
 
-        Returns ``True`` after a successful :meth:`optimize_for_inference` call with ``inplace=True``,
+        Returns ``True`` after a successful :meth:`inference` call with ``inplace=True``,
         meaning the base model has been cleared and :meth:`remove_optimized_model` is a no-op.
 
         Examples:
@@ -1170,7 +1194,7 @@ class RFDETR:
             >>> model._optimized_inplace = False
             >>> model.is_optimized_inplace
             False
-            >>> model.optimize_for_inference(compile=False, inplace=True)
+            >>> model.inference(compile=False, inplace=True)
             >>> model.is_optimized_inplace
             True
         """
@@ -1799,7 +1823,7 @@ class RFDETR:
             logger.warning(
                 "Model is not optimized for inference. Latency may be higher than expected."
                 " For full GPU throughput (e.g. ~8x on T4 via FP16 Tensor Cores),"
-                " call model.optimize_for_inference(dtype=torch.float16).",
+                " call model.inference(dtype=torch.float16).",
             )
             self._has_warned_about_not_being_optimized_for_inference = True
         self.model.model.eval()
@@ -1994,7 +2018,7 @@ class RFDETR:
                         else (
                             " You can explicitly remove the optimized model by calling model.remove_optimized_model()."
                             " Alternatively, you can recompile the optimized model for a different batch size"
-                            " by calling model.optimize_for_inference(batch_size=<new_batch_size>)."
+                            " by calling model.inference(batch_size=<new_batch_size>)."
                         )
                     )
                     raise ValueError(
@@ -2183,7 +2207,7 @@ class RFDETR:
         Raises:
             ValueError: If the `api_key` is not provided and not found in the
                 environment variable `ROBOFLOW_API_KEY`, or if the `size` is not set for custom architectures.
-            RuntimeError: If the model was cleared by ``optimize_for_inference(inplace=True)``.
+            RuntimeError: If the model was cleared by ``inference(inplace=True)``.
 
         Note:
             Bundle creation is delegated to :meth:`export_for_roboflow`, which can be called independently
@@ -2191,7 +2215,7 @@ class RFDETR:
         """
         if getattr(self, "_optimized_inplace", False) or self.model.model is None:
             raise RuntimeError(
-                "Cannot deploy after optimize_for_inference(inplace=True) — "
+                "Cannot deploy after inference(inplace=True) — "
                 "the model weights have been cleared from memory. "
                 "Call export_for_roboflow() before optimizing, then deploy the exported bundle."
             )
@@ -2240,11 +2264,11 @@ class RFDETR:
             PermissionError: If the process lacks write access to *output_dir* or its parent directory.
             OSError: On disk-full, invalid path, or other filesystem failure during directory creation,
                 file write, or ``torch.save``.
-            RuntimeError: If the model was cleared by ``optimize_for_inference(inplace=True)``.
+            RuntimeError: If the model was cleared by ``inference(inplace=True)``.
         """
         if getattr(self, "_optimized_inplace", False) or self.model.model is None:
             raise RuntimeError(
-                "Cannot export after optimize_for_inference(inplace=True) — "
+                "Cannot export after inference(inplace=True) — "
                 "the model has been cleared from memory. "
                 "Call export_for_roboflow() before optimizing."
             )

--- a/src/rfdetr/inference.py
+++ b/src/rfdetr/inference.py
@@ -101,7 +101,7 @@ def _build_model_context(model_config: ModelConfig) -> ModelContext:
 
     Replicates ``Model.__init__`` logic: builds the nn.Module, optionally loads pretrain weights and applies LoRA.  The
     model is intentionally kept on CPU; :func:`_ensure_model_on_device` in ``detr.py`` performs the deferred
-    ``.to(device)`` on the first ``predict()`` / ``export()`` / ``optimize_for_inference()`` call.  Keeping construction
+    ``.to(device)`` on the first ``predict()`` / ``export()`` / ``inference()`` call.  Keeping construction
     CPU-only prevents CUDA initialisation during ``__init__``, which would block DDP strategies (``ddp_notebook``,
     ``ddp_spawn``) from spawning child processes in notebook environments.
 
@@ -160,7 +160,7 @@ def _build_model_context(model_config: ModelConfig) -> ModelContext:
         backbone.encoder.encoder.embeddings.patch_embeddings.num_channels = model_config.num_channels
 
     device = torch.device(args.device)
-    # Keep the model on CPU here; predict() / export() / optimize_for_inference()
+    # Keep the model on CPU here; predict() / export() / inference()
     # will lazily move it to the target device on first use.  Eagerly calling
     # .to("cuda") would initialise the CUDA runtime during __init__(), which
     # prevents DDP strategies (ddp_notebook, ddp_spawn) from forking/spawning

--- a/tests/inference/test_model_inference.py
+++ b/tests/inference/test_model_inference.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-"""Tests for RFDETR.optimize_for_inference()."""
+"""Tests for RFDETR.inference()."""
 
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -15,7 +15,7 @@ from rfdetr.detr import RFDETR
 
 
 class _FakeModel(torch.nn.Module):
-    """Minimal nn.Module that satisfies the optimize_for_inference contract."""
+    """Minimal nn.Module that satisfies the inference contract."""
 
     def __init__(self) -> None:
         super().__init__()
@@ -47,7 +47,23 @@ class _FakeRFDETR(RFDETR):
         return _FakeModelContext()
 
 
-class TestOptimizeForInferenceDtype:
+class TestOptimizeForInferenceDeprecatedAlias:
+    """``optimize_for_inference`` forwards to :meth:`RFDETR.inference` with a deprecation warning."""
+
+    def test_forwards_and_warns(self) -> None:
+        """Calling the deprecated alias emits ``FutureWarning`` and still optimizes the model."""
+        rfdetr = _FakeRFDETR()
+
+        with (
+            patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model),
+            pytest.warns(FutureWarning, match="optimize_for_inference"),
+        ):
+            rfdetr.optimize_for_inference(compile=False)
+
+        assert rfdetr._is_optimized_for_inference is True
+
+
+class TestModelInferenceDtype:
     """Dtype coercion and validation tests."""
 
     def test_string_dtype_float32_is_accepted(self) -> None:
@@ -55,7 +71,7 @@ class TestOptimizeForInferenceDtype:
         rfdetr = _FakeRFDETR()
 
         with patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model):
-            rfdetr.optimize_for_inference(compile=False, dtype="float32")
+            rfdetr.inference(compile=False, dtype="float32")
 
         assert rfdetr._optimized_dtype == torch.float32
 
@@ -64,7 +80,7 @@ class TestOptimizeForInferenceDtype:
         rfdetr = _FakeRFDETR()
 
         with patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model):
-            rfdetr.optimize_for_inference(compile=False, dtype="float16")
+            rfdetr.inference(compile=False, dtype="float16")
 
         assert rfdetr._optimized_dtype == torch.float16
 
@@ -73,7 +89,7 @@ class TestOptimizeForInferenceDtype:
         rfdetr = _FakeRFDETR()
 
         with patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model):
-            rfdetr.optimize_for_inference(compile=False, dtype=torch.float32)
+            rfdetr.inference(compile=False, dtype=torch.float32)
 
         assert rfdetr._optimized_dtype == torch.float32
 
@@ -82,21 +98,21 @@ class TestOptimizeForInferenceDtype:
         rfdetr = _FakeRFDETR()
 
         with pytest.raises(TypeError, match="dtype must be a torch.dtype or a string name of a dtype"):
-            rfdetr.optimize_for_inference(compile=False, dtype=42)  # type: ignore[arg-type]
+            rfdetr.inference(compile=False, dtype=42)  # type: ignore[arg-type]
 
     def test_invalid_dtype_string_raises_type_error(self) -> None:
         """Passing a non-existent dtype string should raise TypeError with a descriptive message."""
         rfdetr = _FakeRFDETR()
 
         with pytest.raises(TypeError, match="dtype must be a torch.dtype or a string name of a dtype"):
-            rfdetr.optimize_for_inference(compile=False, dtype="not_a_dtype")
+            rfdetr.inference(compile=False, dtype="not_a_dtype")
 
     def test_valid_torch_attr_that_is_not_dtype_raises_type_error(self) -> None:
         """'Tensor' is a valid torch attribute but not a torch.dtype — should raise TypeError."""
         rfdetr = _FakeRFDETR()
 
         with pytest.raises(TypeError, match="dtype must be a torch.dtype or a string name of a dtype"):
-            rfdetr.optimize_for_inference(compile=False, dtype="Tensor")  # type: ignore[arg-type]
+            rfdetr.inference(compile=False, dtype="Tensor")  # type: ignore[arg-type]
 
     @pytest.mark.parametrize("dtype_str", ["float32", "float16", "bfloat16"])
     def test_string_dtype_variants_are_accepted(self, dtype_str: str) -> None:
@@ -105,13 +121,13 @@ class TestOptimizeForInferenceDtype:
         expected = getattr(torch, dtype_str)
 
         with patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model):
-            rfdetr.optimize_for_inference(compile=False, dtype=dtype_str)
+            rfdetr.inference(compile=False, dtype=dtype_str)
 
         assert rfdetr._optimized_dtype == expected
 
 
-class TestOptimizeForInferenceCudaDeviceContext:
-    """Verify that optimize_for_inference wraps operations in the correct device context."""
+class TestModelInferenceCudaDeviceContext:
+    """Verify that inference() wraps operations in the correct device context."""
 
     @pytest.mark.gpu
     @patch("rfdetr.detr._move_model_context_to_device")
@@ -142,7 +158,7 @@ class TestOptimizeForInferenceCudaDeviceContext:
                 pass
 
         mock_cuda_device.side_effect = _CapturingDeviceCtx
-        rfdetr.optimize_for_inference(compile=False, dtype=torch.float32)
+        rfdetr.inference(compile=False, dtype=torch.float32)
 
         assert len(entered_devices) == 1
         assert entered_devices[0] == torch.device("cuda", 0)
@@ -157,7 +173,7 @@ class TestOptimizeForInferenceCudaDeviceContext:
             patch("torch.cuda.device") as mock_cuda_device,
             patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model),
         ):
-            rfdetr.optimize_for_inference(compile=False, dtype=torch.float32)
+            rfdetr.inference(compile=False, dtype=torch.float32)
 
         mock_cuda_device.assert_not_called()
 
@@ -190,12 +206,12 @@ class TestOptimizeForInferenceCudaDeviceContext:
                 pass
 
         mock_cuda_device.side_effect = _CapturingCtx
-        rfdetr.optimize_for_inference(compile=False)
+        rfdetr.inference(compile=False)
 
         assert captured.get("device") == expected_device
 
 
-class TestOptimizeForInferenceCompile:
+class TestModelInferenceCompile:
     """Tests for the compile=True path (JIT trace)."""
 
     def test_compile_true_calls_jit_trace(self) -> None:
@@ -207,7 +223,7 @@ class TestOptimizeForInferenceCompile:
             patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model),
             patch("torch.jit.trace", return_value=mock_traced) as mock_trace,
         ):
-            rfdetr.optimize_for_inference(compile=True, batch_size=2)
+            rfdetr.inference(compile=True, batch_size=2)
 
         assert mock_trace.called
         dummy_input: torch.Tensor = mock_trace.call_args.args[1]
@@ -222,7 +238,7 @@ class TestOptimizeForInferenceCompile:
             patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model),
             patch("torch.jit.trace", return_value=rfdetr.model.model),
         ):
-            rfdetr.optimize_for_inference(compile=True, batch_size=4)
+            rfdetr.inference(compile=True, batch_size=4)
 
         assert rfdetr._optimized_has_been_compiled is True
         assert rfdetr._optimized_batch_size == 4
@@ -235,15 +251,15 @@ class TestOptimizeForInferenceCompile:
             patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model),
             patch("torch.jit.trace") as mock_trace,
         ):
-            rfdetr.optimize_for_inference(compile=False)
+            rfdetr.inference(compile=False)
 
         mock_trace.assert_not_called()
         assert rfdetr._optimized_has_been_compiled is False
         assert rfdetr._optimized_batch_size is None
 
 
-class TestOptimizeForInferenceState:
-    """Verify that optimize_for_inference correctly sets internal state flags."""
+class TestModelInferenceState:
+    """Verify that inference() correctly sets internal state flags."""
 
     def test_is_optimized_inplace_false_before_optimization(self) -> None:
         """is_optimized_inplace is False before any optimization is applied."""
@@ -255,7 +271,7 @@ class TestOptimizeForInferenceState:
         rfdetr = _FakeRFDETR()
 
         with patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model):
-            rfdetr.optimize_for_inference(compile=False)
+            rfdetr.inference(compile=False)
 
         assert rfdetr._is_optimized_for_inference is True
 
@@ -264,7 +280,7 @@ class TestOptimizeForInferenceState:
         rfdetr = _FakeRFDETR()
 
         with patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model):
-            rfdetr.optimize_for_inference(compile=False)
+            rfdetr.inference(compile=False)
 
         assert rfdetr.model.inference_model is not None
 
@@ -273,7 +289,7 @@ class TestOptimizeForInferenceState:
         rfdetr = _FakeRFDETR()
 
         with patch("rfdetr.detr.deepcopy", return_value=rfdetr.model.model):
-            rfdetr.optimize_for_inference(compile=False)
+            rfdetr.inference(compile=False)
 
         rfdetr.remove_optimized_model()
 
@@ -286,7 +302,7 @@ class TestOptimizeForInferenceState:
         assert rfdetr.is_optimized_inplace is False
 
 
-class TestOptimizeForInferenceInplace:
+class TestModelInferenceInplace:
     """Tests for the low-memory in-place optimization path."""
 
     def test_inplace_false_keeps_deepcopy_behavior(self) -> None:
@@ -296,7 +312,7 @@ class TestOptimizeForInferenceInplace:
         copied_model = _FakeModel()
 
         with patch("rfdetr.detr.deepcopy", return_value=copied_model) as mock_deepcopy:
-            rfdetr.optimize_for_inference(compile=False)
+            rfdetr.inference(compile=False)
 
         mock_deepcopy.assert_called_once_with(original_model)
         assert rfdetr.model.model is original_model
@@ -310,7 +326,7 @@ class TestOptimizeForInferenceInplace:
         original_model = rfdetr.model.model
 
         with patch("rfdetr.detr.deepcopy") as mock_deepcopy:
-            rfdetr.optimize_for_inference(compile=False, inplace=True)
+            rfdetr.inference(compile=False, inplace=True)
 
         mock_deepcopy.assert_not_called()
         assert rfdetr.model.model is None
@@ -323,7 +339,7 @@ class TestOptimizeForInferenceInplace:
         rfdetr = _FakeRFDETR()
         original_model = rfdetr.model.model
 
-        rfdetr.optimize_for_inference(compile=False, inplace=True)
+        rfdetr.inference(compile=False, inplace=True)
 
         with pytest.warns(UserWarning, match="no effect after inplace optimization"):
             rfdetr.remove_optimized_model()
@@ -334,13 +350,13 @@ class TestOptimizeForInferenceInplace:
         assert rfdetr.is_optimized_inplace is True
 
     def test_second_optimize_after_inplace_raises_runtime_error(self) -> None:
-        """Calling optimize_for_inference() again after inplace=True raises RuntimeError."""
+        """Calling inference() again after inplace=True raises RuntimeError."""
         rfdetr = _FakeRFDETR()
 
-        rfdetr.optimize_for_inference(compile=False, inplace=True)
+        rfdetr.inference(compile=False, inplace=True)
 
         with pytest.raises(RuntimeError, match="base model has been cleared"):
-            rfdetr.optimize_for_inference(compile=False)
+            rfdetr.inference(compile=False)
 
     def test_inplace_true_default_dtype_float32_does_not_cast(self) -> None:
         """Inplace=True with default dtype (float32) leaves weights unchanged — no casting occurs."""
@@ -348,7 +364,7 @@ class TestOptimizeForInferenceInplace:
         original_model = rfdetr.model.model
         original_dtype = original_model.linear.weight.dtype
 
-        rfdetr.optimize_for_inference(compile=False, inplace=True)
+        rfdetr.inference(compile=False, inplace=True)
 
         assert rfdetr.model.inference_model is original_model
         assert original_model.linear.weight.dtype == original_dtype
@@ -368,7 +384,7 @@ class TestOptimizeForInferenceInplace:
         rfdetr = _FakeRFDETR()
         original_model = rfdetr.model.model
 
-        rfdetr.optimize_for_inference(compile=False, dtype=dtype, inplace=True)
+        rfdetr.inference(compile=False, dtype=dtype, inplace=True)
 
         assert rfdetr.model.model is None
         assert rfdetr.model.inference_model is original_model
@@ -385,7 +401,7 @@ class TestOptimizeForInferenceInplace:
             patch.object(original_model, "export", side_effect=RuntimeError("export failed")),
             pytest.raises(RuntimeError, match="export failed"),
         ):
-            rfdetr.optimize_for_inference(compile=False, inplace=True)
+            rfdetr.inference(compile=False, inplace=True)
 
         mock_deepcopy.assert_not_called()
         assert rfdetr.model.model is original_model
@@ -410,7 +426,7 @@ class TestOptimizeForInferenceInplace:
             patch.object(original_model, "export") as mock_export,
             pytest.raises(ValueError, match="floating-point torch.dtype"),
         ):
-            rfdetr.optimize_for_inference(compile=False, dtype=dtype, inplace=True)
+            rfdetr.inference(compile=False, dtype=dtype, inplace=True)
 
         mock_deepcopy.assert_not_called()
         mock_export.assert_not_called()
@@ -430,7 +446,7 @@ class TestOptimizeForInferenceInplace:
             patch("torch.jit.trace") as mock_trace,
             pytest.raises(ValueError, match="inplace=True.*compile=False"),
         ):
-            rfdetr.optimize_for_inference(compile=True, inplace=True)
+            rfdetr.inference(compile=True, inplace=True)
 
         mock_deepcopy.assert_not_called()
         mock_export.assert_not_called()
@@ -443,7 +459,7 @@ class TestOptimizeForInferenceInplace:
         assert rfdetr.is_optimized_inplace is False
 
 
-class TestOptimizeForInferenceExceptionRecovery:
+class TestModelInferenceExceptionRecovery:
     """Verify state consistency when optimization fails mid-execution."""
 
     def test_deepcopy_failure_leaves_clean_state(self) -> None:
@@ -457,7 +473,7 @@ class TestOptimizeForInferenceExceptionRecovery:
             patch("rfdetr.detr.deepcopy", side_effect=RuntimeError("deepcopy failed")),
             pytest.raises(RuntimeError, match="deepcopy failed"),
         ):
-            rfdetr.optimize_for_inference(compile=False)
+            rfdetr.inference(compile=False)
 
         assert rfdetr.model.inference_model is None
         assert rfdetr._is_optimized_for_inference is False
@@ -472,7 +488,7 @@ class TestOptimizeForInferenceExceptionRecovery:
             patch.object(fake_copy, "export", side_effect=RuntimeError("export failed")),
             pytest.raises(RuntimeError, match="export failed"),
         ):
-            rfdetr.optimize_for_inference(compile=False)
+            rfdetr.inference(compile=False)
 
         assert rfdetr._is_optimized_for_inference is False
 
@@ -485,7 +501,7 @@ class TestOptimizeForInferenceExceptionRecovery:
             patch("torch.jit.trace", side_effect=RuntimeError("trace failed")),
             pytest.raises(RuntimeError, match="trace failed"),
         ):
-            rfdetr.optimize_for_inference(compile=True, batch_size=2)
+            rfdetr.inference(compile=True, batch_size=2)
 
         assert rfdetr._optimized_has_been_compiled is False
         assert rfdetr._optimized_batch_size is None
@@ -499,7 +515,7 @@ class TestOptimizeForInferenceExceptionRecovery:
             patch("torch.jit.trace", side_effect=RuntimeError("trace failed")),
             pytest.raises(RuntimeError, match="trace failed"),
         ):
-            rfdetr.optimize_for_inference(compile=True)
+            rfdetr.inference(compile=True)
 
         assert rfdetr._is_optimized_for_inference is False
         assert rfdetr.model.inference_model is None
@@ -523,7 +539,7 @@ class TestOptimizeForInferenceExceptionRecovery:
             patch.object(original_model, "export", side_effect=_mutating_export),
             pytest.raises(RuntimeError, match="export failed mid-mutation"),
         ):
-            rfdetr.optimize_for_inference(compile=False, inplace=True)
+            rfdetr.inference(compile=False, inplace=True)
 
         assert rfdetr._is_optimized_for_inference is False
         assert rfdetr.is_optimized_inplace is False

--- a/tests/inference/test_predict.py
+++ b/tests/inference/test_predict.py
@@ -73,7 +73,7 @@ class TestPredictReturnTypes:
 
 
 class _TupleOutputModelContext:
-    """Model context whose forward returns a 3-tuple, mirroring ``forward_export()`` after ``optimize_for_inference()``.
+    """Model context whose forward returns a 3-tuple, mirroring ``forward_export()`` after ``inference()``.
 
     Regression fixture for GitHub #1208: ``predict()`` mislabels the tuple's third element as ``pred_masks`` instead of
     ``pred_keypoints`` because it reads a nonexistent ``model.model_config`` attribute instead of ``model.args``.
@@ -114,7 +114,7 @@ class _TupleOutputModelContext:
 
 
 def _make_optimized_keypoint_model() -> tuple[RFDETR, _TupleOutputModelContext]:
-    """Build a ``_DummyRFDETR`` wired to look like it already ran ``optimize_for_inference()``."""
+    """Build a ``_DummyRFDETR`` wired to look like it already ran ``inference()``."""
     model = _DummyRFDETR()
     stub = _TupleOutputModelContext()
     model.model = stub
@@ -126,7 +126,7 @@ def _make_optimized_keypoint_model() -> tuple[RFDETR, _TupleOutputModelContext]:
 
 
 class TestPredictOptimizedInferenceKeypoints:
-    """Regression tests for GitHub #1208: optimize_for_inference() breaks keypoint predict()."""
+    """Regression tests for GitHub #1208: inference() breaks keypoint predict()."""
 
     def test_tuple_output_labels_third_slot_as_keypoints_not_masks(self) -> None:
         """The 3rd tuple slot must be labeled pred_keypoints, not pred_masks, when use_grouppose_keypoints=True."""
@@ -1207,20 +1207,20 @@ class TestPredictInputTypeReturnShape:
 
 
 class TestExportInplaceOptimizeGuards:
-    """Roboflow export methods raise a clear error after ``optimize_for_inference(inplace=True)``."""
+    """Roboflow export methods raise a clear error after ``inference(inplace=True)``."""
 
     def test_export_for_roboflow_raises_after_inplace_optimize(self, tmp_path) -> None:
         """``export_for_roboflow`` raises ``RuntimeError`` once the model has been cleared."""
         model = _DummyRFDETR()
         model._optimized_inplace = True
-        with pytest.raises(RuntimeError, match="optimize_for_inference"):
+        with pytest.raises(RuntimeError, match="inference"):
             model.export_for_roboflow(str(tmp_path))
 
     def test_deploy_to_roboflow_raises_after_inplace_optimize(self) -> None:
         """``deploy_to_roboflow`` raises ``RuntimeError`` before any auth/network calls."""
         model = _DummyRFDETR()
         model._optimized_inplace = True
-        with pytest.raises(RuntimeError, match="optimize_for_inference"):
+        with pytest.raises(RuntimeError, match="inference"):
             model.deploy_to_roboflow("ws", "proj", 1)
 
 


### PR DESCRIPTION
This pull request renames the method `RFDETR.optimize_for_inference()` to `RFDETR.inference()` throughout the codebase and documentation, establishing `optimize_for_inference` as a deprecated alias that emits a warning and will be removed in a future release. All references, docstrings, and tests have been updated to use the new method name, and deprecation details are documented for users.

### API Changes and Deprecation

* Renamed `RFDETR.optimize_for_inference()` to `RFDETR.inference()` with identical functionality; the old method is now a deprecated alias that emits a `FutureWarning` and will be removed in v1.11.0. [[1]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86L919-R920) [[2]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86R1081-R1107) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R15)
* Updated all user-facing error messages, warnings, and docstrings to reference `inference()` instead of `optimize_for_inference()`. [[1]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86L1021-R1022) [[2]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86L2186-R2218) [[3]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86L2243-R2271) [[4]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86L1997-R2021) [[5]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86L1141-R1165) F058da93L112L1136, [[6]](diffhunk://#diff-88cb2cb1c972ea4e1b9e1582f78beb4ad32bf7c10709dd837c57a2da1ce98c86L1802-R1826)

### Documentation Updates

* Updated all documentation and migration guides to use `inference()` in place of `optimize_for_inference()`, including code examples and explanations in markdown and notebooks. [[1]](diffhunk://#diff-e1d02b52989f9c3883372fd22d319c3904c72335e92e399fcfa08d749d66713cL29-R29) [[2]](diffhunk://#diff-e1d02b52989f9c3883372fd22d319c3904c72335e92e399fcfa08d749d66713cL202-R202) [[3]](diffhunk://#diff-e1d02b52989f9c3883372fd22d319c3904c72335e92e399fcfa08d749d66713cL229-R230) [[4]](diffhunk://#diff-b0d8e8f60aef72b014216f06c57b552839127648a84af77a36c98003394cffb7R70-R84) [[5]](diffhunk://#diff-7b5f0e0bd948b9c6de698d8ef43672bc172bc37c48e0808dd29dfcc4004e818dL74-R74) [[6]](diffhunk://#diff-9cf17cc773d14fa038442b19a4ccbc8ec9b11234c73af664f9dd1505c6ce1f2dL66-R66)

### Test Suite Updates

* Renamed test file `test_optimize_for_inference.py` to `test_model_inference.py` and updated all tests to use `inference()`; added tests to verify the deprecated alias emits a warning and forwards correctly. [[1]](diffhunk://#diff-eef55311a9f454c8da6c5cc4f0ecbd6f9c1a92f346a3a69ff262684ce6f7bcfcL6-R6) [[2]](diffhunk://#diff-eef55311a9f454c8da6c5cc4f0ecbd6f9c1a92f346a3a69ff262684ce6f7bcfcL18-R18) [[3]](diffhunk://#diff-eef55311a9f454c8da6c5cc4f0ecbd6f9c1a92f346a3a69ff262684ce6f7bcfcL50-R74) [[4]](diffhunk://#diff-eef55311a9f454c8da6c5cc4f0ecbd6f9c1a92f346a3a69ff262684ce6f7bcfcL67-R83) [[5]](diffhunk://#diff-eef55311a9f454c8da6c5cc4f0ecbd6f9c1a92f346a3a69ff262684ce6f7bcfcL76-R92)

### Internal Code Maintenance

* Updated internal references and comments in `src/rfdetr/inference.py` to mention `inference()` instead of `optimize_for_inference()`. [[1]](diffhunk://#diff-e05461e8dfbd3db2e673cba8f1d3b382028955275a6e1b9725b27bb9b9bf54fbL104-R104) [[2]](diffhunk://#diff-e05461e8dfbd3db2e673cba8f1d3b382028955275a6e1b9725b27bb9b9bf54fbL163-R163)
* Added necessary import for the deprecation decorator.