### PR TITLE
fix(ms_deform_attn): expand singleton level dim in export path

### DIFF
--- a/src/rfdetr/models/ops/modules/ms_deform_attn.py
+++ b/src/rfdetr/models/ops/modules/ms_deform_attn.py
@@ -137,6 +137,11 @@ class MSDeformAttn(nn.Module):
 
         Returns:
             Output tensor of shape (N, Length_{query}, C).
+
+        Raises:
+            ValueError: If ``input_spatial_shapes_hw`` is ``None`` in export mode; if the last
+                dimension of ``reference_points`` is not 2 or 4; or (in export mode) if the level
+                dimension is neither 1 nor ``n_levels``.
         """
         batch_size, len_query, _ = query.shape
         batch_size, len_input, _ = input_flatten.shape
@@ -178,9 +183,19 @@ class MSDeformAttn(nn.Module):
             # merged layout is bit-identical to the rank-6 path below (offset_normalizer / reference_points are
             # repeat_interleaved over n_points to match the [n_levels, n_points] flattening order). The core consumes
             # the rank-5 form (detected by ndim). Only reached in export mode, so eager train/inference is unchanged.
+            #
+            # Decoder export mode passes reference_points with level dim 1 (shared across levels); the rank-6 path
+            # broadcasts via None dims. Expand here before repeat_interleave so the merged axis is n_levels*n_points.
             sampling_offsets = self.sampling_offsets(query).view(
                 batch_size, len_query, self.n_heads, self.n_levels * self.n_points, 2
             )
+            n_ref_levels = reference_points.shape[2]
+            if n_ref_levels == 1:
+                reference_points = reference_points.expand(-1, -1, self.n_levels, -1)
+            elif n_ref_levels != self.n_levels:
+                raise ValueError(
+                    f"reference_points level dim must be 1 or n_levels={self.n_levels}, got {n_ref_levels}"
+                )
             if reference_points.shape[-1] == 2:
                 offset_normalizer = torch.stack([input_spatial_shapes[..., 1], input_spatial_shapes[..., 0]], -1)
                 offset_normalizer = offset_normalizer.repeat_interleave(self.n_points, dim=0)  # n_levels*n_points, 2

--- a/src/rfdetr/models/ops/modules/ms_deform_attn.py
+++ b/src/rfdetr/models/ops/modules/ms_deform_attn.py
@@ -123,7 +123,8 @@ class MSDeformAttn(nn.Module):
             query: (N, Length_{query}, C)
             reference_points: (N, Length_{query}, n_levels, 2) with range in [0, 1],
                 top-left (0,0), bottom-right (1, 1), including padding area; or (N, Length_{query}, n_levels, 4) adding
-                additional (w, h) to form reference boxes.
+                additional (w, h) to form reference boxes. In export mode, the level dim may also be 1
+                (e.g. a single shared decoder reference box); it is broadcast to n_levels internally.
             input_flatten: (N, sum_{l=0}^{L-1} H_l * W_l, C)
             input_spatial_shapes: (n_levels, 2), [(H_0, W_0), (H_1, W_1), ..., (H_{L-1}, W_{L-1})]
             input_level_start_index: (n_levels,), [0, H_0*W_0, H_0*W_0+H_1*W_1, ...,

--- a/src/rfdetr/models/ops/modules/ms_deform_attn.py
+++ b/src/rfdetr/models/ops/modules/ms_deform_attn.py
@@ -141,8 +141,8 @@ class MSDeformAttn(nn.Module):
 
         Raises:
             ValueError: If ``input_spatial_shapes_hw`` is ``None`` in export mode; if the last
-                dimension of ``reference_points`` is not 2 or 4; or (in export mode) if the level
-                dimension is neither 1 nor ``n_levels``.
+                dimension of ``reference_points`` is not 2 or 4; or if the level dimension is
+                neither 1 nor ``n_levels`` (checked in both eager and export mode).
         """
         batch_size, len_query, _ = query.shape
         batch_size, len_input, _ = input_flatten.shape

--- a/src/rfdetr/models/ops/modules/ms_deform_attn.py
+++ b/src/rfdetr/models/ops/modules/ms_deform_attn.py
@@ -178,6 +178,16 @@ class MSDeformAttn(nn.Module):
             batch_size, len_query, self.n_heads, self.n_levels * self.n_points
         )
 
+        # Reference points carry either one box per level (level dim == n_levels) or a single
+        # shared box (level dim == 1) broadcast across all levels. Validate here — before the
+        # export/eager split — so malformed input is rejected with the same clear message on both
+        # paths; without this hoist eager silently mis-broadcasts or raises an opaque torch shape
+        # error depending on self._export. Only the export path materializes the singleton via
+        # .expand() below; eager relies on natural broadcasting over the None-inserted level axis.
+        n_ref_levels = reference_points.shape[2]
+        if n_ref_levels not in (1, self.n_levels):
+            raise ValueError(f"reference_points level dim must be 1 or n_levels={self.n_levels}, got {n_ref_levels}")
+
         if self._export:
             # Export path: build sampling_locations at rank 5 by merging (n_levels, n_points) -> n_levels*n_points,
             # so no tensor exceeds rank 5. CoreML's MIL backend rejects rank-6 tensors; XNNPACK is unaffected. The
@@ -190,13 +200,8 @@ class MSDeformAttn(nn.Module):
             sampling_offsets = self.sampling_offsets(query).view(
                 batch_size, len_query, self.n_heads, self.n_levels * self.n_points, 2
             )
-            n_ref_levels = reference_points.shape[2]
             if n_ref_levels == 1:
                 reference_points = reference_points.expand(-1, -1, self.n_levels, -1)
-            elif n_ref_levels != self.n_levels:
-                raise ValueError(
-                    f"reference_points level dim must be 1 or n_levels={self.n_levels}, got {n_ref_levels}"
-                )
             if reference_points.shape[-1] == 2:
                 offset_normalizer = torch.stack([input_spatial_shapes[..., 1], input_spatial_shapes[..., 0]], -1)
                 offset_normalizer = offset_normalizer.repeat_interleave(self.n_points, dim=0)  # n_levels*n_points, 2

--- a/src/rfdetr/models/transformer.py
+++ b/src/rfdetr/models/transformer.py
@@ -673,6 +673,10 @@ class TransformerDecoder(nn.Module):
 
             if self._export:
                 query_sine_embed = gen_sineembed_for_position(obj_center, self.d_model // 2)  # bs, nq, 256*2
+                # "Materialize one shared box to per-level references" happens at different layers per mode:
+                # eager (below) multiplies by valid_ratios to produce per-level refs, while export keeps the
+                # singleton level dim here and defers expansion to MSDeformAttn's internal .expand(). Export's
+                # expand omits eager's valid_ratios scaling — sound only under the no-padding export assumption.
                 refpoints_input = obj_center[:, :, None]  # bs, nq, 1, 4
             else:
                 assert valid_ratios is not None

--- a/tests/models/test_transformer.py
+++ b/tests/models/test_transformer.py
@@ -343,9 +343,7 @@ class TestMSDeformAttnModule:
     def test_export_mode_broadcasts_singleton_level_dim(self) -> None:
         """Checks export mode accepts decoder-style ``(B, Q, 1, 4)`` refs when ``n_levels > 1``."""
         # Use n_points > 1 so a missing expand would yield length n_points vs n_levels*n_points.
-        module = MSDeformAttn(
-            d_model=self._d_model, n_levels=self._n_levels, n_heads=self._n_heads, n_points=2
-        )
+        module = MSDeformAttn(d_model=self._d_model, n_levels=self._n_levels, n_heads=self._n_heads, n_points=2)
         module.eval()
         hw_pairs = self._hw_pairs
         total_len = sum(ht * wd for ht, wd in hw_pairs)

--- a/tests/models/test_transformer.py
+++ b/tests/models/test_transformer.py
@@ -340,6 +340,66 @@ class TestMSDeformAttnModule:
 
         assert module._export
 
+    def test_export_mode_broadcasts_singleton_level_dim(self) -> None:
+        """Checks export mode accepts decoder-style ``(B, Q, 1, 4)`` refs when ``n_levels > 1``."""
+        # Use n_points > 1 so a missing expand would yield length n_points vs n_levels*n_points.
+        module = MSDeformAttn(
+            d_model=self._d_model, n_levels=self._n_levels, n_heads=self._n_heads, n_points=2
+        )
+        module.eval()
+        hw_pairs = self._hw_pairs
+        total_len = sum(ht * wd for ht, wd in hw_pairs)
+        batch_size, num_queries = 1, 3
+        query = torch.randn(batch_size, num_queries, self._d_model)
+        # Decoder export shape: one shared box broadcast across feature levels.
+        ref_pts = torch.rand(batch_size, num_queries, 1, 4)
+        input_flatten = torch.randn(batch_size, total_len, self._d_model)
+        spatial_shapes = torch.tensor(hw_pairs, dtype=torch.long)
+        starts = [sum(ht * wd for ht, wd in hw_pairs[:idx]) for idx in range(self._n_levels)]
+        level_start_index = torch.tensor(starts, dtype=torch.long)
+        assert ref_pts.shape[2] == 1
+        assert self._n_levels > 1
+
+        with torch.no_grad():
+            eager_out = module(
+                query,
+                ref_pts,
+                input_flatten,
+                spatial_shapes,
+                level_start_index,
+                input_spatial_shapes_hw=hw_pairs,
+            )
+            module.export()
+            export_out = module(
+                query,
+                ref_pts,
+                input_flatten,
+                spatial_shapes,
+                level_start_index,
+                input_spatial_shapes_hw=hw_pairs,
+            )
+
+        torch.testing.assert_close(export_out, eager_out, rtol=1e-5, atol=1e-5)
+
+    def test_export_mode_rejects_invalid_reference_level_dim(self) -> None:
+        """Checks export mode raises when reference level dim is neither 1 nor ``n_levels``."""
+        module = MSDeformAttn(
+            d_model=self._d_model, n_levels=self._n_levels, n_heads=self._n_heads, n_points=self._n_points
+        )
+        module.export()
+        query, _, input_flatten, spatial_shapes, level_start_index, hw_pairs = self._make_module_inputs()
+        bad_ref = torch.rand(query.shape[0], query.shape[1], self._n_levels + 1, 4)
+
+        with pytest.raises(ValueError, match="level dim must be 1 or n_levels"):
+            module(
+                query,
+                bad_ref,
+                input_flatten,
+                spatial_shapes,
+                level_start_index,
+                input_spatial_shapes_hw=hw_pairs,
+            )
+
 
 class TestGenEncoderOutputProposalsDynamicBatch:
     """Regression tests for dynamic batch support in gen_encoder_output_proposals.

--- a/tests/models/test_transformer.py
+++ b/tests/models/test_transformer.py
@@ -329,6 +329,33 @@ class TestMSDeformAttnModule:
         bsz, len_q, _ = query.shape
         assert output.shape == (bsz, len_q, self._d_model)
 
+    def test_export_mode_forward_with_full_level_dim_and_last_dim_4(self) -> None:
+        """Export mode forward with reference_points level dim == n_levels and last dim 4 must match eager output.
+
+        Regression: test_export_mode_forward_with_hw_param only exercises the n_ref_levels==n_levels skip-branch
+        (ms_deform_attn.py:206-210) with last dim 2. This covers the sibling last-dim-4 branch combined with a
+        level dim that is already n_levels (not the singleton-broadcast case).
+        """
+        module = MSDeformAttn(
+            d_model=self._d_model, n_levels=self._n_levels, n_heads=self._n_heads, n_points=self._n_points
+        )
+        module.eval()
+        query, _, input_flatten, spatial_shapes, level_start_index, hw_pairs = self._make_module_inputs()
+        ref_pts = torch.rand(query.shape[0], query.shape[1], self._n_levels, 4)
+
+        with torch.no_grad():
+            eager_out = module(
+                query, ref_pts, input_flatten, spatial_shapes, level_start_index, input_spatial_shapes_hw=hw_pairs
+            )
+            module.export()
+            export_out = module(
+                query, ref_pts, input_flatten, spatial_shapes, level_start_index, input_spatial_shapes_hw=hw_pairs
+            )
+
+        bsz, len_q, _ = query.shape
+        assert export_out.shape == (bsz, len_q, self._d_model)
+        torch.testing.assert_close(export_out, eager_out, rtol=1e-5, atol=1e-5)
+
     def test_export_flag_set_after_export_call(self) -> None:
         """Calling .export() must set _export=True, enabling the torch._assert guard path."""
         module = MSDeformAttn(
@@ -340,17 +367,33 @@ class TestMSDeformAttnModule:
 
         assert module._export
 
-    def test_export_mode_broadcasts_singleton_level_dim(self) -> None:
-        """Checks export mode accepts decoder-style ``(B, Q, 1, 4)`` refs when ``n_levels > 1``."""
+    @pytest.mark.parametrize(
+        "last_dim,batch_size",
+        [
+            pytest.param(4, 1, id="last-dim-4-batch-1"),
+            pytest.param(2, 1, id="last-dim-2-batch-1"),
+            pytest.param(4, 2, id="last-dim-4-batch-2"),
+        ],
+    )
+    def test_export_mode_broadcasts_singleton_level_dim(self, last_dim: int, batch_size: int) -> None:
+        """Checks export mode accepts decoder-style ``(B, Q, 1, last_dim)`` refs when ``n_levels > 1``.
+
+        Regression: the original case only covered last_dim=4 with batch_size=1. The singleton-broadcast
+        ``.expand()`` (ms_deform_attn.py:194) feeds both the last-dim-2 (ms_deform_attn.py:199-205) and
+        last-dim-4 (ms_deform_attn.py:206-210) sampling-location branches, and must also broadcast
+        correctly when batch_size > 1 since the expand only touches the level axis, not batch. This also
+        checks that gradients flow back through the ``.expand()`` view to the original singleton-shaped
+        reference_points.
+        """
         # Use n_points > 1 so a missing expand would yield length n_points vs n_levels*n_points.
         module = MSDeformAttn(d_model=self._d_model, n_levels=self._n_levels, n_heads=self._n_heads, n_points=2)
         module.eval()
         hw_pairs = self._hw_pairs
         total_len = sum(ht * wd for ht, wd in hw_pairs)
-        batch_size, num_queries = 1, 3
+        num_queries = 3
         query = torch.randn(batch_size, num_queries, self._d_model)
         # Decoder export shape: one shared box broadcast across feature levels.
-        ref_pts = torch.rand(batch_size, num_queries, 1, 4)
+        ref_pts = torch.rand(batch_size, num_queries, 1, last_dim, requires_grad=True)
         input_flatten = torch.randn(batch_size, total_len, self._d_model)
         spatial_shapes = torch.tensor(hw_pairs, dtype=torch.long)
         starts = [sum(ht * wd for ht, wd in hw_pairs[:idx]) for idx in range(self._n_levels)]
@@ -367,28 +410,134 @@ class TestMSDeformAttnModule:
                 level_start_index,
                 input_spatial_shapes_hw=hw_pairs,
             )
+        module.export()
+        export_out = module(
+            query,
+            ref_pts,
+            input_flatten,
+            spatial_shapes,
+            level_start_index,
+            input_spatial_shapes_hw=hw_pairs,
+        )
+
+        torch.testing.assert_close(export_out.detach(), eager_out, rtol=1e-5, atol=1e-5)
+
+        # Backward-pass check on the new `.expand()` view op (ms_deform_attn.py:194): gradients must
+        # flow back to the original singleton-shaped reference_points, not just the expanded view.
+        export_out.sum().backward()
+        assert ref_pts.grad is not None
+        assert ref_pts.grad.shape == ref_pts.shape
+
+    @pytest.mark.parametrize(
+        "last_dim",
+        [pytest.param(2, id="last-dim-2"), pytest.param(4, id="last-dim-4")],
+    )
+    def test_export_mode_single_level_config_matches_eager(self, last_dim: int) -> None:
+        """Export mode with n_levels=1 (degenerate no-op expand branch) must match eager output.
+
+        Regression: TestMSDeformAttnModule hardcodes n_levels=2 everywhere else, so the
+        ``n_ref_levels == 1`` no-op ``.expand(-1, -1, 1, -1)`` branch (ms_deform_attn.py:192-194) that
+        fires specifically when self.n_levels == 1 was never exercised.
+        """
+        hw_pairs: list[tuple[int, int]] = [(4, 4)]
+        d_model, n_heads, n_points, n_levels = 32, 4, 2, 1
+        module = MSDeformAttn(d_model=d_model, n_levels=n_levels, n_heads=n_heads, n_points=n_points)
+        module.eval()
+        total_len = sum(ht * wd for ht, wd in hw_pairs)
+        batch_size, num_queries = 1, 3
+        query = torch.randn(batch_size, num_queries, d_model)
+        ref_pts = torch.rand(batch_size, num_queries, n_levels, last_dim)
+        input_flatten = torch.randn(batch_size, total_len, d_model)
+        spatial_shapes = torch.tensor(hw_pairs, dtype=torch.long)
+        level_start_index = torch.tensor([0], dtype=torch.long)
+
+        with torch.no_grad():
+            eager_out = module(
+                query, ref_pts, input_flatten, spatial_shapes, level_start_index, input_spatial_shapes_hw=hw_pairs
+            )
             module.export()
             export_out = module(
+                query, ref_pts, input_flatten, spatial_shapes, level_start_index, input_spatial_shapes_hw=hw_pairs
+            )
+
+        assert export_out.shape == (batch_size, num_queries, d_model)
+        torch.testing.assert_close(export_out, eager_out, rtol=1e-5, atol=1e-5)
+
+    @pytest.mark.parametrize(
+        "last_dim,n_points",
+        [
+            pytest.param(4, 1, id="last-dim-4-points-1"),
+            pytest.param(2, 1, id="last-dim-2-points-1"),
+            pytest.param(4, 2, id="last-dim-4-points-2"),
+        ],
+    )
+    def test_export_mode_rejects_invalid_reference_level_dim(self, last_dim: int, n_points: int) -> None:
+        """Checks export mode raises when reference level dim is neither 1 nor ``n_levels``.
+
+        Regression: the original case only covered last_dim=4 with n_points=1 (self._n_points). The
+        level-dim guard (ms_deform_attn.py:195-198) fires before the last-dim branch and before the
+        n_points-dependent merged axis is built, so it must also be verified with last_dim=2 and with
+        n_points>1 (which changes the size of the merged n_levels*n_points sampling axis).
+        """
+        module = MSDeformAttn(d_model=self._d_model, n_levels=self._n_levels, n_heads=self._n_heads, n_points=n_points)
+        module.export()
+        query, _, input_flatten, spatial_shapes, level_start_index, hw_pairs = self._make_module_inputs()
+        bad_ref = torch.rand(query.shape[0], query.shape[1], self._n_levels + 1, last_dim)
+
+        with pytest.raises(ValueError, match="level dim must be 1 or n_levels"):
+            module(
                 query,
-                ref_pts,
+                bad_ref,
                 input_flatten,
                 spatial_shapes,
                 level_start_index,
                 input_spatial_shapes_hw=hw_pairs,
             )
 
-        torch.testing.assert_close(export_out, eager_out, rtol=1e-5, atol=1e-5)
+    @pytest.mark.parametrize(
+        "last_dim",
+        [pytest.param(1, id="last-dim-1"), pytest.param(3, id="last-dim-3")],
+    )
+    def test_eager_mode_rejects_invalid_reference_last_dim(self, last_dim: int) -> None:
+        """Eager mode forward must raise ValueError when reference_points last dim is neither 2 nor 4.
 
-    def test_export_mode_rejects_invalid_reference_level_dim(self) -> None:
-        """Checks export mode raises when reference level dim is neither 1 nor ``n_levels``."""
+        Regression: the ``Raises:`` docstring entry for MSDeformAttn.forward names this contract
+        explicitly (ms_deform_attn.py:233-238), but no test previously exercised it.
+        """
+        module = MSDeformAttn(
+            d_model=self._d_model, n_levels=self._n_levels, n_heads=self._n_heads, n_points=self._n_points
+        )
+        query, _, input_flatten, spatial_shapes, level_start_index, hw_pairs = self._make_module_inputs()
+        bad_ref = torch.rand(query.shape[0], query.shape[1], self._n_levels, last_dim)
+
+        with pytest.raises(ValueError, match="Last dim of reference_points must be 2 or 4"):
+            module(
+                query,
+                bad_ref,
+                input_flatten,
+                spatial_shapes,
+                level_start_index,
+                input_spatial_shapes_hw=hw_pairs,
+            )
+
+    @pytest.mark.parametrize(
+        "last_dim",
+        [pytest.param(1, id="last-dim-1"), pytest.param(3, id="last-dim-3")],
+    )
+    def test_export_mode_rejects_invalid_reference_last_dim(self, last_dim: int) -> None:
+        """Export mode forward must raise ValueError when reference_points last dim is neither 2 nor 4.
+
+        Regression: the ``Raises:`` docstring entry for MSDeformAttn.forward names this contract
+        explicitly (ms_deform_attn.py:211-216), but no test previously exercised it.
+        """
         module = MSDeformAttn(
             d_model=self._d_model, n_levels=self._n_levels, n_heads=self._n_heads, n_points=self._n_points
         )
         module.export()
         query, _, input_flatten, spatial_shapes, level_start_index, hw_pairs = self._make_module_inputs()
-        bad_ref = torch.rand(query.shape[0], query.shape[1], self._n_levels + 1, 4)
+        bad_ref = torch.rand(query.shape[0], query.shape[1], self._n_levels, last_dim)
 
-        with pytest.raises(ValueError, match="level dim must be 1 or n_levels"):
+        with pytest.raises(ValueError, match="Last dim of reference_points must be 2 or 4"):
             module(
                 query,
                 bad_ref,
@@ -556,4 +705,62 @@ def test_ms_deform_attn_core_pytorch_export_compatible() -> None:
     module = _MinimalDeformAttn(hw=levels)
 
     exported = torch.export.export(module, args=(value, spatial_shapes, sampling_locations, attention_weights))
+    assert exported is not None
+
+
+def test_ms_deform_attn_module_export_compatible_with_singleton_level_dim() -> None:
+    """torch.export.export must succeed on MSDeformAttn.forward with decoder-style singleton-level refs.
+
+    Regression test: TestMSDeformAttnModule.test_export_mode_broadcasts_singleton_level_dim only calls
+    module.export() and then runs the module eagerly in Python — it never traces through
+    torch.export.export itself, so the reference_points.shape[2] control-flow branch
+    (ms_deform_attn.py:192-198) was never verified under a real FakeTensor-traced export, which is
+    the actual regime the export() mode is designed for.
+    """
+    hw_pairs: list[tuple[int, int]] = [(4, 4), (2, 2)]
+    d_model, n_heads, n_levels, n_points = 32, 4, 2, 2
+    total_len = sum(ht * wd for ht, wd in hw_pairs)
+    batch_size, num_queries = 1, 3
+
+    class _MSDeformAttnExportWrapper(torch.nn.Module):
+        """Thin wrapper exporting MSDeformAttn.forward via torch.export.export."""
+
+        def __init__(self, hw: list[tuple[int, int]]) -> None:
+            super().__init__()
+            self.attn = MSDeformAttn(d_model=d_model, n_levels=n_levels, n_heads=n_heads, n_points=n_points)
+            self.attn.export()
+            self.hw = hw
+
+        def forward(
+            self,
+            query: torch.Tensor,
+            reference_points: torch.Tensor,
+            input_flatten: torch.Tensor,
+            input_spatial_shapes: torch.Tensor,
+            input_level_start_index: torch.Tensor,
+        ) -> torch.Tensor:
+            """Forward using the module's Python int pairs for export compatibility."""
+            return self.attn(
+                query,
+                reference_points,
+                input_flatten,
+                input_spatial_shapes,
+                input_level_start_index,
+                input_spatial_shapes_hw=self.hw,
+            )
+
+    query = torch.randn(batch_size, num_queries, d_model)
+    # Decoder export shape: one shared box broadcast across feature levels (n_ref_levels == 1 branch).
+    reference_points = torch.rand(batch_size, num_queries, 1, 4)
+    input_flatten = torch.randn(batch_size, total_len, d_model)
+    input_spatial_shapes = torch.tensor(hw_pairs, dtype=torch.long)
+    starts = [sum(ht * wd for ht, wd in hw_pairs[:idx]) for idx in range(n_levels)]
+    input_level_start_index = torch.tensor(starts, dtype=torch.long)
+
+    module = _MSDeformAttnExportWrapper(hw=hw_pairs)
+
+    exported = torch.export.export(
+        module,
+        args=(query, reference_points, input_flatten, input_spatial_shapes, input_level_start_index),
+    )
     assert exported is not None

--- a/tests/models/test_transformer.py
+++ b/tests/models/test_transformer.py
@@ -494,6 +494,29 @@ class TestMSDeformAttnModule:
                 input_spatial_shapes_hw=hw_pairs,
             )
 
+    def test_eager_mode_rejects_invalid_reference_level_dim(self) -> None:
+        """Eager mode forward must raise ValueError when reference level dim is neither 1 nor n_levels.
+
+        Regression: the level-dim guard was hoisted above the export/eager split so both modes
+        reject malformed input with the same message (ms_deform_attn.py:192-198), but only the
+        export-mode path (test_export_mode_rejects_invalid_reference_level_dim) was covered.
+        """
+        module = MSDeformAttn(
+            d_model=self._d_model, n_levels=self._n_levels, n_heads=self._n_heads, n_points=self._n_points
+        )
+        query, _, input_flatten, spatial_shapes, level_start_index, hw_pairs = self._make_module_inputs()
+        bad_ref = torch.rand(query.shape[0], query.shape[1], self._n_levels + 1, 4)
+
+        with pytest.raises(ValueError, match="level dim must be 1 or n_levels"):
+            module(
+                query,
+                bad_ref,
+                input_flatten,
+                spatial_shapes,
+                level_start_index,
+                input_spatial_shapes_hw=hw_pairs,
+            )
+
     @pytest.mark.parametrize(
         "last_dim",
         [pytest.param(1, id="last-dim-1"), pytest.param(3, id="last-dim-3")],


### PR DESCRIPTION
## What does this PR do?

In export mode, `MSDeformAttn` merges `(n_levels, n_points)` into one axis. The decoder still passes `reference_points` with level dim `1` (shared box across levels). Without expanding `1 → n_levels` first, `repeat_interleave` yields the wrong length when `n_levels > 1` and export fails. Eager rank-6 already broadcast that singleton; this restores the same behavior on the rank-5 path and rejects other level sizes.

**Related Issue(s):** Follow-up to #1142 (bug still present there for multi-level export). Related audit: #1024 (Required to enable CoreML, ExecuTorch exports; does not close).

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**
- `RFDETR_SKIP_DINOV2_PREWARM=1 uv run --no-sync pytest tests/models/test_transformer.py::TestMSDeformAttnModule -q` — 6 passed (includes singleton broadcast + invalid level-dim cases)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

No docs change — internal export-path fix only.