### PR TITLE
fix(security): propagate `trust_checkpoint` through model reconstruction

### DIFF
--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -370,20 +370,26 @@ class RFDETR:
     _model_config_class: type[ModelConfig] = ModelConfig
     _train_config_class: type[TrainConfig] = TrainConfig
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, *, trust_checkpoint: bool = False, **kwargs: Any) -> None:
         """Initialize with ModelConfig fields as keyword arguments.
 
-        Passes all kwargs to the variant's ModelConfig. Unknown kwargs raise
+        Passes all remaining kwargs to the variant's ModelConfig. Unknown kwargs raise
         ``pydantic.ValidationError``. See the variant's config class for available
         parameters (e.g. ``RFDETRSmallConfig``).
 
         Args:
+            trust_checkpoint: When ``True``, allow ``pretrain_weights`` to fall back to full
+                pickle deserialization (``weights_only=False``) if safe loading fails. Set this
+                only when ``pretrain_weights`` points to a checkpoint you explicitly trust (e.g.
+                when called internally by :meth:`from_checkpoint`); left ``False`` by default for
+                the ordinary construction path, which only ever downloads official Roboflow-hosted
+                weights.
             **kwargs: ModelConfig field values (e.g. ``resolution``, ``num_classes``,
                 ``pretrain_weights``, ``gradient_checkpointing``).
         """
         self.model_config = self.get_model_config(**kwargs)
         self.maybe_download_pretrain_weights()
-        self.model = self.get_model(self.model_config)
+        self.model = self.get_model(self.model_config, trust_checkpoint=trust_checkpoint)
         self.callbacks: dict[str, list[Callable[..., Any]]] = defaultdict(list)
 
         self.means = list(self.means)
@@ -461,6 +467,9 @@ class RFDETR:
                 (full pickle) if safe deserialization fails.  Only set this for
                 checkpoints from fully trusted sources; the default ``False``
                 keeps the safe loading path and raises if it cannot succeed.
+                Applies to both the initial checkpoint read here and the
+                constructor's own reload of the same file via
+                :func:`~rfdetr.models.weights.load_pretrain_weights`.
             **kwargs: Additional keyword arguments forwarded to the model
                 constructor (e.g. ``accept_platform_model_license=True`` for XLarge / 2XLarge models).
 
@@ -729,6 +738,10 @@ class RFDETR:
         # pretrain_weights is placed after **kwargs so it always wins even if
         # a caller accidentally passes pretrain_weights inside kwargs.
         constructor_kwargs["pretrain_weights"] = str(path)
+        # Model construction reloads this same file via load_pretrain_weights(); without this,
+        # trust_checkpoint=True would bypass the safe-load only for the metadata read above and
+        # then fail identically when the constructor re-reads pretrain_weights.
+        constructor_kwargs["trust_checkpoint"] = trust_checkpoint
 
         # Fields injected from the checkpoint but not supplied by the caller must not be
         # treated as explicit user overrides in Pydantic's model_fields_set.  Downstream
@@ -2005,16 +2018,19 @@ class RFDETR:
         """Retrieve the configuration parameters that will be used for training."""
         return self._train_config_class(**kwargs)
 
-    def get_model(self, config: ModelConfig) -> ModelContext:
+    def get_model(self, config: ModelConfig, *, trust_checkpoint: bool = False) -> ModelContext:
         """Retrieve a model context from the provided architecture configuration.
 
         Args:
             config: Architecture configuration.
+            trust_checkpoint: Forwarded to :func:`~rfdetr.inference._build_model_context` — set
+                ``True`` only when ``config.pretrain_weights`` is a checkpoint the caller
+                explicitly trusts (mirrors ``RFDETR.from_checkpoint(..., trust_checkpoint=True)``).
 
         Returns:
             ModelContext with model, postprocess, device, resolution, args, and class_names attributes.
         """
-        return _build_model_context(config)
+        return _build_model_context(config, trust_checkpoint=trust_checkpoint)
 
     @property
     def class_names(self) -> list[str]:

--- a/src/rfdetr/inference.py
+++ b/src/rfdetr/inference.py
@@ -96,7 +96,7 @@ def _adapt_input_conv(num_channels: int, conv_weight: torch.Tensor) -> torch.Ten
     return weight_out
 
 
-def _build_model_context(model_config: ModelConfig) -> ModelContext:
+def _build_model_context(model_config: ModelConfig, *, trust_checkpoint: bool = False) -> ModelContext:
     """Build a ModelContext from ModelConfig without using legacy main.py:Model.
 
     Replicates ``Model.__init__`` logic: builds the nn.Module, optionally loads pretrain weights and applies LoRA.  The
@@ -107,6 +107,10 @@ def _build_model_context(model_config: ModelConfig) -> ModelContext:
 
     Args:
         model_config: Architecture configuration.
+        trust_checkpoint: Forwarded to :func:`~rfdetr.models.weights.load_pretrain_weights` as its
+            ``trust`` argument — set ``True`` only when ``model_config.pretrain_weights`` is a
+            checkpoint the caller explicitly trusts (mirrors ``RFDETR.from_checkpoint(...,
+            trust_checkpoint=True)``).
 
     Returns:
         ModelContext with the model on CPU, ready for lazy device placement.
@@ -129,7 +133,7 @@ def _build_model_context(model_config: ModelConfig) -> ModelContext:
 
     class_names: list[str] = []
     if model_config.pretrain_weights is not None:
-        class_names = load_pretrain_weights(nn_model, model_config)
+        class_names = load_pretrain_weights(nn_model, model_config, trust=trust_checkpoint)
         # ``load_pretrain_weights`` can mutate ``model_config.num_classes`` and
         # ``model_config.num_keypoints_per_class`` when aligning to checkpoint schema.
         # Keep the derived namespace in sync so postprocess and predict() use correct values.

--- a/src/rfdetr/models/weights.py
+++ b/src/rfdetr/models/weights.py
@@ -264,6 +264,8 @@ def interpolate_position_embeddings(
 def load_pretrain_weights(
     nn_model: LWDETR,
     model_config: ModelConfig,
+    *,
+    trust: bool = False,
 ) -> list[str]:
     """Load pretrained checkpoint weights into *nn_model* in-place.
 
@@ -287,6 +289,10 @@ def load_pretrain_weights(
         nn_model: The model whose weights will be updated in-place.
         model_config: Pydantic ``ModelConfig`` instance. Must have
             ``pretrain_weights``, ``num_classes``, ``num_queries``, and ``group_detr`` attributes.
+        trust: Forwarded to :func:`rfdetr.utilities.io._safe_torch_load` as its ``trust``
+            argument. Set ``True`` only when ``model_config.pretrain_weights`` points to a
+            checkpoint the caller explicitly trusts (mirrors ``RFDETR.from_checkpoint(...,
+            trust_checkpoint=True)``); the safe-load default otherwise applies here too.
 
     Returns:
         List of class name strings from the checkpoint, or an empty list if none are present or if
@@ -316,11 +322,11 @@ def load_pretrain_weights(
     validate_pretrain_weights(pretrain_weights, strict=False)
 
     try:
-        checkpoint = _safe_torch_load(pretrain_weights)
+        checkpoint = _safe_torch_load(pretrain_weights, trust=trust)
     except Exception:
         logger.info("Failed to load pretrain weights, re-downloading")
         download_pretrain_weights(pretrain_weights, redownload=True)
-        checkpoint = _safe_torch_load(pretrain_weights)
+        checkpoint = _safe_torch_load(pretrain_weights, trust=trust)
 
     # Normalize PyTorch Lightning native .ckpt format to the expected {"model": {...}}
     # structure.  PTL stores model weights in "state_dict" with keys prefixed by

--- a/tests/inference/helpers.py
+++ b/tests/inference/helpers.py
@@ -101,6 +101,6 @@ class _DummyRFDETR(RFDETR):
         """Return a minimal namespace with just ``num_channels``."""
         return SimpleNamespace(num_channels=3)
 
-    def get_model(self, config: SimpleNamespace) -> _DummyModel:
+    def get_model(self, config: SimpleNamespace, *, trust_checkpoint: bool = False) -> _DummyModel:
         """Return a fresh ``_DummyModel`` instance."""
         return _DummyModel()

--- a/tests/inference/test_from_checkpoint.py
+++ b/tests/inference/test_from_checkpoint.py
@@ -242,6 +242,33 @@ class TestFromCheckpointEdgeCases:
         call_kwargs = mock_cls.call_args.kwargs
         assert call_kwargs.get("resolution") == 640
 
+    def test_trust_checkpoint_true_forwarded_to_constructor(self, tmp_path: Path) -> None:
+        """trust_checkpoint=True reaches the model constructor, not just the metadata read.
+
+        Regression coverage: the constructor reloads the same checkpoint file via
+        ``load_pretrain_weights`` — without forwarding ``trust_checkpoint`` into
+        ``constructor_kwargs``, that reload always used the unsafe-load default, making
+        ``trust_checkpoint=True`` inert for checkpoints that actually need it.
+        """
+        _, mock_cls = _call_from_checkpoint(
+            _ns("rf-detr-small.pth"),
+            tmp_path / "ckpt.pth",
+            "rfdetr.variants.RFDETRSmall",
+            trust_checkpoint=True,
+        )
+        call_kwargs = mock_cls.call_args.kwargs
+        assert call_kwargs["trust_checkpoint"] is True
+
+    def test_trust_checkpoint_defaults_to_false_in_constructor(self, tmp_path: Path) -> None:
+        """trust_checkpoint defaults to False in the forwarded constructor kwargs."""
+        _, mock_cls = _call_from_checkpoint(
+            _ns("rf-detr-small.pth"),
+            tmp_path / "ckpt.pth",
+            "rfdetr.variants.RFDETRSmall",
+        )
+        call_kwargs = mock_cls.call_args.kwargs
+        assert call_kwargs["trust_checkpoint"] is False
+
     def test_characterization_pretrain_weights_in_kwargs_is_overridden(self, tmp_path: Path) -> None:
         """pretrain_weights passed in **kwargs is silently overridden by the checkpoint path."""
         _, mock_cls = _call_from_checkpoint(

--- a/tests/inference/test_model_inference.py
+++ b/tests/inference/test_model_inference.py
@@ -43,7 +43,7 @@ class _FakeRFDETR(RFDETR):
     def get_model_config(self, **kwargs) -> SimpleNamespace:
         return SimpleNamespace(num_channels=3)
 
-    def get_model(self, config: SimpleNamespace) -> _FakeModelContext:
+    def get_model(self, config: SimpleNamespace, *, trust_checkpoint: bool = False) -> _FakeModelContext:
         return _FakeModelContext()
 
 

--- a/tests/inference/test_predict_eval_mode.py
+++ b/tests/inference/test_predict_eval_mode.py
@@ -41,7 +41,7 @@ class _FakeModelContext:
 class _FakeRFDETR(_BaseFakeRFDETR):
     """Concrete test double: provides a dropout-bearing model for eval-mode tests."""
 
-    def get_model(self, config: SimpleNamespace) -> _FakeModelContext:
+    def get_model(self, config: SimpleNamespace, *, trust_checkpoint: bool = False) -> _FakeModelContext:
         """Return a minimal model context with a dropout-bearing module."""
         return _FakeModelContext()
 

--- a/tests/models/test_weights.py
+++ b/tests/models/test_weights.py
@@ -361,7 +361,7 @@ class TestLoadPretrainWeightsTrustPropagation:
 
             load_pretrain_weights(_fake_nn_model(), mc, trust=True)
 
-        mock_load.assert_called_once_with("/fake/weights.pth", trust=True)
+        mock_load.assert_called_once_with(mc.pretrain_weights, trust=True)
 
     def test_trust_defaults_to_false(self):
         """load_pretrain_weights without a trust kwarg calls _safe_torch_load with trust=False."""
@@ -373,7 +373,7 @@ class TestLoadPretrainWeightsTrustPropagation:
 
             load_pretrain_weights(_fake_nn_model(), mc)
 
-        mock_load.assert_called_once_with("/fake/weights.pth", trust=False)
+        mock_load.assert_called_once_with(mc.pretrain_weights, trust=False)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/models/test_weights.py
+++ b/tests/models/test_weights.py
@@ -332,6 +332,51 @@ class TestLoadPretrainWeightsClassNames:
 
 
 # ---------------------------------------------------------------------------
+# load_pretrain_weights — trust propagation
+# ---------------------------------------------------------------------------
+
+
+class TestLoadPretrainWeightsTrustPropagation:
+    """Verify the ``trust`` kwarg reaches ``_safe_torch_load`` unchanged.
+
+    Regression coverage for a gap where ``RFDETR.from_checkpoint(path, trust_checkpoint=True)`` bypassed the safe-load
+    check only for its own metadata read, then silently reverted to ``trust=False`` when the constructed model reloaded
+    the same file here — making ``trust_checkpoint=True`` inert for any checkpoint that actually needed it.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _patch_io(self, monkeypatch):
+        monkeypatch.setattr("rfdetr.models.weights.download_pretrain_weights", lambda *a, **kw: None)
+        monkeypatch.setattr("rfdetr.models.weights.validate_pretrain_weights", lambda *a, **kw: None)
+        monkeypatch.setattr("rfdetr.models.weights.validate_checkpoint_compatibility", lambda *a, **kw: None)
+        monkeypatch.setattr("rfdetr.models.weights.os.path.isfile", lambda _: True)
+
+    def test_trust_true_forwarded_to_safe_torch_load(self):
+        """load_pretrain_weights(trust=True) calls _safe_torch_load with trust=True."""
+        mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu")
+        checkpoint = _make_checkpoint(num_classes=91)
+
+        with patch("rfdetr.utilities.io._safe_torch_load", return_value=checkpoint) as mock_load:
+            from rfdetr.models.weights import load_pretrain_weights
+
+            load_pretrain_weights(_fake_nn_model(), mc, trust=True)
+
+        mock_load.assert_called_once_with("/fake/weights.pth", trust=True)
+
+    def test_trust_defaults_to_false(self):
+        """load_pretrain_weights without a trust kwarg calls _safe_torch_load with trust=False."""
+        mc = RFDETRBaseConfig(pretrain_weights="/fake/weights.pth", device="cpu")
+        checkpoint = _make_checkpoint(num_classes=91)
+
+        with patch("rfdetr.utilities.io._safe_torch_load", return_value=checkpoint) as mock_load:
+            from rfdetr.models.weights import load_pretrain_weights
+
+            load_pretrain_weights(_fake_nn_model(), mc)
+
+        mock_load.assert_called_once_with("/fake/weights.pth", trust=False)
+
+
+# ---------------------------------------------------------------------------
 # load_pretrain_weights — PTL .ckpt format
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
RFDETR.from_checkpoint(path, trust_checkpoint=True) only bypassed the safe-load check for its own metadata read. Model construction reloads the same file via load_pretrain_weights() -> _safe_torch_load(), which had no way to see the caller's trust_checkpoint value and always used the unsafe-load default (trust=False) -- so trust_checkpoint=True was inert for any checkpoint that genuinely needed it, raising the same RuntimeError it was supposed to bypass.

Threads `trust_checkpoint` through 
`RFDETR.__init__() -> get_model() -> _build_model_context() -> load_pretrain_weights() -> _safe_torch_load()`, and forwards it from `from_checkpoint()`'s constructor_kwargs.
