### PR TITLE
feat(export): fp16 engine arg + export cookbooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,7 +90,7 @@ repos:
     hooks:
       - id: insert-license
         files: \.py$
-        exclude: ^notebooks/
+        exclude: ^(notebooks|docs)/
         args:
           - --license-filepath
           - .github/LICENSE_HEADER.txt

--- a/docs/cookbooks/NOTES.md
+++ b/docs/cookbooks/NOTES.md
@@ -51,6 +51,8 @@ Current tag colours are assigned dynamically by the docs UI, so they may change 
 | File                                | Card title                                      | Version |
 | ----------------------------------- | ----------------------------------------------- | ------- |
 | `custom-augmentations.ipynb`        | Custom Augmentations and Live Training Progress | v1.5.0  |
+| `export-tensorrt.ipynb`             | Export to TensorRT & Run Inference              | v1.8.3  |
+| `export-executorch.ipynb`           | Export to ExecuTorch & Run Inference            | v1.8.3  |
 | `fine-tune_detection.ipynb`         | Fine-Tune RF-DETR Object Detection              | v1.8.0  |
 | `fine-tune_keypoints.ipynb`         | Fine-Tune RF-DETR Keypoint Detection            | v1.8.0  |
 | `fine-tune_segmentation.ipynb`      | Fine-Tune RF-DETR Instance Segmentation         | v1.8.2  |

--- a/docs/cookbooks/NOTES.md
+++ b/docs/cookbooks/NOTES.md
@@ -52,7 +52,7 @@ Current tag colours are assigned dynamically by the docs UI, so they may change 
 | ----------------------------------- | ----------------------------------------------- | ------- |
 | `custom-augmentations.ipynb`        | Custom Augmentations and Live Training Progress | v1.5.0  |
 | `export-tensorrt.ipynb`             | Export to TensorRT & Run Inference              | v1.8.3  |
-| `export-executorch.ipynb`           | Export to ExecuTorch & Run Inference            | v1.8.3  |
+| `export-executorch.ipynb`           | Export to ExecuTorch                            | v1.8.3  |
 | `fine-tune_detection.ipynb`         | Fine-Tune RF-DETR Object Detection              | v1.8.0  |
 | `fine-tune_keypoints.ipynb`         | Fine-Tune RF-DETR Keypoint Detection            | v1.8.0  |
 | `fine-tune_segmentation.ipynb`      | Fine-Tune RF-DETR Instance Segmentation         | v1.8.2  |

--- a/docs/cookbooks/cards.yaml
+++ b/docs/cookbooks/cards.yaml
@@ -1,4 +1,16 @@
 cards:
+  - href: export-tensorrt/
+    name: "Export to TensorRT & Run Inference"
+    labels: [EXPORT, INFERENCE, DEPLOY]
+    version: v1.8.3
+    author: Borda
+    description: "Export RF-DETR to a TensorRT FP16 engine and run inference on it directly — low-latency NVIDIA GPU deployment with supervision-annotated detections."
+  - href: export-executorch/
+    name: "Export to ExecuTorch & Run Inference"
+    labels: [EXPORT, INFERENCE, DEPLOY]
+    version: v1.8.3
+    author: Borda
+    description: "Export RF-DETR to an ExecuTorch .pte program (XNNPACK CPU backend) and run on-device inference with the ExecuTorch runtime — mobile and edge deployment."
   - href: fine-tune_detection/
     name: "Fine-Tune RF-DETR Object Detection"
     labels: [TRAINING, PYTORCH LIGHTNING, INFERENCE]

--- a/docs/cookbooks/cards.yaml
+++ b/docs/cookbooks/cards.yaml
@@ -6,11 +6,11 @@ cards:
     author: Borda
     description: "Export RF-DETR to a TensorRT FP16 engine and run inference on it directly — low-latency NVIDIA GPU deployment with supervision-annotated detections."
   - href: export-executorch/
-    name: "Export to ExecuTorch & Run Inference"
-    labels: [EXPORT, INFERENCE, DEPLOY]
+    name: "Export to ExecuTorch"
+    labels: [EXPORT, DEPLOY]
     version: v1.8.3
     author: Borda
-    description: "Export RF-DETR to an ExecuTorch .pte program (XNNPACK CPU backend) and run on-device inference with the ExecuTorch runtime — mobile and edge deployment."
+    description: "Export RF-DETR to a portable ExecuTorch .pte program (XNNPACK / CoreML / QNN backends) for on-device mobile and edge deployment."
   - href: fine-tune_detection/
     name: "Fine-Tune RF-DETR Object Detection"
     labels: [TRAINING, PYTORCH LIGHTNING, INFERENCE]

--- a/docs/cookbooks/export-executorch.ipynb
+++ b/docs/cookbooks/export-executorch.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d870e078",
+   "id": "c801af66",
    "metadata": {},
    "source": [
     "# RF-DETR → ExecuTorch Export & Inference\n",
@@ -25,38 +25,44 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88c4c997",
+   "id": "7ea2bc25",
    "metadata": {},
    "source": [
     "## 1. Install\n",
     "\n",
     "The `[executorch]` extra provides the exporter and the XNNPACK backend.\n",
     "\n",
-    "`torchaudio` is uninstalled: RF-DETR never uses it, but `transformers` imports it if present, and a\n",
-    "`torch`/`torchaudio` CUDA-version mismatch (common on Colab) makes that import crash `import rfdetr`.\n",
+    "Colab ships mutually inconsistent preinstalled packages that otherwise crash `import rfdetr`, so two are\n",
+    "aligned: `torchaudio` is uninstalled (RF-DETR never uses it, but `transformers` imports it when present and\n",
+    "a `torch`/`torchaudio` CUDA-version mismatch then errors), and `pillow` is force-reinstalled to a clean\n",
+    "version (a half-upgraded PIL breaks `torchvision`'s import with `cannot import name '_Ink'`).\n",
     "\n",
     "> **torch/executorch ABI pin** — loading a `.pte` via `executorch.runtime` needs a `torch` whose ABI\n",
     "> matches the `executorch` wheel. For `executorch==1.3.1`, pin `torch<2.13`; a newer torch can silently\n",
     "> break the runtime with an `undefined symbol` error at import. Export itself is unaffected — only the\n",
-    "> in-process runtime used here for inference."
+    "> in-process runtime used here for inference.\n",
+    "\n",
+    "> **Colab**: after this cell, **Runtime → Restart session**, then run from the next cell — Colab keeps the\n",
+    "> old package versions loaded until a restart."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d4c8c387",
+   "id": "4f9d117b",
    "metadata": {
     "title": "[bash]"
    },
    "outputs": [],
    "source": [
-    "!pip install -q \"rfdetr[executorch]>=1.9.0\" \"torch<2.13\" supervision pillow\n",
+    "!pip install -q \"rfdetr[executorch]>=1.9.0\" \"torch<2.13\" supervision\n",
+    "!pip install -q --force-reinstall --no-deps \"pillow==11.3.0\"\n",
     "!pip uninstall -q -y torchaudio"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1ed2819c",
+   "id": "070652c4",
    "metadata": {},
    "source": [
     "## 2. Setup\n",
@@ -67,7 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "acf94fcd",
+   "id": "b1bdd521",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +89,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d61de1c7",
+   "id": "676b4a36",
    "metadata": {},
    "source": [
     "## 3. Sample image\n",
@@ -95,7 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47ca1660",
+   "id": "41e095b6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +120,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3b4de046",
+   "id": "f1206469",
    "metadata": {},
    "source": [
     "## 4. Export to a `.pte` program\n",
@@ -130,7 +136,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1fb6f95d",
+   "id": "4418bd50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,7 +152,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d0eb3761",
+   "id": "5d15e786",
    "metadata": {},
    "source": [
     "## 5. Load the program\n",
@@ -159,7 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "07efe28f",
+   "id": "ea1144f4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,7 +177,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ece8cb40",
+   "id": "b593e1c0",
    "metadata": {},
    "source": [
     "## 6. Run inference\n",
@@ -187,7 +193,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7f27df31",
+   "id": "c4df1e33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +212,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "149591ce",
+   "id": "bbfae886",
    "metadata": {},
    "source": [
     "## 7. Visualize with supervision\n",
@@ -218,7 +224,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1800adfd",
+   "id": "c2068ec7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,7 +259,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ff8789e6",
+   "id": "3b4a35c3",
    "metadata": {},
    "source": [
     "## Next steps\n",

--- a/docs/cookbooks/export-executorch.ipynb
+++ b/docs/cookbooks/export-executorch.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "8e6ad464",
+   "id": "bc07851a",
    "metadata": {},
    "source": [
     "# RF-DETR → ExecuTorch Export\n",
@@ -23,12 +23,12 @@
     "    `.pte` returns **incorrect detections on real images** — the `to_edge` lowering corrupts the DINOv2\n",
     "    backbone output, and this reproduces on **both XNNPACK and CoreML**. `torch.export` itself is bit-exact\n",
     "    with eager PyTorch, so the model export is correct; the fault is in ExecuTorch's ahead-of-time lowering.\n",
-    "    Track the fix in the linked issue before relying on `.pte` inference."
+    "    Validate `.pte` inference against eager PyTorch on your target before relying on it."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "834220b5",
+   "id": "f9b6a8c1",
    "metadata": {},
    "source": [
     "## 1. Install\n",
@@ -51,7 +51,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49d168a7",
+   "id": "ae48d9d4",
    "metadata": {
     "title": "[bash]"
    },
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43dfb9aa",
+   "id": "5adaff03",
    "metadata": {},
    "source": [
     "## 2. Setup\n",
@@ -75,7 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2ee5a9cd",
+   "id": "bd892ca1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,7 +89,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56ccbb02",
+   "id": "6dcd7fe5",
    "metadata": {},
    "source": [
     "## 3. Export to a `.pte` program\n",
@@ -105,7 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80697508",
+   "id": "b0dd5b6a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,7 +117,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "811948c8",
+   "id": "62022c69",
    "metadata": {},
    "source": [
     "## 4. Other backends\n",
@@ -143,7 +143,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9cac34ed",
+   "id": "fa357f24",
    "metadata": {},
    "source": [
     "## 5. Running the exported `.pte` (reference)\n",
@@ -180,7 +180,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15ffd2eb",
+   "id": "4850bd5c",
    "metadata": {},
    "source": [
     "## Next steps\n",

--- a/docs/cookbooks/export-executorch.ipynb
+++ b/docs/cookbooks/export-executorch.ipynb
@@ -1,0 +1,281 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d870e078",
+   "metadata": {},
+   "source": [
+    "# RF-DETR → ExecuTorch Export & Inference\n",
+    "\n",
+    "Export an RF-DETR detector to an **ExecuTorch program** (`.pte`) and run it on-device with the\n",
+    "ExecuTorch runtime — no GPU required.\n",
+    "\n",
+    "ExecuTorch is PyTorch's on-device inference runtime for mobile and edge hardware. Unlike ONNX or TFLite,\n",
+    "the model is captured directly via `torch.export` (no intermediate conversion) and lowered to a hardware\n",
+    "backend:\n",
+    "\n",
+    "| Backend | Target | Precision |\n",
+    "|---------|--------|-----------|\n",
+    "| **`xnnpack`** (this notebook) | portable CPU (Android / iOS / Linux / macOS) | fp32 |\n",
+    "| `coreml` | Apple Neural Engine | fp16 |\n",
+    "| `qnn` | Qualcomm Snapdragon HTP | fp16 |\n",
+    "\n",
+    "`xnnpack` is the portable, pip-installable default and is validated to match eager PyTorch to ~1e-5."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88c4c997",
+   "metadata": {},
+   "source": [
+    "## 1. Install\n",
+    "\n",
+    "The `[executorch]` extra provides the exporter and the XNNPACK backend.\n",
+    "\n",
+    "`torchaudio` is uninstalled: RF-DETR never uses it, but `transformers` imports it if present, and a\n",
+    "`torch`/`torchaudio` CUDA-version mismatch (common on Colab) makes that import crash `import rfdetr`.\n",
+    "\n",
+    "> **torch/executorch ABI pin** — loading a `.pte` via `executorch.runtime` needs a `torch` whose ABI\n",
+    "> matches the `executorch` wheel. For `executorch==1.3.1`, pin `torch<2.13`; a newer torch can silently\n",
+    "> break the runtime with an `undefined symbol` error at import. Export itself is unaffected — only the\n",
+    "> in-process runtime used here for inference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4c8c387",
+   "metadata": {
+    "title": "[bash]"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install -q \"rfdetr[executorch]>=1.9.0\" \"torch<2.13\" supervision pillow\n",
+    "!pip uninstall -q -y torchaudio"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ed2819c",
+   "metadata": {},
+   "source": [
+    "## 2. Setup\n",
+    "\n",
+    "ExecuTorch export and XNNPACK inference are CPU-only — no GPU is needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acf94fcd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "\n",
+    "EXPORT_DIR = Path(\"export_executorch\")\n",
+    "EXPORT_DIR.mkdir(exist_ok=True)\n",
+    "CONFIDENCE_THRESHOLD = 0.5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d61de1c7",
+   "metadata": {},
+   "source": [
+    "## 3. Sample image\n",
+    "\n",
+    "A single street scene with several COCO classes (dog, bicycle, car) verifies the exported program\n",
+    "produces correct detections."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47ca1660",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import urllib.request\n",
+    "\n",
+    "from PIL import Image\n",
+    "\n",
+    "IMAGE_URL = \"https://media.roboflow.com/notebooks/examples/dog.jpeg\"\n",
+    "IMAGE_PATH = EXPORT_DIR / \"sample.jpg\"\n",
+    "if not IMAGE_PATH.exists():\n",
+    "    urllib.request.urlretrieve(IMAGE_URL, IMAGE_PATH)\n",
+    "\n",
+    "image = Image.open(IMAGE_PATH).convert(\"RGB\")\n",
+    "print(f\"Sample image: {image.size[0]}×{image.size[1]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b4de046",
+   "metadata": {},
+   "source": [
+    "## 4. Export to a `.pte` program\n",
+    "\n",
+    "`format=\"executorch\"` requires an explicit `backend`. The COCO-pretrained `RFDETRSmall` is exported\n",
+    "directly — pass `pretrain_weights=\"<path/to/checkpoint.pth>\"` to export a fine-tuned model instead.\n",
+    "\n",
+    "The file is named after the model variant (`rfdetr-small.pte`). `torch.export` bakes a fixed input shape\n",
+    "into the graph (square at the model's resolution), so `dynamic_batch` is not supported — export one `.pte`\n",
+    "per batch size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1fb6f95d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rfdetr import RFDETRSmall\n",
+    "\n",
+    "model = RFDETRSmall()\n",
+    "resolution = model.model_config.resolution  # square input the graph is traced with\n",
+    "\n",
+    "pte_path = model.export(format=\"executorch\", backend=\"xnnpack\", output_dir=str(EXPORT_DIR))\n",
+    "print(f\"ExecuTorch program: {pte_path}  ({pte_path.stat().st_size / 1e6:.1f} MB)\")\n",
+    "print(f\"Traced input resolution: {resolution}×{resolution}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0eb3761",
+   "metadata": {},
+   "source": [
+    "## 5. Load the program\n",
+    "\n",
+    "`Runtime.get()` returns the process-wide ExecuTorch runtime; `load_program(...).load_method(\"forward\")`\n",
+    "gives a callable graph. (If this import fails with an `undefined symbol` / `dlopen` error, the torch/\n",
+    "executorch ABIs are mismatched — reinstall with `torch<2.13`; see the install note above.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07efe28f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from executorch.runtime import Runtime\n",
+    "\n",
+    "runtime = Runtime.get()\n",
+    "method = runtime.load_program(str(pte_path)).load_method(\"forward\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ece8cb40",
+   "metadata": {},
+   "source": [
+    "## 6. Run inference\n",
+    "\n",
+    "The `.pte` expects the **same input the model was trained on**: NCHW, ImageNet-normalized, at the traced\n",
+    "resolution. `infer_transforms` builds that exact preprocessing pipeline.\n",
+    "\n",
+    "`method.execute([input])` returns the two model outputs in order: `dets` (boxes, `cxcywh`, normalized)\n",
+    "and `labels` (class logits). `post_process` applies sigmoid + top-k, converts to `xyxy`, and rescales the\n",
+    "boxes to the original image size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f27df31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rfdetr.export.benchmark import infer_transforms, post_process\n",
+    "\n",
+    "transforms = infer_transforms((resolution, resolution))\n",
+    "image_tensor, _ = transforms(image, None)\n",
+    "\n",
+    "dets, labels = method.execute([image_tensor[None].float()])\n",
+    "\n",
+    "orig_h, orig_w = image.height, image.width\n",
+    "target_sizes = torch.tensor([[orig_h, orig_w]])\n",
+    "result = post_process({\"dets\": dets, \"labels\": labels}, target_sizes)[0]\n",
+    "print(f\"Raw detections returned by the program: {len(result['scores'])}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "149591ce",
+   "metadata": {},
+   "source": [
+    "## 7. Visualize with supervision\n",
+    "\n",
+    "Wrap the post-processed boxes in a `supervision.Detections`, filter by confidence, and annotate the\n",
+    "original image with COCO class names."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1800adfd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import supervision as sv\n",
+    "\n",
+    "from rfdetr.assets.coco_classes import COCO_CLASSES\n",
+    "\n",
+    "detections = sv.Detections(\n",
+    "    xyxy=result[\"boxes\"].cpu().numpy(),\n",
+    "    confidence=result[\"scores\"].cpu().numpy(),\n",
+    "    class_id=result[\"labels\"].cpu().numpy().astype(int),\n",
+    ")\n",
+    "detections = detections[detections.confidence > CONFIDENCE_THRESHOLD]\n",
+    "\n",
+    "# COCO-pretrained models emit sparse COCO category IDs (1–90) as class_id — look names up in the\n",
+    "# COCO_CLASSES {id: name} dict, not a 0-based list. (Fine-tuned models use 0-based class_names.)\n",
+    "labels_text = [\n",
+    "    f\"{COCO_CLASSES.get(int(c), str(int(c)))} {conf:.2f}\" for c, conf in zip(detections.class_id, detections.confidence)\n",
+    "]\n",
+    "print(f\"Kept {len(detections)} detections above {CONFIDENCE_THRESHOLD}: {labels_text}\")\n",
+    "\n",
+    "annotated = sv.BoxAnnotator(thickness=3).annotate(scene=np.array(image).copy(), detections=detections)\n",
+    "annotated = sv.LabelAnnotator(text_scale=0.6, text_thickness=1, text_padding=4).annotate(\n",
+    "    scene=annotated, detections=detections, labels=labels_text\n",
+    ")\n",
+    "\n",
+    "OUTPUT_PATH = EXPORT_DIR / \"annotated_executorch.jpg\"\n",
+    "Image.fromarray(annotated).save(OUTPUT_PATH)\n",
+    "print(f\"Saved annotated image: {OUTPUT_PATH}\")\n",
+    "sv.plot_image(annotated)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff8789e6",
+   "metadata": {},
+   "source": [
+    "## Next steps\n",
+    "\n",
+    "- **Deploy on-device** — copy the `.pte` to your Android / iOS / edge app and run it with the ExecuTorch\n",
+    "  runtime for that platform. See the [ExecuTorch docs](https://pytorch.org/executorch/).\n",
+    "- **Apple devices** — export with `backend=\"coreml\"` (requires `pip install coremltools`) to run fp16 on\n",
+    "  the Neural Engine. Detections stay correct; raw tensor values differ at fp16 precision.\n",
+    "- **Qualcomm Snapdragon** — export with `backend=\"qnn\", soc=\"SM8650\"` (requires an ExecuTorch source build\n",
+    "  against the QAIRT SDK — not available via pip).\n",
+    "- **Fine-tuned weights** — pass `pretrain_weights=\"<path/to/checkpoint.pth>\"` when constructing the model.\n",
+    "- See the [Export documentation](https://rfdetr.roboflow.com/learn/export/) for all formats and options."
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "title,-all",
+   "main_language": "python",
+   "notebook_metadata_filter": "-all"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/cookbooks/export-executorch.ipynb
+++ b/docs/cookbooks/export-executorch.ipynb
@@ -2,17 +2,14 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "c801af66",
+   "id": "8e6ad464",
    "metadata": {},
    "source": [
-    "# RF-DETR → ExecuTorch Export & Inference\n",
+    "# RF-DETR → ExecuTorch Export\n",
     "\n",
-    "Export an RF-DETR detector to an **ExecuTorch program** (`.pte`) and run it on-device with the\n",
-    "ExecuTorch runtime — no GPU required.\n",
-    "\n",
-    "ExecuTorch is PyTorch's on-device inference runtime for mobile and edge hardware. Unlike ONNX or TFLite,\n",
-    "the model is captured directly via `torch.export` (no intermediate conversion) and lowered to a hardware\n",
-    "backend:\n",
+    "Export an RF-DETR detector to a portable **ExecuTorch program** (`.pte`) for on-device deployment on\n",
+    "mobile and edge hardware. Unlike ONNX or TFLite, the model is captured directly via `torch.export`\n",
+    "(no intermediate conversion) and lowered to a hardware backend:\n",
     "\n",
     "| Backend | Target | Precision |\n",
     "|---------|--------|-----------|\n",
@@ -20,12 +17,18 @@
     "| `coreml` | Apple Neural Engine | fp16 |\n",
     "| `qnn` | Qualcomm Snapdragon HTP | fp16 |\n",
     "\n",
-    "`xnnpack` is the portable, pip-installable default and is validated to match eager PyTorch to ~1e-5."
+    "!!! warning \"On-device inference is currently blocked by an ExecuTorch bug\"\n",
+    "\n",
+    "    This cookbook covers **export only**. On `executorch==1.3.1` (the latest release), running the exported\n",
+    "    `.pte` returns **incorrect detections on real images** — the `to_edge` lowering corrupts the DINOv2\n",
+    "    backbone output, and this reproduces on **both XNNPACK and CoreML**. `torch.export` itself is bit-exact\n",
+    "    with eager PyTorch, so the model export is correct; the fault is in ExecuTorch's ahead-of-time lowering.\n",
+    "    Track the fix in the linked issue before relying on `.pte` inference."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "7ea2bc25",
+   "id": "834220b5",
    "metadata": {},
    "source": [
     "## 1. Install\n",
@@ -37,10 +40,9 @@
     "a `torch`/`torchaudio` CUDA-version mismatch then errors), and `pillow` is force-reinstalled to a clean\n",
     "version (a half-upgraded PIL breaks `torchvision`'s import with `cannot import name '_Ink'`).\n",
     "\n",
-    "> **torch/executorch ABI pin** — loading a `.pte` via `executorch.runtime` needs a `torch` whose ABI\n",
-    "> matches the `executorch` wheel. For `executorch==1.3.1`, pin `torch<2.13`; a newer torch can silently\n",
-    "> break the runtime with an `undefined symbol` error at import. Export itself is unaffected — only the\n",
-    "> in-process runtime used here for inference.\n",
+    "> **`flatc`** — ExecuTorch serializes the `.pte` with the FlatBuffers compiler. It ships in the Linux\n",
+    "> `executorch` wheel (so Colab works out of the box); on macOS install it separately with\n",
+    "> `brew install flatbuffers`.\n",
     "\n",
     "> **Colab**: after this cell, **Runtime → Restart session**, then run from the next cell — Colab keeps the\n",
     "> old package versions loaded until a restart."
@@ -49,7 +51,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4f9d117b",
+   "id": "49d168a7",
    "metadata": {
     "title": "[bash]"
    },
@@ -62,68 +64,35 @@
   },
   {
    "cell_type": "markdown",
-   "id": "070652c4",
+   "id": "43dfb9aa",
    "metadata": {},
    "source": [
     "## 2. Setup\n",
     "\n",
-    "ExecuTorch export and XNNPACK inference are CPU-only — no GPU is needed."
+    "ExecuTorch export is CPU-only — no GPU is needed."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b1bdd521",
+   "id": "2ee5a9cd",
    "metadata": {},
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
     "\n",
-    "import numpy as np\n",
-    "import torch\n",
+    "from rfdetr import RFDETRSmall\n",
     "\n",
     "EXPORT_DIR = Path(\"export_executorch\")\n",
-    "EXPORT_DIR.mkdir(exist_ok=True)\n",
-    "CONFIDENCE_THRESHOLD = 0.5"
+    "EXPORT_DIR.mkdir(exist_ok=True)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "676b4a36",
+   "id": "56ccbb02",
    "metadata": {},
    "source": [
-    "## 3. Sample image\n",
-    "\n",
-    "A single street scene with several COCO classes (dog, bicycle, car) verifies the exported program\n",
-    "produces correct detections."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "41e095b6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import urllib.request\n",
-    "\n",
-    "from PIL import Image\n",
-    "\n",
-    "IMAGE_URL = \"https://media.roboflow.com/notebooks/examples/dog.jpeg\"\n",
-    "IMAGE_PATH = EXPORT_DIR / \"sample.jpg\"\n",
-    "if not IMAGE_PATH.exists():\n",
-    "    urllib.request.urlretrieve(IMAGE_URL, IMAGE_PATH)\n",
-    "\n",
-    "image = Image.open(IMAGE_PATH).convert(\"RGB\")\n",
-    "print(f\"Sample image: {image.size[0]}×{image.size[1]}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f1206469",
-   "metadata": {},
-   "source": [
-    "## 4. Export to a `.pte` program\n",
+    "## 3. Export to a `.pte` program\n",
     "\n",
     "`format=\"executorch\"` requires an explicit `backend`. The COCO-pretrained `RFDETRSmall` is exported\n",
     "directly — pass `pretrain_weights=\"<path/to/checkpoint.pth>\"` to export a fine-tuned model instead.\n",
@@ -136,141 +105,91 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4418bd50",
+   "id": "80697508",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from rfdetr import RFDETRSmall\n",
-    "\n",
     "model = RFDETRSmall()\n",
-    "resolution = model.model_config.resolution  # square input the graph is traced with\n",
     "\n",
     "pte_path = model.export(format=\"executorch\", backend=\"xnnpack\", output_dir=str(EXPORT_DIR))\n",
-    "print(f\"ExecuTorch program: {pte_path}  ({pte_path.stat().st_size / 1e6:.1f} MB)\")\n",
-    "print(f\"Traced input resolution: {resolution}×{resolution}\")"
+    "print(f\"ExecuTorch program: {pte_path}  ({pte_path.stat().st_size / 1e6:.1f} MB)\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5d15e786",
+   "id": "811948c8",
    "metadata": {},
    "source": [
-    "## 5. Load the program\n",
+    "## 4. Other backends\n",
     "\n",
-    "`Runtime.get()` returns the process-wide ExecuTorch runtime; `load_program(...).load_method(\"forward\")`\n",
-    "gives a callable graph. (If this import fails with an `undefined symbol` / `dlopen` error, the torch/\n",
-    "executorch ABIs are mismatched — reinstall with `torch<2.13`; see the install note above.)"
+    "Swap the `backend` argument to target a different on-device runtime:\n",
+    "\n",
+    "=== \"Apple (CoreML, fp16)\"\n",
+    "\n",
+    "    ```python\n",
+    "    # requires: pip install coremltools\n",
+    "    model.export(format=\"executorch\", backend=\"coreml\", output_dir=\"export_executorch\")\n",
+    "    ```\n",
+    "\n",
+    "=== \"Qualcomm Snapdragon (QNN, fp16)\"\n",
+    "\n",
+    "    ```python\n",
+    "    # requires an ExecuTorch source build against the QAIRT SDK (not pip-installable)\n",
+    "    model.export(format=\"executorch\", backend=\"qnn\", soc=\"SM8650\", output_dir=\"export_executorch\")\n",
+    "    ```\n",
+    "\n",
+    "CoreML runs fp16 on the Apple Neural Engine; QNN targets the Snapdragon HTP and bakes in the target SoC."
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ea1144f4",
+   "cell_type": "markdown",
+   "id": "9cac34ed",
    "metadata": {},
-   "outputs": [],
    "source": [
+    "## 5. Running the exported `.pte` (reference)\n",
+    "\n",
+    "!!! warning \"Known bug — returns 0 detections on real images (executorch 1.3.1)\"\n",
+    "\n",
+    "    The code below is the **intended** inference path. On the current ExecuTorch release it produces\n",
+    "    incorrect detections (see the top-of-notebook warning). It is kept here as a reference for when the\n",
+    "    upstream lowering bug is fixed. Validate against eager PyTorch on your target before relying on it.\n",
+    "\n",
+    "The `.pte` expects the same input the model was trained on: NCHW, ImageNet-normalized, at the traced\n",
+    "resolution. `Runtime.load_program(...).load_method(\"forward\")` gives a callable graph whose two outputs\n",
+    "are `dets` (boxes, `cxcywh`, normalized) and `labels` (class logits).\n",
+    "\n",
+    "```python\n",
+    "import torch\n",
     "from executorch.runtime import Runtime\n",
-    "\n",
-    "runtime = Runtime.get()\n",
-    "method = runtime.load_program(str(pte_path)).load_method(\"forward\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b593e1c0",
-   "metadata": {},
-   "source": [
-    "## 6. Run inference\n",
-    "\n",
-    "The `.pte` expects the **same input the model was trained on**: NCHW, ImageNet-normalized, at the traced\n",
-    "resolution. `infer_transforms` builds that exact preprocessing pipeline.\n",
-    "\n",
-    "`method.execute([input])` returns the two model outputs in order: `dets` (boxes, `cxcywh`, normalized)\n",
-    "and `labels` (class logits). `post_process` applies sigmoid + top-k, converts to `xyxy`, and rescales the\n",
-    "boxes to the original image size."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c4df1e33",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "from PIL import Image\n",
     "from rfdetr.export.benchmark import infer_transforms, post_process\n",
     "\n",
+    "image = Image.open(\"image.jpg\").convert(\"RGB\")\n",
+    "resolution = model.model_config.resolution\n",
     "transforms = infer_transforms((resolution, resolution))\n",
     "image_tensor, _ = transforms(image, None)\n",
     "\n",
+    "method = Runtime.get().load_program(str(pte_path)).load_method(\"forward\")\n",
     "dets, labels = method.execute([image_tensor[None].float()])\n",
     "\n",
-    "orig_h, orig_w = image.height, image.width\n",
-    "target_sizes = torch.tensor([[orig_h, orig_w]])\n",
+    "target_sizes = torch.tensor([[image.height, image.width]])\n",
     "result = post_process({\"dets\": dets, \"labels\": labels}, target_sizes)[0]\n",
-    "print(f\"Raw detections returned by the program: {len(result['scores'])}\")"
+    "# result[\"boxes\"], result[\"scores\"], result[\"labels\"] — filter by confidence, then annotate.\n",
+    "```"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "bbfae886",
-   "metadata": {},
-   "source": [
-    "## 7. Visualize with supervision\n",
-    "\n",
-    "Wrap the post-processed boxes in a `supervision.Detections`, filter by confidence, and annotate the\n",
-    "original image with COCO class names."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c2068ec7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import supervision as sv\n",
-    "\n",
-    "from rfdetr.assets.coco_classes import COCO_CLASSES\n",
-    "\n",
-    "detections = sv.Detections(\n",
-    "    xyxy=result[\"boxes\"].cpu().numpy(),\n",
-    "    confidence=result[\"scores\"].cpu().numpy(),\n",
-    "    class_id=result[\"labels\"].cpu().numpy().astype(int),\n",
-    ")\n",
-    "detections = detections[detections.confidence > CONFIDENCE_THRESHOLD]\n",
-    "\n",
-    "# COCO-pretrained models emit sparse COCO category IDs (1–90) as class_id — look names up in the\n",
-    "# COCO_CLASSES {id: name} dict, not a 0-based list. (Fine-tuned models use 0-based class_names.)\n",
-    "labels_text = [\n",
-    "    f\"{COCO_CLASSES.get(int(c), str(int(c)))} {conf:.2f}\" for c, conf in zip(detections.class_id, detections.confidence)\n",
-    "]\n",
-    "print(f\"Kept {len(detections)} detections above {CONFIDENCE_THRESHOLD}: {labels_text}\")\n",
-    "\n",
-    "annotated = sv.BoxAnnotator(thickness=3).annotate(scene=np.array(image).copy(), detections=detections)\n",
-    "annotated = sv.LabelAnnotator(text_scale=0.6, text_thickness=1, text_padding=4).annotate(\n",
-    "    scene=annotated, detections=detections, labels=labels_text\n",
-    ")\n",
-    "\n",
-    "OUTPUT_PATH = EXPORT_DIR / \"annotated_executorch.jpg\"\n",
-    "Image.fromarray(annotated).save(OUTPUT_PATH)\n",
-    "print(f\"Saved annotated image: {OUTPUT_PATH}\")\n",
-    "sv.plot_image(annotated)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3b4a35c3",
+   "id": "15ffd2eb",
    "metadata": {},
    "source": [
     "## Next steps\n",
     "\n",
     "- **Deploy on-device** — copy the `.pte` to your Android / iOS / edge app and run it with the ExecuTorch\n",
     "  runtime for that platform. See the [ExecuTorch docs](https://pytorch.org/executorch/).\n",
-    "- **Apple devices** — export with `backend=\"coreml\"` (requires `pip install coremltools`) to run fp16 on\n",
-    "  the Neural Engine. Detections stay correct; raw tensor values differ at fp16 precision.\n",
-    "- **Qualcomm Snapdragon** — export with `backend=\"qnn\", soc=\"SM8650\"` (requires an ExecuTorch source build\n",
-    "  against the QAIRT SDK — not available via pip).\n",
     "- **Fine-tuned weights** — pass `pretrain_weights=\"<path/to/checkpoint.pth>\"` when constructing the model.\n",
+    "- **For working inference today**, use the [TensorRT cookbook](export-tensorrt/) (NVIDIA GPU) or\n",
+    "  [`inference-models`](https://github.com/roboflow/inference/tree/main/inference_models) (PyTorch / ONNX / TensorRT).\n",
     "- See the [Export documentation](https://rfdetr.roboflow.com/learn/export/) for all formats and options."
    ]
   }

--- a/docs/cookbooks/export-tensorrt.ipynb
+++ b/docs/cookbooks/export-tensorrt.ipynb
@@ -1,0 +1,293 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0e131c26",
+   "metadata": {},
+   "source": [
+    "# RF-DETR → TensorRT Export & Inference\n",
+    "\n",
+    "Export an RF-DETR detector to a **TensorRT engine** (`.trt`) and run inference on it directly.\n",
+    "\n",
+    "TensorRT delivers the lowest latency on NVIDIA GPUs. `export(format=\"trt\")` compiles a GPU-specific FP16\n",
+    "engine in-process via the TensorRT Python API.\n",
+    "\n",
+    "| Step | What happens |\n",
+    "|------|--------------|\n",
+    "| **Export** | `RFDETRSmall` → `rfdetr-small.trt` (FP16) |\n",
+    "| **Load** | Deserialize the engine with `TRTInference` (sync mode, no `pycuda`) |\n",
+    "| **Infer** | Preprocess → run engine → post-process → `supervision` detections |\n",
+    "\n",
+    "> **Portability**: a `.trt` engine is locked to the **GPU architecture and TensorRT version** of the\n",
+    "> machine that built it. Build it on the same GPU family you deploy on. For a portable, multi-backend\n",
+    "> path that manages its own engine, prefer `inference-models` (see the closing note)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f378513f",
+   "metadata": {},
+   "source": [
+    "## 1. Install\n",
+    "\n",
+    "The `[tensorrt]` extra pulls in `tensorrt` + `polygraphy` (no `trtexec` binary needed). Requires a\n",
+    "CUDA GPU with a matching NVIDIA driver.\n",
+    "\n",
+    "`torchaudio` is uninstalled: RF-DETR never uses it, but `transformers` imports it if present, and a\n",
+    "`torch`/`torchaudio` CUDA-version mismatch (common on Colab) makes that import crash `import rfdetr`.\n",
+    "\n",
+    "> **Colab**: select a GPU runtime (**Runtime → Change runtime type → GPU**) before running."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "96e53699",
+   "metadata": {
+    "title": "[bash]"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install -q \"rfdetr[onnx,tensorrt]>=1.9.0\" supervision pillow\n",
+    "!pip uninstall -q -y torchaudio"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28e11675",
+   "metadata": {},
+   "source": [
+    "## 2. Setup and GPU check\n",
+    "\n",
+    "TensorRT export and inference both require CUDA — fail fast with a clear message if no GPU is visible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b361dd17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "\n",
+    "if not torch.cuda.is_available():\n",
+    "    raise RuntimeError(\"TensorRT export and inference require a CUDA GPU; none is available.\")\n",
+    "print(f\"GPU: {torch.cuda.get_device_name(0)}\")\n",
+    "\n",
+    "EXPORT_DIR = Path(\"export_tensorrt\")\n",
+    "EXPORT_DIR.mkdir(exist_ok=True)\n",
+    "CONFIDENCE_THRESHOLD = 0.5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7326c74",
+   "metadata": {},
+   "source": [
+    "## 3. Sample image\n",
+    "\n",
+    "A single street scene with several COCO classes (dog, bicycle, car) is enough to verify the engine\n",
+    "produces correct detections. The image is downloaded once and reused."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ecf3223f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import urllib.request\n",
+    "\n",
+    "from PIL import Image\n",
+    "\n",
+    "IMAGE_URL = \"https://media.roboflow.com/notebooks/examples/dog.jpeg\"\n",
+    "IMAGE_PATH = EXPORT_DIR / \"sample.jpg\"\n",
+    "if not IMAGE_PATH.exists():\n",
+    "    urllib.request.urlretrieve(IMAGE_URL, IMAGE_PATH)\n",
+    "\n",
+    "image = Image.open(IMAGE_PATH).convert(\"RGB\")\n",
+    "print(f\"Sample image: {image.size[0]}×{image.size[1]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8363ca3",
+   "metadata": {},
+   "source": [
+    "## 4. Export to a TensorRT engine\n",
+    "\n",
+    "`format=\"trt\"` (alias of `\"tensorrt\"`) compiles the engine in one call. The COCO-pretrained `RFDETRSmall`\n",
+    "is used directly — pass `pretrain_weights=\"<path/to/checkpoint.pth>\"` to export your own fine-tuned model\n",
+    "instead. Engine compilation is the slow step (tens of seconds to a few minutes); it runs once and writes\n",
+    "the `.trt` file to `output_dir`.\n",
+    "\n",
+    "The engine is FP16 by default (lowest latency); it automatically falls back to FP32 (with a warning) if\n",
+    "your TensorRT build doesn't expose the FP16 builder flag. Pass `fp16=False` to force FP32 explicitly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80858784",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rfdetr import RFDETRSmall\n",
+    "\n",
+    "model = RFDETRSmall()\n",
+    "\n",
+    "engine_path = model.export(format=\"trt\", output_dir=str(EXPORT_DIR))\n",
+    "print(f\"TensorRT engine: {engine_path}  ({engine_path.stat().st_size / 1e6:.1f} MB)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b35a254a",
+   "metadata": {},
+   "source": [
+    "## 5. Load the engine\n",
+    "\n",
+    "`TRTInference` deserializes the `.trt` file and allocates GPU I/O bindings. `sync_mode=True` uses\n",
+    "`execute_v2` — a blocking call that needs no `pycuda` (async mode requires a CUDA stream and `pycuda`).\n",
+    "The engine's input tensor shape drives preprocessing so the image is resized to exactly what the graph\n",
+    "expects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22136133",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rfdetr.export.benchmark import TRTInference, infer_transforms, post_process\n",
+    "\n",
+    "trt_model = TRTInference(str(engine_path), device=\"cuda:0\", sync_mode=True)\n",
+    "\n",
+    "input_name = trt_model.input_names[0]\n",
+    "_, _, input_h, input_w = trt_model.bindings[input_name].shape\n",
+    "print(f\"Engine input '{input_name}': {input_h}×{input_w}\")\n",
+    "\n",
+    "transforms = infer_transforms((input_h, input_w))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aacaf748",
+   "metadata": {},
+   "source": [
+    "## 6. Run inference\n",
+    "\n",
+    "The pipeline mirrors what `predict()` does internally, but against the raw engine:\n",
+    "\n",
+    "1. **Preprocess** — resize to the engine resolution, ImageNet-normalize, add a batch dim.\n",
+    "2. **Execute** — the engine returns `dets` (boxes, `cxcywh`, normalized) and `labels` (class logits).\n",
+    "3. **Post-process** — `post_process` runs sigmoid + top-k, converts to `xyxy`, and rescales boxes to the\n",
+    "   original image size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59596ce6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_tensor, _ = transforms(image, None)\n",
+    "blob = {input_name: image_tensor[None].to(\"cuda:0\")}\n",
+    "\n",
+    "outputs = trt_model(blob)\n",
+    "trt_model.synchronize()\n",
+    "\n",
+    "orig_h, orig_w = image.height, image.width\n",
+    "target_sizes = torch.tensor([[orig_h, orig_w]], device=\"cuda:0\")\n",
+    "result = post_process(outputs, target_sizes)[0]\n",
+    "print(f\"Raw detections returned by the engine: {len(result['scores'])}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61247ca6",
+   "metadata": {},
+   "source": [
+    "## 7. Visualize with supervision\n",
+    "\n",
+    "Wrap the post-processed boxes in a `supervision.Detections`, filter by confidence, and annotate the\n",
+    "original image with class names from the COCO label set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "226348c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import supervision as sv\n",
+    "\n",
+    "from rfdetr.assets.coco_classes import COCO_CLASSES\n",
+    "\n",
+    "detections = sv.Detections(\n",
+    "    xyxy=result[\"boxes\"].cpu().numpy(),\n",
+    "    confidence=result[\"scores\"].cpu().numpy(),\n",
+    "    class_id=result[\"labels\"].cpu().numpy().astype(int),\n",
+    ")\n",
+    "detections = detections[detections.confidence > CONFIDENCE_THRESHOLD]\n",
+    "\n",
+    "# COCO-pretrained models emit sparse COCO category IDs (1–90) as class_id — look names up in the\n",
+    "# COCO_CLASSES {id: name} dict, not a 0-based list. (Fine-tuned models use 0-based class_names.)\n",
+    "labels = [\n",
+    "    f\"{COCO_CLASSES.get(int(c), str(int(c)))} {conf:.2f}\" for c, conf in zip(detections.class_id, detections.confidence)\n",
+    "]\n",
+    "print(f\"Kept {len(detections)} detections above {CONFIDENCE_THRESHOLD}: {labels}\")\n",
+    "\n",
+    "annotated = sv.BoxAnnotator(thickness=3).annotate(scene=np.array(image).copy(), detections=detections)\n",
+    "annotated = sv.LabelAnnotator(text_scale=0.6, text_thickness=1, text_padding=4).annotate(\n",
+    "    scene=annotated, detections=detections, labels=labels\n",
+    ")\n",
+    "\n",
+    "OUTPUT_PATH = EXPORT_DIR / \"annotated_tensorrt.jpg\"\n",
+    "Image.fromarray(annotated).save(OUTPUT_PATH)\n",
+    "print(f\"Saved annotated image: {OUTPUT_PATH}\")\n",
+    "sv.plot_image(annotated)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8bfa8915",
+   "metadata": {},
+   "source": [
+    "## Next steps\n",
+    "\n",
+    "- **Production inference** — [`inference-models`](https://github.com/roboflow/inference/tree/main/inference_models)\n",
+    "  is the recommended way to serve RF-DETR. It builds and manages its own TensorRT engine and exposes a\n",
+    "  unified API across PyTorch / ONNX / TensorRT backends, so you do **not** feed it the `.trt` produced here:\n",
+    "\n",
+    "  ```python\n",
+    "  from inference_models import AutoModel, BackendType\n",
+    "\n",
+    "  model = AutoModel.from_pretrained(\"rfdetr-small\", backend=BackendType.TRT)\n",
+    "  detections = model(image)[0].to_supervision()\n",
+    "  ```\n",
+    "\n",
+    "- **Custom resolution** — pass `shape=(H, W)` to `export()` (each dim divisible by the model's block size).\n",
+    "- **Fine-tuned weights** — pass `pretrain_weights=\"<path/to/checkpoint.pth>\"` when constructing the model.\n",
+    "- See the [Export documentation](https://rfdetr.roboflow.com/learn/export/) for all formats and options."
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "title,-all",
+   "main_language": "python",
+   "notebook_metadata_filter": "-all"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/cookbooks/export-tensorrt.ipynb
+++ b/docs/cookbooks/export-tensorrt.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "c226bc5e",
+   "id": "7eea78f8",
    "metadata": {},
    "source": [
     "# RF-DETR → TensorRT Export & Inference\n",
@@ -24,35 +24,40 @@
   },
   {
    "cell_type": "markdown",
-   "id": "89c0c828",
+   "id": "2f9b24ac",
    "metadata": {},
    "source": [
     "## 1. Install\n",
     "\n",
     "`rfdetr[tensorrt]` provides the exporter; `inference-models[trt10]` provides the TensorRT inference runtime.\n",
     "\n",
-    "`torchaudio` is uninstalled: RF-DETR never uses it, but `transformers` imports it if present, and a\n",
-    "`torch`/`torchaudio` CUDA-version mismatch (common on Colab) makes that import crash `import rfdetr`.\n",
+    "Colab ships mutually inconsistent preinstalled packages that otherwise crash `import rfdetr`, so two are\n",
+    "aligned: `torchaudio` is uninstalled (RF-DETR never uses it, but `transformers` imports it when present and\n",
+    "a `torch`/`torchaudio` CUDA-version mismatch then errors), and `pillow` is force-reinstalled to a clean\n",
+    "version (a half-upgraded PIL breaks `torchvision`'s import with `cannot import name '_Ink'`).\n",
     "\n",
-    "> **Colab**: select a GPU runtime (**Runtime → Change runtime type → GPU**) before running."
+    "> **Colab**: select a GPU runtime (**Runtime → Change runtime type → GPU**), and after this cell\n",
+    "> **Runtime → Restart session** before running the next cell — Colab keeps old package versions loaded\n",
+    "> until a restart."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d39ae6b9",
+   "id": "673a924f",
    "metadata": {
     "title": "[bash]"
    },
    "outputs": [],
    "source": [
-    "!pip install -q \"rfdetr[onnx,tensorrt]>=1.9.0\" \"inference-models[trt10]\" supervision pillow\n",
+    "!pip install -q \"rfdetr[onnx,tensorrt]>=1.9.0\" \"inference-models[trt10]\" supervision\n",
+    "!pip install -q --force-reinstall --no-deps \"pillow==11.3.0\"\n",
     "!pip uninstall -q -y torchaudio"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "d5174325",
+   "id": "2d21b249",
    "metadata": {},
    "source": [
     "## 2. Setup and GPU check\n",
@@ -63,7 +68,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f96c797e",
+   "id": "9e799600",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +88,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "caec1f9e",
+   "id": "f46eaf29",
    "metadata": {},
    "source": [
     "## 3. Sample image\n",
@@ -95,7 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d8f043c7",
+   "id": "8b3cfbaa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +119,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "af797a20",
+   "id": "988f53a8",
    "metadata": {},
    "source": [
     "## 4. Export a TensorRT engine\n",
@@ -133,7 +138,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16ef2396",
+   "id": "4636b993",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,7 +152,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19a7ec7f",
+   "id": "dc0738e5",
    "metadata": {},
    "source": [
     "## 5. Run inference with `inference-models`\n",
@@ -161,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a46fc372",
+   "id": "d4e43276",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,7 +182,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5978e6ba",
+   "id": "5a4a0a77",
    "metadata": {},
    "source": [
     "## 6. Visualize with supervision\n",
@@ -189,7 +194,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7a96c265",
+   "id": "b7b423c6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,7 +217,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "115c016b",
+   "id": "4bf39b26",
    "metadata": {},
    "source": [
     "## Next steps\n",

--- a/docs/cookbooks/export-tensorrt.ipynb
+++ b/docs/cookbooks/export-tensorrt.ipynb
@@ -2,36 +2,34 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "0e131c26",
+   "id": "c226bc5e",
    "metadata": {},
    "source": [
     "# RF-DETR → TensorRT Export & Inference\n",
     "\n",
-    "Export an RF-DETR detector to a **TensorRT engine** (`.trt`) and run inference on it directly.\n",
+    "Export an RF-DETR detector to a **TensorRT engine** (`.trt`), then run inference with\n",
+    "[`inference-models`](https://github.com/roboflow/inference/tree/main/inference_models) — the recommended\n",
+    "multi-backend runtime — using its TensorRT backend.\n",
     "\n",
-    "TensorRT delivers the lowest latency on NVIDIA GPUs. `export(format=\"trt\")` compiles a GPU-specific FP16\n",
-    "engine in-process via the TensorRT Python API.\n",
+    "| Step | What |\n",
+    "|------|------|\n",
+    "| **Export** | `RFDETRSmall` → `rfdetr-small.trt` (FP16) — raw-TensorRT deployment artifact |\n",
+    "| **Infer** | `inference-models` `AutoModel(backend=TRT)` → `supervision` detections |\n",
     "\n",
-    "| Step | What happens |\n",
-    "|------|--------------|\n",
-    "| **Export** | `RFDETRSmall` → `rfdetr-small.trt` (FP16) |\n",
-    "| **Load** | Deserialize the engine with `TRTInference` (sync mode, no `pycuda`) |\n",
-    "| **Infer** | Preprocess → run engine → post-process → `supervision` detections |\n",
-    "\n",
-    "> **Portability**: a `.trt` engine is locked to the **GPU architecture and TensorRT version** of the\n",
-    "> machine that built it. Build it on the same GPU family you deploy on. For a portable, multi-backend\n",
-    "> path that manages its own engine, prefer `inference-models` (see the closing note)."
+    "> **Two engines, on purpose.** The `.trt` from the export step is a standalone artifact for raw TensorRT\n",
+    "> deployment, locked to this GPU + TensorRT version. `inference-models` builds and manages its **own**\n",
+    "> engine internally, so it does not load that file — it is the easier, portable path and handles\n",
+    "> preprocessing, postprocessing, and class names for you."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f378513f",
+   "id": "89c0c828",
    "metadata": {},
    "source": [
     "## 1. Install\n",
     "\n",
-    "The `[tensorrt]` extra pulls in `tensorrt` + `polygraphy` (no `trtexec` binary needed). Requires a\n",
-    "CUDA GPU with a matching NVIDIA driver.\n",
+    "`rfdetr[tensorrt]` provides the exporter; `inference-models[trt10]` provides the TensorRT inference runtime.\n",
     "\n",
     "`torchaudio` is uninstalled: RF-DETR never uses it, but `transformers` imports it if present, and a\n",
     "`torch`/`torchaudio` CUDA-version mismatch (common on Colab) makes that import crash `import rfdetr`.\n",
@@ -42,19 +40,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96e53699",
+   "id": "d39ae6b9",
    "metadata": {
     "title": "[bash]"
    },
    "outputs": [],
    "source": [
-    "!pip install -q \"rfdetr[onnx,tensorrt]>=1.9.0\" supervision pillow\n",
+    "!pip install -q \"rfdetr[onnx,tensorrt]>=1.9.0\" \"inference-models[trt10]\" supervision pillow\n",
     "!pip uninstall -q -y torchaudio"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "28e11675",
+   "id": "d5174325",
    "metadata": {},
    "source": [
     "## 2. Setup and GPU check\n",
@@ -65,7 +63,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b361dd17",
+   "id": "f96c797e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,19 +83,19 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7326c74",
+   "id": "caec1f9e",
    "metadata": {},
    "source": [
     "## 3. Sample image\n",
     "\n",
-    "A single street scene with several COCO classes (dog, bicycle, car) is enough to verify the engine\n",
-    "produces correct detections. The image is downloaded once and reused."
+    "A single street scene with several COCO classes (dog, bicycle, car) is enough to verify detections. The\n",
+    "image is downloaded once and reused."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ecf3223f",
+   "id": "d8f043c7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,24 +114,26 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b8363ca3",
+   "id": "af797a20",
    "metadata": {},
    "source": [
-    "## 4. Export to a TensorRT engine\n",
+    "## 4. Export a TensorRT engine\n",
     "\n",
-    "`format=\"trt\"` (alias of `\"tensorrt\"`) compiles the engine in one call. The COCO-pretrained `RFDETRSmall`\n",
-    "is used directly — pass `pretrain_weights=\"<path/to/checkpoint.pth>\"` to export your own fine-tuned model\n",
-    "instead. Engine compilation is the slow step (tens of seconds to a few minutes); it runs once and writes\n",
-    "the `.trt` file to `output_dir`.\n",
+    "`format=\"trt\"` (alias of `\"tensorrt\"`) compiles the engine from the COCO-pretrained `RFDETRSmall` — pass\n",
+    "`pretrain_weights=\"<path/to/checkpoint.pth>\"` to export your own fine-tuned model instead. Compilation is\n",
+    "the slow step (tens of seconds to a few minutes); it writes the `.trt` file to `output_dir`.\n",
     "\n",
     "The engine is FP16 by default (lowest latency); it automatically falls back to FP32 (with a warning) if\n",
-    "your TensorRT build doesn't expose the FP16 builder flag. Pass `fp16=False` to force FP32 explicitly."
+    "your TensorRT build doesn't expose the FP16 builder flag. Pass `fp16=False` to force FP32 explicitly.\n",
+    "\n",
+    "This `.trt` is the raw-deployment artifact. The inference step below uses `inference-models`, which builds\n",
+    "its own engine — it does **not** load this file (see the intro note)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80858784",
+   "id": "16ef2396",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,104 +147,57 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b35a254a",
+   "id": "19a7ec7f",
    "metadata": {},
    "source": [
-    "## 5. Load the engine\n",
+    "## 5. Run inference with `inference-models`\n",
     "\n",
-    "`TRTInference` deserializes the `.trt` file and allocates GPU I/O bindings. `sync_mode=True` uses\n",
-    "`execute_v2` — a blocking call that needs no `pycuda` (async mode requires a CUDA stream and `pycuda`).\n",
-    "The engine's input tensor shape drives preprocessing so the image is resized to exactly what the graph\n",
-    "expects."
+    "`AutoModel.from_pretrained(\"rfdetr-small\", backend=BackendType.TRT)` loads the model and builds a TensorRT\n",
+    "engine for inference. Calling it on an image returns per-image predictions; `.to_supervision()` converts\n",
+    "them to a `supervision.Detections` with class names already attached — no manual preprocessing, box\n",
+    "decoding, or COCO-id mapping."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22136133",
+   "id": "a46fc372",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from rfdetr.export.benchmark import TRTInference, infer_transforms, post_process\n",
+    "from inference_models import AutoModel, BackendType\n",
     "\n",
-    "trt_model = TRTInference(str(engine_path), device=\"cuda:0\", sync_mode=True)\n",
+    "trt_model = AutoModel.from_pretrained(\"rfdetr-small\", backend=BackendType.TRT)\n",
     "\n",
-    "input_name = trt_model.input_names[0]\n",
-    "_, _, input_h, input_w = trt_model.bindings[input_name].shape\n",
-    "print(f\"Engine input '{input_name}': {input_h}×{input_w}\")\n",
-    "\n",
-    "transforms = infer_transforms((input_h, input_w))"
+    "predictions = trt_model(np.array(image))\n",
+    "detections = predictions[0].to_supervision()\n",
+    "detections = detections[detections.confidence > CONFIDENCE_THRESHOLD]\n",
+    "print(f\"Kept {len(detections)} detections above {CONFIDENCE_THRESHOLD}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "aacaf748",
+   "id": "5978e6ba",
    "metadata": {},
    "source": [
-    "## 6. Run inference\n",
+    "## 6. Visualize with supervision\n",
     "\n",
-    "The pipeline mirrors what `predict()` does internally, but against the raw engine:\n",
-    "\n",
-    "1. **Preprocess** — resize to the engine resolution, ImageNet-normalize, add a batch dim.\n",
-    "2. **Execute** — the engine returns `dets` (boxes, `cxcywh`, normalized) and `labels` (class logits).\n",
-    "3. **Post-process** — `post_process` runs sigmoid + top-k, converts to `xyxy`, and rescales boxes to the\n",
-    "   original image size."
+    "`to_supervision()` attaches class names under `detections.data[\"class_name\"]`; fall back to the raw\n",
+    "`class_id` if absent. Annotate the original image with boxes and labels."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59596ce6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "image_tensor, _ = transforms(image, None)\n",
-    "blob = {input_name: image_tensor[None].to(\"cuda:0\")}\n",
-    "\n",
-    "outputs = trt_model(blob)\n",
-    "trt_model.synchronize()\n",
-    "\n",
-    "orig_h, orig_w = image.height, image.width\n",
-    "target_sizes = torch.tensor([[orig_h, orig_w]], device=\"cuda:0\")\n",
-    "result = post_process(outputs, target_sizes)[0]\n",
-    "print(f\"Raw detections returned by the engine: {len(result['scores'])}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "61247ca6",
-   "metadata": {},
-   "source": [
-    "## 7. Visualize with supervision\n",
-    "\n",
-    "Wrap the post-processed boxes in a `supervision.Detections`, filter by confidence, and annotate the\n",
-    "original image with class names from the COCO label set."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "226348c2",
+   "id": "7a96c265",
    "metadata": {},
    "outputs": [],
    "source": [
     "import supervision as sv\n",
     "\n",
-    "from rfdetr.assets.coco_classes import COCO_CLASSES\n",
-    "\n",
-    "detections = sv.Detections(\n",
-    "    xyxy=result[\"boxes\"].cpu().numpy(),\n",
-    "    confidence=result[\"scores\"].cpu().numpy(),\n",
-    "    class_id=result[\"labels\"].cpu().numpy().astype(int),\n",
-    ")\n",
-    "detections = detections[detections.confidence > CONFIDENCE_THRESHOLD]\n",
-    "\n",
-    "# COCO-pretrained models emit sparse COCO category IDs (1–90) as class_id — look names up in the\n",
-    "# COCO_CLASSES {id: name} dict, not a 0-based list. (Fine-tuned models use 0-based class_names.)\n",
-    "labels = [\n",
-    "    f\"{COCO_CLASSES.get(int(c), str(int(c)))} {conf:.2f}\" for c, conf in zip(detections.class_id, detections.confidence)\n",
-    "]\n",
-    "print(f\"Kept {len(detections)} detections above {CONFIDENCE_THRESHOLD}: {labels}\")\n",
+    "class_names = list(detections.data.get(\"class_name\", [str(c) for c in detections.class_id]))\n",
+    "labels = [f\"{name} {conf:.2f}\" for name, conf in zip(class_names, detections.confidence)]\n",
+    "print(f\"Detections: {labels}\")\n",
     "\n",
     "annotated = sv.BoxAnnotator(thickness=3).annotate(scene=np.array(image).copy(), detections=detections)\n",
     "annotated = sv.LabelAnnotator(text_scale=0.6, text_thickness=1, text_padding=4).annotate(\n",
@@ -259,24 +212,17 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8bfa8915",
+   "id": "115c016b",
    "metadata": {},
    "source": [
     "## Next steps\n",
     "\n",
-    "- **Production inference** — [`inference-models`](https://github.com/roboflow/inference/tree/main/inference_models)\n",
-    "  is the recommended way to serve RF-DETR. It builds and manages its own TensorRT engine and exposes a\n",
-    "  unified API across PyTorch / ONNX / TensorRT backends, so you do **not** feed it the `.trt` produced here:\n",
-    "\n",
-    "  ```python\n",
-    "  from inference_models import AutoModel, BackendType\n",
-    "\n",
-    "  model = AutoModel.from_pretrained(\"rfdetr-small\", backend=BackendType.TRT)\n",
-    "  detections = model(image)[0].to_supervision()\n",
-    "  ```\n",
-    "\n",
-    "- **Custom resolution** — pass `shape=(H, W)` to `export()` (each dim divisible by the model's block size).\n",
-    "- **Fine-tuned weights** — pass `pretrain_weights=\"<path/to/checkpoint.pth>\"` when constructing the model.\n",
+    "- **Backend selection** — `AutoModel.from_pretrained` also accepts `backend=\"onnx\"` or `backend=\"torch\"`;\n",
+    "  drop the `backend=` argument to let it pick the best available automatically.\n",
+    "- **Local checkpoint** — `AutoModel.from_pretrained(\"<path/to/checkpoint.pth>\", model_type=\"rfdetr-small\")`\n",
+    "  loads your own fine-tuned weights.\n",
+    "- **Raw `.trt` deployment** — use the engine exported in step 4 directly with the TensorRT runtime when you\n",
+    "  need a standalone artifact (no `inference-models` dependency).\n",
     "- See the [Export documentation](https://rfdetr.roboflow.com/learn/export/) for all formats and options."
    ]
   }

--- a/docs/learn/export.md
+++ b/docs/learn/export.md
@@ -60,24 +60,25 @@ This command saves the ONNX model to the `output` directory by default.
 
 The `export()` method accepts several parameters to customize the export process:
 
-| Parameter          | Default    | Description                                                                                                                                                                                     |
-| ------------------ | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `output_dir`       | `"output"` | Directory where the exported model will be saved.                                                                                                                                               |
-| `format`           | `"onnx"`   | Export format: `"onnx"`, `"tflite"`, `"tensorrt"` (alias: `"trt"`), or `"executorch"`.                                                                                                          |
-| `quantization`     | `None`     | TFLite quantization mode: `None`/`"fp32"`, `"fp16"`, or `"int8"`. Only used when `format="tflite"`.                                                                                             |
-| `calibration_data` | `None`     | Calibration data for TFLite export. Image directory, `.npy` file path, NumPy array, or `None`. See [TFLite Export](#tflite-export).                                                             |
-| `max_images`       | `100`      | Maximum number of images to load from a calibration directory for TFLite INT8 quantization. Ignored for other calibration data formats.                                                         |
-| `infer_dir`        | `None`     | Optional directory of sample images for inference validation during export tracing. If not provided, a random dummy image is generated.                                                         |
-| `backbone_only`    | `False`    | Export only the backbone feature extractor instead of the full model.                                                                                                                           |
-| `opset_version`    | `17`       | ONNX opset version to use for export. Higher versions support more operations.                                                                                                                  |
-| `verbose`          | `True`     | Whether to print verbose export information.                                                                                                                                                    |
-| `shape`            | `None`     | Input shape as tuple `(height, width)`. Each dimension must be divisible by the selected model's block size (`patch_size * num_windows`). If not provided, uses the model's default resolution. |
-| `batch_size`       | `1`        | Batch size for the exported model.                                                                                                                                                              |
-| `dynamic_batch`    | `False`    | If `True`, export with a dynamic batch dimension so the ONNX model accepts variable batch sizes at runtime.                                                                                     |
-| `patch_size`       | `None`     | Backbone patch size override. Defaults to the value from `model_config.patch_size`. Must match the instantiated model's patch size when provided.                                               |
-| `backend`          | `None`     | Backend for ExecuTorch: `"xnnpack"` (CPU, fp32), `"coreml"` (Apple, fp16), or `"qnn"` (Qualcomm HTP, fp16). Required when `format="executorch"`.                                                |
-| `soc`              | `None`     | Target SoC chip identifier for the `"qnn"` backend (e.g. `"SM8650"` for Snapdragon 8 Gen 3). Required when `backend="qnn"`.                                                                     |
-| `notes`            | `None`     | Optional user-defined metadata (string, dict, list, or any JSON-serialisable value) to embed in the exported ONNX model under the `"rfdetr_notes"` metadata property.                           |
+| Parameter          | Default    | Description                                                                                                                                                                                      |
+| ------------------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `output_dir`       | `"output"` | Directory where the exported model will be saved.                                                                                                                                                |
+| `format`           | `"onnx"`   | Export format: `"onnx"`, `"tflite"`, `"tensorrt"` (alias: `"trt"`), or `"executorch"`.                                                                                                           |
+| `quantization`     | `None`     | TFLite quantization mode: `None`/`"fp32"`, `"fp16"`, or `"int8"`. Only used when `format="tflite"`.                                                                                              |
+| `calibration_data` | `None`     | Calibration data for TFLite export. Image directory, `.npy` file path, NumPy array, or `None`. See [TFLite Export](#tflite-export).                                                              |
+| `max_images`       | `100`      | Maximum number of images to load from a calibration directory for TFLite INT8 quantization. Ignored for other calibration data formats.                                                          |
+| `infer_dir`        | `None`     | Optional directory of sample images for inference validation during export tracing. If not provided, a random dummy image is generated.                                                          |
+| `backbone_only`    | `False`    | Export only the backbone feature extractor instead of the full model.                                                                                                                            |
+| `opset_version`    | `17`       | ONNX opset version to use for export. Higher versions support more operations.                                                                                                                   |
+| `verbose`          | `True`     | Whether to print verbose export information.                                                                                                                                                     |
+| `shape`            | `None`     | Input shape as tuple `(height, width)`. Each dimension must be divisible by the selected model's block size (`patch_size * num_windows`). If not provided, uses the model's default resolution.  |
+| `batch_size`       | `1`        | Batch size for the exported model.                                                                                                                                                               |
+| `dynamic_batch`    | `False`    | If `True`, export with a dynamic batch dimension so the ONNX model accepts variable batch sizes at runtime.                                                                                      |
+| `patch_size`       | `None`     | Backbone patch size override. Defaults to the value from `model_config.patch_size`. Must match the instantiated model's patch size when provided.                                                |
+| `backend`          | `None`     | Backend for ExecuTorch: `"xnnpack"` (CPU, fp32), `"coreml"` (Apple, fp16), or `"qnn"` (Qualcomm HTP, fp16). Required when `format="executorch"`.                                                 |
+| `soc`              | `None`     | Target SoC chip identifier for the `"qnn"` backend (e.g. `"SM8650"` for Snapdragon 8 Gen 3). Required when `backend="qnn"`.                                                                      |
+| `fp16`             | `True`     | Build the TensorRT engine with FP16 precision (only used when `format="tensorrt"`). Pass `False` to build an FP32 engine — required on TensorRT builds that do not expose the FP16 builder flag. |
+| `notes`            | `None`     | Optional user-defined metadata (string, dict, list, or any JSON-serialisable value) to embed in the exported ONNX model under the `"rfdetr_notes"` metadata property.                            |
 
 ## Advanced Export Examples
 

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -1388,6 +1388,7 @@ class RFDETR:
         *,
         backend: str | None = None,
         soc: str | None = None,
+        fp16: bool = True,
         notes: object = None,
     ) -> Path:
         """Export the trained model to ONNX, TFLite, TensorRT, or ExecuTorch format.
@@ -1455,6 +1456,10 @@ class RFDETR:
                 :class:`~executorch.backends.qualcomm.serialization.qc_schema.QcomChipset` name, e.g. ``"SM8650"``
                 (Snapdragon 8 Gen 3); see that enum for the full list of supported chips.  Has no effect for
                 ``"xnnpack"`` or ``"coreml"``.
+            fp16: Build the TensorRT engine with FP16 precision.  Only applies when ``format="tensorrt"``
+                (alias ``"trt"``); ignored for every other format.  Defaults to ``True`` for lowest latency
+                on NVIDIA GPUs.  Pass ``False`` to build an FP32 engine — required on TensorRT builds that do
+                not expose the FP16 builder flag (``export()`` otherwise aborts while configuring FP16).
             notes: Optional user-defined metadata (string, dict, list, or
                 any JSON-serialisable value) to embed in the exported ONNX model under the ``"rfdetr_notes"`` metadata
                 property.  When ``None`` no metadata entry is written.  String values are stored verbatim; all other
@@ -1639,6 +1644,7 @@ class RFDETR:
                 calibration_data=calibration_data,
                 max_images=max_images,
                 verbose=verbose,
+                fp16=fp16,
             )
         finally:
             self.model.model = self.model.model.to(device)

--- a/src/rfdetr/export/_tensorrt.py
+++ b/src/rfdetr/export/_tensorrt.py
@@ -57,7 +57,8 @@ def build_engine(onnx_path: str, *, fp16: bool = True, verbose: bool = False, dr
 
     Args:
         onnx_path: Path to the source ``.onnx`` file.
-        fp16: Enable FP16 precision when building the engine.
+        fp16: Enable FP16 precision when building the engine.  Automatically downgraded to FP32 (with a
+            warning) on TensorRT builds that do not expose the FP16 builder flag.
         verbose: Emit extra progress logging.
         dry_run: Log the intended build and return the engine path without
             building anything (no TensorRT / GPU required).
@@ -84,6 +85,23 @@ def build_engine(onnx_path: str, *, fp16: bool = True, verbose: bool = False, dr
 
     if engine_from_network is None:
         raise ImportError("TensorRT export requires the 'tensorrt' extra. Install with: pip install rfdetr[tensorrt]")
+
+    if fp16:
+        # Some TensorRT builds (e.g. lean/partial wheels) do not expose the FP16 builder flag. polygraphy aborts
+        # when asked to set an unavailable flag, so probe for it up front and fall back to an FP32 engine instead
+        # of crashing the whole export.
+        try:
+            import tensorrt as trt
+
+            if not hasattr(trt.BuilderFlag, "FP16"):
+                logger.warning(
+                    "TensorRT %s does not expose the FP16 builder flag; building an FP32 engine instead. "
+                    "Pass fp16=False to silence this warning.",
+                    getattr(trt, "__version__", "unknown"),
+                )
+                fp16 = False
+        except ImportError:
+            pass  # a missing/broken tensorrt import is surfaced by the polygraphy build chain below
 
     if verbose:
         logger.info(f"Building TensorRT engine (fp16={fp16}) from {onnx_path}")

--- a/src/rfdetr/export/main.py
+++ b/src/rfdetr/export/main.py
@@ -46,6 +46,7 @@ def _convert_onnx_export(
     calibration_data: str | np.ndarray[Any, Any] | None,
     max_images: int,
     verbose: bool,
+    fp16: bool = True,
 ) -> Path:
     """Dispatch :meth:`rfdetr.detr.RFDETR.export`'s post-ONNX-export conversion (TFLite / TensorRT / none).
 
@@ -57,6 +58,8 @@ def _convert_onnx_export(
         calibration_data: Representative images for TFLite INT8 calibration (ignored for other formats).
         max_images: Maximum calibration images to load from a directory (ignored for other formats).
         verbose: Print conversion progress information.
+        fp16: Build the TensorRT engine with FP16 precision (ignored for other formats). Pass ``False`` to
+            build an FP32 engine — useful on TensorRT builds that do not expose the FP16 builder flag.
 
     Returns:
         Path to the final exported artifact (``.onnx``, ``.tflite``, or ``.trt``).
@@ -95,7 +98,7 @@ def _convert_onnx_export(
         from rfdetr.export._tensorrt import build_engine
 
         logger.info("Converting ONNX model to TensorRT engine")
-        engine_file = build_engine(output_file, verbose=verbose)
+        engine_file = build_engine(output_file, fp16=fp16, verbose=verbose)
         logger.info(f"Successfully exported TensorRT engine to: {engine_file}")
         return Path(engine_file)
 
@@ -305,7 +308,9 @@ def main(args: argparse.Namespace) -> None:
     onnx_path = output_file  # preserve ONNX path before any post-processing step overwrites it
 
     if args.tensorrt:
-        output_file = build_engine(onnx_path, verbose=args.verbose, dry_run=args.dry_run)
+        output_file = build_engine(
+            onnx_path, fp16=getattr(args, "fp16", True), verbose=args.verbose, dry_run=args.dry_run
+        )
 
     # TODO: register --tflite, --quantization, --calibration-data, --max-images in the
     # argparser to enable TFLite export via CLI.  Until then, use RFDETR.export(format="tflite").

--- a/tests/export/test_export.py
+++ b/tests/export/test_export.py
@@ -330,6 +330,26 @@ def test_rfdetr_export_tensorrt_calls_build_engine_with_onnx_path(
     assert str(result) == str(tmp_path / "inference_model.trt")
 
 
+@pytest.mark.parametrize("fp16", [pytest.param(True, id="fp16"), pytest.param(False, id="fp32")])
+def test_rfdetr_export_tensorrt_forwards_fp16(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, fp16: bool) -> None:
+    """`RFDETR.export(format="tensorrt", fp16=...)` must forward the precision flag to `build_engine`.
+
+    Passing ``fp16=False`` lets callers build an FP32 engine on TensorRT builds that lack the FP16 builder flag.
+    """
+    model = _make_tensorrt_export_model()
+    onnx_output = str(tmp_path / "inference_model.onnx")
+    mock_build_engine = MagicMock(return_value=str(tmp_path / "inference_model.trt"))
+
+    monkeypatch.setattr("rfdetr.export.main.make_infer_image", lambda *_a, **_kw: _make_mock_infer_tensor())
+    monkeypatch.setattr("rfdetr.export.main.export_onnx", lambda *_a, **_kw: onnx_output)
+    monkeypatch.setattr("rfdetr.detr.deepcopy", lambda x: x)
+    monkeypatch.setattr("rfdetr.export._tensorrt.build_engine", mock_build_engine)
+
+    _detr_module.RFDETR.export(model, output_dir=str(tmp_path), format="tensorrt", fp16=fp16, shape=(14, 14))
+
+    assert mock_build_engine.call_args.kwargs["fp16"] == fp16
+
+
 def test_rfdetr_export_tensorrt_failure_restores_device(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """A `build_engine` failure must still restore the live model to its original device.
 
@@ -713,7 +733,7 @@ class TestCliExportMain:
         ):
             _cli_export_module.main(args)
 
-        mock_build_engine.assert_called_once_with(onnx_output, verbose=True, dry_run=True)
+        mock_build_engine.assert_called_once_with(onnx_output, fp16=True, verbose=True, dry_run=True)
 
     def test_tensorrt_false_does_not_call_build_engine(self, output_dir: str) -> None:
         """When tensorrt=False (default), main() must not call build_engine."""

--- a/tests/export/test_tensorrt_export.py
+++ b/tests/export/test_tensorrt_export.py
@@ -9,9 +9,21 @@ The engine is built via the TensorRT Python API through `polygraphy`; these test
 points so they run without TensorRT, a GPU, or `polygraphy` installed.
 """
 
+import sys
+
 import pytest
 
 from rfdetr.export import _tensorrt as tensorrt_export
+
+
+def _patch_polygraphy_chain(monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Stub the polygraphy build chain and return the dict that captures CreateConfig kwargs."""
+    config_kwargs: dict = {}
+    monkeypatch.setattr(tensorrt_export, "network_from_onnx_path", lambda path: ("network", path))
+    monkeypatch.setattr(tensorrt_export, "CreateConfig", lambda **kwargs: config_kwargs.update(kwargs) or "config")
+    monkeypatch.setattr(tensorrt_export, "engine_from_network", lambda network, config: "engine")
+    monkeypatch.setattr(tensorrt_export, "save_engine", lambda engine, path: None)
+    return config_kwargs
 
 
 @pytest.mark.parametrize(
@@ -81,3 +93,21 @@ def test_build_engine_invokes_polygraphy_and_saves_trt(monkeypatch: pytest.Monke
     assert config_kwargs == {"fp16": fp16}
     assert build_args == {"network": ("network", "/tmp/model.onnx"), "config": "config-sentinel"}
     assert saved == {"engine": "engine-sentinel", "path": "/tmp/model.trt"}
+
+
+def test_build_engine_downgrades_to_fp32_when_fp16_flag_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A TensorRT build without the FP16 builder flag must fall back to an FP32 engine instead of aborting."""
+
+    class _FakeTrt:
+        __version__ = "11.1.0.106"
+
+        class BuilderFlag:  # deliberately lacks an ``FP16`` attribute
+            INT8 = 0
+
+    config_kwargs = _patch_polygraphy_chain(monkeypatch)
+    monkeypatch.setitem(sys.modules, "tensorrt", _FakeTrt)
+
+    result = tensorrt_export.build_engine("/tmp/model.onnx", fp16=True)
+
+    assert result == "/tmp/model.trt"
+    assert config_kwargs == {"fp16": False}


### PR DESCRIPTION
This pull request adds new documentation and example notebooks for exporting RF-DETR models to TensorRT and ExecuTorch formats, and updates related documentation to clarify export options and improve discoverability. It also adjusts the pre-commit license header insertion to avoid running on documentation files.

**New export cookbooks and documentation:**

* Added two new example notebooks: `export-tensorrt.ipynb` (demonstrates exporting to TensorRT and running inference on NVIDIA GPUs) and `export-executorch.ipynb` (demonstrates exporting to ExecuTorch and running inference on mobile/edge devices). Both include full, step-by-step guides with visualization. [[1]](diffhunk://#diff-4fc5369c2452d3da9c1c38d27a7a547410cd89087330be2aac4729b4d6992191R1-R289) [[2]](diffhunk://#diff-d68a1babaec3cd0e0f696d23d0154e5329f1d91c61e41fb7b819e3f47a52dad6R1-R277)
* Registered the new cookbooks in `cards.yaml` for discoverability, including descriptions, labels, and versioning metadata.
* Updated the cookbooks table in `NOTES.md` to include the new export notebooks and their versions.

**Export documentation improvements:**

* Clarified the `export()` method documentation to document the new `fp16` parameter for TensorRT export and improved the formatting of the parameters table. [[1]](diffhunk://#diff-76bf72360ae4b094d0fe12835eae94e7fa98534d371672cb78af21088eae67e8L64-R64) [[2]](diffhunk://#diff-76bf72360ae4b094d0fe12835eae94e7fa98534d371672cb78af21088eae67e8R80)

**Tooling and configuration:**

* Updated `.pre-commit-config.yaml` so that the license header insertion hook excludes files in the `docs/` directory instead of `notebooks/`, preventing license headers from being inserted into documentation files.