### PR TITLE
perf(eval): avoid per-iter GPU sync in matching

### DIFF
--- a/docs/learn/train/training-parameters.md
+++ b/docs/learn/train/training-parameters.md
@@ -109,9 +109,10 @@ For example, `RFDETRSegXLarge` uses `624x624`, which is valid because `624` is d
 
 ## EMA (Exponential Moving Average)
 
-| Parameter | Type   | Default | Description                                                                                                          |
-| --------- | ------ | ------- | -------------------------------------------------------------------------------------------------------------------- |
-| `use_ema` | `bool` | `True`  | Enables Exponential Moving Average of weights. Produces a smoothed checkpoint that often improves final performance. |
+| Parameter       | Type   | Default | Description                                                                                                                                                                                                                              |
+| --------------- | ------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `use_ema`       | `bool` | `True`  | Enables Exponential Moving Average of weights. Produces a smoothed checkpoint that often improves final performance.                                                                                                                     |
+| `eval_ema_only` | `bool` | `False` | Validation-only: forward through the EMA model instead of the base model, halving per-batch validation compute. Requires `use_ema=True`. `val/mAP_*` then reports EMA-model quality, not base-model quality — see Evaluation Parameters. |
 
 !!! info "What is EMA?"
 
@@ -200,12 +201,14 @@ model.train(
 
 ## Evaluation Parameters
 
-| Parameter               | Type                | Default | Description                                                                                                        |
-| ----------------------- | ------------------- | ------- | ------------------------------------------------------------------------------------------------------------------ |
-| `eval_max_dets`         | `int`               | `500`   | Maximum number of detections per image considered during COCO evaluation. Lower values speed up evaluation.        |
-| `eval_interval`         | `int`               | `1`     | Run COCO evaluation every N epochs. Set to a higher value to reduce evaluation overhead during long training runs. |
-| `log_per_class_metrics` | `bool`              | `True`  | Log per-class AP metrics to the console and loggers. Disable to reduce log verbosity when there are many classes.  |
-| `progress_bar`          | str \| bool \| None | `None`  | Progress bar style: `"tqdm"`, `"rich"`, or `None`. Legacy booleans are still accepted.                             |
+| Parameter                    | Type                | Default | Description                                                                                                                                                                                                                                                          |
+| ---------------------------- | ------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `eval_max_dets`              | `int`               | `500`   | Maximum number of detections per image considered during COCO evaluation. Lower values speed up evaluation.                                                                                                                                                          |
+| `eval_interval`              | `int`               | `1`     | Run COCO evaluation every N epochs. Set to a higher value to reduce evaluation overhead during long training runs.                                                                                                                                                   |
+| `log_per_class_metrics`      | `bool`              | `True`  | Log per-class AP metrics to the console and loggers. Disable to reduce log verbosity when there are many classes.                                                                                                                                                    |
+| `eval_ema_only`              | `bool`              | `False` | Forward through the EMA model only during validation, skipping the duplicate base-model pass. Requires `use_ema=True`. See [EMA](#ema-exponential-moving-average).                                                                                                   |
+| `eval_masks_head_resolution` | `bool`              | `False` | Segmentation only. Skip upsampling predicted masks to full image resolution during validation, comparing at the mask head's native (lower) resolution instead. `val/segm_mAP` is then not comparable to a full-resolution run. No effect on `RFDETR.predict` output. |
+| `progress_bar`               | str \| bool \| None | `None`  | Progress bar style: `"tqdm"`, `"rich"`, or `None`. Legacy booleans are still accepted.                                                                                                                                                                               |
 
 ## Keypoint Preview Parameters
 
@@ -266,47 +269,49 @@ The parameters below are available for fine-grained control over training behavi
 
 Below is a summary table of all training parameters:
 
-| Parameter                  | Type                | Default        | Description                                                                                                                           |
-| -------------------------- | ------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `dataset_dir`              | str                 | Required       | Path to COCO or YOLO formatted dataset with train/valid/test splits.                                                                  |
-| `output_dir`               | str                 | "output"       | Directory for checkpoints, logs, and other training artifacts.                                                                        |
-| `epochs`                   | int                 | 100            | Number of full passes over the dataset.                                                                                               |
-| `batch_size`               | int or "auto"       | 4              | Samples per iteration. Set to `"auto"` to let RF-DETR probe the GPU for the largest safe batch size. Balance with `grad_accum_steps`. |
-| `grad_accum_steps`         | int                 | 4              | Gradient accumulation steps for effective larger batch sizes.                                                                         |
-| `lr`                       | float               | 1e-4           | Learning rate for the model (excluding encoder).                                                                                      |
-| `lr_encoder`               | float               | 1.5e-4         | Learning rate for the backbone encoder.                                                                                               |
-| `resolution`               | int                 | Model-specific | Input image size (must be divisible by the selected model's `patch_size * num_windows`).                                              |
-| `weight_decay`             | float               | 1e-4           | L2 regularization coefficient.                                                                                                        |
-| `device`                   | str                 | "cuda"         | Training device: cuda, cpu, or mps.                                                                                                   |
-| `use_ema`                  | bool                | True           | Enable Exponential Moving Average of weights.                                                                                         |
-| `gradient_checkpointing`   | bool                | False          | Trade compute for memory during backprop.                                                                                             |
-| `checkpoint_interval`      | int                 | 10             | Save checkpoint every N epochs.                                                                                                       |
-| `resume`                   | str                 | None           | Path to checkpoint for resuming training.                                                                                             |
-| `tensorboard`              | bool                | True           | Enable TensorBoard logging.                                                                                                           |
-| `wandb`                    | bool                | False          | Enable Weights & Biases logging.                                                                                                      |
-| `project`                  | str                 | None           | W&B project name.                                                                                                                     |
-| `run`                      | str                 | None           | W&B run name.                                                                                                                         |
-| `early_stopping`           | bool                | False          | Enable early stopping.                                                                                                                |
-| `early_stopping_patience`  | int                 | 10             | Epochs without improvement before stopping.                                                                                           |
-| `early_stopping_min_delta` | float               | 0.001          | Minimum validation metric change to qualify as improvement.                                                                           |
-| `early_stopping_use_ema`   | bool                | False          | Use EMA model for early stopping metrics.                                                                                             |
-| `eval_max_dets`            | int                 | 500            | Maximum detections per image considered during COCO evaluation.                                                                       |
-| `eval_interval`            | int                 | 1              | Run COCO evaluation every N epochs.                                                                                                   |
-| `log_per_class_metrics`    | bool                | True           | Log per-class AP metrics to the console and loggers.                                                                                  |
-| `progress_bar`             | str \| bool \| None | None           | Progress bar style: `"tqdm"`, `"rich"`, or `None`. Legacy booleans are still accepted.                                                |
-| `accelerator`              | str                 | "auto"         | PyTorch Lightning accelerator. "auto" selects GPU/MPS/CPU automatically.                                                              |
-| `seed`                     | int                 | None           | Random seed for reproducibility. None means no fixed seed.                                                                            |
-| `lr_scheduler`             | str \| Callable     | "step"         | Scheduler preset ("step"/"cosine"), dotted import path, or callable.                                                                  |
-| `lr_scheduler_kwargs`      | dict                | {}             | Keyword arguments for an explicit scheduler; also carries lr_drop / min_factor for the managed presets.                               |
-| `lr_scheduler_interval`    | str                 | "step"         | Explicit-scheduler stepping cadence: "step" or "epoch".                                                                               |
-| `lr_scheduler_monitor`     | str                 | "val/loss"     | Metric fed to ReduceLROnPlateau.                                                                                                      |
-| `lr_min_factor`            | float               | 0.0            | Deprecated — use lr_scheduler_kwargs["min_factor"]. Cosine-preset floor as a fraction of the initial LR.                              |
-| `lr_drop`                  | int                 | 100            | Deprecated — use lr_scheduler_kwargs["lr_drop"]. Epoch at which the "step" preset drops the LR by 10x.                                |
-| `warmup_epochs`            | float               | 0.0            | Number of linear warmup epochs at the start of training.                                                                              |
-| `drop_path`                | float               | 0.0            | Stochastic depth drop-path rate for the backbone.                                                                                     |
-| `compute_val_loss`         | bool                | True           | Compute and log loss during validation.                                                                                               |
-| `compute_test_loss`        | bool                | True           | Compute and log loss during the test run.                                                                                             |
-| `fp16_eval`                | bool                | False          | Run evaluation in FP16 precision to reduce memory usage.                                                                              |
-| `pin_memory`               | bool                | None           | Pin DataLoader memory. None defers to PyTorch Lightning's default.                                                                    |
-| `persistent_workers`       | bool                | None           | Keep DataLoader workers alive between epochs. None uses PTL default.                                                                  |
-| `prefetch_factor`          | int                 | None           | Number of batches prefetched per worker. None uses PyTorch default.                                                                   |
+| Parameter                    | Type                | Default        | Description                                                                                                                           |
+| ---------------------------- | ------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `dataset_dir`                | str                 | Required       | Path to COCO or YOLO formatted dataset with train/valid/test splits.                                                                  |
+| `output_dir`                 | str                 | "output"       | Directory for checkpoints, logs, and other training artifacts.                                                                        |
+| `epochs`                     | int                 | 100            | Number of full passes over the dataset.                                                                                               |
+| `batch_size`                 | int or "auto"       | 4              | Samples per iteration. Set to `"auto"` to let RF-DETR probe the GPU for the largest safe batch size. Balance with `grad_accum_steps`. |
+| `grad_accum_steps`           | int                 | 4              | Gradient accumulation steps for effective larger batch sizes.                                                                         |
+| `lr`                         | float               | 1e-4           | Learning rate for the model (excluding encoder).                                                                                      |
+| `lr_encoder`                 | float               | 1.5e-4         | Learning rate for the backbone encoder.                                                                                               |
+| `resolution`                 | int                 | Model-specific | Input image size (must be divisible by the selected model's `patch_size * num_windows`).                                              |
+| `weight_decay`               | float               | 1e-4           | L2 regularization coefficient.                                                                                                        |
+| `device`                     | str                 | "cuda"         | Training device: cuda, cpu, or mps.                                                                                                   |
+| `use_ema`                    | bool                | True           | Enable Exponential Moving Average of weights.                                                                                         |
+| `gradient_checkpointing`     | bool                | False          | Trade compute for memory during backprop.                                                                                             |
+| `checkpoint_interval`        | int                 | 10             | Save checkpoint every N epochs.                                                                                                       |
+| `resume`                     | str                 | None           | Path to checkpoint for resuming training.                                                                                             |
+| `tensorboard`                | bool                | True           | Enable TensorBoard logging.                                                                                                           |
+| `wandb`                      | bool                | False          | Enable Weights & Biases logging.                                                                                                      |
+| `project`                    | str                 | None           | W&B project name.                                                                                                                     |
+| `run`                        | str                 | None           | W&B run name.                                                                                                                         |
+| `early_stopping`             | bool                | False          | Enable early stopping.                                                                                                                |
+| `early_stopping_patience`    | int                 | 10             | Epochs without improvement before stopping.                                                                                           |
+| `early_stopping_min_delta`   | float               | 0.001          | Minimum validation metric change to qualify as improvement.                                                                           |
+| `early_stopping_use_ema`     | bool                | False          | Use EMA model for early stopping metrics.                                                                                             |
+| `eval_max_dets`              | int                 | 500            | Maximum detections per image considered during COCO evaluation.                                                                       |
+| `eval_interval`              | int                 | 1              | Run COCO evaluation every N epochs.                                                                                                   |
+| `log_per_class_metrics`      | bool                | True           | Log per-class AP metrics to the console and loggers.                                                                                  |
+| `eval_ema_only`              | bool                | False          | Forward through the EMA model only during validation. Requires use_ema=True.                                                          |
+| `eval_masks_head_resolution` | bool                | False          | Segmentation only. Compare masks at native (lower) resolution instead of upsampling; not comparable across runs.                      |
+| `progress_bar`               | str \| bool \| None | None           | Progress bar style: `"tqdm"`, `"rich"`, or `None`. Legacy booleans are still accepted.                                                |
+| `accelerator`                | str                 | "auto"         | PyTorch Lightning accelerator. "auto" selects GPU/MPS/CPU automatically.                                                              |
+| `seed`                       | int                 | None           | Random seed for reproducibility. None means no fixed seed.                                                                            |
+| `lr_scheduler`               | str \| Callable     | "step"         | Scheduler preset ("step"/"cosine"), dotted import path, or callable.                                                                  |
+| `lr_scheduler_kwargs`        | dict                | {}             | Keyword arguments for an explicit scheduler; also carries lr_drop / min_factor for the managed presets.                               |
+| `lr_scheduler_interval`      | str                 | "step"         | Explicit-scheduler stepping cadence: "step" or "epoch".                                                                               |
+| `lr_scheduler_monitor`       | str                 | "val/loss"     | Metric fed to ReduceLROnPlateau.                                                                                                      |
+| `lr_min_factor`              | float               | 0.0            | Deprecated — use lr_scheduler_kwargs["min_factor"]. Cosine-preset floor as a fraction of the initial LR.                              |
+| `lr_drop`                    | int                 | 100            | Deprecated — use lr_scheduler_kwargs["lr_drop"]. Epoch at which the "step" preset drops the LR by 10x.                                |
+| `warmup_epochs`              | float               | 0.0            | Number of linear warmup epochs at the start of training.                                                                              |
+| `drop_path`                  | float               | 0.0            | Stochastic depth drop-path rate for the backbone.                                                                                     |
+| `compute_val_loss`           | bool                | True           | Compute and log loss during validation.                                                                                               |
+| `compute_test_loss`          | bool                | True           | Compute and log loss during the test run.                                                                                             |
+| `fp16_eval`                  | bool                | False          | Run evaluation in FP16 precision to reduce memory usage.                                                                              |
+| `pin_memory`                 | bool                | None           | Pin DataLoader memory. None defers to PyTorch Lightning's default.                                                                    |
+| `persistent_workers`         | bool                | None           | Keep DataLoader workers alive between epochs. None uses PTL default.                                                                  |
+| `prefetch_factor`            | int                 | None           | Number of batches prefetched per worker. None uses PyTorch default.                                                                   |

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -1057,6 +1057,10 @@ class TrainConfig(BaseConfig):
     do_random_resize_via_padding: bool = False
     use_ema: bool = True
     ema_update_interval: int = 1
+    # Validation-only: forward through the EMA model instead of the base model, and skip the
+    # duplicate base-model forward pass COCOEvalCallback would otherwise also run — halves
+    # per-batch validation compute when EMA is enabled. Requires use_ema=True.
+    eval_ema_only: bool = False
     num_workers: int = 2
     weight_decay: float = 1e-4
     amp_dtype: Literal["auto", "bf16", "fp16"] = Field(
@@ -1085,6 +1089,12 @@ class TrainConfig(BaseConfig):
     eval_max_dets: int = 500
     eval_interval: int = 1
     log_per_class_metrics: bool = True
+    # Segmentation only. Skip upsampling predicted masks to full image resolution during
+    # validation/test, returning them at the mask head's native (lower) resolution instead —
+    # cheaper, but ground-truth masks must then be compared at that same lower resolution
+    # (handled in COCOEvalCallback). No effect on non-segmentation models or on inference output
+    # (RFDETR.predict always upsamples regardless of this flag).
+    eval_masks_native_resolution: bool = False
     aug_config: Optional[Dict[str, Any]] = None
     scale_jitter: bool = True
     augmentation_backend: AugmentationBackend | Literal["cpu", "auto"] = "cpu"
@@ -1301,6 +1311,13 @@ class TrainConfig(BaseConfig):
         if "." not in optimizer:
             _resolve_native_optimizer(optimizer)
         return optimizer
+
+    @model_validator(mode="after")
+    def validate_eval_ema_only(self) -> "TrainConfig":
+        """``eval_ema_only`` has no EMA model to evaluate without ``use_ema=True``."""
+        if self.eval_ema_only and not self.use_ema:
+            raise ValueError("eval_ema_only=True requires use_ema=True.")
+        return self
 
     @model_validator(mode="after")
     def validate_optimizer_kwargs(self) -> "TrainConfig":

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -1060,6 +1060,12 @@ class TrainConfig(BaseConfig):
     # Validation-only: forward through the EMA model instead of the base model, and skip the
     # duplicate base-model forward pass COCOEvalCallback would otherwise also run — halves
     # per-batch validation compute when EMA is enabled. Requires use_ema=True.
+    # Metric-key remap: when active, val/mAP_50_95 (and val/segm_mAP_*) report EMA-model
+    # quality, not base-model quality — the base model is never evaluated this epoch. Best-
+    # checkpoint tracking follows: the "regular" checkpoint track sees no data (safely no-ops)
+    # while the EMA checkpoint track receives the real per-epoch EMA score. val/F1 is not
+    # remapped (no parallel EMA-tracked accumulator) and still reflects EMA-quality predictions
+    # under the regular key.
     eval_ema_only: bool = False
     num_workers: int = 2
     weight_decay: float = 1e-4
@@ -1094,7 +1100,11 @@ class TrainConfig(BaseConfig):
     # cheaper, but ground-truth masks must then be compared at that same lower resolution
     # (handled in COCOEvalCallback). No effect on non-segmentation models or on inference output
     # (RFDETR.predict always upsamples regardless of this flag).
-    eval_masks_native_resolution: bool = False
+    # Metric comparability: GT masks are nearest-downsized to the mask head's native resolution
+    # (e.g. 512x512 -> ~16x16) before comparison, so val/segm_mAP under this flag is NOT
+    # comparable to a full-resolution run — small objects can collapse to empty masks at the
+    # lower resolution, and IoU is computed on a coarser pixel grid either way.
+    eval_masks_head_resolution: bool = False
     aug_config: Optional[Dict[str, Any]] = None
     scale_jitter: bool = True
     augmentation_backend: AugmentationBackend | Literal["cpu", "auto"] = "cpu"

--- a/src/rfdetr/evaluation/matching.py
+++ b/src/rfdetr/evaluation/matching.py
@@ -97,36 +97,47 @@ def _match_single_class(
     else:
         iou_matrix = _compute_mask_iou(pred_sorted, gt_items)  # [N, M]
 
-    device = pred_scores.device
-    gt_matched = torch.zeros(m, dtype=torch.bool, device=device)
-    pred_match = torch.zeros(n, dtype=torch.long, device=device)
-    pred_ignore = torch.zeros(n, dtype=torch.bool, device=device)
+    # The greedy matching below is inherently sequential (each GT can only be claimed
+    # once, so iteration i depends on the outcome of i-1) — it cannot be vectorized away.
+    # But on CUDA, comparing a 0-dim tensor against a Python float inside the loop
+    # (`if best_nc_iou >= iou_threshold`) forces a device-to-host sync every iteration,
+    # turning what should be O(1) host-side work into O(N) GPU pipeline stalls. Move the
+    # IoU matrix and crowd mask to host memory once, then run the loop on plain
+    # numpy/Python values so no per-iteration tensor sync occurs (regression: #416).
+    iou_matrix_np = iou_matrix.detach().cpu().numpy()  # [N, M]
+    gt_crowd_np = gt_crowd.detach().cpu().numpy()  # [M]
+
+    gt_matched_np = np.zeros(m, dtype=np.bool_)
+    pred_match_np = np.zeros(n, dtype=np.int64)
+    pred_ignore_np = np.zeros(n, dtype=np.bool_)
+    any_crowd = bool(gt_crowd_np.any())
 
     for i in range(n):
-        ious = iou_matrix[i]  # [M]
+        ious = iou_matrix_np[i]  # [M]
 
         # Try to match to a non-crowd GT (each non-crowd GT matched at most once).
-        nc_ious = ious.clone()
-        nc_ious[gt_crowd] = -1.0
-        nc_ious[gt_matched & ~gt_crowd] = -1.0  # already claimed
+        nc_ious = ious.copy()
+        nc_ious[gt_crowd_np] = -1.0
+        nc_ious[gt_matched_np & ~gt_crowd_np] = -1.0  # already claimed
 
-        best_nc_iou, best_nc_idx = nc_ious.max(dim=0)
+        best_nc_idx = int(np.argmax(nc_ious))
+        best_nc_iou = nc_ious[best_nc_idx]
         if best_nc_iou >= iou_threshold:
-            pred_match[i] = 1
-            gt_matched[best_nc_idx] = True
+            pred_match_np[i] = 1
+            gt_matched_np[best_nc_idx] = True
         # A detection matched to a crowd GT is ignored (not a false positive).
-        elif gt_crowd.any():
-            crowd_ious = ious.clone()
-            crowd_ious[~gt_crowd] = -1.0
+        elif any_crowd:
+            crowd_ious = ious.copy()
+            crowd_ious[~gt_crowd_np] = -1.0
             if crowd_ious.max() >= iou_threshold:
-                pred_ignore[i] = True
-            # else: false positive — pred_match stays 0
+                pred_ignore_np[i] = True
+            # else: false positive — pred_match_np stays 0
 
-    total_gt = int((~gt_crowd).sum().item())
+    total_gt = int((~gt_crowd_np).sum())
     return (
         np.asarray(pred_scores_sorted.float().cpu().numpy(), dtype=np.float32),
-        np.asarray(pred_match.cpu().numpy(), dtype=np.int64),
-        np.asarray(pred_ignore.cpu().numpy(), dtype=np.bool_),
+        pred_match_np,
+        pred_ignore_np,
         total_gt,
     )
 

--- a/src/rfdetr/evaluation/matching.py
+++ b/src/rfdetr/evaluation/matching.py
@@ -104,13 +104,14 @@ def _match_single_class(
     # turning what should be O(1) host-side work into O(N) GPU pipeline stalls. Move the
     # IoU matrix and crowd mask to host memory once, then run the loop on plain
     # numpy/Python values so no per-iteration tensor sync occurs (regression: #416).
-    iou_matrix_np = iou_matrix.detach().cpu().numpy()  # [N, M]
+    iou_matrix_np = iou_matrix.detach().float().cpu().numpy()  # [N, M] -- float() guards bf16/fp16 (no numpy dtype)
     gt_crowd_np = gt_crowd.detach().cpu().numpy()  # [M]
 
     gt_matched_np = np.zeros(m, dtype=np.bool_)
     pred_match_np = np.zeros(n, dtype=np.int64)
     pred_ignore_np = np.zeros(n, dtype=np.bool_)
     any_crowd = bool(gt_crowd_np.any())
+    not_crowd_np = ~gt_crowd_np  # crowd mask is loop-invariant — compute the negation once
 
     for i in range(n):
         ious = iou_matrix_np[i]  # [M]
@@ -118,7 +119,7 @@ def _match_single_class(
         # Try to match to a non-crowd GT (each non-crowd GT matched at most once).
         nc_ious = ious.copy()
         nc_ious[gt_crowd_np] = -1.0
-        nc_ious[gt_matched_np & ~gt_crowd_np] = -1.0  # already claimed
+        nc_ious[gt_matched_np & not_crowd_np] = -1.0  # already claimed
 
         best_nc_idx = int(np.argmax(nc_ious))
         best_nc_iou = nc_ious[best_nc_idx]
@@ -128,7 +129,7 @@ def _match_single_class(
         # A detection matched to a crowd GT is ignored (not a false positive).
         elif any_crowd:
             crowd_ious = ious.copy()
-            crowd_ious[~gt_crowd_np] = -1.0
+            crowd_ious[not_crowd_np] = -1.0
             if crowd_ious.max() >= iou_threshold:
                 pred_ignore_np[i] = True
             # else: false positive — pred_match_np stays 0

--- a/src/rfdetr/models/lwdetr.py
+++ b/src/rfdetr/models/lwdetr.py
@@ -911,6 +911,8 @@ def build_criterion_and_postprocessors(args: "BuilderArgs") -> tuple[SetCriterio
         num_keypoints_per_class=getattr(args, "num_keypoints_per_class", []),
         # Older detection-only namespaces may omit keypoint postprocess knobs; keep the ModelConfig default.
         trace_alpha=getattr(args, "postprocess_trace_alpha", 0.2),
+        # Older namespaces may omit this TrainConfig-only knob; default preserves full upsample.
+        upsample_masks_to_image_size=not getattr(args, "eval_masks_native_resolution", False),
     )
 
     return criterion, postprocess

--- a/src/rfdetr/models/lwdetr.py
+++ b/src/rfdetr/models/lwdetr.py
@@ -912,7 +912,7 @@ def build_criterion_and_postprocessors(args: "BuilderArgs") -> tuple[SetCriterio
         # Older detection-only namespaces may omit keypoint postprocess knobs; keep the ModelConfig default.
         trace_alpha=getattr(args, "postprocess_trace_alpha", 0.2),
         # Older namespaces may omit this TrainConfig-only knob; default preserves full upsample.
-        upsample_masks_to_image_size=not getattr(args, "eval_masks_native_resolution", False),
+        upsample_masks_to_image_size=not getattr(args, "eval_masks_head_resolution", False),
     )
 
     return criterion, postprocess

--- a/src/rfdetr/models/postprocess.py
+++ b/src/rfdetr/models/postprocess.py
@@ -33,11 +33,13 @@ class PostProcess(nn.Module):
         num_select: int = 300,
         num_keypoints_per_class: list[int] | None = None,
         trace_alpha: float = 0.2,
+        upsample_masks_to_image_size: bool = True,
     ) -> None:
         super().__init__()
         self.num_select = num_select
         self.num_keypoints_per_class = num_keypoints_per_class or []
         self.trace_alpha = trace_alpha
+        self.upsample_masks_to_image_size = upsample_masks_to_image_size
 
     @torch.no_grad()
     def forward(self, outputs: dict[str, torch.Tensor], target_sizes: torch.Tensor) -> list[dict[str, torch.Tensor]]:
@@ -63,7 +65,9 @@ class PostProcess(nn.Module):
         boxes = self._gather_and_scale_boxes(out_bbox, topk_boxes, target_sizes)
 
         if out_masks is not None:
-            return self._postprocess_masks(out_masks, scores, labels, boxes, topk_boxes, target_sizes)
+            return self._postprocess_masks(
+                out_masks, scores, labels, boxes, topk_boxes, target_sizes, self.upsample_masks_to_image_size
+            )
         if out_keypoints is not None:
             return self._postprocess_keypoints(out_keypoints, scores, labels, boxes, topk_boxes, target_sizes)
         return self._postprocess_boxes(scores, labels, boxes)
@@ -150,8 +154,9 @@ class PostProcess(nn.Module):
         boxes: torch.Tensor,
         topk_boxes: torch.Tensor,
         target_sizes: torch.Tensor,
+        upsample_masks_to_image_size: bool = True,
     ) -> list[dict[str, torch.Tensor]]:
-        """Attach resized segmentation masks for selected detections.
+        """Attach segmentation masks for selected detections.
 
         Args:
             out_masks: Raw mask logits with shape ``(B, Q, Hm, Wm)``.
@@ -159,12 +164,22 @@ class PostProcess(nn.Module):
             labels: Selected class labels with shape ``(B, K)``.
             boxes: Selected absolute boxes with shape ``(B, K, 4)``.
             topk_boxes: Selected query indices with shape ``(B, K)``.
-            target_sizes: Per-image ``(height, width)`` tensor used for mask
-                resizing.
+            target_sizes: Per-image ``(height, width)`` tensor used for mask resizing when
+                ``upsample_masks_to_image_size`` is ``True``.
+            upsample_masks_to_image_size: When ``True`` (default), resize masks to the target
+                image size — the standard behaviour required for correct-resolution inference
+                output. When ``False``, skip the resize and return masks thresholded at the
+                model's native ``(Hm, Wm)`` mask-head resolution instead — cheaper (no
+                interpolation, no chunking needed) but masks are then at a different resolution
+                than boxes/ground truth; callers comparing them against full-resolution masks
+                (e.g. COCO segm mAP) must downsize the other side to match, or the comparison is
+                meaningless. Intended for opt-in, validation-only cost reduction (see
+                ``TrainConfig.eval_masks_native_resolution``), not for inference output.
 
         Returns:
-            One result dict per image containing scores, labels, boxes, and
-            boolean masks resized to the target image size.
+            One result dict per image containing scores, labels, boxes, and boolean masks —
+            resized to the target image size, or left at native mask-head resolution per
+            ``upsample_masks_to_image_size``.
         """
         results = []
         for i in range(out_masks.shape[0]):
@@ -175,6 +190,10 @@ class PostProcess(nn.Module):
                 0,
                 k_idx.unsqueeze(-1).unsqueeze(-1).repeat(1, out_masks.shape[-2], out_masks.shape[-1]),
             )  # [K, Hm, Wm]
+            if not upsample_masks_to_image_size:
+                res_i["masks"] = (masks_i > 0.0).unsqueeze(1)  # [K,1,Hm,Wm] bool, native resolution
+                results.append(res_i)
+                continue
             h, w = target_sizes[i].tolist()
             # Upsample in chunks and threshold *inside* the comprehension so only one float32 chunk
             # is live at a time; the accumulated list holds bool tensors (1 byte/pixel vs 4 for float32).

--- a/src/rfdetr/models/postprocess.py
+++ b/src/rfdetr/models/postprocess.py
@@ -174,7 +174,7 @@ class PostProcess(nn.Module):
                 than boxes/ground truth; callers comparing them against full-resolution masks
                 (e.g. COCO segm mAP) must downsize the other side to match, or the comparison is
                 meaningless. Intended for opt-in, validation-only cost reduction (see
-                ``TrainConfig.eval_masks_native_resolution``), not for inference output.
+                ``TrainConfig.eval_masks_head_resolution``), not for inference output.
 
         Returns:
             One result dict per image containing scores, labels, boxes, and boolean masks —

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -174,7 +174,9 @@ class COCOEvalCallback(Callback):
         self._use_segm_metrics = self._segmentation and not self._keypoint_mode
         iou_type: Any = ["bbox", "segm"] if self._use_segm_metrics else "bbox"
         kwargs: dict[str, Any] = dict(
-            class_metrics=True,
+            # Skipping per-class computation (not just its table rendering) when the
+            # caller has no use for it saves real per-epoch compute cost (#416).
+            class_metrics=self._log_per_class_metrics,
             max_detection_thresholds=[1, 10, self._max_dets],
             # Disable torchmetrics' built-in cross-rank sync: its `gather_all_tensors` requires every
             # state tensor to have the same ndim on all ranks, but DDP seg validation produces
@@ -754,7 +756,7 @@ class COCOEvalCallback(Callback):
             ema_iou_type: Any = ["bbox", "segm"] if self._use_segm_metrics else "bbox"
             self.map_metric_ema = MeanAveragePrecision(
                 iou_type=ema_iou_type,
-                class_metrics=True,
+                class_metrics=self._log_per_class_metrics,
                 max_detection_thresholds=[1, 10, self._max_dets],
                 backend="faster_coco_eval",
                 sync_on_compute=False,  # we merge state across ranks ourselves (see map_metric in setup)

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -117,6 +117,10 @@ class COCOEvalCallback(Callback):
         eval_interval: Run validation metrics every N epochs. Test metrics are
             always computed when ``trainer.test()`` is called.
         log_per_class_metrics: When ``False``, skip per-class AP logging/table.
+        eval_ema_only: When ``True``, ``validation_step`` already forwarded through the EMA
+            model directly (see ``TrainConfig.eval_ema_only``), so the independent duplicate
+            EMA forward pass this callback would otherwise run every validation batch is
+            skipped.
     """
 
     def __init__(
@@ -127,12 +131,14 @@ class COCOEvalCallback(Callback):
         log_per_class_metrics: bool = True,
         keypoint_oks_sigmas: list[float] | None = None,
         in_notebook: bool | None = None,
+        eval_ema_only: bool = False,
     ) -> None:
         super().__init__()
         self._max_dets = max_dets
         self._segmentation = segmentation
         self._eval_interval = max(1, int(eval_interval))
         self._log_per_class_metrics = bool(log_per_class_metrics)
+        self._eval_ema_only = bool(eval_ema_only)
         self._class_names: list[str] = []
         self._cat_id_to_name: dict[int, str] = {}
         self._f1_local: dict[int, dict[str, Any]] = init_matching_accumulator()
@@ -414,7 +420,8 @@ class COCOEvalCallback(Callback):
         if not isinstance(outputs, Mapping):
             return
         preds: list[dict[str, Tensor]] = self._convert_preds(outputs["results"])
-        targets = self._convert_targets(outputs["targets"])
+        targets_raw = self._convert_targets(outputs["targets"])
+        targets = self._align_gt_masks_to_pred_resolution(preds, targets_raw) if self._use_segm_metrics else targets_raw
 
         self.map_metric.update(preds, targets)
 
@@ -430,9 +437,12 @@ class COCOEvalCallback(Callback):
         # forward pass + update when the averaged model is available.  ema_cb._average_model
         # availability is rank-invariant (EMA updates fire on the same global step on every
         # rank), so per-rank EMA update counts stay consistent.
+        # Skipped entirely when eval_ema_only=True: validation_step already forwarded through
+        # the EMA model directly (RFDETRModelModule._resolve_eval_model), so this second,
+        # independent EMA forward pass would be pure duplicate compute (#416).
         ema_cb = self._get_ema_callback(trainer)
         ema_inner = _get_ema_inner_module(ema_cb)
-        if ema_cb is not None and ema_inner is not None and self.map_metric_ema is not None:
+        if not self._eval_ema_only and ema_cb is not None and ema_inner is not None and self.map_metric_ema is not None:
             samples, _ = batch
             orig_sizes = torch.stack([t["orig_size"] for t in outputs["targets"]]).to(pl_module.device)
             ema_underlying = ema_inner.model
@@ -441,7 +451,12 @@ class COCOEvalCallback(Callback):
                 ema_outputs = ema_underlying(samples)
                 ema_results = pl_module.postprocess(ema_outputs, orig_sizes)
             ema_preds = self._convert_preds(ema_results)
-            self.map_metric_ema.update(ema_preds, targets)
+            ema_targets = (
+                self._align_gt_masks_to_pred_resolution(ema_preds, targets_raw)
+                if self._use_segm_metrics
+                else targets_raw
+            )
+            self.map_metric_ema.update(ema_preds, ema_targets)
             self._update_keypoint_oks_metric(
                 trainer,
                 {"results": ema_results, "targets": outputs["targets"]},
@@ -495,7 +510,8 @@ class COCOEvalCallback(Callback):
         if not isinstance(outputs, Mapping):
             return
         preds: list[dict[str, Tensor]] = self._convert_preds(outputs["results"])
-        targets = self._convert_targets(outputs["targets"])
+        targets_raw = self._convert_targets(outputs["targets"])
+        targets = self._align_gt_masks_to_pred_resolution(preds, targets_raw) if self._use_segm_metrics else targets_raw
 
         self.map_metric.update(preds, targets)
 
@@ -1177,5 +1193,40 @@ class COCOEvalCallback(Callback):
                 entry["masks"] = masks
             if "iscrowd" in t:
                 entry["iscrowd"] = t["iscrowd"]
+            out.append(entry)
+        return out
+
+    @staticmethod
+    def _align_gt_masks_to_pred_resolution(
+        preds: list[dict[str, Tensor]], targets: list[dict[str, Tensor]]
+    ) -> list[dict[str, Tensor]]:
+        """Downsize ground-truth masks to match predicted masks' resolution when they differ.
+
+        ``_convert_targets`` already normalises GT masks to ``orig_size``, matching predictions in the default
+        (``upsample_masks_to_image_size=True``) case. When ``TrainConfig.eval_masks_native_resolution`` is set,
+        ``PostProcess`` instead returns predicted masks at the mask head's native (lower) resolution — comparing
+        them against full-resolution GT masks would silently produce meaningless IoU values (both
+        ``torchmetrics.MeanAveragePrecision``'s RLE encoding and ``matching.build_matching_data`` require both
+        sides on the same pixel grid), not an error. This brings GT masks down to the prediction's resolution so the
+        comparison stays valid, just at lower fidelity.
+
+        Args:
+            preds: Per-image prediction dicts, already through ``_convert_preds``.
+            targets: Per-image target dicts, already through ``_convert_targets`` (GT masks at ``orig_size``).
+
+        Returns:
+            ``targets`` unchanged when no masks are present or resolutions already match; otherwise a new list with
+            each target's masks nearest-downsized to match its paired prediction's mask resolution.
+        """
+        out = []
+        for p, t in zip(preds, targets):
+            p_masks, t_masks = p.get("masks"), t.get("masks")
+            if p_masks is None or t_masks is None or p_masks.shape[-2:] == t_masks.shape[-2:]:
+                out.append(t)
+                continue
+            h, w = p_masks.shape[-2:]
+            resized = F.interpolate(t_masks.float().unsqueeze(1), size=(int(h), int(w)), mode="nearest").squeeze(1)
+            entry = dict(t)
+            entry["masks"] = resized.bool()
             out.append(entry)
         return out

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -409,6 +409,15 @@ class COCOEvalCallback(Callback):
         When an EMA callback is present the EMA model is run on the same batch in a separate ``torch.no_grad()`` forward
         pass so that base and EMA metrics are computed from independent predictions.
 
+        When ``eval_ema_only`` is active and the EMA model has warmed up, ``validation_step`` already forwarded
+        through the EMA-averaged weights (see ``RFDETRModelModule._resolve_eval_model``) — these predictions are
+        routed to the EMA mAP/checkpoint track (``map_metric_ema`` / ``val/ema_*``) instead of the regular one,
+        which never ran a base-model forward pass this batch. Without this routing, the regular ``val/mAP_50_95``
+        key silently reflects EMA quality while ``BestModelCallback`` checkpoints the (unevaluated) base weights
+        under that key — a metric/weights mismatch. The macro-F1 sweep (``val/F1``) has no parallel EMA-tracked
+        accumulator and is not rerouted; under ``eval_ema_only`` it reflects EMA-quality predictions logged under
+        the regular key, a known limitation of this mode.
+
         Args:
             trainer: The PTL Trainer.
             pl_module: The LightningModule.
@@ -423,25 +432,32 @@ class COCOEvalCallback(Callback):
         targets_raw = self._convert_targets(outputs["targets"])
         targets = self._align_gt_masks_to_pred_resolution(preds, targets_raw) if self._use_segm_metrics else targets_raw
 
-        self.map_metric.update(preds, targets)
+        # ema_cb._average_model availability is rank-invariant (EMA updates fire on the same
+        # global step on every rank), so per-rank EMA-forward decisions stay consistent.
+        ema_cb = self._get_ema_callback(trainer)
+        ema_inner = _get_ema_inner_module(ema_cb)
+        used_ema_forward = self._eval_ema_only and ema_inner is not None
+        if used_ema_forward:
+            if self.map_metric_ema is not None:
+                self.map_metric_ema.update(preds, targets)
+                self._ema_has_updates = True
+        else:
+            self.map_metric.update(preds, targets)
 
         iou_type = "segm" if self._use_segm_metrics else "bbox"
         batch_matching = build_matching_data(preds, targets, iou_threshold=0.5, iou_type=iou_type)
         merge_matching_data(self._f1_local, batch_matching)
-        self._update_keypoint_oks_metric(trainer, outputs, split="val")
+        self._update_keypoint_oks_metric(trainer, outputs, split="val_ema" if used_ema_forward else "val")
 
         # Run EMA model separately on the same batch so that base and EMA metrics
         # are computed from independent forward passes rather than being aliases.
         # The EMA metric object itself is created on every rank in
         # on_validation_epoch_start (_prepare_ema_metric); here we only run the EMA
-        # forward pass + update when the averaged model is available.  ema_cb._average_model
-        # availability is rank-invariant (EMA updates fire on the same global step on every
-        # rank), so per-rank EMA update counts stay consistent.
+        # forward pass + update when the averaged model is available.
         # Skipped entirely when eval_ema_only=True: validation_step already forwarded through
-        # the EMA model directly (RFDETRModelModule._resolve_eval_model), so this second,
-        # independent EMA forward pass would be pure duplicate compute (#416).
-        ema_cb = self._get_ema_callback(trainer)
-        ema_inner = _get_ema_inner_module(ema_cb)
+        # the EMA model directly (RFDETRModelModule._resolve_eval_model) and the primary preds
+        # above are already routed to the EMA track, so this second, independent EMA forward
+        # pass would be pure duplicate compute (#416).
         if not self._eval_ema_only and ema_cb is not None and ema_inner is not None and self.map_metric_ema is not None:
             samples, _ = batch
             orig_sizes = torch.stack([t["orig_size"] for t in outputs["targets"]]).to(pl_module.device)
@@ -1203,7 +1219,7 @@ class COCOEvalCallback(Callback):
         """Downsize ground-truth masks to match predicted masks' resolution when they differ.
 
         ``_convert_targets`` already normalises GT masks to ``orig_size``, matching predictions in the default
-        (``upsample_masks_to_image_size=True``) case. When ``TrainConfig.eval_masks_native_resolution`` is set,
+        (``upsample_masks_to_image_size=True``) case. When ``TrainConfig.eval_masks_head_resolution`` is set,
         ``PostProcess`` instead returns predicted masks at the mask head's native (lower) resolution — comparing
         them against full-resolution GT masks would silently produce meaningless IoU values (both
         ``torchmetrics.MeanAveragePrecision``'s RLE encoding and ``matching.build_matching_data`` require both

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -33,6 +33,7 @@ from rfdetr.config import (
 from rfdetr.datasets.coco import compute_multi_scale_scales
 from rfdetr.models.lwdetr import build_criterion_from_config, build_model_from_config
 from rfdetr.models.weights import apply_lora, interpolate_position_embeddings, load_pretrain_weights
+from rfdetr.training.callbacks.coco_eval import _get_ema_inner_module
 from rfdetr.training.param_groups import get_param_dict
 from rfdetr.utilities.logger import get_logger
 
@@ -903,18 +904,29 @@ class RFDETRModelModule(LightningModule):
         base+EMA forward pass ``COCOEvalCallback`` would otherwise also run every validation
         batch (see issue 416). Falls back to the base model when EMA is enabled but not yet
         warmed up (e.g. the very first validation epoch, before ``RFDETREMACallback.setup``
-        has built its averaged model).
+        has built its averaged model), or when this module isn't attached to a ``Trainer`` at
+        all (``LightningModule.trainer`` raises ``RuntimeError`` rather than returning ``None``
+        when unattached — e.g. ``validation_step`` called directly outside ``Trainer.fit``/
+        ``Trainer.validate``).
+
+        Uses the same ``_get_ema_inner_module`` helper as ``COCOEvalCallback`` (see
+        ``coco_eval.py``) so both consumers resolve the EMA-averaged detection net through one
+        shared code path instead of independently duck-typing ``RFDETREMACallback``.
 
         Returns:
-            The base model, or the EMA-averaged inner module when ``eval_ema_only`` is active
-            and available.
+            The base model, or the EMA-averaged inner module's underlying detection net when
+            ``eval_ema_only`` is active and available.
         """
         if not self.train_config.eval_ema_only:
             return self.model
-        for callback in getattr(self.trainer, "callbacks", []):
-            averaged = getattr(callback, "_average_model", None)
-            if averaged is not None:
-                return averaged.module
+        try:
+            callbacks = getattr(self.trainer, "callbacks", [])
+        except RuntimeError:
+            return self.model
+        for callback in callbacks:
+            ema_inner = _get_ema_inner_module(callback)
+            if ema_inner is not None:
+                return ema_inner.model
         return self.model
 
     def validation_step(self, batch: tuple[Any, Any], batch_idx: int) -> dict[str, Any]:

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -895,6 +895,28 @@ class RFDETRModelModule(LightningModule):
         )
         self.log("val/loss", loss, prog_bar=True, on_epoch=True, sync_dist=True, batch_size=batch_size)
 
+    def _resolve_eval_model(self) -> Any:
+        """Return the model to forward through for validation.
+
+        When ``TrainConfig.eval_ema_only`` is set, validation forwards through the EMA-averaged
+        weights directly instead of the base model — this replaces the second, duplicate
+        base+EMA forward pass ``COCOEvalCallback`` would otherwise also run every validation
+        batch (see issue 416). Falls back to the base model when EMA is enabled but not yet
+        warmed up (e.g. the very first validation epoch, before ``RFDETREMACallback.setup``
+        has built its averaged model).
+
+        Returns:
+            The base model, or the EMA-averaged inner module when ``eval_ema_only`` is active
+            and available.
+        """
+        if not self.train_config.eval_ema_only:
+            return self.model
+        for callback in getattr(self.trainer, "callbacks", []):
+            averaged = getattr(callback, "_average_model", None)
+            if averaged is not None:
+                return averaged.module
+        return self.model
+
     def validation_step(self, batch: tuple[Any, Any], batch_idx: int) -> dict[str, Any]:
         """Run forward pass and postprocess for one validation step.
 
@@ -909,7 +931,7 @@ class RFDETRModelModule(LightningModule):
             Dict with ``results`` (postprocessed predictions) and ``targets``.
         """
         samples, targets = batch
-        outputs = self.model(samples)
+        outputs = self._resolve_eval_model()(samples)
         if self.train_config.compute_val_loss:
             loss_dict = self.criterion(outputs, targets)
             weight_dict = self.criterion.weight_dict

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -513,6 +513,7 @@ def build_trainer(
             eval_interval=tc.eval_interval,
             log_per_class_metrics=tc.log_per_class_metrics,
             keypoint_oks_sigmas=tc.keypoint_oks_sigmas,
+            eval_ema_only=tc.eval_ema_only,
         )
     )
 

--- a/tests/evaluation/test_evaluation.py
+++ b/tests/evaluation/test_evaluation.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 import torch
+from torchvision.ops import box_iou
 
 from rfdetr.evaluation.matching import (
     _compute_mask_iou,
@@ -185,13 +186,58 @@ class TestMatchSingleClass:
         assert matches[0] == 1
         assert total_gt == 1
 
+    @staticmethod
+    def _reference_greedy_match(
+        order: list[int],
+        iou_matrix: torch.Tensor,
+        gt_crowd: torch.Tensor,
+        iou_threshold: float,
+    ) -> tuple[np.ndarray, np.ndarray, int]:
+        """Naive, independently-written greedy matcher used as a ground-truth oracle.
+
+        Reimplements the COCO greedy-matching contract directly from spec with plain Python
+        loops and no shared code with ``_match_single_class`` (no numpy vectorization, no
+        hoisted crowd mask) — a divergence in the optimized/numpy-ported implementation (e.g. a
+        tie-break or crowd-handling regression) will disagree with this reference instead of
+        silently agreeing with itself.
+
+        Args:
+            order: Detection indices into ``iou_matrix``'s rows, in descending-score order.
+            iou_matrix: Pairwise IoU, ``[n_preds, n_gt]``, rows in original (unsorted) order.
+            gt_crowd: Bool tensor ``[n_gt]``, ``True`` for crowd instances.
+            iou_threshold: Minimum IoU to count as a positive match.
+
+        Returns:
+            Tuple ``(matches, ignore, total_gt)`` aligned to ``order``.
+        """
+        n_gt = iou_matrix.shape[1]
+        gt_matched = [False] * n_gt
+        matches = np.zeros(len(order), dtype=np.int64)
+        ignore = np.zeros(len(order), dtype=np.bool_)
+        for out_i, orig_i in enumerate(order):
+            best_iou, best_gt = -1.0, -1
+            for j in range(n_gt):
+                if gt_crowd[j] or gt_matched[j]:
+                    continue
+                iou = float(iou_matrix[orig_i, j])
+                if iou > best_iou:
+                    best_iou, best_gt = iou, j
+            if best_gt != -1 and best_iou >= iou_threshold:
+                matches[out_i] = 1
+                gt_matched[best_gt] = True
+                continue
+            for j in range(n_gt):
+                if gt_crowd[j] and float(iou_matrix[orig_i, j]) >= iou_threshold:
+                    ignore[out_i] = True
+                    break
+        total_gt = int((~gt_crowd.numpy()).sum())
+        return matches, ignore, total_gt
+
     def test_greedy_loop_does_not_sync_a_tensor_per_detection(self) -> None:
         """Regression test for #416: the per-detection greedy loop must not force one device-to-host tensor sync
-        (``Tensor.__bool__``) per detection.
-
-        On CUDA each such sync is a pipeline stall; the loop should convert IoUs to host data once, then run the
-        inherently-sequential greedy matching on plain Python/numpy values.
-        """
+        (``Tensor.__bool__``) per detection, and the numpy-ported matching output must agree with an independent
+        reference implementation of the same algorithm at scale (matches/ignore/total_gt) — the sync-count assert alone
+        cannot catch a logic regression in the torch->numpy port (e.g. a tie-break or crowd-handling change)."""
         n, m = 50, 10
         scores = torch.rand(n)
         preds = torch.rand(n, 4) * 100
@@ -199,6 +245,7 @@ class TestMatchSingleClass:
         gts = torch.rand(m, 4) * 100
         gts[:, 2:] += gts[:, :2] + 1.0
         gt_crowd = torch.zeros(m, dtype=torch.bool)
+        gt_crowd[:3] = True  # exercise the crowd/ignore branch at scale, not just n<=3 cases
 
         call_count = 0
         orig_bool = torch.Tensor.__bool__
@@ -209,13 +256,21 @@ class TestMatchSingleClass:
             return orig_bool(self)
 
         with patch.object(torch.Tensor, "__bool__", counting_bool):
-            self._run(scores, preds, gts, gt_crowd=gt_crowd)
+            scores_out, matches, ignore, total_gt = self._run(scores, preds, gts, gt_crowd=gt_crowd)
 
         assert call_count < n, (
             f"_match_single_class triggered {call_count} tensor->bool syncs for n={n} "
             "detections; expected O(1) syncs, not O(n) — the greedy loop should operate "
             "on host data, not per-iteration device tensor comparisons"
         )
+
+        order = torch.argsort(scores, descending=True).tolist()
+        iou_matrix = box_iou(preds, gts)
+        ref_matches, ref_ignore, ref_total_gt = self._reference_greedy_match(order, iou_matrix, gt_crowd, 0.5)
+        assert list(scores_out) == pytest.approx(scores[order].tolist())
+        assert np.array_equal(matches, ref_matches)
+        assert np.array_equal(ignore, ref_ignore)
+        assert total_gt == ref_total_gt
 
 
 # ---------------------------------------------------------------------------

--- a/tests/evaluation/test_evaluation.py
+++ b/tests/evaluation/test_evaluation.py
@@ -185,6 +185,38 @@ class TestMatchSingleClass:
         assert matches[0] == 1
         assert total_gt == 1
 
+    def test_greedy_loop_does_not_sync_a_tensor_per_detection(self) -> None:
+        """Regression test for #416: the per-detection greedy loop must not force one device-to-host tensor sync
+        (``Tensor.__bool__``) per detection.
+
+        On CUDA each such sync is a pipeline stall; the loop should convert IoUs to host data once, then run the
+        inherently-sequential greedy matching on plain Python/numpy values.
+        """
+        n, m = 50, 10
+        scores = torch.rand(n)
+        preds = torch.rand(n, 4) * 100
+        preds[:, 2:] += preds[:, :2] + 1.0
+        gts = torch.rand(m, 4) * 100
+        gts[:, 2:] += gts[:, :2] + 1.0
+        gt_crowd = torch.zeros(m, dtype=torch.bool)
+
+        call_count = 0
+        orig_bool = torch.Tensor.__bool__
+
+        def counting_bool(self: torch.Tensor) -> bool:
+            nonlocal call_count
+            call_count += 1
+            return orig_bool(self)
+
+        with patch.object(torch.Tensor, "__bool__", counting_bool):
+            self._run(scores, preds, gts, gt_crowd=gt_crowd)
+
+        assert call_count < n, (
+            f"_match_single_class triggered {call_count} tensor->bool syncs for n={n} "
+            "detections; expected O(1) syncs, not O(n) — the greedy loop should operate "
+            "on host data, not per-iteration device tensor comparisons"
+        )
+
 
 # ---------------------------------------------------------------------------
 # build_matching_data

--- a/tests/models/test_builder_characterization.py
+++ b/tests/models/test_builder_characterization.py
@@ -367,6 +367,19 @@ class TestBuildModelContextCharacterization:
         ctx = _build_model_context(mc)
         assert ctx.args.output_dir == "output"
 
+    def test_predict_postprocess_always_upsamples_masks_regardless_of_eval_flag(self) -> None:
+        """RFDETR.predict's PostProcess must always upsample masks to full image resolution.
+
+        TrainConfig.eval_masks_head_resolution is a validation-only cost-saving knob; it must never leak into the
+        inference/predict path via ``_build_model_context``'s internal dummy ``TrainConfig`` — deployment predictions
+        always report at native image resolution regardless of how the checkpoint was trained.
+        """
+        from rfdetr.detr import _build_model_context
+
+        mc = RFDETRSegNanoConfig(pretrain_weights=None, device="cpu")
+        ctx = _build_model_context(mc)
+        assert ctx.postprocess.upsample_masks_to_image_size is True
+
 
 # ---------------------------------------------------------------------------
 # RFDETRModelModule.__init__ characterization

--- a/tests/models/test_builders.py
+++ b/tests/models/test_builders.py
@@ -161,15 +161,15 @@ class TestBuildCriterionFromConfig:
         criterion, _ = build_criterion_from_config(mc, tc, defaults=custom_defaults)
         assert criterion.focal_alpha == pytest.approx(0.5), f"Expected focal_alpha=0.5, got {criterion.focal_alpha}"
 
-    def test_eval_masks_native_resolution_disables_postprocess_upsample(self) -> None:
-        """TrainConfig.eval_masks_native_resolution=True must reach PostProcess.upsample_masks_to_image_size=False."""
+    def test_eval_masks_head_resolution_disables_postprocess_upsample(self) -> None:
+        """TrainConfig.eval_masks_head_resolution=True must reach PostProcess.upsample_masks_to_image_size=False."""
         mc = RFDETRSegNanoConfig()
-        tc = SegmentationTrainConfig(dataset_dir="/tmp", eval_masks_native_resolution=True)
+        tc = SegmentationTrainConfig(dataset_dir="/tmp", eval_masks_head_resolution=True)
         _, postprocess = build_criterion_from_config(mc, tc)
         assert postprocess.upsample_masks_to_image_size is False
 
-    def test_eval_masks_native_resolution_defaults_to_upsampling(self) -> None:
-        """eval_masks_native_resolution=False (default) preserves full-resolution mask upsampling."""
+    def test_eval_masks_head_resolution_defaults_to_upsampling(self) -> None:
+        """eval_masks_head_resolution=False (default) preserves full-resolution mask upsampling."""
         mc = RFDETRSegNanoConfig()
         tc = SegmentationTrainConfig(dataset_dir="/tmp")
         _, postprocess = build_criterion_from_config(mc, tc)

--- a/tests/models/test_builders.py
+++ b/tests/models/test_builders.py
@@ -160,3 +160,17 @@ class TestBuildCriterionFromConfig:
         custom_defaults = replace(MODEL_DEFAULTS, focal_alpha=0.5)
         criterion, _ = build_criterion_from_config(mc, tc, defaults=custom_defaults)
         assert criterion.focal_alpha == pytest.approx(0.5), f"Expected focal_alpha=0.5, got {criterion.focal_alpha}"
+
+    def test_eval_masks_native_resolution_disables_postprocess_upsample(self) -> None:
+        """TrainConfig.eval_masks_native_resolution=True must reach PostProcess.upsample_masks_to_image_size=False."""
+        mc = RFDETRSegNanoConfig()
+        tc = SegmentationTrainConfig(dataset_dir="/tmp", eval_masks_native_resolution=True)
+        _, postprocess = build_criterion_from_config(mc, tc)
+        assert postprocess.upsample_masks_to_image_size is False
+
+    def test_eval_masks_native_resolution_defaults_to_upsampling(self) -> None:
+        """eval_masks_native_resolution=False (default) preserves full-resolution mask upsampling."""
+        mc = RFDETRSegNanoConfig()
+        tc = SegmentationTrainConfig(dataset_dir="/tmp")
+        _, postprocess = build_criterion_from_config(mc, tc)
+        assert postprocess.upsample_masks_to_image_size is True

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -469,6 +469,31 @@ class TestTrainConfigT42PromotedFields:
         with pytest.raises((ValueError, ValidationError)):
             self._tc(tmp_path, auto_batch_ema_headroom=ema_headroom)
 
+    def test_eval_ema_only_requires_use_ema(self, tmp_path):
+        """eval_ema_only=True with use_ema=False must raise — no EMA model exists to evaluate."""
+        with pytest.raises(ValidationError, match="eval_ema_only"):
+            self._tc(tmp_path, eval_ema_only=True, use_ema=False)
+
+    def test_eval_ema_only_accepted_with_use_ema(self, tmp_path):
+        """eval_ema_only=True is accepted when use_ema=True (the default)."""
+        tc = self._tc(tmp_path, eval_ema_only=True, use_ema=True)
+        assert tc.eval_ema_only is True
+
+    def test_eval_ema_only_defaults_to_false(self, tmp_path):
+        """eval_ema_only defaults to False, preserving current dual base+EMA validation behaviour."""
+        tc = self._tc(tmp_path)
+        assert tc.eval_ema_only is False
+
+    def test_eval_masks_native_resolution_defaults_to_false(self, tmp_path):
+        """eval_masks_native_resolution defaults to False, preserving full-resolution mask upsampling."""
+        tc = self._tc(tmp_path)
+        assert tc.eval_masks_native_resolution is False
+
+    def test_eval_masks_native_resolution_can_be_enabled(self, tmp_path):
+        """eval_masks_native_resolution=True is accepted (opt-in, no cross-field constraint)."""
+        tc = self._tc(tmp_path, eval_masks_native_resolution=True)
+        assert tc.eval_masks_native_resolution is True
+
 
 class TestTrainConfigLRScheduler:
     """Configurable LR-scheduler surface: preset validation, explicit paths/callables, and deprecation folding."""

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -484,15 +484,15 @@ class TestTrainConfigT42PromotedFields:
         tc = self._tc(tmp_path)
         assert tc.eval_ema_only is False
 
-    def test_eval_masks_native_resolution_defaults_to_false(self, tmp_path):
-        """eval_masks_native_resolution defaults to False, preserving full-resolution mask upsampling."""
+    def test_eval_masks_head_resolution_defaults_to_false(self, tmp_path):
+        """eval_masks_head_resolution defaults to False, preserving full-resolution mask upsampling."""
         tc = self._tc(tmp_path)
-        assert tc.eval_masks_native_resolution is False
+        assert tc.eval_masks_head_resolution is False
 
-    def test_eval_masks_native_resolution_can_be_enabled(self, tmp_path):
-        """eval_masks_native_resolution=True is accepted (opt-in, no cross-field constraint)."""
-        tc = self._tc(tmp_path, eval_masks_native_resolution=True)
-        assert tc.eval_masks_native_resolution is True
+    def test_eval_masks_head_resolution_can_be_enabled(self, tmp_path):
+        """eval_masks_head_resolution=True is accepted (opt-in, no cross-field constraint)."""
+        tc = self._tc(tmp_path, eval_masks_head_resolution=True)
+        assert tc.eval_masks_head_resolution is True
 
 
 class TestTrainConfigLRScheduler:

--- a/tests/models/test_postprocess.py
+++ b/tests/models/test_postprocess.py
@@ -168,3 +168,55 @@ class TestPostProcessMasks:
         masks = results[0]["masks"]
         assert masks.shape == (num_select, 1, img_h, img_w)
         assert masks.dtype == torch.bool
+
+    def test_native_resolution_skips_upsample_when_flag_false(self):
+        """upsample_masks_to_image_size=False returns masks at native mask-head resolution instead of target_sizes (opt-
+        in validation-cost reduction, see TrainConfig.eval_masks_native_resolution)."""
+        batch, num_queries, mask_h, mask_w = 1, 8, 16, 16
+        num_select, img_h, img_w = 8, 512, 512
+        out_masks = torch.randn(batch, num_queries, mask_h, mask_w)
+        scores = torch.rand(batch, num_select)
+        labels = torch.zeros(batch, num_select, dtype=torch.long)
+        boxes = torch.zeros(batch, num_select, 4)
+        topk_boxes = torch.arange(num_select).unsqueeze(0)
+        target_sizes = torch.tensor([[img_h, img_w]])
+
+        results = PostProcess._postprocess_masks(
+            out_masks, scores, labels, boxes, topk_boxes, target_sizes, upsample_masks_to_image_size=False
+        )
+
+        masks = results[0]["masks"]
+        assert masks.shape == (num_select, 1, mask_h, mask_w)
+        assert masks.dtype == torch.bool
+
+    def test_native_resolution_thresholds_at_zero_same_as_upsampled_path(self):
+        """Native-resolution masks apply the same logit > 0.0 threshold as the upsampled path."""
+        out_masks = torch.tensor([[[[5.0, -5.0], [-1.0, 1.0]]]])  # [B=1, Q=1, Hm=2, Wm=2]
+        scores = torch.tensor([[0.9]])
+        labels = torch.zeros(1, 1, dtype=torch.long)
+        boxes = torch.zeros(1, 1, 4)
+        topk_boxes = torch.tensor([[0]])
+        target_sizes = torch.tensor([[100, 100]])
+
+        results = PostProcess._postprocess_masks(
+            out_masks, scores, labels, boxes, topk_boxes, target_sizes, upsample_masks_to_image_size=False
+        )
+
+        expected = torch.tensor([[True, False], [False, True]])
+        assert torch.equal(results[0]["masks"].squeeze(1)[0], expected)
+
+    def test_forward_threads_upsample_flag_from_constructor(self):
+        """PostProcess.forward() must respect the constructor's upsample_masks_to_image_size setting."""
+        batch, num_queries, mask_h, mask_w = 1, 4, 8, 8
+        num_classes = 2
+        pp = PostProcess(num_select=4, upsample_masks_to_image_size=False)
+        outputs = {
+            "pred_logits": torch.randn(batch, num_queries, num_classes),
+            "pred_boxes": torch.rand(batch, num_queries, 4),
+            "pred_masks": torch.randn(batch, num_queries, mask_h, mask_w),
+        }
+        target_sizes = torch.tensor([[256, 256]])
+
+        results = pp(outputs, target_sizes)
+
+        assert results[0]["masks"].shape[-2:] == (mask_h, mask_w)

--- a/tests/models/test_postprocess.py
+++ b/tests/models/test_postprocess.py
@@ -171,7 +171,7 @@ class TestPostProcessMasks:
 
     def test_native_resolution_skips_upsample_when_flag_false(self):
         """upsample_masks_to_image_size=False returns masks at native mask-head resolution instead of target_sizes (opt-
-        in validation-cost reduction, see TrainConfig.eval_masks_native_resolution)."""
+        in validation-cost reduction, see TrainConfig.eval_masks_head_resolution)."""
         batch, num_queries, mask_h, mask_w = 1, 8, 16, 16
         num_select, img_h, img_w = 8, 512, 512
         out_masks = torch.randn(batch, num_queries, mask_h, mask_w)

--- a/tests/training/callbacks/test_coco_eval_callback.py
+++ b/tests/training/callbacks/test_coco_eval_callback.py
@@ -1156,7 +1156,9 @@ class TestValidationBatchEndEvalEmaOnly:
         return ema_cb
 
     def test_eval_ema_only_true_skips_duplicate_ema_forward(self) -> None:
-        """eval_ema_only=True must never call the EMA model's forward a second time."""
+        """eval_ema_only=True must never call the EMA model's forward a second time, and must route the single forward's
+        predictions to the EMA metric/checkpoint track (not the regular one, which never ran a base-model forward this
+        batch — regression for the val/mAP_50_95 metric/checkpoint-weights mismatch)."""
         ema_underlying = MagicMock(name="ema_underlying_model", return_value={"ema": True})
         cb = COCOEvalCallback(eval_ema_only=True)
         trainer = _make_trainer(callbacks=[self._ema_callback_with_underlying(ema_underlying)])
@@ -1170,7 +1172,31 @@ class TestValidationBatchEndEvalEmaOnly:
         cb.on_validation_batch_end(trainer, module, outputs, batch, 0)
 
         ema_underlying.assert_not_called()
+        cb.map_metric_ema.update.assert_called_once()
+        cb.map_metric.update.assert_not_called()
+        assert cb._ema_has_updates is True
+
+    def test_eval_ema_only_true_falls_back_to_regular_track_when_ema_not_warmed_up(self) -> None:
+        """eval_ema_only=True with no averaged EMA model yet available must route predictions to the regular map_metric,
+        mirroring RFDETRModelModule._resolve_eval_model's own base-model fallback — otherwise the EMA track would record
+        an update that never actually came from an EMA forward pass."""
+        cb = COCOEvalCallback(eval_ema_only=True)
+        ema_cb = MagicMock(name="ema_callback")
+        ema_cb.get_ema_model_state_dict = MagicMock(name="get_ema_model_state_dict")
+        ema_cb._average_model = None
+        trainer = _make_trainer(callbacks=[ema_cb])
+        module = _cpu_module()
+        cb.setup(trainer, module, stage="fit")
+        cb.map_metric = MagicMock(name="map_metric")
+        cb.map_metric_ema = MagicMock(name="map_metric_ema")
+
+        outputs = {"results": _detection_preds(0), "targets": _detection_targets()}
+        batch = (torch.zeros(1), None)
+        cb.on_validation_batch_end(trainer, module, outputs, batch, 0)
+
+        cb.map_metric.update.assert_called_once()
         cb.map_metric_ema.update.assert_not_called()
+        assert cb._ema_has_updates is False
 
     def test_eval_ema_only_false_still_runs_duplicate_ema_forward(self) -> None:
         """eval_ema_only=False (default) must preserve the existing independent base+EMA forward behaviour."""
@@ -1222,6 +1248,47 @@ class TestValidationBatchEndEvalEmaOnly:
         cb.on_validation_batch_end(trainer, module, outputs, None, 0)
 
         called_targets = cb.map_metric.update.call_args[0][1]
+        assert called_targets[0]["masks"].shape[-2:] == (4, 4)
+
+    def test_eval_ema_only_and_native_resolution_masks_combined(self) -> None:
+        """eval_ema_only=True and native-resolution mask predictions active together (the #416 commenter's actual
+        workaround) must route to map_metric_ema with GT masks aligned to the native pred resolution — neither flag's
+        handling should interfere with the other."""
+        ema_underlying = MagicMock(name="ema_underlying_model", return_value={"ema": True})
+        cb = COCOEvalCallback(eval_ema_only=True, segmentation=True)
+        trainer = _make_trainer(callbacks=[self._ema_callback_with_underlying(ema_underlying)])
+        module = _cpu_module()
+        cb.setup(trainer, module, stage="fit")
+        cb.map_metric = MagicMock(name="map_metric")
+        cb.map_metric_ema = MagicMock(name="map_metric_ema")
+
+        pred_masks = torch.zeros(1, 4, 4, dtype=torch.bool)
+        gt_masks = torch.ones(1, 8, 8, dtype=torch.bool)
+        outputs = {
+            "results": [
+                {
+                    "scores": torch.tensor([0.9]),
+                    "labels": torch.tensor([0]),
+                    "boxes": torch.zeros(1, 4),
+                    "masks": pred_masks,
+                }
+            ],
+            "targets": [
+                {
+                    "boxes": torch.tensor([[0.5, 0.5, 0.1, 0.1]]),
+                    "labels": torch.tensor([0]),
+                    "orig_size": torch.tensor([8, 8]),
+                    "masks": gt_masks,
+                }
+            ],
+        }
+        batch = (torch.zeros(1), None)
+
+        cb.on_validation_batch_end(trainer, module, outputs, batch, 0)
+
+        ema_underlying.assert_not_called()
+        cb.map_metric.update.assert_not_called()
+        called_targets = cb.map_metric_ema.update.call_args[0][1]
         assert called_targets[0]["masks"].shape[-2:] == (4, 4)
 
 
@@ -1364,7 +1431,7 @@ class TestConvertTargets:
 class TestAlignGtMasksToPredResolution:
     """_align_gt_masks_to_pred_resolution() keeps GT/pred mask comparisons size-consistent when
     PostProcess.upsample_masks_to_image_size=False returns predictions at native, lower resolution
-    (TrainConfig.eval_masks_native_resolution — regression coverage for #416)."""
+    (TrainConfig.eval_masks_head_resolution — regression coverage for #416)."""
 
     def test_downsizes_gt_masks_to_match_smaller_pred_resolution(self) -> None:
         """GT masks at 8x8 must be nearest-downsized to match 4x4 predicted masks."""
@@ -1378,6 +1445,24 @@ class TestAlignGtMasksToPredResolution:
 
         assert out[0]["masks"].shape[-2:] == (4, 4)
         assert out[0]["masks"].dtype == torch.bool
+
+    def test_upsizes_gt_masks_to_match_larger_pred_resolution(self) -> None:
+        """GT masks at 4x4 must be nearest-upsized to match 8x8 predicted (native-resolution) masks — the reverse of the
+        downsize case; F.interpolate(mode="nearest") fires on any shape mismatch, either direction."""
+        pred_masks = torch.zeros(1, 8, 8, dtype=torch.bool)
+        gt_masks = torch.zeros(1, 4, 4, dtype=torch.bool)
+        gt_masks[0, :2, :2] = True  # top-left quadrant filled
+        preds = [{"masks": pred_masks}]
+        targets = [{"masks": gt_masks, "labels": torch.tensor([0])}]
+
+        out = COCOEvalCallback._align_gt_masks_to_pred_resolution(preds, targets)
+
+        assert out[0]["masks"].shape[-2:] == (8, 8)
+        assert out[0]["masks"].dtype == torch.bool
+        # nearest-neighbor upsize must preserve the filled quadrant's extent (top-left half).
+        assert out[0]["masks"][0, :4, :4].all()
+        assert not out[0]["masks"][0, 4:, :].any()
+        assert not out[0]["masks"][0, :, 4:].any()
 
     def test_leaves_targets_unchanged_when_resolutions_already_match(self) -> None:
         """No resize (and no copy) is needed when pred and GT masks already share a resolution."""

--- a/tests/training/callbacks/test_coco_eval_callback.py
+++ b/tests/training/callbacks/test_coco_eval_callback.py
@@ -1143,6 +1143,88 @@ class TestOnTestEpochEnd:
         assert not any(k.startswith("val/") for k in logged_keys)
 
 
+class TestValidationBatchEndEvalEmaOnly:
+    """eval_ema_only=True must skip the duplicate EMA forward pass in on_validation_batch_end — validation_step already
+    forwarded through the EMA model directly (regression for #416)."""
+
+    @staticmethod
+    def _ema_callback_with_underlying(ema_underlying: MagicMock) -> MagicMock:
+        """Return an EMA callback mock wired so _get_ema_inner_module(cb).model is ema_underlying."""
+        ema_cb = MagicMock(name="ema_callback")
+        ema_cb.get_ema_model_state_dict = MagicMock(name="get_ema_model_state_dict")
+        ema_cb._average_model = SimpleNamespace(module=SimpleNamespace(model=ema_underlying))
+        return ema_cb
+
+    def test_eval_ema_only_true_skips_duplicate_ema_forward(self) -> None:
+        """eval_ema_only=True must never call the EMA model's forward a second time."""
+        ema_underlying = MagicMock(name="ema_underlying_model", return_value={"ema": True})
+        cb = COCOEvalCallback(eval_ema_only=True)
+        trainer = _make_trainer(callbacks=[self._ema_callback_with_underlying(ema_underlying)])
+        module = _cpu_module()
+        cb.setup(trainer, module, stage="fit")
+        cb.map_metric = MagicMock(name="map_metric")
+        cb.map_metric_ema = MagicMock(name="map_metric_ema")
+
+        outputs = {"results": _detection_preds(0), "targets": _detection_targets()}
+        batch = (torch.zeros(1), None)
+        cb.on_validation_batch_end(trainer, module, outputs, batch, 0)
+
+        ema_underlying.assert_not_called()
+        cb.map_metric_ema.update.assert_not_called()
+
+    def test_eval_ema_only_false_still_runs_duplicate_ema_forward(self) -> None:
+        """eval_ema_only=False (default) must preserve the existing independent base+EMA forward behaviour."""
+        ema_underlying = MagicMock(name="ema_underlying_model", return_value={"ema": True})
+        cb = COCOEvalCallback(eval_ema_only=False)
+        trainer = _make_trainer(callbacks=[self._ema_callback_with_underlying(ema_underlying)])
+        module = _cpu_module()
+        cb.setup(trainer, module, stage="fit")
+        cb.map_metric = MagicMock(name="map_metric")
+        cb.map_metric_ema = MagicMock(name="map_metric_ema")
+
+        outputs = {"results": _detection_preds(0), "targets": _detection_targets()}
+        batch = (torch.zeros(1), None)
+        cb.on_validation_batch_end(trainer, module, outputs, batch, 0)
+
+        ema_underlying.assert_called_once()
+        cb.map_metric_ema.update.assert_called_once()
+
+    def test_on_validation_batch_end_aligns_gt_masks_to_native_res_predictions(self) -> None:
+        """When predicted masks are at native (lower) resolution, map_metric.update must receive GT masks downsized to
+        match — otherwise segm IoU is computed on mismatched pixel grids (#416)."""
+        cb = COCOEvalCallback(segmentation=True)
+        trainer = _make_trainer()
+        module = _cpu_module()
+        cb.setup(trainer, module, stage="fit")
+        cb.map_metric = MagicMock(name="map_metric")
+
+        pred_masks = torch.zeros(1, 4, 4, dtype=torch.bool)
+        gt_masks = torch.ones(1, 8, 8, dtype=torch.bool)
+        outputs = {
+            "results": [
+                {
+                    "scores": torch.tensor([0.9]),
+                    "labels": torch.tensor([0]),
+                    "boxes": torch.zeros(1, 4),
+                    "masks": pred_masks,
+                }
+            ],
+            "targets": [
+                {
+                    "boxes": torch.tensor([[0.5, 0.5, 0.1, 0.1]]),
+                    "labels": torch.tensor([0]),
+                    "orig_size": torch.tensor([8, 8]),
+                    "masks": gt_masks,
+                }
+            ],
+        }
+
+        cb.on_validation_batch_end(trainer, module, outputs, None, 0)
+
+        called_targets = cb.map_metric.update.call_args[0][1]
+        assert called_targets[0]["masks"].shape[-2:] == (4, 4)
+
+
 class TestConvertPreds:
     """_convert_preds() normalizes prediction dicts for metric consumers."""
 
@@ -1277,6 +1359,57 @@ class TestConvertTargets:
         ]
         out = cb._convert_targets(targets)
         assert set(out[0].keys()) == {"boxes", "labels"}
+
+
+class TestAlignGtMasksToPredResolution:
+    """_align_gt_masks_to_pred_resolution() keeps GT/pred mask comparisons size-consistent when
+    PostProcess.upsample_masks_to_image_size=False returns predictions at native, lower resolution
+    (TrainConfig.eval_masks_native_resolution — regression coverage for #416)."""
+
+    def test_downsizes_gt_masks_to_match_smaller_pred_resolution(self) -> None:
+        """GT masks at 8x8 must be nearest-downsized to match 4x4 predicted masks."""
+        pred_masks = torch.zeros(1, 4, 4, dtype=torch.bool)
+        gt_masks = torch.zeros(1, 8, 8, dtype=torch.bool)
+        gt_masks[0, :4, :4] = True  # top-left quadrant filled
+        preds = [{"masks": pred_masks}]
+        targets = [{"masks": gt_masks, "labels": torch.tensor([0])}]
+
+        out = COCOEvalCallback._align_gt_masks_to_pred_resolution(preds, targets)
+
+        assert out[0]["masks"].shape[-2:] == (4, 4)
+        assert out[0]["masks"].dtype == torch.bool
+
+    def test_leaves_targets_unchanged_when_resolutions_already_match(self) -> None:
+        """No resize (and no copy) is needed when pred and GT masks already share a resolution."""
+        pred_masks = torch.zeros(1, 8, 8, dtype=torch.bool)
+        gt_masks = torch.ones(1, 8, 8, dtype=torch.bool)
+        preds = [{"masks": pred_masks}]
+        targets = [{"masks": gt_masks, "labels": torch.tensor([0])}]
+
+        out = COCOEvalCallback._align_gt_masks_to_pred_resolution(preds, targets)
+
+        assert out[0] is targets[0]
+        assert torch.equal(out[0]["masks"], gt_masks)
+
+    def test_leaves_targets_unchanged_when_no_masks_present(self) -> None:
+        """Detection-only (no 'masks' key) inputs pass through untouched."""
+        preds = [{"boxes": torch.zeros(1, 4)}]
+        targets = [{"boxes": torch.zeros(1, 4), "labels": torch.tensor([0])}]
+
+        out = COCOEvalCallback._align_gt_masks_to_pred_resolution(preds, targets)
+
+        assert out[0] is targets[0]
+
+    def test_original_target_dict_not_mutated(self) -> None:
+        """Resizing must return a new dict, never mutate the caller's target in place."""
+        pred_masks = torch.zeros(1, 4, 4, dtype=torch.bool)
+        gt_masks = torch.ones(1, 8, 8, dtype=torch.bool)
+        preds = [{"masks": pred_masks}]
+        targets = [{"masks": gt_masks, "labels": torch.tensor([0])}]
+
+        COCOEvalCallback._align_gt_masks_to_pred_resolution(preds, targets)
+
+        assert targets[0]["masks"].shape[-2:] == (8, 8)
 
 
 def _ema_callback() -> MagicMock:

--- a/tests/training/callbacks/test_coco_eval_callback.py
+++ b/tests/training/callbacks/test_coco_eval_callback.py
@@ -141,6 +141,20 @@ class TestSetup:
         assert "segm" not in cb.map_metric.iou_type
         assert "keypoints" not in cb.map_metric.iou_type
 
+    def test_log_per_class_metrics_false_disables_class_metrics_compute(self) -> None:
+        """Regression test for #416: log_per_class_metrics=False must also skip the expensive per-class
+        MeanAveragePrecision compute, not merely the table rendering at epoch end — otherwise the flag silently fails to
+        reduce cost."""
+        cb = COCOEvalCallback(log_per_class_metrics=False)
+        cb.setup(_make_trainer(), _make_pl_module(), stage="fit")
+        assert cb.map_metric.class_metrics is False
+
+    def test_log_per_class_metrics_true_enables_class_metrics_compute(self) -> None:
+        """log_per_class_metrics=True (default) keeps class_metrics compute enabled."""
+        cb = COCOEvalCallback(log_per_class_metrics=True)
+        cb.setup(_make_trainer(), _make_pl_module(), stage="fit")
+        assert cb.map_metric.class_metrics is True
+
 
 class TestOnFitStart:
     """on_fit_start() populates class names from the datamodule."""

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -1409,6 +1409,54 @@ class TestValidationStep:
         assert "val/loss" not in logged_keys
         assert "results" in result and "targets" in result
 
+    def test_eval_ema_only_forwards_through_ema_model_not_base(self, tmp_path):
+        """eval_ema_only=True must forward through the EMA-averaged model, not the base model (regression for #416:
+
+        this replaces the duplicate base+EMA forward pass COCOEvalCallback would otherwise run).
+        """
+        tc = _base_train_config(tmp_path, eval_ema_only=True, use_ema=True)
+        module, fake_model, fake_criterion, _ = _build_module(train_config=tc, tmp_path=tmp_path)
+        samples, targets = _make_batch()
+        fake_model.return_value = {"base": True}
+        fake_criterion.return_value = {"loss_ce": torch.tensor(0.5)}
+        fake_criterion.weight_dict = {"loss_ce": 1.0}
+
+        ema_model = MagicMock(name="ema_model", return_value={"ema": True})
+        fake_ema_callback = SimpleNamespace(_average_model=SimpleNamespace(module=ema_model))
+        module.trainer = SimpleNamespace(callbacks=[fake_ema_callback])
+        module.log = MagicMock()
+        module.log_dict = MagicMock()
+
+        module.validation_step((samples, targets), batch_idx=0)
+
+        ema_model.assert_called_once()
+        fake_model.assert_not_called()
+
+    def test_eval_ema_only_falls_back_to_base_model_when_ema_not_warmed_up(self, tmp_path):
+        """eval_ema_only=True must fall back to the base model if the EMA callback has no averaged model yet (e.g. very
+        first validation before EMA warm-up)."""
+        tc = _base_train_config(tmp_path, eval_ema_only=True, use_ema=True)
+        module, fake_model, fake_criterion, _ = _build_module(train_config=tc, tmp_path=tmp_path)
+        samples, targets = _make_batch()
+        fake_model.return_value = {"base": True}
+        fake_criterion.return_value = {"loss_ce": torch.tensor(0.5)}
+        fake_criterion.weight_dict = {"loss_ce": 1.0}
+
+        fake_ema_callback = SimpleNamespace(_average_model=None)
+        module.trainer = SimpleNamespace(callbacks=[fake_ema_callback])
+        module.log = MagicMock()
+        module.log_dict = MagicMock()
+
+        module.validation_step((samples, targets), batch_idx=0)
+
+        fake_model.assert_called_once()
+
+    def test_eval_ema_only_false_does_not_touch_trainer(self, tmp_path):
+        """eval_ema_only=False (default) must not access self.trainer at all — validation_step must stay usable without
+        a Trainer attached, as every other test in this class relies on."""
+        result, _, module = self._run_val_step(tmp_path)
+        assert "results" in result
+
 
 class TestTestStep:
     """Tests for test_step() — verifies output dict shape, postprocessor invocation with correct original sizes, and

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -1422,7 +1422,7 @@ class TestValidationStep:
         fake_criterion.weight_dict = {"loss_ce": 1.0}
 
         ema_model = MagicMock(name="ema_model", return_value={"ema": True})
-        fake_ema_callback = SimpleNamespace(_average_model=SimpleNamespace(module=ema_model))
+        fake_ema_callback = SimpleNamespace(_average_model=SimpleNamespace(module=SimpleNamespace(model=ema_model)))
         module.trainer = SimpleNamespace(callbacks=[fake_ema_callback])
         module.log = MagicMock()
         module.log_dict = MagicMock()
@@ -1456,6 +1456,27 @@ class TestValidationStep:
         a Trainer attached, as every other test in this class relies on."""
         result, _, module = self._run_val_step(tmp_path)
         assert "results" in result
+
+    def test_eval_ema_only_falls_back_to_base_model_when_trainer_unattached(self, tmp_path):
+        """eval_ema_only=True must fall back to the base model — not raise — when the module isn't attached to a Trainer
+        at all.
+
+        ``LightningModule.trainer`` raises ``RuntimeError`` (not ``None``) when unattached, so a naive
+        ``getattr(self.trainer, ...)`` would crash instead of falling back (regression: module never has a Trainer wired
+        up in this test module, matching the direct/standalone validation_step-call scenario).
+        """
+        tc = _base_train_config(tmp_path, eval_ema_only=True, use_ema=True)
+        module, fake_model, fake_criterion, _ = _build_module(train_config=tc, tmp_path=tmp_path)
+        samples, targets = _make_batch()
+        fake_model.return_value = {"base": True}
+        fake_criterion.return_value = {"loss_ce": torch.tensor(0.5)}
+        fake_criterion.weight_dict = {"loss_ce": 1.0}
+        module.log = MagicMock()
+        module.log_dict = MagicMock()
+
+        module.validation_step((samples, targets), batch_idx=0)
+
+        fake_model.assert_called_once()
 
 
 class TestTestStep:


### PR DESCRIPTION
This pull request introduces several optimizations and new configuration options to reduce validation compute costs, especially for segmentation models using EMA (Exponential Moving Average) weights. The main changes add an option to validate using only the EMA model (avoiding duplicate forward passes), enable validation at native mask-head resolution (skipping expensive upsampling), and ensure ground-truth masks are correctly resized to match predictions when needed. Several internal refactorings improve efficiency and correctness in matching and evaluation.

**Validation compute optimizations:**

* Added `eval_ema_only` to `TrainConfig`, allowing validation to run only through the EMA model (when enabled), halving per-batch validation compute by skipping the duplicate base-model forward pass. Includes validation logic to enforce `use_ema=True` when `eval_ema_only=True` (`src/rfdetr/config.py`, `src/rfdetr/training/module_model.py`, `src/rfdetr/training/callbacks/coco_eval.py`). [[1]](diffhunk://#diff-8234f50bded952af8b2719bc9dc3bb60e36cce3e81c3c536b813696360577189R1060-R1063) [[2]](diffhunk://#diff-8234f50bded952af8b2719bc9dc3bb60e36cce3e81c3c536b813696360577189R1315-R1321) [[3]](diffhunk://#diff-23abcb291c6af5b421635bdc43a4a852b0a25d82e899a099609e9b82d60343d7R898-R919) [[4]](diffhunk://#diff-23abcb291c6af5b421635bdc43a4a852b0a25d82e899a099609e9b82d60343d7L912-R934) [[5]](diffhunk://#diff-b87ee117fc11463986ce6fc13ccaabfbc1ceb267a729b0d1705ee374677130deR134-R141) [[6]](diffhunk://#diff-b87ee117fc11463986ce6fc13ccaabfbc1ceb267a729b0d1705ee374677130deR440-R445)
* Updated `COCOEvalCallback` to respect `eval_ema_only` by skipping the duplicate EMA forward pass and to propagate this setting from `TrainConfig` (`src/rfdetr/training/callbacks/coco_eval.py`). [[1]](diffhunk://#diff-b87ee117fc11463986ce6fc13ccaabfbc1ceb267a729b0d1705ee374677130deR134-R141) [[2]](diffhunk://#diff-b87ee117fc11463986ce6fc13ccaabfbc1ceb267a729b0d1705ee374677130deR440-R445)

**Segmentation mask evaluation improvements:**

* Added `eval_masks_native_resolution` to `TrainConfig` and corresponding logic in postprocessing and evaluation: when enabled, predicted masks are not upsampled to the image size during validation/test, and ground-truth masks are automatically downsized to match prediction resolution for correct metric computation (`src/rfdetr/config.py`, `src/rfdetr/models/postprocess.py`, `src/rfdetr/training/callbacks/coco_eval.py`, `src/rfdetr/models/lwdetr.py`). [[1]](diffhunk://#diff-8234f50bded952af8b2719bc9dc3bb60e36cce3e81c3c536b813696360577189R1092-R1097) [[2]](diffhunk://#diff-f028c01da6aea8246f6f321d52c4e1114b1ee00213c83658ebff081821556f00R36-R42) [[3]](diffhunk://#diff-f028c01da6aea8246f6f321d52c4e1114b1ee00213c83658ebff081821556f00L66-R70) [[4]](diffhunk://#diff-f028c01da6aea8246f6f321d52c4e1114b1ee00213c83658ebff081821556f00R157-R182) [[5]](diffhunk://#diff-f028c01da6aea8246f6f321d52c4e1114b1ee00213c83658ebff081821556f00R193-R196) [[6]](diffhunk://#diff-b785afd54616483f394a8cc0eec9df589ac585e3a5c7a062ff687f53166a5bc4R914-R915) [[7]](diffhunk://#diff-b87ee117fc11463986ce6fc13ccaabfbc1ceb267a729b0d1705ee374677130deL415-R424) [[8]](diffhunk://#diff-b87ee117fc11463986ce6fc13ccaabfbc1ceb267a729b0d1705ee374677130deL442-R459) [[9]](diffhunk://#diff-b87ee117fc11463986ce6fc13ccaabfbc1ceb267a729b0d1705ee374677130deL496-R514) [[10]](diffhunk://#diff-b87ee117fc11463986ce6fc13ccaabfbc1ceb267a729b0d1705ee374677130deR1198-R1232)

**Efficiency and correctness improvements:**

* Refactored the mask matching logic to avoid CUDA device-to-host synchronization bottlenecks by moving tensors to CPU and using NumPy for the matching loop, significantly improving performance on GPU (`src/rfdetr/evaluation/matching.py`).
* Ensured per-class metrics computation is only performed when enabled, saving compute when not required (`src/rfdetr/training/callbacks/coco_eval.py`). [[1]](diffhunk://#diff-b87ee117fc11463986ce6fc13ccaabfbc1ceb267a729b0d1705ee374677130deL177-R185) [[2]](diffhunk://#diff-b87ee117fc11463986ce6fc13ccaabfbc1ceb267a729b0d1705ee374677130deL757-R775)

These changes collectively make validation faster and more configurable, especially for large segmentation models and when using EMA weights.

---

resolves #416