### PR TITLE
docs: add GA4 tracking to release/latest

### DIFF
--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -10,6 +10,16 @@
 
 {% block extrahead %}
   {{ super() }}
+  {% set ga4_measurement_id = "G-5M220DKLMB" %}
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{ ga4_measurement_id }}"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){window.dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '{{ ga4_measurement_id }}');
+  </script>
   <link rel="preconnect" href="https://storage.googleapis.com">
 
   {% if page %}


### PR DESCRIPTION
Cherry-picks #1220 (`856ad54b`) onto `release/latest`.

## Why

GA4 tracking landed on `develop`, so it is live at `rfdetr.roboflow.com/develop/` — but `rfdetr.roboflow.com/` redirects to `latest/`, which is built from this branch. Verified against the deployed site:

```
/develop/  → googletagmanager.com/gtag/js?id=G-5M220DKLMB  ✓
/latest/   → no gtag                                        ✗
```

So the public docs are currently untracked. `workflow_dispatch` alone can't fix it — `publish-docs.yml` checks out `ref: inputs.target`, so deploying `latest` from a branch without the snippet just rebuilds it without gtag.

## Effect

Merging triggers `publish-docs.yml` (`push release/latest → mike deploy --push --update-aliases latest`), which republishes `latest/` with the tag.

Single file, identical to the `develop` version of `docs/theme/main.html`. No conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)