### PR TITLE
feat(training): always save EMA-named checkpoints

### DIFF
--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -40,7 +40,12 @@ class BestModelCallback(ModelCheckpoint):
 
     At the end of training the overall winner (regular vs EMA, strict ``>`` for EMA) is copied to
     ``checkpoint_best_total.pth`` and optimizer/scheduler state is stripped via
-    :func:`rfdetr.util.misc.strip_checkpoint`.
+    :func:`rfdetr.util.misc.strip_checkpoint`.  The stripped payload records ``best_total_source``
+    (``"ema"`` or ``"regular"``) so the winning source is recoverable after reload.
+
+    When EMA tracking is enabled (``monitor_ema`` set), EMA-named checkpoints are always left on disk for clarity:
+    ``checkpoint_best_ema.pth`` (backfilled with the final EMA weights if the EMA metric never improved) and
+    ``last_ema.pth`` (final EMA weights, mirroring ``last.pth`` for the live model).
 
     Checkpoints are only updated on validation epochs where the monitor metric is actually logged.  On non-eval epochs
     (when ``eval_interval > 1`` causes COCO evaluation to be skipped) the callback is a no-op.
@@ -223,11 +228,51 @@ class BestModelCallback(ModelCheckpoint):
                 if state_dict is not None:
                     return cast("dict[str, Tensor]", state_dict)
                 break
-        logger.warning(
-            "EMA metric improved but EMA callback weights were unavailable; saving current model weights as fallback."
-        )
+        logger.warning("EMA callback weights were unavailable; saving current model weights as fallback.")
         raw = BestModelCallback._unwrap_model(pl_module)
         return raw.state_dict()
+
+    def _write_ema_checkpoint(
+        self,
+        trainer: Trainer,
+        pl_module: LightningModule,
+        ema_state_dict: dict[str, Tensor],
+        dest: Path,
+    ) -> None:
+        """Build and save an EMA checkpoint payload to ``dest``.
+
+        Enriches the training config with dataset class names so reloaded checkpoints return the correct labels
+        rather than COCO defaults (#509), then writes an unstripped PTL-compatible payload.
+
+        Args:
+            trainer: Active Lightning trainer providing epoch/step counters.
+            pl_module: The ``RFDETRModelModule`` being trained.
+            ema_state_dict: EMA model weights to persist.
+            dest: Destination checkpoint path.
+
+        Note:
+            Internal helper called by ``on_validation_end`` (best EMA) and ``on_fit_end``
+            (guaranteed ``checkpoint_best_ema.pth`` and ``last_ema.pth``).
+        """
+        ema_train_config = cast("RFDETRModelModule", pl_module).train_config
+        dataset_class_names = getattr(trainer.datamodule, "class_names", None)  # type: ignore[attr-defined]
+        if (
+            dataset_class_names is not None
+            and hasattr(ema_train_config, "model_copy")
+            and getattr(ema_train_config, "class_names", None) is None
+        ):
+            ema_train_config = ema_train_config.model_copy(update={"class_names": dataset_class_names})
+        ema_args_dict = ema_train_config.model_dump() if hasattr(ema_train_config, "model_dump") else ema_train_config
+        torch.save(
+            self._build_checkpoint_payload(
+                ema_state_dict,
+                ema_args_dict,
+                trainer,
+                model_name=self._resolve_model_name(pl_module),
+                model_config_dict=self._serialize_model_config(pl_module, ema_state_dict),
+            ),
+            dest,
+        )
 
     @staticmethod
     def _serialize_model_config(
@@ -467,31 +512,7 @@ class BestModelCallback(ModelCheckpoint):
             self._best_ema = ema_val
             self._output_dir.mkdir(parents=True, exist_ok=True)
             ema_state_dict = self._get_ema_model_state_dict(trainer, pl_module)
-            # Enrich train_config with dataset class names so reloaded checkpoints
-            # return the correct labels, not COCO defaults (#509).
-            ema_train_config = cast("RFDETRModelModule", pl_module).train_config
-            dataset_class_names = getattr(trainer.datamodule, "class_names", None)  # type: ignore[attr-defined]
-            if (
-                dataset_class_names is not None
-                and hasattr(ema_train_config, "model_copy")
-                and getattr(ema_train_config, "class_names", None) is None
-            ):
-                ema_train_config = ema_train_config.model_copy(update={"class_names": dataset_class_names})
-            ema_args_dict = (
-                ema_train_config.model_dump() if hasattr(ema_train_config, "model_dump") else ema_train_config
-            )
-            ema_model_name = self._resolve_model_name(pl_module)
-            ema_model_config_dict = self._serialize_model_config(pl_module, ema_state_dict)
-            torch.save(
-                self._build_checkpoint_payload(
-                    ema_state_dict,
-                    ema_args_dict,
-                    trainer,
-                    model_name=ema_model_name,
-                    model_config_dict=ema_model_config_dict,
-                ),
-                self._output_dir / "checkpoint_best_ema.pth",
-            )
+            self._write_ema_checkpoint(trainer, pl_module, ema_state_dict, self._output_dir / "checkpoint_best_ema.pth")
             logger.info(
                 "Best EMA mAP improved to %.4f (epoch %d)",
                 ema_val,
@@ -529,17 +550,33 @@ class BestModelCallback(ModelCheckpoint):
 
         # Strict > for EMA to win (matches legacy behaviour).
         best_is_ema = self._best_ema > best_regular
-        best_path = ema_path if (best_is_ema and ema_path.exists()) else regular_path
+        # ``chose_ema`` reflects the source actually copied: EMA can win the comparison yet be
+        # unavailable on disk, in which case regular is used and recorded.
+        chose_ema = best_is_ema and ema_path.exists()
+        best_path = ema_path if chose_ema else regular_path
 
         if best_path and best_path.exists():
             shutil.copy2(best_path, total_path)
-            strip_checkpoint(total_path)
+            # Record the winning source in the payload so anyone reloading
+            # checkpoint_best_total.pth can tell EMA from regular weights.
+            strip_checkpoint(total_path, extra_metadata={"best_total_source": "ema" if chose_ema else "regular"})
             logger.info(
                 "Best total checkpoint saved from %s (regular=%.4f, ema=%.4f)",
-                "EMA" if best_is_ema else "regular",
+                "EMA" if chose_ema else "regular",
                 best_regular,
                 self._best_ema,
             )
+
+        # When EMA tracking is enabled, always leave EMA-named checkpoints on disk for clarity:
+        # a guaranteed checkpoint_best_ema.pth (backfilled with final EMA weights when the EMA metric
+        # never improved) and last_ema.pth (final EMA weights, mirroring last.pth for the live model).
+        if self._monitor_ema is not None:
+            self._output_dir.mkdir(parents=True, exist_ok=True)
+            ema_state_dict = self._get_ema_model_state_dict(trainer, pl_module)
+            if not ema_path.exists():
+                self._write_ema_checkpoint(trainer, pl_module, ema_state_dict, ema_path)
+                logger.info("EMA metric never improved; saved final EMA weights as %s", ema_path.name)
+            self._write_ema_checkpoint(trainer, pl_module, ema_state_dict, self._output_dir / "last_ema.pth")
 
         if self._run_test:
             # Only call trainer.test() when the module actually defines test_step().

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -40,7 +40,7 @@ class BestModelCallback(ModelCheckpoint):
 
     At the end of training the overall winner (regular vs EMA, strict ``>`` for EMA) is copied to
     ``checkpoint_best_total.pth`` and optimizer/scheduler state is stripped via
-    :func:`rfdetr.util.misc.strip_checkpoint`.  The stripped payload records ``best_total_source``
+    :func:`rfdetr.utilities.state_dict.strip_checkpoint`.  The stripped payload records ``best_total_source``
     (``"ema"`` or ``"regular"``) so the winning source is recoverable after reload.
 
     When EMA tracking is enabled (``monitor_ema`` set), EMA-named checkpoints are always left on disk for clarity:

--- a/src/rfdetr/utilities/state_dict.py
+++ b/src/rfdetr/utilities/state_dict.py
@@ -132,7 +132,10 @@ def _make_fit_loop_state(epoch: int) -> dict[str, Any]:
     }
 
 
-def strip_checkpoint(checkpoint: str | os.PathLike[str]) -> None:
+def strip_checkpoint(
+    checkpoint: str | os.PathLike[str],
+    extra_metadata: dict[str, Any] | None = None,
+) -> None:
     """Strip a checkpoint file down to ``model``, ``args``, and PTL-compatible keys.
 
     Preserves ``model_name`` (when present) so that ``RFDETR.from_checkpoint()`` can still resolve the model class from
@@ -146,6 +149,18 @@ def strip_checkpoint(checkpoint: str | os.PathLike[str]) -> None:
 
     Args:
         checkpoint: Path to the ``.pth`` checkpoint file to strip in place.
+        extra_metadata: Optional key/value pairs merged into the stripped checkpoint. Used to record provenance that is
+            not derivable from the surviving keys (e.g. ``{"best_total_source": "ema"}`` for
+            ``checkpoint_best_total.pth``). Keys overwrite same-named preserved keys.
+
+    Examples:
+        >>> import tempfile
+        >>> import torch
+        >>> path = tempfile.NamedTemporaryFile(suffix=".pth", delete=False).name
+        >>> torch.save({"model": {}, "args": {}, "optimizer_states": [1]}, path)
+        >>> strip_checkpoint(path, extra_metadata={"best_total_source": "ema"})
+        >>> torch.load(path, weights_only=False)["best_total_source"]
+        'ema'
     """
     from pathlib import Path
 
@@ -181,6 +196,9 @@ def strip_checkpoint(checkpoint: str | os.PathLike[str]) -> None:
         for loop_key in ("validate_loop", "test_loop"):
             if loop_key not in loops:
                 loops[loop_key] = {"state_dict": {}}
+    # Merge caller-supplied provenance last so it wins over any preserved key of the same name.
+    if extra_metadata:
+        new_state_dict.update(extra_metadata)
     # Create the temp file in the destination directory so os.replace stays on the same filesystem (atomic).
     checkpoint_dir = os.path.dirname(os.path.abspath(os.fspath(checkpoint)))
     with tempfile.NamedTemporaryFile(dir=checkpoint_dir, delete=False) as tmp_file:

--- a/tests/training/callbacks/test_best_model_callback.py
+++ b/tests/training/callbacks/test_best_model_callback.py
@@ -373,6 +373,7 @@ class TestBestModelCallback:
         data = torch.load(total, map_location="cpu", weights_only=False)
         assert "model" in data
         assert "args" in data
+        assert data["best_total_source"] == "regular"
 
     def test_best_total_ema_wins(self, tmp_path: Path) -> None:
         """EMA wins when best_ema > best_regular (strict >)."""
@@ -400,6 +401,7 @@ class TestBestModelCallback:
         total_data = torch.load(total, map_location="cpu", weights_only=False)
         # total is stripped so only model + args
         assert total_data["model"] == ema_data["model"]
+        assert total_data["best_total_source"] == "ema"
 
     def test_best_total_ema_equal_uses_regular(self, tmp_path: Path) -> None:
         """When best_ema == best_regular, regular wins (strict > for EMA)."""
@@ -426,6 +428,64 @@ class TestBestModelCallback:
         )
         total_data = torch.load(total, map_location="cpu", weights_only=False)
         assert total_data["model"] == regular_data["model"]
+        assert total_data["best_total_source"] == "regular"
+
+    def test_last_ema_saved_when_ema_enabled(self, tmp_path: Path) -> None:
+        """on_fit_end writes last_ema.pth with the final EMA weights when EMA tracking is enabled."""
+        cb = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95", run_test=False)
+        pl_module = _make_pl_module()
+        trainer = _make_trainer({"val/mAP_50_95": 0.6, "val/ema_mAP_50_95": 0.7})
+        cb.on_validation_end(trainer, pl_module)
+
+        cb.on_fit_end(trainer, pl_module)
+
+        assert (tmp_path / "last_ema.pth").exists()
+
+    def test_last_ema_not_saved_when_ema_disabled(self, tmp_path: Path) -> None:
+        """on_fit_end must not write last_ema.pth when EMA tracking is disabled (monitor_ema=None)."""
+        cb = BestModelCallback(output_dir=str(tmp_path), monitor_ema=None, run_test=False)
+        pl_module = _make_pl_module()
+        trainer = _make_trainer({"val/mAP_50_95": 0.6})
+        cb.on_validation_end(trainer, pl_module)
+
+        cb.on_fit_end(trainer, pl_module)
+
+        assert not (tmp_path / "last_ema.pth").exists()
+
+    def test_best_ema_backfilled_when_metric_never_improved(self, tmp_path: Path) -> None:
+        """When the EMA metric never beats 0.0, on_fit_end backfills checkpoint_best_ema.pth with final EMA weights."""
+        cb = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95", run_test=False)
+        pl_module = _make_pl_module()
+        # EMA metric stays at 0.0 so on_validation_end never saves checkpoint_best_ema.pth.
+        trainer = _make_trainer({"val/mAP_50_95": 0.6, "val/ema_mAP_50_95": 0.0})
+        cb.on_validation_end(trainer, pl_module)
+        assert not (tmp_path / "checkpoint_best_ema.pth").exists()
+
+        cb.on_fit_end(trainer, pl_module)
+
+        assert (tmp_path / "checkpoint_best_ema.pth").exists()
+
+    def test_best_ema_not_overwritten_when_metric_improved(self, tmp_path: Path) -> None:
+        """on_fit_end must not rewrite checkpoint_best_ema.pth when a true best was saved during training."""
+        cb = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95", run_test=False)
+        pl_module = _make_pl_module()
+        trainer = _make_trainer({"val/mAP_50_95": 0.5, "val/ema_mAP_50_95": 0.7})
+        cb.on_validation_end(trainer, pl_module)
+        assert (tmp_path / "checkpoint_best_ema.pth").exists()
+
+        # Spy that records each destination while delegating to the real writer.
+        written: list[str] = []
+        real_writer = cb._write_ema_checkpoint
+
+        def _spy(trainer_arg, module_arg, state_dict_arg, dest) -> None:
+            written.append(Path(dest).name)
+            real_writer(trainer_arg, module_arg, state_dict_arg, dest)
+
+        cb._write_ema_checkpoint = _spy  # type: ignore[method-assign]
+        cb.on_fit_end(trainer, pl_module)
+
+        assert "checkpoint_best_ema.pth" not in written
+        assert "last_ema.pth" in written
 
     def test_best_total_stripped_of_optimizer(self, tmp_path: Path) -> None:
         """checkpoint_best_total.pth must NOT contain optimizer or lr_scheduler keys."""
@@ -1457,8 +1517,8 @@ class TestBestEmaStatePersistence:
         """on_fit_end picks EMA winner correctly when _best_ema is properly restored.
 
         Without the fix: _best_ema=0.0 after resume, so regular (0.6) wins over the true EMA best (0.8) —
-        checkpoint_best_total.pth is built from the wrong source.  Use epoch number as a distinguisher: pre-resume EMA
-        was saved at epoch 3; regular was saved at epoch 1; total epoch must be 3 (EMA epoch) when EMA correctly wins.
+        checkpoint_best_total.pth is built from the wrong source.  The payload's ``best_total_source`` field records
+        which source won, so EMA selection is asserted directly instead of via a saved-epoch proxy.
         """
         # Pre-resume epoch 1: regular best=0.6.
         cb_pre = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95", run_test=False)
@@ -1483,16 +1543,13 @@ class TestBestEmaStatePersistence:
         total = tmp_path / "checkpoint_best_total.pth"
         assert total.exists()
         total_data = torch.load(total, map_location="cpu", weights_only=False)
-        # strip_checkpoint preserves the `loops` key.
-        # epoch_progress.current.completed == trainer.current_epoch + 1 at save time.
-        # EMA checkpoint was saved at epoch 3 → completed=4.
-        # Regular checkpoint was saved at epoch 1 → completed=2.
-        # If _best_ema was NOT restored (bug), regular wins → completed=2.
-        # If _best_ema IS restored (fix), EMA wins → completed=4.
-        completed = total_data["loops"]["fit_loop"]["epoch_progress"]["current"]["completed"]
-        assert completed == 4, (
-            "on_fit_end must select EMA (epoch 3, best=0.8) over regular (epoch 1, best=0.6); "
-            f"got epoch_completed={completed} — _best_ema not restored from state_dict"
+        # best_total_source records the winning source directly.
+        # If _best_ema was NOT restored (bug), regular wins → "regular".
+        # If _best_ema IS restored (fix), EMA wins → "ema".
+        source = total_data["best_total_source"]
+        assert source == "ema", (
+            "on_fit_end must select EMA (best=0.8) over regular (best=0.6); "
+            f"got best_total_source={source!r} — _best_ema not restored from state_dict"
         )
 
     @pytest.mark.parametrize(

--- a/tests/training/callbacks/test_best_model_callback.py
+++ b/tests/training/callbacks/test_best_model_callback.py
@@ -399,7 +399,7 @@ class TestBestModelCallback:
             weights_only=False,
         )
         total_data = torch.load(total, map_location="cpu", weights_only=False)
-        # total is stripped so only model + args
+        # total is stripped but keeps provenance keys (e.g. best_total_source) beyond model + args
         assert total_data["model"] == ema_data["model"]
         assert total_data["best_total_source"] == "ema"
 

--- a/tests/utilities/test_state_dict.py
+++ b/tests/utilities/test_state_dict.py
@@ -491,3 +491,17 @@ class TestStripCheckpoint:
         strip_checkpoint(ckpt_path)
         result = torch.load(ckpt_path, map_location="cpu", weights_only=False)
         assert "loops" not in result
+
+    def test_strip_writes_extra_metadata(self, tmp_path) -> None:
+        """extra_metadata key/value pairs are merged into the stripped checkpoint."""
+        ckpt_path = self._make_minimal_ckpt(tmp_path)
+        strip_checkpoint(ckpt_path, extra_metadata={"best_total_source": "ema"})
+        result = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+        assert result["best_total_source"] == "ema"
+
+    def test_strip_extra_metadata_overrides_preserved_key(self, tmp_path) -> None:
+        """extra_metadata wins over a preserved same-named key."""
+        ckpt_path = self._make_minimal_ckpt(tmp_path, extra={"rfdetr_version": "1.0.0"})
+        strip_checkpoint(ckpt_path, extra_metadata={"rfdetr_version": "override"})
+        result = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+        assert result["rfdetr_version"] == "override"


### PR DESCRIPTION
- strip_checkpoint() gains optional extra_metadata to merge provenance into the stripped payload
- on_fit_end records best_total_source ("ema" or "regular") in checkpoint_best_total.pth, computed from chose_ema so a missing EMA file falls back to regular
- guarantee checkpoint_best_ema.pth (backfilled with final EMA weights when the EMA metric never improved) and always write last_ema.pth when monitor_ema is set
- extract _write_ema_checkpoint helper and reuse it in on_validation_end to dedupe the EMA save path
- add tests for best_total_source, EMA backfill, last_ema, non-overwrite, and extra_metadata

