### PR TITLE
docs(cookbooks): add native CoreML export notebook

### DIFF
--- a/docs/cookbooks/NOTES.md
+++ b/docs/cookbooks/NOTES.md
@@ -41,6 +41,8 @@ If jupytext is not installed: `pip install jupytext` (or `uv add jupytext --dev`
 Available labels (reuse these to keep tags standardised): `TRAINING`, `AUGMENTATION`, `EXPORT`, `TFLITE`, `PYTORCH LIGHTNING`, `INFERENCE`, `SEGMENTATION`, `DEPLOY`.
 Current tag colours are assigned dynamically by the docs UI, so they may change if cards or labels are added or reordered.
 
+Write markdown cells in plain, notebook-portable Markdown only — no MkDocs Material syntax (`!!! note`, `=== "Tab"`, admonition blocks). `mkdocs-jupyter` renders the site copy through the same plain renderer as a raw `.ipynb`, so MkDocs-only syntax shows up as literal text (e.g. `!!! warning "..."`) instead of a styled callout. Use a blockquote (`> **Note:** ...`) for callouts instead.
+
 ## Removing a notebook
 
 1. Delete the `.ipynb` file.
@@ -52,8 +54,9 @@ Current tag colours are assigned dynamically by the docs UI, so they may change 
 | ----------------------------------- | ----------------------------------------------- | ------- |
 | `custom-augmentations.ipynb`        | Custom Augmentations and Live Training Progress | v1.5.0  |
 | `custom-optimizer-scheduler.ipynb`  | Custom Optimizer and LR Scheduler               | v1.9.0  |
-| `export-tensorrt.ipynb`             | Export to TensorRT & Run Inference              | v1.8.3  |
-| `export-executorch.ipynb`           | Export to ExecuTorch & Run Inference            | v1.8.3  |
+| `export-coreml.ipynb`               | Export to Native CoreML & Run Inference         | v1.9.0  |
+| `export-tensorrt.ipynb`             | Export to TensorRT & Run Inference              | v1.9.0  |
+| `export-executorch.ipynb`           | Export to ExecuTorch & Run Inference            | v1.9.0  |
 | `fine-tune_detection.ipynb`         | Fine-Tune RF-DETR Object Detection              | v1.8.0  |
 | `fine-tune_keypoints.ipynb`         | Fine-Tune RF-DETR Keypoint Detection            | v1.8.0  |
 | `fine-tune_segmentation.ipynb`      | Fine-Tune RF-DETR Instance Segmentation         | v1.8.2  |

--- a/docs/cookbooks/NOTES.md
+++ b/docs/cookbooks/NOTES.md
@@ -41,7 +41,7 @@ If jupytext is not installed: `pip install jupytext` (or `uv add jupytext --dev`
 Available labels (reuse these to keep tags standardised): `TRAINING`, `AUGMENTATION`, `EXPORT`, `TFLITE`, `PYTORCH LIGHTNING`, `INFERENCE`, `SEGMENTATION`, `DEPLOY`.
 Current tag colours are assigned dynamically by the docs UI, so they may change if cards or labels are added or reordered.
 
-Write markdown cells in plain, notebook-portable Markdown only — no MkDocs Material syntax (`!!! note`, `=== "Tab"`, admonition blocks). `mkdocs-jupyter` renders the site copy through the same plain renderer as a raw `.ipynb`, so MkDocs-only syntax shows up as literal text (e.g. `!!! warning "..."`) instead of a styled callout. Use a blockquote (`> **Note:** ...`) for callouts instead.
+For newly added or updated notebooks, write markdown cells in plain, notebook-portable Markdown only — no MkDocs Material syntax (`!!! note`, `=== "Tab"`, admonition blocks). `mkdocs-jupyter` renders the site copy through the same plain renderer as a raw `.ipynb`, so MkDocs-only syntax shows up as literal text (e.g. `!!! warning "..."`) instead of a styled callout. Use a blockquote (`> **Note:** ...`) for callouts instead.
 
 ## Removing a notebook
 

--- a/docs/cookbooks/cards.yaml
+++ b/docs/cookbooks/cards.yaml
@@ -1,14 +1,20 @@
 cards:
+  - href: export-coreml/
+    name: "Export to Native CoreML & Run Inference"
+    labels: [EXPORT, INFERENCE, DEPLOY]
+    version: v1.9.0
+    author: Borda
+    description: "Export RF-DETR directly to a native CoreML .mlpackage (no ONNX, no ExecuTorch) and run it with coremltools — the lowest-friction path for Xcode / Apple-platform deployment."
   - href: export-tensorrt/
     name: "Export to TensorRT & Run Inference"
     labels: [EXPORT, INFERENCE, DEPLOY]
-    version: v1.8.3
+    version: v1.9.0
     author: Borda
     description: "Export RF-DETR to a TensorRT FP16 engine and run inference on it directly — low-latency NVIDIA GPU deployment with supervision-annotated detections."
   - href: export-executorch/
     name: "Export to ExecuTorch & Run Inference"
     labels: [EXPORT, INFERENCE, DEPLOY]
-    version: v1.8.3
+    version: v1.9.0
     author: Borda
     description: "Export RF-DETR to a portable ExecuTorch .pte program (XNNPACK / CoreML / QNN backends) and run it on the CPU — on-device mobile and edge deployment with supervision-annotated detections."
   - href: fine-tune_detection/

--- a/docs/cookbooks/export-coreml.ipynb
+++ b/docs/cookbooks/export-coreml.ipynb
@@ -1,0 +1,262 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e3ce9e88",
+   "metadata": {},
+   "source": [
+    "# RF-DETR → Native CoreML Export & Inference\n",
+    "\n",
+    "Export an RF-DETR detector directly to a native **CoreML `.mlpackage`** you can drag straight into Xcode —\n",
+    "no ONNX intermediary and no ExecuTorch runtime involved.\n",
+    "\n",
+    "> **Not the same as the ExecuTorch CoreML backend.** `format=\"coreml\"` (this notebook) exports via\n",
+    "> `torch.export` + `coremltools` straight to a native `.mlpackage`. `format=\"executorch\", backend=\"coreml\"`\n",
+    "> is a different path — it produces a `.pte` file for the ExecuTorch runtime instead. See the\n",
+    "> [ExecuTorch cookbook](export-executorch/) for that path.\n",
+    "\n",
+    "> **macOS only.** Running (not just building) a CoreML model requires the Core ML runtime, which only\n",
+    "> exists on macOS / iOS. This notebook must run on a **local macOS machine** — it will not work on Colab\n",
+    "> or any Linux runner."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac905f11",
+   "metadata": {},
+   "source": [
+    "## 1. Install\n",
+    "\n",
+    "The `[coreml]` extra provides `coremltools`, the exporter's only dependency beyond `torch`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aa06fb0d",
+   "metadata": {
+    "title": "[bash]"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install -q \"rfdetr[coreml]>=1.9.0\" supervision"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f47977e",
+   "metadata": {},
+   "source": [
+    "## 2. Setup\n",
+    "\n",
+    "CoreML export itself runs on CPU — no GPU is needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf61c100",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "from rfdetr import RFDETRSmall\n",
+    "\n",
+    "EXPORT_DIR = Path(\"export_coreml\")\n",
+    "EXPORT_DIR.mkdir(exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c205fee5",
+   "metadata": {},
+   "source": [
+    "## 3. Export to a `.mlpackage`\n",
+    "\n",
+    "The COCO-pretrained `RFDETRSmall` is exported directly — pass `pretrain_weights=\"<path/to/checkpoint.pth>\"`\n",
+    "to export a fine-tuned model instead.\n",
+    "\n",
+    "The file is named after the model variant (`rfdetr-small.mlpackage`). `dynamic_batch=True` is not\n",
+    "supported — fixed shapes are required for reliable ANE / GPU scheduling, so export one `.mlpackage` per\n",
+    "batch size.\n",
+    "\n",
+    "Export defaults to `coreml_precision=\"float32\"` for tight CPU parity with eager PyTorch. Pass\n",
+    "`coreml_precision=\"float16\"` instead for a smaller, ANE-oriented bundle (expect larger numeric drift)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dafc5276",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = RFDETRSmall()\n",
+    "\n",
+    "mlpackage_path = model.export(format=\"coreml\", output_dir=str(EXPORT_DIR))\n",
+    "print(f\"CoreML package: {mlpackage_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96ffef9c",
+   "metadata": {},
+   "source": [
+    "## 4. Sample image\n",
+    "\n",
+    "A single street scene with several COCO classes (dog, person, backpack, car) is enough to verify\n",
+    "detections. The image is downloaded once and reused."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38ded628",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import urllib.request\n",
+    "\n",
+    "from PIL import Image\n",
+    "\n",
+    "IMAGE_URL = \"https://media.roboflow.com/notebooks/examples/dog.jpeg\"\n",
+    "IMAGE_PATH = EXPORT_DIR / \"sample.jpg\"\n",
+    "if not IMAGE_PATH.exists():\n",
+    "    urllib.request.urlretrieve(IMAGE_URL, IMAGE_PATH)\n",
+    "\n",
+    "image = Image.open(IMAGE_PATH).convert(\"RGB\")\n",
+    "print(f\"Sample image: {image.size[0]}×{image.size[1]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72f3b56b",
+   "metadata": {},
+   "source": [
+    "## 5. Run the `.mlpackage` with `coremltools`\n",
+    "\n",
+    "`coremltools` infers its own input/output names for the `.mlpackage` spec — they are **not** renamed to\n",
+    "`input` / `dets` / `labels`. Read the input name and output order from `mlmodel.get_spec().description`\n",
+    "instead of hardcoding them, then match outputs **by position** in the same order as the ONNX\n",
+    "`output_names` contract (`dets, labels` for detection; `dets, labels, masks` for segmentation).\n",
+    "\n",
+    "Preprocessing is the same NCHW, ImageNet-normalized pipeline the ONNX and ExecuTorch exports expect —\n",
+    "`infer_transforms` builds it directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05b46c36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import coremltools as ct\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "\n",
+    "from rfdetr.export.benchmark import infer_transforms, post_process\n",
+    "\n",
+    "CONFIDENCE_THRESHOLD = 0.5\n",
+    "\n",
+    "resolution = model.model_config.resolution\n",
+    "image_tensor, _ = infer_transforms((resolution, resolution))(image, None)\n",
+    "pixel_values = image_tensor[None].numpy()\n",
+    "\n",
+    "mlmodel = ct.models.MLModel(str(mlpackage_path))\n",
+    "spec = mlmodel.get_spec()\n",
+    "input_name = spec.description.input[0].name\n",
+    "output_names = [o.name for o in spec.description.output]\n",
+    "\n",
+    "prediction = mlmodel.predict({input_name: pixel_values})\n",
+    "dets, labels = (torch.from_numpy(np.asarray(prediction[name], dtype=np.float32)) for name in output_names[:2])\n",
+    "\n",
+    "target_sizes = torch.tensor([[image.height, image.width]])\n",
+    "result = post_process({\"dets\": dets, \"labels\": labels}, target_sizes)[0]\n",
+    "print(f\"Top score: {result['scores'][0]:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8265e69",
+   "metadata": {},
+   "source": [
+    "## 6. Visualize with supervision\n",
+    "\n",
+    "`post_process` returns boxes in absolute `xyxy` pixel coordinates along with scores and COCO class ids.\n",
+    "Filter by confidence, wrap the result in a `supervision.Detections`, and annotate the original image.\n",
+    "\n",
+    "Annotate the **PIL image** rather than `np.array(image)`. supervision's annotators accept either, but a\n",
+    "numpy scene is assumed to be OpenCV-style BGR — handing them an RGB array swaps the red and blue channels\n",
+    "of the annotations, and `sv.plot_image` then swaps the photo itself. Passing PIL lets supervision convert\n",
+    "in both directions and keeps the colours right."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35702116",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import supervision as sv\n",
+    "\n",
+    "from rfdetr.assets.coco_classes import COCO_CLASSES\n",
+    "\n",
+    "keep = result[\"scores\"] > CONFIDENCE_THRESHOLD\n",
+    "detections = sv.Detections(\n",
+    "    xyxy=result[\"boxes\"][keep].numpy(),\n",
+    "    confidence=result[\"scores\"][keep].numpy(),\n",
+    "    class_id=result[\"labels\"][keep].numpy().astype(int),\n",
+    ")\n",
+    "print(f\"Kept {len(detections)} detections above {CONFIDENCE_THRESHOLD}\")\n",
+    "\n",
+    "names = [COCO_CLASSES.get(int(c), str(c)) for c in detections.class_id]\n",
+    "annotation_labels = [f\"{name} {conf:.2f}\" for name, conf in zip(names, detections.confidence)]\n",
+    "print(f\"Detections: {annotation_labels}\")\n",
+    "\n",
+    "annotated = sv.BoxAnnotator(thickness=3).annotate(scene=image.copy(), detections=detections)\n",
+    "annotated = sv.LabelAnnotator(text_scale=0.6, text_thickness=1, text_padding=4).annotate(\n",
+    "    scene=annotated, detections=detections, labels=annotation_labels\n",
+    ")\n",
+    "\n",
+    "OUTPUT_PATH = EXPORT_DIR / \"annotated_coreml.jpg\"\n",
+    "annotated.save(OUTPUT_PATH)\n",
+    "print(f\"Saved annotated image: {OUTPUT_PATH}\")\n",
+    "sv.plot_image(annotated)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb085a15",
+   "metadata": {},
+   "source": [
+    "## Next steps\n",
+    "\n",
+    "- **Deploy in Xcode** — drag `rfdetr-small.mlpackage` into your Xcode project and load it with the\n",
+    "  `Vision` or `CoreML` framework for on-device iOS / macOS inference.\n",
+    "- **Fine-tuned weights** — pass `pretrain_weights=\"<path/to/checkpoint.pth>\"` when constructing the model.\n",
+    "- **Smaller bundle** — pass `coreml_precision=\"float16\"` to `export()` for an ANE-oriented build (expect\n",
+    "  larger numeric drift from the fp32 PyTorch baseline).\n",
+    "- **On-device via ExecuTorch instead** — see the [ExecuTorch cookbook](export-executorch/) for the\n",
+    "  `format=\"executorch\", backend=\"coreml\"` path, which produces a `.pte` for the ExecuTorch runtime rather\n",
+    "  than a native `.mlpackage`.\n",
+    "- See the [Export documentation](https://rfdetr.roboflow.com/learn/export/) for all formats and options."
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "title,-all",
+   "main_language": "python",
+   "notebook_metadata_filter": "-all",
+   "text_representation": {
+    "extension": ".py",
+    "format_name": "percent"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/cookbooks/export-coreml.ipynb
+++ b/docs/cookbooks/export-coreml.ipynb
@@ -13,7 +13,7 @@
     "> **Not the same as the ExecuTorch CoreML backend.** `format=\"coreml\"` (this notebook) exports via\n",
     "> `torch.export` + `coremltools` straight to a native `.mlpackage`. `format=\"executorch\", backend=\"coreml\"`\n",
     "> is a different path — it produces a `.pte` file for the ExecuTorch runtime instead. See the\n",
-    "> [ExecuTorch cookbook](export-executorch/) for that path.\n",
+    "> [ExecuTorch cookbook](../export-executorch/) for that path.\n",
     "\n",
     "> **macOS only.** Running (not just building) a CoreML model requires the Core ML runtime, which only\n",
     "> exists on macOS / iOS. This notebook must run on a **local macOS machine** — it will not work on Colab\n",
@@ -81,7 +81,7 @@
     "supported — fixed shapes are required for reliable ANE / GPU scheduling, so export one `.mlpackage` per\n",
     "batch size.\n",
     "\n",
-    "Export defaults to `coreml_precision=\"float32\"` for tight CPU parity with eager PyTorch. Pass\n",
+    "Export leaves `coreml_precision` at its default `None`, which selects FP32 for tight CPU parity with eager PyTorch. Pass\n",
     "`coreml_precision=\"float16\"` instead for a smaller, ANE-oriented bundle (expect larger numeric drift)."
    ]
   },
@@ -239,7 +239,7 @@
     "- **Fine-tuned weights** — pass `pretrain_weights=\"<path/to/checkpoint.pth>\"` when constructing the model.\n",
     "- **Smaller bundle** — pass `coreml_precision=\"float16\"` to `export()` for an ANE-oriented build (expect\n",
     "  larger numeric drift from the fp32 PyTorch baseline).\n",
-    "- **On-device via ExecuTorch instead** — see the [ExecuTorch cookbook](export-executorch/) for the\n",
+    "- **On-device via ExecuTorch instead** — see the [ExecuTorch cookbook](../export-executorch/) for the\n",
     "  `format=\"executorch\", backend=\"coreml\"` path, which produces a `.pte` for the ExecuTorch runtime rather\n",
     "  than a native `.mlpackage`.\n",
     "- See the [Export documentation](https://rfdetr.roboflow.com/learn/export/) for all formats and options."


### PR DESCRIPTION
This pull request adds a new end-to-end export and inference guide for CoreML, updates the documentation to include the new CoreML export path, and standardizes versioning for related deployment cookbooks. The most important changes are outlined below.

---

**New CoreML Export Support**

* Added a new notebook, `export-coreml.ipynb`, demonstrating how to export RF-DETR models directly to a native CoreML `.mlpackage` and run inference with `coremltools` on macOS. The guide covers installation, export, inference, and visualization, and clarifies the difference between native CoreML export and ExecuTorch's CoreML backend.

**Documentation Updates**

* Added an entry for the new CoreML export notebook to `cards.yaml`, including a description, labels, author, and version. Updated the version numbers for the TensorRT and ExecuTorch export cookbooks to v1.9.0 for consistency.
* Updated the table of available cookbooks in `NOTES.md` to include the new CoreML export notebook and reflect the new versions for TensorRT and ExecuTorch export guides.

**Authoring Guidelines**

* Added a note to `NOTES.md` instructing authors to use plain, notebook-portable Markdown (not MkDocs Material syntax) in markdown cells, to ensure compatibility with `mkdocs-jupyter` rendering.