### PR TITLE
Optimize GPU memory usage for box iou during loss calculation

### DIFF
--- a/src/rfdetr/models/criterion.py
+++ b/src/rfdetr/models/criterion.py
@@ -302,11 +302,9 @@ class SetCriterion(nn.Module):
             src_boxes = outputs["pred_boxes"][idx]
             target_boxes = torch.cat([t["boxes"][i] for t, (_, i) in zip(targets, indices)], dim=0)
 
-            iou_targets = torch.diag(
-                box_ops.box_iou(
-                    box_ops.box_cxcywh_to_xyxy(src_boxes.detach()),
-                    box_ops.box_cxcywh_to_xyxy(target_boxes),
-                )[0]
+            iou_targets, _ = box_ops.elementwise_box_iou(
+                box_ops.box_cxcywh_to_xyxy(src_boxes.detach()),
+                box_ops.box_cxcywh_to_xyxy(target_boxes),
             )
             pos_ious = iou_targets.clone().detach()
             prob = src_logits.sigmoid()
@@ -331,11 +329,9 @@ class SetCriterion(nn.Module):
             src_boxes = outputs["pred_boxes"][idx]
             target_boxes = torch.cat([t["boxes"][i] for t, (_, i) in zip(targets, indices)], dim=0)
 
-            iou_targets = torch.diag(
-                box_ops.box_iou(
-                    box_ops.box_cxcywh_to_xyxy(src_boxes.detach()),
-                    box_ops.box_cxcywh_to_xyxy(target_boxes),
-                )[0]
+            iou_targets, _ = box_ops.elementwise_box_iou(
+                box_ops.box_cxcywh_to_xyxy(src_boxes.detach()),
+                box_ops.box_cxcywh_to_xyxy(target_boxes),
             )
             pos_ious = iou_targets.clone().detach()
             # pos_ious_func = pos_ious ** 2
@@ -369,11 +365,9 @@ class SetCriterion(nn.Module):
             src_boxes = outputs["pred_boxes"][idx]
             target_boxes = torch.cat([t["boxes"][i] for t, (_, i) in zip(targets, indices)], dim=0)
 
-            iou_targets = torch.diag(
-                box_ops.box_iou(
-                    box_ops.box_cxcywh_to_xyxy(src_boxes.detach()),
-                    box_ops.box_cxcywh_to_xyxy(target_boxes),
-                )[0]
+            iou_targets, _ = box_ops.elementwise_box_iou(
+                box_ops.box_cxcywh_to_xyxy(src_boxes.detach()),
+                box_ops.box_cxcywh_to_xyxy(target_boxes),
             )
             pos_ious = iou_targets.clone().detach()
 
@@ -473,11 +467,9 @@ class SetCriterion(nn.Module):
         losses = {}
         losses["loss_bbox"] = loss_bbox.sum() / num_boxes
 
-        loss_giou = 1 - torch.diag(
-            box_ops.generalized_box_iou(
-                box_ops.box_cxcywh_to_xyxy(src_boxes),
-                box_ops.box_cxcywh_to_xyxy(target_boxes),
-            )
+        loss_giou = 1 - box_ops.elementwise_generalized_box_iou(
+            box_ops.box_cxcywh_to_xyxy(src_boxes),
+            box_ops.box_cxcywh_to_xyxy(target_boxes),
         )
         losses["loss_giou"] = loss_giou.sum() / num_boxes
         return losses

--- a/src/rfdetr/utilities/box_ops.py
+++ b/src/rfdetr/utilities/box_ops.py
@@ -69,6 +69,59 @@ def box_iou(boxes1: Tensor, boxes2: Tensor) -> tuple[Tensor, Tensor]:
     return iou, union
 
 
+def elementwise_box_iou(boxes1: Tensor, boxes2: Tensor) -> tuple[Tensor, Tensor]:
+    """Compute IoU and union for pre-matched box pairs.
+
+    Unlike ``box_iou``, this avoids materializing the full NxN pairwise matrix
+    (of which only the diagonal is used for matched pairs), so peak memory is
+    O(N) instead of O(N^2). ``boxes1`` and ``boxes2`` must have the same length
+    and be in [x0, y0, x1, y1] format.
+
+    Returns:
+        iou: the [N] tensor of IoU values for each matched pair.
+        union: the [N] tensor of union areas for each matched pair.
+    """
+    area1 = box_area(boxes1)
+    area2 = box_area(boxes2)
+
+    lt = torch.max(boxes1[:, :2], boxes2[:, :2])  # [N,2]
+    rb = torch.min(boxes1[:, 2:], boxes2[:, 2:])  # [N,2]
+
+    wh = (rb - lt).clamp(min=0)  # [N,2]
+    inter = wh[:, 0] * wh[:, 1]  # [N]
+
+    union = area1 + area2 - inter
+
+    eps = 1e-7
+    # Clamp only the degenerate (union==0) case so identical non-degenerate boxes
+    # yield IoU==1.0 exactly; adding eps unconditionally would break that identity.
+    iou = inter / union.clamp(min=eps)
+    return iou, union
+
+
+def elementwise_generalized_box_iou(boxes1: Tensor, boxes2: Tensor) -> Tensor:
+    """Generalized IoU from https://giou.stanford.edu/ for pre-matched box pairs.
+
+    Equivalent to the diagonal of ``generalized_box_iou`` but without building the
+    NxN matrix, giving O(N) instead of O(N^2) peak memory. The boxes should be in
+    [x0, y0, x1, y1] format, and ``boxes1``/``boxes2`` must have the same length.
+
+    Returns a [N] tensor, one GIoU value per matched pair.
+    """
+    # Degenerate (zero-area) boxes would divide 0/0; eps in the denominators keeps results finite.
+    iou, union = elementwise_box_iou(boxes1, boxes2)
+
+    lt = torch.min(boxes1[:, :2], boxes2[:, :2])
+    rb = torch.max(boxes1[:, 2:], boxes2[:, 2:])
+
+    wh = (rb - lt).clamp(min=0)  # [N,2]
+    area = wh[:, 0] * wh[:, 1]
+
+    eps = 1e-7
+    # Clamp only when enclosing area is zero (degenerate enclosing box) so normal boxes remain exact.
+    return iou - (area - union) / area.clamp(min=eps)
+
+
 def generalized_box_iou(boxes1: Tensor, boxes2: Tensor) -> Tensor:
     """Generalized IoU from https://giou.stanford.edu/
 

--- a/src/rfdetr/utilities/box_ops.py
+++ b/src/rfdetr/utilities/box_ops.py
@@ -69,18 +69,33 @@ def box_iou(boxes1: Tensor, boxes2: Tensor) -> tuple[Tensor, Tensor]:
     return iou, union
 
 
+def _assert_equal_length(boxes1: Tensor, boxes2: Tensor) -> None:
+    """Reject unequal-length operands so a length-1 side cannot silently broadcast."""
+    if boxes1.shape[0] != boxes2.shape[0]:
+        raise ValueError(
+            "elementwise box ops expect boxes1 and boxes2 to have the same length, "
+            f"got {boxes1.shape[0]} and {boxes2.shape[0]}"
+        )
+
+
 def elementwise_box_iou(boxes1: Tensor, boxes2: Tensor) -> tuple[Tensor, Tensor]:
     """Compute IoU and union for pre-matched box pairs.
 
     Unlike ``box_iou``, this avoids materializing the full NxN pairwise matrix
     (of which only the diagonal is used for matched pairs), so peak memory is
     O(N) instead of O(N^2). ``boxes1`` and ``boxes2`` must have the same length
-    and be in [x0, y0, x1, y1] format.
+    and be in [x0, y0, x1, y1] format; a length mismatch raises ``ValueError``
+    rather than silently broadcasting a length-1 operand.
+
+    The numerics (op order and the ``eps=1e-7`` union clamp) are identical to the
+    diagonal of ``box_iou``, so results carry no dtype dependence beyond that of
+    the pairwise version under FP16/FP32.
 
     Returns:
         iou: the [N] tensor of IoU values for each matched pair.
         union: the [N] tensor of union areas for each matched pair.
     """
+    _assert_equal_length(boxes1, boxes2)
     area1 = box_area(boxes1)
     area2 = box_area(boxes2)
 
@@ -104,10 +119,12 @@ def elementwise_generalized_box_iou(boxes1: Tensor, boxes2: Tensor) -> Tensor:
 
     Equivalent to the diagonal of ``generalized_box_iou`` but without building the
     NxN matrix, giving O(N) instead of O(N^2) peak memory. The boxes should be in
-    [x0, y0, x1, y1] format, and ``boxes1``/``boxes2`` must have the same length.
+    [x0, y0, x1, y1] format, and ``boxes1``/``boxes2`` must have the same length; a
+    length mismatch raises ``ValueError`` rather than silently broadcasting.
 
     Returns a [N] tensor, one GIoU value per matched pair.
     """
+    _assert_equal_length(boxes1, boxes2)
     # Degenerate (zero-area) boxes would divide 0/0; eps in the denominators keeps results finite.
     iou, union = elementwise_box_iou(boxes1, boxes2)
 

--- a/tests/utilities/test_box_ops.py
+++ b/tests/utilities/test_box_ops.py
@@ -4,6 +4,7 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
+import pytest
 import torch
 
 from rfdetr.utilities.box_ops import (
@@ -64,42 +65,141 @@ def test_elementwise_generalized_box_iou_matches_pairwise_diagonal() -> None:
     torch.testing.assert_close(boxes2.grad, boxes2_ref.grad)
 
 
-def test_elementwise_box_iou_zero_area_boxes_are_finite() -> None:
-    """Zero-area boxes yield finite elementwise IoU/union instead of a 0/0 NaN."""
-    zero_box = torch.tensor([[10.0, 10.0, 10.0, 10.0]])  # w = h = 0
+@pytest.mark.parametrize(
+    "boxes1,boxes2",
+    [
+        pytest.param(
+            torch.tensor([[0.0, 0.0, 1.0, 1.0]]),
+            torch.tensor([[5.0, 5.0, 6.0, 6.0]]),
+            id="disjoint",
+        ),
+        pytest.param(
+            torch.tensor([[0.0, 0.0, 1.0, 1.0]]),
+            torch.tensor([[1.0, 0.0, 2.0, 1.0]]),
+            id="edge-touch",
+        ),
+        pytest.param(
+            torch.tensor([[0.0, 0.0, 1e8, 1e8]]),
+            torch.tensor([[5e7, 5e7, 1.5e8, 1.5e8]]),
+            id="large-coord",
+        ),
+    ],
+)
+def test_elementwise_matches_pairwise_diagonal_edge_regimes(boxes1: torch.Tensor, boxes2: torch.Tensor) -> None:
+    """Elementwise IoU/GIoU match the pairwise diagonal across disjoint, edge-touch, and large-coord regimes."""
+    iou, _ = elementwise_box_iou(boxes1, boxes2)
+    giou = elementwise_generalized_box_iou(boxes1, boxes2)
 
-    iou, union = elementwise_box_iou(zero_box, zero_box)
+    iou_ref, _ = box_iou(boxes1, boxes2)
+    giou_ref = generalized_box_iou(boxes1, boxes2)
+
+    torch.testing.assert_close(iou, torch.diag(iou_ref))
+    torch.testing.assert_close(giou, torch.diag(giou_ref))
+
+
+def test_elementwise_box_iou_identical_boxes_give_exact_unit_iou() -> None:
+    """Identical boxes give IoU exactly 1.0 — the union clamp preserves the identity (not just assert_close)."""
+    boxes = _random_xyxy_boxes(16, seed=7)
+
+    iou, _ = elementwise_box_iou(boxes, boxes)
+
+    assert torch.equal(iou, torch.ones_like(iou))
+
+
+def test_elementwise_generalized_box_iou_identical_boxes_give_exact_unit_giou() -> None:
+    """Identical boxes give GIoU exactly 1.0 (enclosing area equals union, so the correction is zero)."""
+    boxes = _random_xyxy_boxes(16, seed=7)
+
+    giou = elementwise_generalized_box_iou(boxes, boxes)
+
+    assert torch.equal(giou, torch.ones_like(giou))
+
+
+def test_elementwise_box_iou_mixed_degeneracy_batch_is_finite_and_matches_diagonal() -> None:
+    """A normal/zero-area/disjoint batch stays finite and its non-degenerate rows match the pairwise diagonal."""
+    boxes1 = torch.tensor([[0.0, 0.0, 2.0, 2.0], [5.0, 5.0, 5.0, 5.0], [0.0, 0.0, 1.0, 1.0]])
+    boxes2 = torch.tensor([[1.0, 1.0, 3.0, 3.0], [5.0, 5.0, 5.0, 5.0], [10.0, 10.0, 11.0, 11.0]])
+
+    iou, union = elementwise_box_iou(boxes1, boxes2)
+    iou_ref, _ = box_iou(boxes1, boxes2)
 
     assert torch.isfinite(iou).all()
     assert torch.isfinite(union).all()
+    torch.testing.assert_close(iou[[0, 2]], torch.diag(iou_ref)[[0, 2]])
 
 
-def test_elementwise_generalized_box_iou_zero_area_boxes_are_finite() -> None:
-    """Degenerate zero-area boxes give finite elementwise GIoU instead of NaN/inf."""
+def test_elementwise_box_iou_degenerate_row_does_not_pollute_neighbour_grads() -> None:
+    """A degenerate zero-area row keeps the gradients of its neighbour rows finite under ``backward()``."""
+    boxes1 = torch.tensor(
+        [[0.0, 0.0, 2.0, 2.0], [5.0, 5.0, 5.0, 5.0], [0.0, 0.0, 1.0, 1.0]],
+        requires_grad=True,
+    )
+    boxes2 = torch.tensor(
+        [[1.0, 1.0, 3.0, 3.0], [5.0, 5.0, 5.0, 5.0], [10.0, 10.0, 11.0, 11.0]],
+        requires_grad=True,
+    )
+
+    iou, _ = elementwise_box_iou(boxes1, boxes2)
+    iou.sum().backward()
+
+    assert torch.isfinite(boxes1.grad[[0, 2]]).all()
+    assert torch.isfinite(boxes2.grad[[0, 2]]).all()
+
+
+def test_elementwise_box_iou_empty_input_returns_empty() -> None:
+    """Empty (N=0) input returns empty IoU/union tensors without error."""
+    empty = torch.empty(0, 4)
+
+    iou, union = elementwise_box_iou(empty, empty)
+
+    assert iou.shape == (0,)
+    assert union.shape == (0,)
+
+
+def test_elementwise_generalized_box_iou_empty_input_returns_empty() -> None:
+    """Empty (N=0) input returns an empty GIoU tensor without error."""
+    empty = torch.empty(0, 4)
+
+    giou = elementwise_generalized_box_iou(empty, empty)
+
+    assert giou.shape == (0,)
+
+
+def test_elementwise_box_iou_rejects_unequal_length() -> None:
+    """Mismatched operand lengths raise ValueError instead of silently broadcasting a length-1 side."""
+    boxes1 = _random_xyxy_boxes(3, seed=4)
+    boxes2 = _random_xyxy_boxes(1, seed=5)
+
+    with pytest.raises(ValueError, match="same length"):
+        elementwise_box_iou(boxes1, boxes2)
+
+
+def test_elementwise_generalized_box_iou_rejects_unequal_length() -> None:
+    """The GIoU variant also raises ValueError on mismatched operand lengths."""
+    boxes1 = _random_xyxy_boxes(3, seed=4)
+    boxes2 = _random_xyxy_boxes(1, seed=5)
+
+    with pytest.raises(ValueError, match="same length"):
+        elementwise_generalized_box_iou(boxes1, boxes2)
+
+
+@pytest.mark.parametrize(
+    "iou_fn",
+    [
+        pytest.param(box_iou, id="box_iou"),
+        pytest.param(elementwise_box_iou, id="elementwise_box_iou"),
+        pytest.param(generalized_box_iou, id="generalized_box_iou"),
+        pytest.param(elementwise_generalized_box_iou, id="elementwise_generalized_box_iou"),
+    ],
+)
+def test_zero_area_boxes_are_finite(iou_fn) -> None:
+    """Degenerate zero-area boxes yield finite results (no 0/0 NaN) across every IoU/GIoU variant."""
     zero_box = torch.tensor([[10.0, 10.0, 10.0, 10.0]])  # w = h = 0
 
-    giou = elementwise_generalized_box_iou(zero_box, zero_box)
+    result = iou_fn(zero_box, zero_box)
+    tensors = result if isinstance(result, tuple) else (result,)
 
-    assert torch.isfinite(giou).all()
-
-
-def test_box_iou_zero_area_boxes_are_finite() -> None:
-    """Zero-area boxes yield finite IoU/union instead of a 0/0 NaN."""
-    zero_box = torch.tensor([[10.0, 10.0, 10.0, 10.0]])  # w = h = 0
-
-    iou, union = box_iou(zero_box, zero_box)
-
-    assert torch.isfinite(iou).all()
-    assert torch.isfinite(union).all()
-
-
-def test_generalized_box_iou_zero_area_boxes_are_finite() -> None:
-    """Degenerate zero-area boxes give finite GIoU instead of NaN/inf."""
-    zero_box = torch.tensor([[10.0, 10.0, 10.0, 10.0]])  # w = h = 0
-
-    giou = generalized_box_iou(zero_box, zero_box)
-
-    assert torch.isfinite(giou).all()
+    assert all(torch.isfinite(t).all() for t in tensors)
 
 
 def test_masks_to_boxes_passes_ij_indexing_to_meshgrid(monkeypatch) -> None:

--- a/tests/utilities/test_box_ops.py
+++ b/tests/utilities/test_box_ops.py
@@ -6,7 +6,81 @@
 
 import torch
 
-from rfdetr.utilities.box_ops import box_iou, generalized_box_iou, masks_to_boxes
+from rfdetr.utilities.box_ops import (
+    box_iou,
+    elementwise_box_iou,
+    elementwise_generalized_box_iou,
+    generalized_box_iou,
+    masks_to_boxes,
+)
+
+
+def _random_xyxy_boxes(n: int, seed: int = 0) -> torch.Tensor:
+    """Generate ``n`` non-degenerate random boxes in xyxy format."""
+    gen = torch.Generator().manual_seed(seed)
+    xy1 = torch.rand(n, 2, generator=gen)
+    xy2 = xy1 + torch.rand(n, 2, generator=gen) * 0.5 + 0.01
+    return torch.cat([xy1, xy2], dim=-1)
+
+
+def test_elementwise_box_iou_matches_pairwise_diagonal() -> None:
+    """Elementwise IoU/union equal the diagonal of the pairwise ``box_iou``, including gradients."""
+    boxes1 = _random_xyxy_boxes(64, seed=2).requires_grad_(True)
+    boxes2 = _random_xyxy_boxes(64, seed=3).requires_grad_(True)
+
+    boxes1_ref = boxes1.detach().clone().requires_grad_(True)
+    boxes2_ref = boxes2.detach().clone().requires_grad_(True)
+
+    iou, union = elementwise_box_iou(boxes1, boxes2)
+    iou_ref, union_ref = box_iou(boxes1_ref, boxes2_ref)
+
+    torch.testing.assert_close(iou, torch.diag(iou_ref))
+    torch.testing.assert_close(union, torch.diag(union_ref))
+
+    iou.sum().backward()
+    torch.diag(iou_ref).sum().backward()
+
+    torch.testing.assert_close(boxes1.grad, boxes1_ref.grad)
+    torch.testing.assert_close(boxes2.grad, boxes2_ref.grad)
+
+
+def test_elementwise_generalized_box_iou_matches_pairwise_diagonal() -> None:
+    """Elementwise GIoU equals the diagonal of the pairwise ``generalized_box_iou``, including gradients."""
+    boxes1 = _random_xyxy_boxes(64, seed=0).requires_grad_(True)
+    boxes2 = _random_xyxy_boxes(64, seed=1).requires_grad_(True)
+
+    boxes1_ref = boxes1.detach().clone().requires_grad_(True)
+    boxes2_ref = boxes2.detach().clone().requires_grad_(True)
+
+    result = elementwise_generalized_box_iou(boxes1, boxes2)
+    expected = torch.diag(generalized_box_iou(boxes1_ref, boxes2_ref))
+
+    torch.testing.assert_close(result, expected)
+
+    result.sum().backward()
+    expected.sum().backward()
+
+    torch.testing.assert_close(boxes1.grad, boxes1_ref.grad)
+    torch.testing.assert_close(boxes2.grad, boxes2_ref.grad)
+
+
+def test_elementwise_box_iou_zero_area_boxes_are_finite() -> None:
+    """Zero-area boxes yield finite elementwise IoU/union instead of a 0/0 NaN."""
+    zero_box = torch.tensor([[10.0, 10.0, 10.0, 10.0]])  # w = h = 0
+
+    iou, union = elementwise_box_iou(zero_box, zero_box)
+
+    assert torch.isfinite(iou).all()
+    assert torch.isfinite(union).all()
+
+
+def test_elementwise_generalized_box_iou_zero_area_boxes_are_finite() -> None:
+    """Degenerate zero-area boxes give finite elementwise GIoU instead of NaN/inf."""
+    zero_box = torch.tensor([[10.0, 10.0, 10.0, 10.0]])  # w = h = 0
+
+    giou = elementwise_generalized_box_iou(zero_box, zero_box)
+
+    assert torch.isfinite(giou).all()
 
 
 def test_box_iou_zero_area_boxes_are_finite() -> None:


### PR DESCRIPTION
## What does this PR do?

There was unnecessary computation which created a huge matrix in memory when calculating box iou. It caused unpredictable training OOM, depending on torch memory cache allocator trying to find memory to store such matrix. And it had to do it for encoder and every decoder layer.

## Type of Change

- optimization

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
