### PR TITLE
releasing `1.9.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0] — 2026-07-27
+
 - Default dataset augmentations now use torchvision-native transforms **unless Albumentations is installed**, in which case `augmentation_backend="auto"`/`"cpu"` (the default) auto-selects Albumentations instead — identical user code can therefore resolve to a different resize backend (and slightly different pixel values / mAP) purely based on whether `rfdetr[augment]` is installed. Pass `augmentation_backend="torchvision"` to pin torchvision regardless of what is installed. Non-empty custom `aug_config` dictionaries use the optional Albumentations integration and Kornia GPU backend, both via `pip install 'rfdetr[augment]'`. The `[train]` extra no longer installs Albumentations or Kornia. See the migration guide's "Upgrade 1.8 → 1.9" section for remediation steps. ([#1112](https://github.com/roboflow/rf-detr/pull/1112))
 
 ### Added
@@ -27,16 +29,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keypoint L1-loss helper (`compute_l1_keypoint_loss`) now returns **graph-connected** zeros on its out-of-schema class-index guard instead of detached `new_zeros`. A detached zero left the keypoint-head parameters without a gradient path on that batch, which desyncs `DistributedDataParallel`'s gradient reducer across ranks (hang or "parameter did not receive grad") when the guard fires on some ranks but not others. This is a prerequisite for the multi-GPU keypoint training above.
 - Non-square Albumentations training resize (`aug_config` set, `augmentation_backend` resolving to `"albumentations"`) no longer silently inflates every image's longest side to `max_size` (1333 by default). `SmallestMaxSize` → `LongestMaxSize` always forces an exact resize in Albumentations, not a conditional cap; a new `CappedLongestMaxSize` internal transform only shrinks, never upscales, matching torchvision's `RandomResize` semantics.
 - Explicit `augmentation_backend="albumentations"` now raises a clear `ImportError` immediately if Albumentations is not installed, instead of resolving successfully and failing later, deep in dataset construction.
+- `RFDETR.from_checkpoint(..., trust_checkpoint=True)` now actually works. It previously bypassed the safe-load check only for the checkpoint's own metadata read; model construction then silently reloaded the same file through `load_pretrain_weights()` with the unsafe-load default, so `trust_checkpoint=True` had no effect on checkpoints that genuinely needed it and raised the same `RuntimeError` it was supposed to bypass. ([#1239](https://github.com/roboflow/rf-detr/pull/1239))
 - Segmentation evaluation resized ground-truth masks to each image's original resolution before comparison, a lossy round trip vs. the mask head's native grid; GT masks now resize directly to each prediction's own pixel grid, so segm mAP is computed on consistent pixel grids. ([#1241](https://github.com/roboflow/rf-detr/pull/1241))
-- `pip install 'rfdetr[onnx]'` (and `[tflite]`) no longer hangs building `onnxsim` from source on CPython 3.11/3.13 and Linux aarch64. The previous `onnxsim<0.6.0` pin resolved to 0.5.0, which ships no wheels for those targets, so pip compiled onnxsim's bundled onnxruntime/onnx from source. The constraint is now `onnxsim>=0.7.0`, which publishes prebuilt wheels across CPython 3.10–3.13 on Linux x86_64/aarch64, Windows x86_64, and macOS arm64. ([#749](https://github.com/roboflow/rf-detr/pull/749))
+- `pip install 'rfdetr[onnx]'` (and `[tflite]`) no longer hangs building `onnxsim` from source on CPython 3.11/3.13 and Linux aarch64. The previous `onnxsim<0.6.0` pin resolved to 0.5.0, which ships no wheels for those targets, so pip compiled onnxsim's bundled onnxruntime/onnx from source. The constraint is now `onnxsim>=0.7.0`, which publishes prebuilt wheels across CPython 3.10–3.13 on Linux x86_64/aarch64, Windows x86_64, and macOS arm64. ([#1242](https://github.com/roboflow/rf-detr/pull/1242))
 
 ### Deprecated
 
 - `RFDETR.optimize_for_inference()` renamed to `RFDETR.inference()` (same signature). The old name is kept as a deprecated alias that forwards to `inference()` and emits a `FutureWarning`. Deprecated since v1.9.0, will be removed in v1.11.0.
 
+### Changed
+
+- Matched-pair IoU targets in the classification/matching losses now compute via `elementwise_box_iou`/`elementwise_generalized_box_iou` (new public helpers in `rfdetr.utilities.box_ops`) instead of `torch.diag(box_iou(...))`. The old path built the full NxN pairwise IoU matrix just to read its diagonal; the new one computes only the N matched pairs directly, reducing peak GPU memory during loss calculation. Both new helpers raise `ValueError` on mismatched-length inputs instead of silently broadcasting. ([#1245](https://github.com/roboflow/rf-detr/pull/1245))
+- The `[tensorrt]` extra no longer installs `pycuda`. It's only needed for `TRTInference`'s async benchmarking mode, which now requires the separate `[tensorrt-bench]` extra (`pip install 'rfdetr[tensorrt-bench]'`) — the standard export→engine path (`polygraphy`, no `pycuda`) is unaffected. ([#1246](https://github.com/roboflow/rf-detr/pull/1246))
+
+### Security
+
+- `RFDETR.from_checkpoint()` now uses safe deserialization by default (`weights_only=True`) instead of always running full pickle deserialization. Checkpoints containing custom Python objects beyond `argparse.Namespace` or `types.SimpleNamespace` need the new keyword-only `trust_checkpoint: bool = False` parameter set to `True` to opt into the old (unsafe) behavior; resume-from-checkpoint during training honors the same `trust_checkpoint` flag. ([#1179](https://github.com/roboflow/rf-detr/pull/1179))
+- TensorRT export no longer shells out to the `trtexec` CLI — engines are built in-process through the `polygraphy` Python API, removing the subprocess/shell-injection surface entirely. ([#853](https://github.com/roboflow/rf-detr/pull/853))
+
 ### Removed
 
-- `[kornia]` extra renamed to `[augment]`. A deprecated `[kornia]` alias extra (`pip install 'rfdetr[kornia]'` → installs `rfdetr[augment]`) is kept for one release for backward compatibility.
+- `[kornia]` extra removed — GPU-side augmentation now installs via `[augment]` (`pip install 'rfdetr[augment]'`) instead. There is no `[kornia]` alias extra; `pip install 'rfdetr[kornia]'` will fail.
 - `rfdetr.util.*` and `rfdetr.deploy` import paths, deprecated since v1.6.0 with `remove_in="1.9.0"`. Use `rfdetr.utilities.*`, `rfdetr.assets.coco_classes`, `rfdetr.training.drop_schedule`, `rfdetr.training.param_groups`, `rfdetr.visualize.data`, `rfdetr.models.heads.segmentation`, and `rfdetr.export` instead.
 - `rfdetr._namespace.build_namespace(model_config, train_config)`, deprecated since v1.7.0 with `remove_in="1.9.0"`. Use `rfdetr.models.build_model_from_config` and `build_criterion_from_config` instead.
 - The `train_config` argument to `load_pretrain_weights(nn_model, model_config, train_config)`, deprecated since v1.7.0 with `remove_in="1.9.0"`. Call it with just `(nn_model, model_config)`.
@@ -50,14 +63,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `trust_checkpoint: bool = False` keyword-only parameter on `RFDETR.from_checkpoint()` to opt into full pickle deserialization for trusted checkpoint files.
 - `optimize_for_inference(inplace=True)` — new keyword-only argument on `RFDETR.optimize_for_inference()`; skips the deep-copy of the base model for memory-constrained inference-only deployments (~0.5× model-weight peak memory reduction). Requires `compile=False`. After inplace optimization, `export()` raises `RuntimeError` and `remove_optimized_model()` issues a `UserWarning` and returns cleanly instead of silently clearing state. New `RFDETR.is_optimized_inplace` property returns `True` after a successful inplace optimization. ([#1089](https://github.com/roboflow/rf-detr/pull/1089))
 - `CocoKeypointSchema.keypoint_flip_pairs` and `YoloKeypointSchema.keypoint_flip_pairs` fields — horizontal-flip swap pairs inferred automatically from keypoint names (left/right naming convention) for COCO schemas, and from `flip_idx` permutation for YOLO schemas. Auto-populated by `infer_coco_keypoint_schema` and `infer_yolo_keypoint_schema` respectively. ([#1164](https://github.com/roboflow/rf-detr/pull/1164))
 - `infer_coco_keypoint_schema` and `infer_yolo_keypoint_schema` re-exported from `rfdetr.datasets` (previously only accessible from `rfdetr.datasets._keypoint_schema`). ([#1164](https://github.com/roboflow/rf-detr/pull/1164))
 
 ### Changed
 
-- `RFDETR.from_checkpoint()` now uses safe deserialization by default (`weights_only=True`). Checkpoints containing custom Python objects beyond `argparse.Namespace` or `types.SimpleNamespace` must pass `trust_checkpoint=True`. Previously, full pickle deserialization was always used.
 - Horizontal flip detection in `AlbumentationsWrapper` now uses Albumentations `ReplayCompose` replay metadata instead of heuristic bbox-center mirroring; eliminates false positives on non-flip transforms that shift box centers. Falls back to `alb.Compose` with a `UserWarning` when `albumentations <1.3` is detected. ([#1164](https://github.com/roboflow/rf-detr/pull/1164))
 - Keypoint schema inference now supports native COCO format (`dataset_file="coco"`) in addition to `"roboflow"` and `"yolo"`. ([#1164](https://github.com/roboflow/rf-detr/pull/1164))
 - `_keypoint_schema_cache` key changed from `dataset_dir` (string) to `(dataset_file, dataset_dir)` tuple to prevent cross-format cache collisions when the same directory is used with different dataset formats. ([#1164](https://github.com/roboflow/rf-detr/pull/1164))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rfdetr"
-version = "1.8.3"
+version = "1.9.0"
 description = "RF-DETR"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
# v1.9.0: Configurable Training, ExecuTorch & CoreML Export, Multi-GPU Keypoints

## 📋 Summary

RF-DETR v1.9.0 makes training more configurable and deployment more portable. The training optimizer and LR scheduler are now pluggable (any `torch.optim` name, dotted import path, or callable), keypoint/pose models can train under multi-GPU and multi-node DDP, and models export to ExecuTorch (`.pte`) and native CoreML (`.mlpackage`) for on-device inference, alongside an improved TensorRT export path. Checkpoint loading is also hardened: `RFDETR.from_checkpoint()` now defaults to safe (`weights_only=True`) deserialization. The default augmentation backend changes in this release — see the migration guide before upgrading if you rely on the previous default.

## ✨ Spotlights / highlights

### ExecuTorch export

```python
model = RFDETRSmall()
model.export(format="executorch", backend="xnnpack")  # or "coreml", "qnn"
```

### Native CoreML export

```python
model = RFDETRSmall()
model.export(format="coreml", coreml_precision="float16")  # .mlpackage, no ONNX intermediary
```

### Multi-GPU / multi-node keypoint training

```python
RFDETRKeypointPreview().train(
    dataset_dir="...",
    strategy="ddp",
    devices=4,
    grad_accum_steps=1,
)
```

### Configurable optimizer & LR scheduler

```python
from rfdetr.config import TrainConfig

TrainConfig(
    optimizer="pytorch_optimizer.Lion",
    lr_scheduler="torch.optim.lr_scheduler.OneCycleLR",
    lr_scheduler_kwargs={"max_lr": 1e-3, "total_steps": 10_000},
)
```

### Safe checkpoint loading by default

```python
model.from_checkpoint("checkpoint.pth")  # now weights_only=True by default
model.from_checkpoint("legacy_checkpoint.pth", trust_checkpoint=True)  # opt-in for trusted files
```

## 🔄 Migration guide

### Breaking changes

**`albumentations` and `kornia` extras merged into `augment`**

| Old extra                                | New extra               |
| ---------------------------------------- | ----------------------- |
| `rfdetr[train]` (implied albumentations) | `rfdetr[train,augment]` |
| `rfdetr[kornia]`                         | `rfdetr[augment]`       |

There is no `[kornia]` compatibility alias — `pip install 'rfdetr[kornia]'` fails after upgrading.

**Default resize interpolation changed** — pixel values and mAP may shift. The default resize backend changed from Albumentations to torchvision. To restore the previous behaviour:

```bash
pip install 'rfdetr[augment]'
```

```python
from rfdetr.datasets.aug_configs import AUG_CONFIG
train_config = TrainConfig(aug_config=AUG_CONFIG, ...)
```

Installing `rfdetr[augment]` is not by itself sufficient to pin behaviour — pass `augmentation_backend="torchvision"` explicitly to pin it regardless of what's installed.

**Unrecognised `train()` kwargs now raise `ValueError`** — `TrainConfig` uses `extra="forbid"`; a typo'd kwarg that previously trained silently with defaults now raises immediately with a suggestion.

### Removed

Deprecated in earlier releases, removed as of v1.9:

- `rfdetr.util.*` and `rfdetr.deploy.*` import paths (deprecated since v1.6) → `rfdetr.utilities.*`, `rfdetr.assets.coco_classes`, `rfdetr.training.drop_schedule`, `rfdetr.training.param_groups`, `rfdetr.visualize.data`, `rfdetr.models.heads.segmentation`, `rfdetr.export`
- `build_namespace(model_config, train_config)` (deprecated since v1.7) → `build_model_from_config` / `build_criterion_from_config`
- `load_pretrain_weights(nn_model, model_config, train_config)`'s `train_config` argument (deprecated since v1.7) → call `(nn_model, model_config)`
- `start_epoch`, `do_benchmark`, `callbacks` kwargs on `.train()`/`.evaluate()` (deprecated since v1.7) → `resume=`, `rfdetr.export.benchmark`, PTL `Callback` objects respectively
- Misplaced config fields — `TrainConfig.{group_detr, ia_bce_loss, segmentation_head, num_select}` → `ModelConfig`; `ModelConfig.cls_loss_coef` → `TrainConfig` (deprecated since v1.7)
- `RFDETRLarge`'s silent fallback to `RFDETRLargeDeprecatedConfig` on checkpoint/config incompatibility — now raises the original error; use `RFDETRLargeDeprecated` directly for legacy Large weights

### Deprecated in v1.9 → Remove in v1.11

- `RFDETR.optimize_for_inference()` renamed to `RFDETR.inference()` (same signature) — old name kept as an alias, emits `FutureWarning`
- `TrainConfig.lr_drop` and `lr_min_factor` — pass through `lr_scheduler_kwargs` instead

Full details, including code before/after examples for every item above: `docs/getting-started/migration.md` → "Upgrade 1.8 → 1.9".

## 📝 Notable changes

### 🚀 Added

- **Native CoreML export** — `RFDETR.export(format="coreml")` produces a `.mlpackage` (mlprogram, iOS 16+) directly from `torch.export`, no ONNX intermediary; `coreml_precision="float32"|"float16"` controls compute precision. Install with `pip install 'rfdetr[coreml]'` (macOS only, `coremltools>=8.0,<10.0`). Distinct from ExecuTorch's `format="executorch", backend="coreml"` `.pte` path. (#1235, #1244)
- **ExecuTorch (`.pte`) export** — `RFDETR.export(format="executorch")` for XNNPACK CPU, Core ML, and experimental Qualcomm QNN backends; static-shape deformable-attention export, fail-fast validation for unsupported dynamic batching. (#1142, #1231, #1237)
- **TensorRT export improvements** — `RFDETR.export(format="tensorrt")` (alias `"trt"`) builds `.trt` engines in-process; configurable `fp16: bool = True` precision with automatic FP32 fallback. (#853, #1231)
- **`RFDETR.evaluate(*, split="test"|"val", **kwargs)`** — runs COCO evaluation (mAP, mAR, macro-F1, per-class AP) on the in-memory model without a checkpoint reload. (#1134)
- **Multi-GPU / multi-node keypoint (pose) training under DDP** — keypoint models train with `strategy="ddp"`/`"auto"`, `devices>1`, `num_nodes>1`. Sharded strategies (FSDP/DeepSpeed) remain unsupported and now fail with a clear error. (#1232)
- **Configurable training optimizer** — `TrainConfig.optimizer: str | Callable = "adamw"` plus `optimizer_kwargs`. (#1006)
- **Configurable LR schedulers** — `TrainConfig.lr_scheduler: str | Callable = "step"` plus `lr_scheduler_kwargs`, `lr_scheduler_interval`, `lr_scheduler_monitor`; end-to-end `ReduceLROnPlateau` support. (#1217)
- **`TrainConfig.scale_jitter: bool = True`** — independent control of the resize→crop→resize training branch, decoupled from `aug_config`. (#1037)
- **Torchvision-native augmentation backend + selectable backends** — `AugmentationBackend.TV`/`.ALBU`/`.KORNIA`; `augmentation_backend="torchvision"` always pins torchvision. (#1112)
- **Mask-aware dataset grids** — instance-segmentation label validation renders masks in `save_grids`. (#1014)
- **`TrainConfig.eval_ema_only: bool = False`** — opt-in EMA-only evaluation. (#1225)

### ⚠️ Breaking Changes

- **Augmentation backend default** — training/validation/export now resolve to torchvision-native transforms unless Albumentations is installed; `[train]` no longer bundles Albumentations/Kornia. See migration guide. (#1112)
- **Unrecognised `train()`/`evaluate()` kwargs now raise `ValueError`** instead of silently training with defaults. (#1178)

### 🌱 Changed

- Always save EMA-named checkpoints (`checkpoint_best_ema.pth`, `last_ema.pth`) when `monitor_ema` is set; `checkpoint_best_total.pth` records provenance. (#1216)
- Epoch-level train loss shown in the training progress bar. (#1211)
- Improved training performance — foreach EMA update, gated validation loop, TF32 enabled. (#1226)
- Improved evaluation performance — removed per-iteration GPU sync in matching. (#1225)
- Matched-pair IoU targets in the loss computation now use new O(N) `elementwise_box_iou`/`elementwise_generalized_box_iou` helpers instead of building the full NxN pairwise matrix and reading its diagonal, reducing peak GPU memory during loss calculation. (#1245)
- `[tensorrt]` no longer installs `pycuda` — it's only needed for `TRTInference`'s async benchmarking mode, now under the separate `[tensorrt-bench]` extra. The standard export→engine path is unaffected. (#1246)

### 🗑️ Deprecated

- `RFDETR.optimize_for_inference()` → `RFDETR.inference()` (same signature). (#1212)
- `TrainConfig.lr_drop` / `lr_min_factor` → `lr_scheduler_kwargs`. (#1217)

### ❌ Removed

- `rfdetr.util.*`, `rfdetr.deploy`, `build_namespace()`, `load_pretrain_weights()`'s `train_config` arg, `start_epoch`/`do_benchmark`/`callbacks` train() kwargs, misplaced `TrainConfig`/`ModelConfig` fields, `RFDETRLarge`'s silent legacy-config fallback — all deprecated since v1.6/v1.7, removed as scheduled. (#1218)
- `[kornia]` pip extra — folded into `[augment]`, no compatibility alias. (#1142, #1112)

### 🔧 Fixed

- First `predict()`/`inference()` call no longer silently breaks subsequent `backward()` gradients. (#1178)
- Optimized keypoint models correctly return `sv.KeyPoints`. (#1210)
- `predict()` resize antialias disabled to match training/val preprocessing. (#1206)
- ONNX export at non-native resolution no longer crashes. (#1207)
- Keypoint DDP training no longer hangs on the out-of-schema loss guard (graph-connected zeros instead of detached). (#1232)
- `window_block_indexes` override now correctly forwarded to DINOv2. (#1224)
- Non-square Albumentations training resize no longer inflates every image to `max_size`. (#1112, #1183)
- **`RFDETR.from_checkpoint(..., trust_checkpoint=True)` now actually works** — it previously bypassed the safe-load check only for the checkpoint's metadata read; model construction silently reloaded the same file without the caller's trust setting and raised anyway. (#1239)
- Segmentation evaluation now resizes ground-truth masks directly to each prediction's own pixel grid instead of each image's original resolution, removing a lossy round trip vs. the mask head's native grid — segm mAP is computed on consistent pixel grids. (#1241)
- `pip install 'rfdetr[onnx]'` (and `[tflite]`) no longer hangs building `onnxsim` from source on CPython 3.11/3.13 and Linux aarch64 — the `onnxsim<0.6.0` pin resolved to a version with no prebuilt wheels for those targets; now `onnxsim>=0.7.0`. (#1242)

### 🔒 Security

- Safe checkpoint loading by default — `RFDETR.from_checkpoint()` uses `weights_only=True`; opt into full pickle deserialization via `trust_checkpoint=True` for trusted/legacy files. (#1179)
- TensorRT export no longer shells out to `trtexec` — engines build in-process via the `polygraphy` Python API, removing the subprocess/shell-injection surface entirely. (#853)

---

## 🏆 Contributors

- **Anatoly Ryabchenko** (@anatoly-ryabchenko, [LinkedIn](https://www.linkedin.com/in/anatoly-ryabchenko/)) — ExecuTorch (.pte) export; `RFDETR.evaluate()` in-memory COCO eval
- **Robin Cole** (@robmarkcole, [LinkedIn](https://www.linkedin.com/in/robmarkcole/)) — dataset augmentation refactor onto torchvision-native transforms with a selectable Albumentations/Kornia backend
- **Michael Mohamed** (@michaelmohamed) — multi-GPU/multi-node DDP keypoint (pose) training
- **M. Fazri Nizar** (@mfazrinizar, [LinkedIn](https://www.linkedin.com/in/mfazrinizar)) — third-party training optimizer support; epoch-level train loss in the progress bar
- **Stefan Schneider** (@hinogi) — strict-mypy typing cleanup across export, models, evaluation, platform, and utilities
- **Jonas Pirner** (@pirnerjonas) — mask-aware dataset grids for instance-segmentation label validation
- **Omkar Kabde** (@omkar-334, [LinkedIn](https://www.linkedin.com/in/omkar-kabde/)) — decoupled the resize scale-jitter branch from `aug_config` via the new `scale_jitter` flag
- **Brian Cong** (@congbrian, [LinkedIn](https://www.linkedin.com/in/brian-cong-babb042a0/)) — native CoreML export; typed `drop_schedule`/`models.math`; fixed the ExecuTorch export level-dim shape mismatch
- **Ömer Günaydın** (@siromermer, [LinkedIn](https://www.linkedin.com/in/%C3%B6mer-g%C3%BCnayd%C4%B1n-17811b216)) — fixed YOLO split-directory resolution to honor `data.yaml` paths
- **Deependu** (@deependujha) — fixed a spurious `pyDeprecate` CLI warning
- **Peter Robicheaux** (@probicheaux, [LinkedIn](https://www.linkedin.com/in/peter-robicheaux-01958813b/)) — docs: NAS platform availability note, citation author correction
- **Matvei Popov** (@Matvezy, [LinkedIn](https://www.linkedin.com/in/matvezy)) — platform-vs-paper NAS comparison chart in the README
- **ARDA7787** (@ARDA7787) — fixed a resource leak by closing the HTTP response with a context manager in `_download_file`
- **Erik** (@Erol444, [LinkedIn](https://linkedin.com/in/erik-kokalj)) — GA4 tracking on the docs site
- **Sergii Bondariev** (@sergii-bond, [LinkedIn](https://www.linkedin.com/in/sergiibondariev/)) — reduced peak GPU memory in the loss computation's box-IoU matching
- **Takeshi Watanabe** (@take-cheeze) — fixed the `[onnx]`/`[tflite]` install hang caused by a stale `onnxsim` pin
- **Jirka Borovec** (@Borda, [LinkedIn](https://linkedin.com/in/jirka-borovec)) — safe checkpoint loading by default, TensorRT export rewrite onto in-process polygraphy (no more `trtexec` subprocess), configurable LR schedulers, always-saved EMA checkpoints, removed the 1.9.0-scheduled deprecated APIs, TensorRT fp16 export, segmentation-eval mask-resize fix

---

**Full changelog**: https://github.com/roboflow/rf-detr/compare/1.8.3...1.9.0