### PR TITLE
docs: add GA4 tracking

### DIFF
--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -10,6 +10,15 @@
 
 {% block extrahead %}
   {{ super() }}
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-5M220DKLMB"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-5M220DKLMB');
+  </script>
   <link rel="preconnect" href="https://storage.googleapis.com">
 
   {% if page %}

--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -10,14 +10,15 @@
 
 {% block extrahead %}
   {{ super() }}
+  {% set ga4_measurement_id = "G-5M220DKLMB" %}
   <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-5M220DKLMB"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{ ga4_measurement_id }}"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
+    function gtag(){window.dataLayer.push(arguments);}
     gtag('js', new Date());
 
-    gtag('config', 'G-5M220DKLMB');
+    gtag('config', '{{ ga4_measurement_id }}');
   </script>
   <link rel="preconnect" href="https://storage.googleapis.com">
 


### PR DESCRIPTION
## Summary

- add the RF-DETR GA4 tag to the MkDocs global `extrahead` block
- load measurement ID `G-5M220DKLMB` on every generated documentation page

## Why

Track traffic and engagement for `rfdetr.roboflow.com` in its dedicated GA4 property and web stream.

## Validation

- `git diff --check`
- parsed `docs/theme/main.html` with Jinja successfully
- full `mkdocs build` was attempted locally but could not complete because the repository dependency chain requires TensorRT, which has no Apple Silicon wheel; CI remains the authoritative full build