### PR TITLE
test(markers): drop dead marks, rename e2e marks to e2e_ prefix

### DIFF
--- a/.github/workflows/ci-integrations.yml
+++ b/.github/workflows/ci-integrations.yml
@@ -115,27 +115,6 @@ jobs:
         continue-on-error: true
         run: uv cache prune --ci
 
-  executorch-guardian:
-    runs-on: ubuntu-latest
-    needs: executorch-parity
-    if: always()
-    steps:
-      - name: 📋 Display test result
-        run: echo "${{ needs.executorch-parity.result }}"
-      - name: ❌ Fail guardian on test failure
-        if: needs.executorch-parity.result == 'failure'
-        run: exit 1
-      # Ensure that cancelled or skipped test runs still cause this guardian job to fail,
-      # using an explicit exit code instead of relying on timeout behavior.
-      - name: ⚠️ cancelled or skipped...
-        if: contains(fromJSON('["cancelled", "skipped"]'), needs.executorch-parity.result)
-        run: |
-          echo "executorch-parity job result is '${{ needs.executorch-parity.result }}'; failing explicitly."
-          exit 1
-      - name: ✅ tests succeeded
-        if: needs.executorch-parity.result == 'success'
-        run: echo "All ExecuTorch parity tests completed successfully in job 'executorch-parity'."
-
   coreml-parity:
     name: CoreML parity
     # coremltools + the CoreML runtime are macOS-only, so unlike executorch-parity (portable
@@ -190,27 +169,6 @@ jobs:
       - name: Minimize uv cache
         continue-on-error: true
         run: uv cache prune --ci
-
-  coreml-guardian:
-    runs-on: ubuntu-latest
-    needs: coreml-parity
-    if: always()
-    steps:
-      - name: 📋 Display test result
-        run: echo "${{ needs.coreml-parity.result }}"
-      - name: ❌ Fail guardian on test failure
-        if: needs.coreml-parity.result == 'failure'
-        run: exit 1
-      # Ensure that cancelled or skipped test runs still cause this guardian job to fail,
-      # using an explicit exit code instead of relying on timeout behavior.
-      - name: ⚠️ cancelled or skipped...
-        if: contains(fromJSON('["cancelled", "skipped"]'), needs.coreml-parity.result)
-        run: |
-          echo "coreml-parity job result is '${{ needs.coreml-parity.result }}'; failing explicitly."
-          exit 1
-      - name: ✅ tests succeeded
-        if: needs.coreml-parity.result == 'success'
-        run: echo "All CoreML parity tests completed successfully in job 'coreml-parity'."
 
   tensorrt-parity:
     name: TensorRT parity
@@ -269,23 +227,25 @@ jobs:
         continue-on-error: true
         run: uv cache prune --ci
 
-  tensorrt-guardian:
+  export-priority-guardian:
     runs-on: ubuntu-latest
-    needs: tensorrt-parity
+    needs: [executorch-parity, coreml-parity, tensorrt-parity]
     if: always()
     steps:
-      - name: 📋 Display test result
-        run: echo "${{ needs.tensorrt-parity.result }}"
-      - name: ❌ Fail guardian on test failure
-        if: needs.tensorrt-parity.result == 'failure'
-        run: exit 1
-      # Ensure that cancelled or skipped test runs still cause this guardian job to fail,
-      # using an explicit exit code instead of relying on timeout behavior.
-      - name: ⚠️ cancelled or skipped...
-        if: contains(fromJSON('["cancelled", "skipped"]'), needs.tensorrt-parity.result)
+      - name: 📋 Display parity job results
         run: |
-          echo "tensorrt-parity job result is '${{ needs.tensorrt-parity.result }}'; failing explicitly."
+          echo "executorch-parity: ${{ needs.executorch-parity.result }}"
+          echo "coreml-parity:     ${{ needs.coreml-parity.result }}"
+          echo "tensorrt-parity:   ${{ needs.tensorrt-parity.result }}"
+      # Fail explicitly on any non-success result (failure, cancelled, or skipped) instead of
+      # relying on timeout behavior, so a cancelled or skipped parity job still blocks the gate.
+      - name: ❌ Fail guardian unless every parity job succeeded
+        if: >-
+          needs.executorch-parity.result != 'success' ||
+          needs.coreml-parity.result != 'success' ||
+          needs.tensorrt-parity.result != 'success'
+        run: |
+          echo "One or more export parity jobs did not succeed; failing explicitly."
           exit 1
-      - name: ✅ tests succeeded
-        if: needs.tensorrt-parity.result == 'success'
-        run: echo "All TensorRT parity tests completed successfully in job 'tensorrt-parity'."
+      - name: ✅ all parity jobs succeeded
+        run: echo "All export parity jobs (executorch, coreml, tensorrt) completed successfully."

--- a/.github/workflows/ci-integrations.yml
+++ b/.github/workflows/ci-integrations.yml
@@ -211,3 +211,81 @@ jobs:
       - name: ✅ tests succeeded
         if: needs.coreml-parity.result == 'success'
         run: echo "All CoreML parity tests completed successfully in job 'coreml-parity'."
+
+  tensorrt-parity:
+    name: TensorRT parity
+    # TensorRT engine build + runtime inference need a real GPU + CUDA driver, so unlike the CPU
+    # integration jobs this runs on the self-hosted GPU runner (same as ci-tests-gpu.yml).
+    runs-on: Roboflow-GPU-VM-Runner
+    timeout-minutes: 25
+    concurrency:
+      group: pytest-tensorrt-${{ github.ref }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    env:
+      # UV_TORCH_BACKEND=auto (GPU) works only with uv pip, not uv sync; overrides the workflow-level
+      # "cpu" default which is wrong for this GPU job.
+      UV_TORCH_BACKEND: "auto"
+    steps:
+      - name: 🖥️ Print GPU information
+        run: nvidia-smi
+      - name: 📥 Checkout the repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: 🐍 Install uv and set Python version
+        uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
+        with:
+          version: "0.9.26"
+          python-version: "3.12"
+          activate-environment: true
+
+      - name: 🚀 Install Packages (tensorrt + onnx extras)
+        timeout-minutes: 8
+        # [tensorrt] provides pycuda/tensorrt/polygraphy for the engine build; [onnx] provides the ONNX
+        # export toolchain (the e2e exports RFDETRNano to ONNX first). --group ci-gpu-pin matches the GPU
+        # runner's CUDA driver (torch<2.11), same as ci-tests-gpu.yml.
+        run: uv pip install -e ".[tensorrt,onnx,train,augment,cli,visual]" --group tests --group ci-gpu-pin
+
+      - name: 🔎 Verify tensorrt import
+        # Guard against a silently-skipped parity test: TestTensorRTEndToEnd is gated by a skipif on
+        # tensorrt availability, so a broken/missing wheel would skip it (false green) instead of failing red.
+        run: |
+          from rfdetr.export._tensorrt import _IS_TENSORRT_AVAILABLE
+
+          assert _IS_TENSORRT_AVAILABLE, "tensorrt/polygraphy installed but not detected as available"
+          print("tensorrt import OK")
+        shell: python
+
+      - name: 🧪 Run TensorRT end-to-end parity tests
+        # Real ONNX->engine build + GPU inference is heavy; single-worker, opt-in marker (see pyproject.toml
+        # `e2e_tensorrt`) — excluded from the ci-tests-gpu.yml default filter (`and not e2e_tensorrt`) so it
+        # only runs here.
+        run: |
+          uv run --no-sync pytest tests/export/test_tensorrt_export.py \
+            -m e2e_tensorrt -n 1 \
+            --timeout=600 \
+            --durations=20
+
+      - name: Minimize uv cache
+        continue-on-error: true
+        run: uv cache prune --ci
+
+  tensorrt-guardian:
+    runs-on: ubuntu-latest
+    needs: tensorrt-parity
+    if: always()
+    steps:
+      - name: 📋 Display test result
+        run: echo "${{ needs.tensorrt-parity.result }}"
+      - name: ❌ Fail guardian on test failure
+        if: needs.tensorrt-parity.result == 'failure'
+        run: exit 1
+      # Ensure that cancelled or skipped test runs still cause this guardian job to fail,
+      # using an explicit exit code instead of relying on timeout behavior.
+      - name: ⚠️ cancelled or skipped...
+        if: contains(fromJSON('["cancelled", "skipped"]'), needs.tensorrt-parity.result)
+        run: |
+          echo "tensorrt-parity job result is '${{ needs.tensorrt-parity.result }}'; failing explicitly."
+          exit 1
+      - name: ✅ tests succeeded
+        if: needs.tensorrt-parity.result == 'success'
+        run: echo "All TensorRT parity tests completed successfully in job 'tensorrt-parity'."

--- a/.github/workflows/ci-integrations.yml
+++ b/.github/workflows/ci-integrations.yml
@@ -107,7 +107,7 @@ jobs:
         # executorch export is heavy; run single-worker as advised for this suite.
         run: |
           uv run --no-sync pytest tests/export/test_executorch_export.py \
-            -m executorch -n 1 \
+            -m e2e_executorch -n 1 \
             --timeout=600 \
             --durations=20
 
@@ -179,11 +179,11 @@ jobs:
 
       - name: 🧪 Run CoreML end-to-end parity tests
         # Real ct.convert + mlmodel.predict + download_assets is heavy/network; single-worker,
-        # opt-in marker (see pyproject.toml `coreml_e2e`) — deliberately excluded from the
-        # ci-tests-cpu.yml default filter (`and not coreml_e2e`) so it only runs here.
+        # opt-in marker (see pyproject.toml `e2e_coreml`) — deliberately excluded from the
+        # ci-tests-cpu.yml default filter (`and not e2e_coreml`) so it only runs here.
         run: |
           uv run --no-sync pytest tests/export/test_coreml_export.py \
-            -m coreml_e2e -n 1 \
+            -m e2e_coreml -n 1 \
             --timeout=600 \
             --durations=20
 

--- a/.github/workflows/ci-integrations.yml
+++ b/.github/workflows/ci-integrations.yml
@@ -198,7 +198,7 @@ jobs:
 
       - name: 🚀 Install Packages (tensorrt + onnx extras)
         timeout-minutes: 8
-        # [tensorrt] provides pycuda/tensorrt/polygraphy for the engine build; [onnx] provides the ONNX
+        # [tensorrt] provides tensorrt/polygraphy for the engine build; [onnx] provides the ONNX
         # export toolchain (the e2e exports RFDETRNano to ONNX first). --group ci-gpu-pin matches the GPU
         # runner's CUDA driver (torch<2.11), same as ci-tests-gpu.yml.
         run: uv pip install -e ".[tensorrt,onnx,train,augment,cli,visual]" --group tests --group ci-gpu-pin
@@ -211,6 +211,42 @@ jobs:
 
           assert _IS_TENSORRT_AVAILABLE, "tensorrt/polygraphy installed but not detected as available"
           print("tensorrt import OK")
+        shell: python
+
+      - name: 🔗 Expose CUDA runtime (libcudart.so) to the loader
+        # The engine build succeeds, but polygraphy's TrtRunner separately dlopen's the *unversioned*
+        # `libcudart.so` for CUDA stream management. The GPU wheels ship it only as `libcudart.so.12`
+        # (e.g. under torch/lib), which the dynamic loader does not resolve by bare name — hence
+        # `OSError: libcudart.so: cannot open shared object file` at runtime. Symlink the versioned
+        # library to `libcudart.so` in a job-local dir and prepend it to LD_LIBRARY_PATH.
+        run: |
+          import glob
+          import os
+          import pathlib
+          import site
+
+          roots = list(site.getsitepackages())
+          venv = os.environ.get("VIRTUAL_ENV")
+          if venv:
+              roots.append(os.path.join(venv, "lib"))
+          candidates = []
+          for root in roots:
+              candidates += glob.glob(os.path.join(root, "**", "libcudart.so*"), recursive=True)
+          candidates += glob.glob("/usr/local/cuda*/lib64/libcudart.so*")
+          candidates = sorted({c for c in candidates if os.path.exists(c)}, key=len)
+          assert candidates, "libcudart.so* not found in installed wheels or system CUDA"
+          source = candidates[0]
+
+          lib_dir = pathlib.Path(os.environ["RUNNER_TEMP"]) / "cudalibs"
+          lib_dir.mkdir(parents=True, exist_ok=True)
+          link = lib_dir / "libcudart.so"
+          if link.is_symlink() or link.exists():
+              link.unlink()
+          link.symlink_to(source)
+          print(f"linked {link} -> {source}")
+
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
+              env_file.write(f"LD_LIBRARY_PATH={lib_dir}{os.pathsep}{os.environ.get('LD_LIBRARY_PATH', '')}\n")
         shell: python
 
       - name: 🧪 Run TensorRT end-to-end parity tests

--- a/.github/workflows/ci-tests-cpu.yml
+++ b/.github/workflows/ci-tests-cpu.yml
@@ -65,7 +65,7 @@ jobs:
       - name: 🧪 Run the Test
         run: |
           uv run --no-sync pytest src/ tests/ \
-            -n 2 -m "not gpu and not coco17 and not coreml_e2e" \
+            -n 2 -m "not gpu and not coco17 and not e2e_coreml" \
             --ignore=tests/run_smoke_all_models.py \
             --ignore=tests/legacy/test_checkpoint_compat.py \
             --cov=rfdetr --cov-report=xml \

--- a/.github/workflows/ci-tests-cpu.yml
+++ b/.github/workflows/ci-tests-cpu.yml
@@ -65,7 +65,7 @@ jobs:
       - name: 🧪 Run the Test
         run: |
           uv run --no-sync pytest src/ tests/ \
-            -n 2 -m "not gpu and not coco17 and not e2e_coreml" \
+            -n 2 -m "not gpu and not coco17 and not e2e_coreml and not e2e_executorch" \
             --ignore=tests/run_smoke_all_models.py \
             --ignore=tests/legacy/test_checkpoint_compat.py \
             --cov=rfdetr --cov-report=xml \

--- a/.github/workflows/ci-tests-gpu.yml
+++ b/.github/workflows/ci-tests-gpu.yml
@@ -56,7 +56,7 @@ jobs:
       - name: 🧪 Run the Test
         run: |
           uv run --no-sync pytest tests/ \
-          -m gpu \
+          -m "gpu and not e2e_tensorrt" \
           --ignore=tests/legacy/test_checkpoint_compat.py \
           -n 3 \
           --reruns 1 --only-rerun "OutOfMemoryError" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,6 +288,9 @@ pythonpath = ["src", "."]
 markers = [
     "gpu: tests that require GPU or are slow on CPU",
     "coco17: tests that require COCO 2017 images or annotations",
+    # `flaky` is provided by pytest-rerunfailures; registered here too for clarity and to stay
+    # safe under --strict-markers (used by tests/benchmarks/test_training_*.py).
+    "flaky: tests that may fail due to nondeterminism and are retried via pytest-rerunfailures",
     "e2e_executorch: ExecuTorch end-to-end export + numerical parity (opt-in)",
     "e2e_coreml: CoreML end-to-end convert + numerical parity (structured and photo inputs; opt-in)",
     "e2e_tensorrt: TensorRT end-to-end ONNX->engine build + parity (GPU, opt-in)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -284,6 +284,7 @@ markers = [
     "coco17: tests that require COCO 2017 images or annotations",
     "e2e_executorch: ExecuTorch end-to-end export + numerical parity (opt-in)",
     "e2e_coreml: CoreML end-to-end convert + numerical parity (structured and photo inputs; opt-in)",
+    "e2e_tensorrt: TensorRT end-to-end ONNX->engine build + parity (GPU, opt-in)",
 ]
 filterwarnings = [
     # pytest-xdist workers close their channel before teardown completes;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,10 +72,16 @@ onnx = [
     "polygraphy",
 ]
 tensorrt = [
-    "pycuda",
     "onnxruntime-gpu",
     "tensorrt>=8.6.1",
     "polygraphy",
+]
+# pycuda is only used by async TRTInference in rfdetr.export.benchmark. It ships as an sdist
+# and builds against the CUDA toolkit dev headers (cuda.h), which a GPU driver alone does not
+# provide. Keep it out of the base [tensorrt] extra so the ONNX->engine parity path (polygraphy
+# TrtRunner, no pycuda) installs on a driver-only runner; async benchmarking opts into it here.
+tensorrt-bench = [
+    "pycuda>=2024.1",
 ]
 tflite = [
     # TFLite conversion routes every export through the ONNX pipeline first (export_onnx's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -282,11 +282,8 @@ pythonpath = ["src", "."]
 markers = [
     "gpu: tests that require GPU or are slow on CPU",
     "coco17: tests that require COCO 2017 images or annotations",
-    "flaky: tests that may fail due to nondeterminism",
-    "tflite: tests requiring onnx2tf and TFLite dependencies",
-    "executorch: tests requiring the executorch package",
-    "coreml: CoreML unit/wiring/op-coverage tests requiring coremltools (typically macOS)",
-    "coreml_e2e: CoreML end-to-end convert + numerical parity (structured and photo inputs; opt-in)",
+    "e2e_executorch: ExecuTorch end-to-end export + numerical parity (opt-in)",
+    "e2e_coreml: CoreML end-to-end convert + numerical parity (structured and photo inputs; opt-in)",
 ]
 filterwarnings = [
     # pytest-xdist workers close their channel before teardown completes;

--- a/src/rfdetr/export/_tensorrt.py
+++ b/src/rfdetr/export/_tensorrt.py
@@ -41,11 +41,15 @@ try:
         network_from_onnx_path,
         save_engine,
     )
+
+    _IS_TENSORRT_AVAILABLE = True
 except ImportError:  # pragma: no cover - exercised via the guard in build_engine
     CreateConfig = None
     engine_from_network = None
     network_from_onnx_path = None
     save_engine = None
+
+    _IS_TENSORRT_AVAILABLE = False
 
 
 def build_engine(onnx_path: str, *, fp16: bool = True, verbose: bool = False, dry_run: bool = False) -> str:

--- a/src/rfdetr/export/benchmark.py
+++ b/src/rfdetr/export/benchmark.py
@@ -311,7 +311,8 @@ class TRTInference:
         if not self.sync_mode:
             if not cuda:
                 raise ImportError(
-                    "pycuda is not installed. Please install `pycuda` to use TRTInference with async mode."
+                    "pycuda is not installed. Install the `tensorrt-bench` extra "
+                    "(pip install 'rfdetr[tensorrt-bench]') to use TRTInference with async mode."
                 )
 
             self.stream = cuda.Stream()

--- a/tests/cli/test_smoke.py
+++ b/tests/cli/test_smoke.py
@@ -14,6 +14,7 @@ with the YAML init_args, and verify every specified field survived the round-tri
 
 import importlib
 import pathlib
+import sys
 
 import pytest
 import yaml
@@ -70,10 +71,10 @@ def _instantiate(class_path: str, init_args: dict) -> object:
 class TestCLIEntrypoint:
     """Module entrypoint and CLI import tests."""
 
+    @pytest.mark.flaky(reruns=3, condition=sys.platform == "darwin")
     def test_python_module_entrypoint_runs(self) -> None:
         """Python -m rfdetr --help exits 0 and mentions rfdetr."""
         import subprocess
-        import sys
 
         result = subprocess.run(
             [sys.executable, "-m", "rfdetr", "--help"],
@@ -110,7 +111,6 @@ class TestCLIHelp:
     def test_fit_help_exposes_model_config(self):
         """Rfdetr fit --help output lists model.model_config arguments."""
         import io
-        import sys
 
         buf = io.StringIO()
         old_stdout = sys.stdout
@@ -124,7 +124,6 @@ class TestCLIHelp:
     def test_fit_help_exposes_train_config(self):
         """Rfdetr fit --help output lists model.train_config arguments."""
         import io
-        import sys
 
         buf = io.StringIO()
         old_stdout = sys.stdout

--- a/tests/export/conftest.py
+++ b/tests/export/conftest.py
@@ -23,8 +23,8 @@ from PIL import Image
 
 # ImageNet statistics used by predict-style preprocessing; parity inputs are normalized to
 # roughly this range so the backbone sees realistic activations.
-_IMAGENET_MEAN = (0.485, 0.456, 0.406)
-_IMAGENET_STD = (0.229, 0.224, 0.225)
+_IMAGENET_MEAN: tuple[float, float, float] = (0.485, 0.456, 0.406)
+_IMAGENET_STD: tuple[float, float, float] = (0.229, 0.224, 0.225)
 
 
 def _structured_parity_input(

--- a/tests/export/conftest.py
+++ b/tests/export/conftest.py
@@ -1,0 +1,149 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Shared export-parity helpers for the backend export test suites.
+
+These builders and comparison seams are backend-agnostic and used by the CoreML, ExecuTorch, and TensorRT end-to-end
+tests so the three suites stay structurally aligned instead of each re-implementing input synthesis and output
+comparison.
+
+Backend-specific execution (``coremltools``/``executorch``/``polygraphy`` runtimes) stays in each test module; only the
+eager reference forward, the deterministic input builders, and the per-output max-abs-diff loop live here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import torch
+import torchvision.transforms.functional as TF  # noqa: N812 — standard torchvision alias
+from PIL import Image
+
+# ImageNet statistics used by predict-style preprocessing; parity inputs are normalized to
+# roughly this range so the backbone sees realistic activations.
+_IMAGENET_MEAN = (0.485, 0.456, 0.406)
+_IMAGENET_STD = (0.229, 0.224, 0.225)
+
+
+def _structured_parity_input(
+    batch: int,
+    channels: int,
+    height: int,
+    width: int,
+) -> torch.Tensor:
+    """Build a deterministic, spatially correlated ``NCHW`` tensor for export parity.
+
+    Combines a smooth spatial gradient with a coarse checkerboard so the backbone sees
+    local structure (unlike ``torch.randn``, which can mask export/runtime divergence).
+
+    Args:
+        batch: Batch size.
+        channels: Channel count (typically 3).
+        height: Spatial height.
+        width: Spatial width.
+
+    Returns:
+        Float tensor shaped ``(batch, channels, height, width)`` in roughly ImageNet-normalized range.
+    """
+    ys = torch.linspace(-1.0, 1.0, height).view(1, 1, height, 1)
+    xs = torch.linspace(-1.0, 1.0, width).view(1, 1, 1, width)
+    gradient = (0.35 * ys + 0.25 * xs).expand(1, channels, height, width).clone()
+    # Per-channel offset so RGB planes are not identical.
+    for c in range(channels):
+        gradient[:, c] = gradient[:, c] + 0.05 * (c - 1)
+
+    tile = 16
+    yy = (torch.arange(height).view(height, 1) // tile) % 2
+    xx = (torch.arange(width).view(1, width) // tile) % 2
+    checker = ((yy + xx) % 2).to(dtype=torch.float32).view(1, 1, height, width)
+    checker = (checker * 0.4 - 0.2).expand(1, channels, height, width)
+
+    sample = gradient + checker
+    return sample.expand(batch, channels, height, width).contiguous()
+
+
+def _parity_input_from_image(path: Path, resolution: int) -> torch.Tensor:
+    """Load an RGB image, resize to square ``resolution``, and ImageNet-normalize (predict-style).
+
+    Args:
+        path: Path to an RGB image file.
+        resolution: Square side length matching the exported model.
+
+    Returns:
+        Float tensor shaped ``(1, 3, resolution, resolution)``.
+
+    Raises:
+        FileNotFoundError: If ``path`` does not exist.
+    """
+    if not path.is_file():
+        raise FileNotFoundError(f"parity fixture image not found: {path}")
+    with Image.open(path) as img:
+        image = img.convert("RGB")
+    tensor = TF.to_tensor(image)
+    tensor = TF.resize(tensor, [resolution, resolution], antialias=False)
+    tensor = TF.normalize(tensor, _IMAGENET_MEAN, _IMAGENET_STD)
+    return tensor.unsqueeze(0)
+
+
+def eager_reference_tensors(pytorch_model: torch.nn.Module, example_input: torch.Tensor) -> list[torch.Tensor]:
+    """Run *example_input* through the eager export-mode model; return flattened float CPU output tensors.
+
+    The export-mode ``forward`` can mutate its input in place, so a fresh clone is fed in. The output
+    (tuple or pytree) is flattened and filtered to tensors so backends that yield outputs in a flat
+    order can be paired positionally.
+
+    Args:
+        pytorch_model: Export-mode PyTorch module on CPU.
+        example_input: ``(N, C, H, W)`` example tensor.
+
+    Returns:
+        One detached float CPU tensor per model output, in flattened order.
+
+    Raises:
+        AssertionError: If the model produces no tensor outputs.
+    """
+    from torch.utils._pytree import tree_flatten
+
+    with torch.no_grad():
+        eager_out = pytorch_model(example_input.clone())
+    tensors = [t.detach().float().cpu() for t in tree_flatten(eager_out)[0] if isinstance(t, torch.Tensor)]
+    assert tensors, "export-mode forward produced no tensor outputs to compare"
+    return tensors
+
+
+def max_abs_output_diffs(
+    eager_tensors: list[torch.Tensor],
+    other_tensors: list[torch.Tensor],
+    *,
+    check_shape: bool = True,
+    names: list[str] | None = None,
+) -> list[float]:
+    """Pair eager and backend output tensors positionally; return per-output max-abs-diff.
+
+    Args:
+        eager_tensors: Reference tensors from :func:`eager_reference_tensors`.
+        other_tensors: Backend (CoreML/ExecuTorch/TensorRT) output tensors, same order.
+        check_shape: Assert each paired output has matching shape before diffing.
+        names: Optional backend output names, used only to enrich assertion messages.
+
+    Returns:
+        One max-abs-diff per output tensor.
+
+    Raises:
+        AssertionError: If output counts (or, when ``check_shape``, shapes) disagree.
+    """
+    assert len(other_tensors) == len(eager_tensors), (
+        f"backend output count {len(other_tensors)} != PyTorch {len(eager_tensors)}"
+        + (f" (names={names})" if names is not None else "")
+    )
+    diffs: list[float] = []
+    for idx, (eager, other) in enumerate(zip(eager_tensors, other_tensors)):
+        if check_shape:
+            name_hint = f" (name={names[idx]!r})" if names is not None else ""
+            assert eager.shape == other.shape, (
+                f"output[{idx}] shape mismatch: PyTorch {tuple(eager.shape)} vs backend {tuple(other.shape)}{name_hint}"
+            )
+        diffs.append((eager - other.float()).abs().max().item())
+    return diffs

--- a/tests/export/test_coreml_export.py
+++ b/tests/export/test_coreml_export.py
@@ -27,82 +27,23 @@ from unittest import mock
 import numpy as np
 import pytest
 import torch
-import torchvision.transforms.functional as TF  # noqa: N812 — standard torchvision alias
 from PIL import Image
 from supervision.assets import ImageAssets, download_assets
 
 from rfdetr.export._coreml import _IS_COREMLTOOLS_AVAILABLE
 from rfdetr.export._coreml.converter import _check_coremltools_available, export_coreml
+from tests.export.conftest import (
+    _parity_input_from_image,
+    _structured_parity_input,
+    eager_reference_tensors,
+    max_abs_output_diffs,
+)
 
 coreml_only = pytest.mark.skipif(not _IS_COREMLTOOLS_AVAILABLE, reason="coremltools not installed")
 
 # FLOAT32 CoreML convert matches eager to ~1e-5 on boxes/logits; masks need a bit more
 # headroom (~8e-5 observed on SegNano). Bound stays well under structural-failure scale (>=1e-3).
 _COREML_MAX_ABS_DIFF = 1e-4
-
-# ImageNet stats used by RF-DETR preprocess / exported CoreML bundles.
-_IMAGENET_MEAN = (0.485, 0.456, 0.406)
-_IMAGENET_STD = (0.229, 0.224, 0.225)
-
-
-def _structured_parity_input(
-    batch: int,
-    channels: int,
-    height: int,
-    width: int,
-) -> torch.Tensor:
-    """Build a deterministic, spatially correlated ``NCHW`` tensor for export parity.
-
-    Combines a smooth spatial gradient with a coarse checkerboard so the backbone sees
-    local structure (unlike ``torch.randn``, which can mask export/runtime divergence).
-
-    Args:
-        batch: Batch size.
-        channels: Channel count (typically 3).
-        height: Spatial height.
-        width: Spatial width.
-
-    Returns:
-        Float tensor shaped ``(batch, channels, height, width)`` in roughly ImageNet-normalized range.
-    """
-    ys = torch.linspace(-1.0, 1.0, height).view(1, 1, height, 1)
-    xs = torch.linspace(-1.0, 1.0, width).view(1, 1, 1, width)
-    gradient = (0.35 * ys + 0.25 * xs).expand(1, channels, height, width).clone()
-    # Per-channel offset so RGB planes are not identical.
-    for c in range(channels):
-        gradient[:, c] = gradient[:, c] + 0.05 * (c - 1)
-
-    tile = 16
-    yy = (torch.arange(height).view(height, 1) // tile) % 2
-    xx = (torch.arange(width).view(1, width) // tile) % 2
-    checker = ((yy + xx) % 2).to(dtype=torch.float32).view(1, 1, height, width)
-    checker = (checker * 0.4 - 0.2).expand(1, channels, height, width)
-
-    sample = gradient + checker
-    return sample.expand(batch, channels, height, width).contiguous()
-
-
-def _parity_input_from_image(path: Path, resolution: int) -> torch.Tensor:
-    """Load an RGB image, resize to square ``resolution``, and ImageNet-normalize (predict-style).
-
-    Args:
-        path: Path to an RGB image file.
-        resolution: Square side length matching the exported model.
-
-    Returns:
-        Float tensor shaped ``(1, 3, resolution, resolution)``.
-
-    Raises:
-        FileNotFoundError: If ``path`` does not exist.
-    """
-    if not path.is_file():
-        raise FileNotFoundError(f"parity fixture image not found: {path}")
-    with Image.open(path) as img:
-        image = img.convert("RGB")
-    tensor = TF.to_tensor(image)
-    tensor = TF.resize(tensor, [resolution, resolution], antialias=False)
-    tensor = TF.normalize(tensor, _IMAGENET_MEAN, _IMAGENET_STD)
-    return tensor.unsqueeze(0)
 
 
 def _coreml_parity_diffs(
@@ -129,11 +70,7 @@ def _coreml_parity_diffs(
     """
     import coremltools as ct
 
-    with torch.no_grad():
-        eager_out = pytorch_model(example_input.clone())
-    if not isinstance(eager_out, tuple):
-        raise AssertionError(f"export-mode forward must return a tuple, got {type(eager_out)!r}")
-    eager_tensors = [t.detach().float().cpu() for t in eager_out if isinstance(t, torch.Tensor)]
+    eager_tensors = eager_reference_tensors(pytorch_model, example_input)
 
     # CPU_ONLY avoids ANE/GPU fp16 execution drift when validating FLOAT32 bundles.
     mlmodel = ct.models.MLModel(str(mlpackage_path), compute_units=ct.ComputeUnit.CPU_ONLY)
@@ -143,17 +80,7 @@ def _coreml_parity_diffs(
     prediction = mlmodel.predict({input_name: np.ascontiguousarray(example_input.detach().cpu().numpy())})
     coreml_tensors = [torch.from_numpy(np.asarray(prediction[name], dtype=np.float32)) for name in output_names]
 
-    assert len(coreml_tensors) == len(eager_tensors), (
-        f"CoreML output count {len(coreml_tensors)} != PyTorch {len(eager_tensors)} (spec names={output_names})"
-    )
-    diffs: list[float] = []
-    for idx, (eager, coreml) in enumerate(zip(eager_tensors, coreml_tensors)):
-        assert eager.shape == coreml.shape, (
-            f"output[{idx}] shape mismatch: PyTorch {tuple(eager.shape)} vs CoreML {tuple(coreml.shape)} "
-            f"(name={output_names[idx]!r})"
-        )
-        diffs.append((eager - coreml).abs().max().item())
-    return diffs
+    return max_abs_output_diffs(eager_tensors, coreml_tensors, check_shape=True, names=output_names)
 
 
 def validate_detection_coreml_vs_pytorch(

--- a/tests/export/test_coreml_export.py
+++ b/tests/export/test_coreml_export.py
@@ -8,10 +8,10 @@
 Covers:
 * ``export_coreml()`` — argument/dependency behaviour (``coremltools`` mocked where needed)
 * ``format="coreml"`` wiring through ``RFDETR.export()``
-* End-to-end convert + numerical parity (``@pytest.mark.coreml_e2e``, opt-in)
+* End-to-end convert + numerical parity (``@pytest.mark.e2e_coreml``, opt-in)
 
 Parity inputs are spatially structured (gradient + checkerboard) and
-``download_assets(ImageAssets.PEOPLE_WALKING)`` under ``coreml_e2e`` (no committed images).
+``download_assets(ImageAssets.PEOPLE_WALKING)`` under ``e2e_coreml`` (no committed images).
 Random Gaussian noise is intentionally avoided: it can hide export/runtime divergence that
 only appears on correlated image structure.
 """
@@ -442,9 +442,9 @@ def coreml_export(
 
 
 @coreml_only
-@pytest.mark.coreml_e2e
+@pytest.mark.e2e_coreml
 class TestCoreMLEndToEnd:
-    """Real CoreML export + FLOAT32 CPU numerical parity (``-m coreml_e2e``)."""
+    """Real CoreML export + FLOAT32 CPU numerical parity (``-m e2e_coreml``)."""
 
     def test_mlpackage_written(self, coreml_export: tuple[Any, torch.Tensor, Path, Any]) -> None:
         """Export must write a non-empty ``.mlpackage`` directory/bundle."""

--- a/tests/export/test_executorch_export.py
+++ b/tests/export/test_executorch_export.py
@@ -34,28 +34,31 @@ from rfdetr.export._executorch.converter import (
     export_executorch,
 )
 from tests._online import is_online
+from tests.export.conftest import eager_reference_tensors, max_abs_output_diffs
 
 executorch_only = pytest.mark.skipif(not _IS_EXECUTORCH_AVAILABLE, reason="executorch not installed")
 
 
-def _runtime_parity(model: Any, example: torch.Tensor, pte_path: Path) -> list[float]:
+def _executorch_runtime_tensors(pte_path: Path, example: torch.Tensor) -> list[torch.Tensor]:
+    """Load the ``.pte`` and run *example* through the ExecuTorch ``forward`` method; return output tensors.
+
+    The export-mode forward mutates its input in place, so a fresh clone is fed to the runtime.
+    """
+    _check_executorch_available(require_runtime=True)
+    from executorch.runtime import Runtime
+
+    method = Runtime.get().load_program(str(pte_path)).load_method("forward")
+    return [t for t in method.execute([example.clone()]) if isinstance(t, torch.Tensor)]
+
+
+def _runtime_parity(model: Any, example: torch.Tensor, pte_path: Path, *, check_shape: bool = True) -> list[float]:
     """Run *example* through the eager model and the ExecuTorch runtime; return per-output max-abs-diff.
 
     The export-mode forward mutates its input in place, so a fresh clone is fed to each run.
     """
-    _check_executorch_available(require_runtime=True)
-    from executorch.runtime import Runtime
-    from torch.utils._pytree import tree_flatten
-
-    with torch.no_grad():
-        eager_out = model(example.clone())
-    eager_tensors = [t for t in tree_flatten(eager_out)[0] if isinstance(t, torch.Tensor)]
-
-    method = Runtime.get().load_program(str(pte_path)).load_method("forward")
-    runtime_tensors = [t for t in method.execute([example.clone()]) if isinstance(t, torch.Tensor)]
-
-    assert len(runtime_tensors) == len(eager_tensors), "ExecuTorch output count differs from the source model"
-    return [(eager - runtime).abs().max().item() for eager, runtime in zip(eager_tensors, runtime_tensors)]
+    eager_tensors = eager_reference_tensors(model, example)
+    runtime_tensors = _executorch_runtime_tensors(pte_path, example)
+    return max_abs_output_diffs(eager_tensors, runtime_tensors, check_shape=check_shape)
 
 
 # ---------------------------------------------------------------------------
@@ -751,14 +754,69 @@ def photo_asset(tmp_path_factory: pytest.TempPathFactory) -> Path:
     return destination / filename
 
 
-@pytest.fixture(scope="module")
-def exported(tmp_path_factory: pytest.TempPathFactory) -> tuple[Any, torch.Tensor, Path]:
-    """Export RFDETRNano to a ``.pte`` once and reuse it across the parity checks."""
-    from rfdetr import RFDETRNano
+# XNNPACK fp32 matches eager to ~1e-5 on boxes/logits (observed: pred_boxes 0.0, pred_logits ~1.0e-5 with
+# random weights); the bound keeps modest headroom, robust to BLAS/XNNPACK build differences while still
+# failing on a structural regression (those diverge by >=1e-3). Segmentation masks get a little more headroom.
+_EXECUTORCH_DETECTION_MAX_ABS_DIFF = 5e-5
+_EXECUTORCH_SEGMENTATION_MAX_ABS_DIFF = 1e-4
 
+
+def validate_detection_executorch_vs_pytorch(pte_path: Path, model: Any, example: torch.Tensor) -> None:
+    """Compare ExecuTorch detection outputs (boxes, logits) to eager export-mode PyTorch.
+
+    Args:
+        pte_path: Path to the exported ``.pte``.
+        model: Export-mode PyTorch module on CPU.
+        example: ``(N, C, H, W)`` tensor used for both forwards.
+
+    Raises:
+        AssertionError: When output count/shape disagrees or max-abs-diff exceeds tolerance.
+    """
+    diffs = _runtime_parity(model, example, pte_path)
+    assert len(diffs) == 2, f"detection export must yield (boxes, logits), got {len(diffs)} outputs"
+    assert max(diffs) < _EXECUTORCH_DETECTION_MAX_ABS_DIFF, (
+        f"ExecuTorch detection outputs diverge from PyTorch: max abs diff {max(diffs)} "
+        f"(boxes={diffs[0]}, logits={diffs[1]}, bound={_EXECUTORCH_DETECTION_MAX_ABS_DIFF})"
+    )
+
+
+def validate_segmentation_executorch_vs_pytorch(pte_path: Path, model: Any, example: torch.Tensor) -> None:
+    """Compare ExecuTorch segmentation outputs (boxes, logits, masks) to eager export-mode PyTorch.
+
+    Args:
+        pte_path: Path to the exported ``.pte``.
+        model: Export-mode PyTorch segmentation module on CPU.
+        example: ``(N, C, H, W)`` tensor used for both forwards.
+
+    Raises:
+        AssertionError: When output count/shape disagrees or max-abs-diff exceeds tolerance.
+    """
+    diffs = _runtime_parity(model, example, pte_path)
+    assert len(diffs) == 3, f"segmentation export must yield (boxes, logits, masks), got {len(diffs)} outputs"
+    assert max(diffs) < _EXECUTORCH_SEGMENTATION_MAX_ABS_DIFF, (
+        f"ExecuTorch segmentation outputs diverge from PyTorch: max abs diff {max(diffs)} "
+        f"(boxes={diffs[0]}, logits={diffs[1]}, masks={diffs[2]}, bound={_EXECUTORCH_SEGMENTATION_MAX_ABS_DIFF})"
+    )
+
+
+_EXECUTORCH_E2E_VARIANTS = [
+    ("RFDETRNano", validate_detection_executorch_vs_pytorch),
+    ("RFDETRSegNano", validate_segmentation_executorch_vs_pytorch),
+]
+
+
+@pytest.fixture(scope="module", params=_EXECUTORCH_E2E_VARIANTS, ids=["detection", "segmentation"])
+def exported(
+    request: pytest.FixtureRequest, tmp_path_factory: pytest.TempPathFactory
+) -> tuple[Any, torch.Tensor, Path, Any]:
+    """Export RFDETRNano/RFDETRSegNano to a ``.pte`` once per variant and reuse across the parity checks."""
+    import rfdetr
+
+    model_cls_name, validate_fn = request.param
+    model_cls = getattr(rfdetr, model_cls_name)
     torch.manual_seed(42)
-    out_dir = tmp_path_factory.mktemp("executorch")
-    detector = RFDETRNano(pretrain_weights=None)
+    out_dir = tmp_path_factory.mktemp(f"executorch_{model_cls_name.lower()}")
+    detector = model_cls(pretrain_weights=None)
     pte_path = detector.export(output_dir=str(out_dir), format="executorch", backend="xnnpack", verbose=False)
 
     model = detector.model.model.to("cpu").eval()
@@ -766,32 +824,45 @@ def exported(tmp_path_factory: pytest.TempPathFactory) -> tuple[Any, torch.Tenso
     # .contiguous() is a no-op for a fresh randn but states the runtime's requirement explicitly:
     # ExecuTorch ignores input strides and reads the buffer as contiguous NCHW (see issue #1233).
     example = torch.randn(1, 3, detector.model.resolution, detector.model.resolution).contiguous()
-    return model, example, Path(pte_path)
+    return model, example, Path(pte_path), validate_fn
 
 
 @executorch_only
 @pytest.mark.e2e_executorch
 class TestExecutorchEndToEnd:
-    """End-to-end export of a real RF-DETR model, gated on the executorch package."""
+    """End-to-end export of a real RF-DETR model (detection + segmentation), gated on the executorch package."""
 
-    def test_pte_file_written(self, exported: tuple[Any, torch.Tensor, Path]) -> None:
-        _, _, pte_path = exported
+    def test_pte_file_written(self, exported: tuple[Any, torch.Tensor, Path, Any]) -> None:
+        """The exported artifact must be a non-empty ``.pte`` file."""
+        _, _, pte_path, _ = exported
         assert pte_path.is_file()
         assert pte_path.suffix == ".pte"
         assert pte_path.stat().st_size > 0
 
-    def test_runtime_output_matches_pytorch(self, exported: tuple[Any, torch.Tensor, Path]) -> None:
+    def test_forward_method_loads(self, exported: tuple[Any, torch.Tensor, Path, Any]) -> None:
+        """The exported ``.pte`` must expose a loadable ``forward`` method (runtime metadata smoke check)."""
+        _, _, pte_path, _ = exported
+        _check_executorch_available(require_runtime=True)
+        from executorch.runtime import Runtime
+
+        method = Runtime.get().load_program(str(pte_path)).load_method("forward")
+        assert method is not None
+
+    def test_output_shapes_and_dtypes_match(self, exported: tuple[Any, torch.Tensor, Path, Any]) -> None:
+        """Each ExecuTorch runtime output must match the eager forward's shape and be float32."""
+        model, example, pte_path, _ = exported
+        eager = eager_reference_tensors(model, example)
+        runtime = _executorch_runtime_tensors(pte_path, example)
+        assert [tuple(r.shape) for r in runtime] == [tuple(e.shape) for e in eager]
+        assert {r.dtype for r in runtime} == {torch.float32}
+
+    def test_runtime_output_matches_pytorch(self, exported: tuple[Any, torch.Tensor, Path, Any]) -> None:
         """ExecuTorch runtime output must match the eager PyTorch forward within XNNPACK fp32 tolerance."""
-        model, example, pte_path = exported
-        diffs = _runtime_parity(model, example, pte_path)
-        assert diffs, "expected at least one output to compare"
-        # XNNPACK fp32 path matches eager to ~1e-5 (observed: pred_boxes 0.0, pred_logits ~1.0e-5 with random
-        # weights).  The bound keeps modest headroom over that so it is robust to BLAS/XNNPACK build differences
-        # while still failing on a structural regression (those diverge by >=1e-3).
-        assert max(diffs) < 5e-5, f"ExecuTorch outputs diverge from PyTorch: max abs diff {max(diffs)}"
+        model, example, pte_path, validate_fn = exported
+        validate_fn(pte_path, model, example)
 
     def test_preprocessed_image_detections_match_pytorch(
-        self, exported: tuple[Any, torch.Tensor, Path], photo_asset: Path
+        self, exported: tuple[Any, torch.Tensor, Path, Any], photo_asset: Path
     ) -> None:
         """Detections from an image fed through ``infer_transforms`` must match the eager forward.
 

--- a/tests/export/test_executorch_export.py
+++ b/tests/export/test_executorch_export.py
@@ -770,7 +770,7 @@ def exported(tmp_path_factory: pytest.TempPathFactory) -> tuple[Any, torch.Tenso
 
 
 @executorch_only
-@pytest.mark.executorch
+@pytest.mark.e2e_executorch
 class TestExecutorchEndToEnd:
     """End-to-end export of a real RF-DETR model, gated on the executorch package."""
 

--- a/tests/export/test_executorch_export.py
+++ b/tests/export/test_executorch_export.py
@@ -880,7 +880,7 @@ class TestExecutorchEndToEnd:
 
         from rfdetr.export.benchmark import infer_transforms, post_process
 
-        model, example, pte_path = exported
+        model, example, pte_path, _ = exported
         resolution = int(example.shape[-1])
         image = Image.open(photo_asset).convert("RGB")
         tensor, _ = infer_transforms((resolution, resolution))(image, None)

--- a/tests/export/test_executorch_export.py
+++ b/tests/export/test_executorch_export.py
@@ -756,9 +756,12 @@ def photo_asset(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
 # XNNPACK fp32 matches eager to ~1e-5 on boxes/logits (observed: pred_boxes 0.0, pred_logits ~1.0e-5 with
 # random weights); the bound keeps modest headroom, robust to BLAS/XNNPACK build differences while still
-# failing on a structural regression (those diverge by >=1e-3). Segmentation masks get a little more headroom.
+# failing on a structural regression (those diverge by >=1e-3).
 _EXECUTORCH_DETECTION_MAX_ABS_DIFF = 5e-5
-_EXECUTORCH_SEGMENTATION_MAX_ABS_DIFF = 1e-4
+# Segmentation masks are upsampled/decoded (more compute steps) so they carry more numerical noise:
+# observed mask max-abs-diff ~1.04e-4 on the CI runner with pinned seeds. Set ~2x headroom over that
+# while staying well under the >=1e-3 structural-failure scale.
+_EXECUTORCH_SEGMENTATION_MAX_ABS_DIFF = 2e-4
 
 
 def validate_detection_executorch_vs_pytorch(pte_path: Path, model: Any, example: torch.Tensor) -> None:

--- a/tests/export/test_parity_helpers.py
+++ b/tests/export/test_parity_helpers.py
@@ -1,0 +1,66 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Error-path coverage for the shared export-parity helpers in ``tests/export/conftest.py``.
+
+These guards only fire when a backend diverges structurally (output count/shape mismatch, an empty forward, or a missing
+fixture image), so the green-path end-to-end suites never exercise them. The checks here are backend-agnostic and CPU-
+only.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tests.export.conftest import (
+    _parity_input_from_image,
+    eager_reference_tensors,
+    max_abs_output_diffs,
+)
+
+
+class _NoTensorModule(torch.nn.Module):
+    """Stub export-mode module whose forward yields no tensor outputs."""
+
+    def forward(self, x: torch.Tensor) -> tuple[()]:
+        """Return an empty output tuple regardless of input."""
+        return ()
+
+
+class TestMaxAbsOutputDiffs:
+    """Guards on positional pairing of eager and backend output tensors."""
+
+    def test_count_mismatch_raises(self) -> None:
+        """A differing number of eager vs backend tensors must raise AssertionError."""
+        eager = [torch.zeros(2, 2)]
+        other = [torch.zeros(2, 2), torch.zeros(2, 2)]
+        with pytest.raises(AssertionError, match="output count"):
+            max_abs_output_diffs(eager, other)
+
+    def test_shape_mismatch_raises(self) -> None:
+        """Paired outputs with differing shapes must raise AssertionError when check_shape is set."""
+        eager = [torch.zeros(2, 2)]
+        other = [torch.zeros(2, 3)]
+        with pytest.raises(AssertionError, match="shape mismatch"):
+            max_abs_output_diffs(eager, other, check_shape=True)
+
+
+class TestEagerReferenceTensors:
+    """Guard on the eager reference forward producing comparable tensors."""
+
+    def test_no_tensor_outputs_raises(self) -> None:
+        """A model that yields no tensor outputs must raise AssertionError."""
+        with pytest.raises(AssertionError, match="no tensor outputs"):
+            eager_reference_tensors(_NoTensorModule(), torch.zeros(1, 3, 8, 8))
+
+
+class TestParityInputFromImage:
+    """Guard on the image-input builder for missing fixture files."""
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        """A path that does not exist must raise FileNotFoundError."""
+        with pytest.raises(FileNotFoundError, match="not found"):
+            _parity_input_from_image(tmp_path / "missing.png", 64)

--- a/tests/export/test_parity_helpers.py
+++ b/tests/export/test_parity_helpers.py
@@ -12,6 +12,8 @@ only.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 import torch
 

--- a/tests/export/test_tensorrt_export.py
+++ b/tests/export/test_tensorrt_export.py
@@ -5,15 +5,34 @@
 # ------------------------------------------------------------------------
 """Tests for the in-process TensorRT engine builder (`build_engine`).
 
-The engine is built via the TensorRT Python API through `polygraphy`; these tests monkeypatch the polygraphy entry
-points so they run without TensorRT, a GPU, or `polygraphy` installed.
+The unit tests monkeypatch the polygraphy entry points so they run without TensorRT, a GPU, or `polygraphy` installed.
+The end-to-end class (``@pytest.mark.e2e_tensorrt``, GPU + ``rfdetr[tensorrt]``, opt-in) builds a real engine from an
+exported RF-DETR ONNX and checks runtime parity — mirroring the CoreML and ExecuTorch export suites.
 """
 
+from __future__ import annotations
+
 import sys
+from pathlib import Path
 
 import pytest
+import torch
 
 from rfdetr.export import _tensorrt as tensorrt_export
+from rfdetr.export._tensorrt import _IS_TENSORRT_AVAILABLE
+from tests.export.conftest import (
+    _structured_parity_input,
+    eager_reference_tensors,
+    max_abs_output_diffs,
+)
+
+tensorrt_only = pytest.mark.skipif(not _IS_TENSORRT_AVAILABLE, reason="tensorrt not installed")
+
+# A FP32 TensorRT engine still fuses/reorders kernels relative to eager PyTorch, so it diverges more
+# than the XNNPACK CPU path (~1e-5). The bound tolerates kernel-level numerical differences while still
+# failing on a structural regression (outputs collapse by >=1e-1). Recalibrate once real GPU numbers are
+# observed in the tensorrt-parity CI job.
+_TENSORRT_MAX_ABS_DIFF = 1e-2
 
 
 def _patch_polygraphy_chain(monkeypatch: pytest.MonkeyPatch) -> dict:
@@ -26,88 +45,157 @@ def _patch_polygraphy_chain(monkeypatch: pytest.MonkeyPatch) -> dict:
     return config_kwargs
 
 
-@pytest.mark.parametrize(
-    ("onnx_path", "expected_engine"),
-    [
-        pytest.param("/output/rfdetr.onnx", "/output/rfdetr.trt", id="plain-path"),
-        pytest.param("/path with spaces/model.onnx", "/path with spaces/model.trt", id="path-with-spaces"),
-        pytest.param("/model;rm -rf /.onnx", "/model;rm -rf /.onnx.trt", id="shell-metachar"),
-        pytest.param("/data/my.onnx.backup/model.onnx", "/data/my.onnx.backup/model.trt", id="earlier-onnx-in-dir"),
-        pytest.param("/output/model_v1.onnx.old.onnx", "/output/model_v1.onnx.old.trt", id="double-onnx-in-filename"),
-        pytest.param("/output/model_without_extension", "/output/model_without_extension.trt", id="no-onnx-extension"),
-    ],
-)
-def test_build_engine_dry_run_derives_trt_path(onnx_path: str, expected_engine: str) -> None:
-    """Only the final suffix is swapped to ``.trt``; earlier ``.onnx`` segments are never corrupted."""
-    result = tensorrt_export.build_engine(onnx_path, dry_run=True)
+class TestBuildEngineDryRun:
+    """Dry-run derives the ``.trt`` path without touching the polygraphy build chain."""
 
-    assert result == expected_engine
-
-
-def test_build_engine_dry_run_does_not_build(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Dry-run must return the engine path without invoking the polygraphy build chain."""
-    called: list[str] = []
-    monkeypatch.setattr(tensorrt_export, "engine_from_network", lambda *a, **k: called.append("built"))
-
-    result = tensorrt_export.build_engine("/tmp/model.onnx", dry_run=True)
-
-    assert result == "/tmp/model.trt"
-    assert not called, "dry_run must not invoke the polygraphy build chain"
-
-
-def test_build_engine_without_polygraphy_raises(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A missing polygraphy/tensorrt install must raise an actionable ImportError."""
-    monkeypatch.setattr(tensorrt_export, "engine_from_network", None)
-
-    with pytest.raises(ImportError, match=r"rfdetr\[tensorrt\]"):
-        tensorrt_export.build_engine("/tmp/model.onnx")
-
-
-@pytest.mark.parametrize("fp16", [pytest.param(True, id="fp16"), pytest.param(False, id="fp32")])
-def test_build_engine_invokes_polygraphy_and_saves_trt(monkeypatch: pytest.MonkeyPatch, fp16: bool) -> None:
-    """build_engine wires ONNX -> config -> engine -> save and returns the ``.trt`` path."""
-    config_kwargs: dict = {}
-    build_args: dict = {}
-    saved: dict = {}
-
-    monkeypatch.setattr(tensorrt_export, "network_from_onnx_path", lambda path: ("network", path))
-    monkeypatch.setattr(
-        tensorrt_export, "CreateConfig", lambda **kwargs: config_kwargs.update(kwargs) or "config-sentinel"
+    @pytest.mark.parametrize(
+        ("onnx_path", "expected_engine"),
+        [
+            pytest.param("/output/rfdetr.onnx", "/output/rfdetr.trt", id="plain-path"),
+            pytest.param("/path with spaces/model.onnx", "/path with spaces/model.trt", id="path-with-spaces"),
+            pytest.param("/model;rm -rf /.onnx", "/model;rm -rf /.onnx.trt", id="shell-metachar"),
+            pytest.param("/data/my.onnx.backup/model.onnx", "/data/my.onnx.backup/model.trt", id="earlier-onnx-in-dir"),
+            pytest.param(
+                "/output/model_v1.onnx.old.onnx", "/output/model_v1.onnx.old.trt", id="double-onnx-in-filename"
+            ),
+            pytest.param(
+                "/output/model_without_extension", "/output/model_without_extension.trt", id="no-onnx-extension"
+            ),
+        ],
     )
+    def test_derives_trt_path(self, onnx_path: str, expected_engine: str) -> None:
+        """Only the final suffix is swapped to ``.trt``; earlier ``.onnx`` segments are never corrupted."""
+        result = tensorrt_export.build_engine(onnx_path, dry_run=True)
 
-    def _engine_from_network(network, config):
-        build_args["network"] = network
-        build_args["config"] = config
-        return "engine-sentinel"
+        assert result == expected_engine
 
-    def _save_engine(engine, path):
-        saved["engine"] = engine
-        saved["path"] = path
+    def test_does_not_build(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Dry-run must return the engine path without invoking the polygraphy build chain."""
+        called: list[str] = []
+        monkeypatch.setattr(tensorrt_export, "engine_from_network", lambda *a, **k: called.append("built"))
 
-    monkeypatch.setattr(tensorrt_export, "engine_from_network", _engine_from_network)
-    monkeypatch.setattr(tensorrt_export, "save_engine", _save_engine)
+        result = tensorrt_export.build_engine("/tmp/model.onnx", dry_run=True)
 
-    result = tensorrt_export.build_engine("/tmp/model.onnx", fp16=fp16)
-
-    assert result == "/tmp/model.trt"
-    assert config_kwargs == {"fp16": fp16}
-    assert build_args == {"network": ("network", "/tmp/model.onnx"), "config": "config-sentinel"}
-    assert saved == {"engine": "engine-sentinel", "path": "/tmp/model.trt"}
+        assert result == "/tmp/model.trt"
+        assert not called, "dry_run must not invoke the polygraphy build chain"
 
 
-def test_build_engine_downgrades_to_fp32_when_fp16_flag_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A TensorRT build without the FP16 builder flag must fall back to an FP32 engine instead of aborting."""
+class TestBuildEngineDependencyGuard:
+    """A missing polygraphy/tensorrt install raises an actionable ImportError."""
 
-    class _FakeTrt:
-        __version__ = "11.1.0.106"
+    def test_missing_polygraphy_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A missing polygraphy/tensorrt install must raise an actionable ImportError."""
+        monkeypatch.setattr(tensorrt_export, "engine_from_network", None)
 
-        class BuilderFlag:  # deliberately lacks an ``FP16`` attribute
-            INT8 = 0
+        with pytest.raises(ImportError, match=r"rfdetr\[tensorrt\]"):
+            tensorrt_export.build_engine("/tmp/model.onnx")
 
-    config_kwargs = _patch_polygraphy_chain(monkeypatch)
-    monkeypatch.setitem(sys.modules, "tensorrt", _FakeTrt)
 
-    result = tensorrt_export.build_engine("/tmp/model.onnx", fp16=True)
+class TestBuildEngineWiring:
+    """``build_engine`` wires ONNX -> config -> engine -> save and returns the ``.trt`` path."""
 
-    assert result == "/tmp/model.trt"
-    assert config_kwargs == {"fp16": False}
+    @pytest.mark.parametrize("fp16", [pytest.param(True, id="fp16"), pytest.param(False, id="fp32")])
+    def test_invokes_polygraphy_and_saves_trt(self, monkeypatch: pytest.MonkeyPatch, fp16: bool) -> None:
+        """build_engine wires ONNX -> config -> engine -> save and returns the ``.trt`` path."""
+        config_kwargs: dict = {}
+        build_args: dict = {}
+        saved: dict = {}
+
+        monkeypatch.setattr(tensorrt_export, "network_from_onnx_path", lambda path: ("network", path))
+        monkeypatch.setattr(
+            tensorrt_export, "CreateConfig", lambda **kwargs: config_kwargs.update(kwargs) or "config-sentinel"
+        )
+
+        def _engine_from_network(network, config):
+            build_args["network"] = network
+            build_args["config"] = config
+            return "engine-sentinel"
+
+        def _save_engine(engine, path):
+            saved["engine"] = engine
+            saved["path"] = path
+
+        monkeypatch.setattr(tensorrt_export, "engine_from_network", _engine_from_network)
+        monkeypatch.setattr(tensorrt_export, "save_engine", _save_engine)
+
+        result = tensorrt_export.build_engine("/tmp/model.onnx", fp16=fp16)
+
+        assert result == "/tmp/model.trt"
+        assert config_kwargs == {"fp16": fp16}
+        assert build_args == {"network": ("network", "/tmp/model.onnx"), "config": "config-sentinel"}
+        assert saved == {"engine": "engine-sentinel", "path": "/tmp/model.trt"}
+
+
+class TestBuildEngineFp16Fallback:
+    """A TensorRT build lacking the FP16 builder flag falls back to FP32 instead of aborting."""
+
+    def test_downgrades_to_fp32_when_fp16_flag_unavailable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A TensorRT build without the FP16 builder flag must fall back to an FP32 engine instead of aborting."""
+
+        class _FakeTrt:
+            __version__ = "11.1.0.106"
+
+            class BuilderFlag:  # deliberately lacks an ``FP16`` attribute
+                INT8 = 0
+
+        config_kwargs = _patch_polygraphy_chain(monkeypatch)
+        monkeypatch.setitem(sys.modules, "tensorrt", _FakeTrt)
+
+        result = tensorrt_export.build_engine("/tmp/model.onnx", fp16=True)
+
+        assert result == "/tmp/model.trt"
+        assert config_kwargs == {"fp16": False}
+
+
+@tensorrt_only
+@pytest.mark.gpu
+@pytest.mark.e2e_tensorrt
+class TestTensorRTEndToEnd:
+    """Real ONNX -> TensorRT engine build + runtime parity on GPU (requires ``rfdetr[tensorrt]`` and CUDA)."""
+
+    @pytest.fixture(scope="class")
+    def trt_engine(self, tmp_path_factory: pytest.TempPathFactory) -> tuple[torch.nn.Module, torch.Tensor, Path]:
+        """Export RFDETRNano to ONNX, build a FP32 ``.trt`` engine, and reuse it across the parity checks."""
+        from rfdetr import RFDETRNano
+        from rfdetr.export._tensorrt import build_engine
+
+        torch.manual_seed(42)
+        out_dir = tmp_path_factory.mktemp("tensorrt")
+        detector = RFDETRNano(pretrain_weights=None)
+        onnx_path = detector.export(output_dir=str(out_dir), format="onnx", verbose=False)
+        engine_path = build_engine(str(onnx_path), fp16=False, verbose=False)
+
+        model = detector.model.model.to("cpu").eval()
+        model.export()
+        resolution = int(detector.model.resolution)
+        example = _structured_parity_input(1, 3, resolution, resolution)
+        return model, example, Path(engine_path)
+
+    def test_engine_file_written(self, trt_engine: tuple[torch.nn.Module, torch.Tensor, Path]) -> None:
+        """build_engine must produce a non-empty ``.trt`` engine from the exported ONNX."""
+        _, _, engine_path = trt_engine
+        assert engine_path.is_file()
+        assert engine_path.suffix == ".trt"
+        assert engine_path.stat().st_size > 0
+
+    def test_runtime_output_matches_pytorch(self, trt_engine: tuple[torch.nn.Module, torch.Tensor, Path]) -> None:
+        """The TensorRT engine's outputs (dets, labels) must match eager PyTorch within FP32 tolerance."""
+        import numpy as np
+        from polygraphy.backend.common import BytesFromPath
+        from polygraphy.backend.trt import EngineFromBytes, TrtRunner
+
+        model, example, engine_path = trt_engine
+        eager_tensors = eager_reference_tensors(model, example)
+
+        feed = {"input": np.ascontiguousarray(example.detach().cpu().numpy())}
+        load_engine = EngineFromBytes(BytesFromPath(str(engine_path)))
+        with TrtRunner(load_engine) as runner:
+            outputs = runner.infer(feed_dict=feed)
+        output_names = ["dets", "labels"]
+        trt_tensors = [torch.from_numpy(np.asarray(outputs[name], dtype=np.float32)) for name in output_names]
+
+        diffs = max_abs_output_diffs(eager_tensors, trt_tensors, check_shape=True, names=output_names)
+        assert max(diffs) < _TENSORRT_MAX_ABS_DIFF, (
+            f"TensorRT outputs diverge from PyTorch: max abs diff {max(diffs)} "
+            f"(dets={diffs[0]}, labels={diffs[1]}, bound={_TENSORRT_MAX_ABS_DIFF})"
+        )


### PR DESCRIPTION
This pull request introduces a new TensorRT end-to-end parity test suite, improves the structure and maintainability of export backend parity tests, and standardizes opt-in test markers for CoreML, ExecuTorch, and TensorRT. The changes include adding a dedicated TensorRT test job, extracting and sharing common test utilities, updating test markers and filters, and refactoring test code for clarity and reuse.

**New TensorRT parity test integration:**

* Adds a new `tensorrt-parity` job to `.github/workflows/ci-integrations.yml` to run end-to-end ONNX→TensorRT export and parity tests on a GPU runner, with a corresponding guardian job to enforce test result reporting.

**Test marker standardization and filter updates:**

* Renames and standardizes opt-in test markers in `pyproject.toml` for CoreML (`e2e_coreml`), ExecuTorch (`e2e_executorch`), and TensorRT (`e2e_tensorrt`), updating workflow filters in `.github/workflows/ci-integrations.yml`, `.github/workflows/ci-tests-cpu.yml`, and `.github/workflows/ci-tests-gpu.yml` to use the new markers and ensure these heavy tests only run in their dedicated jobs. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L285-R287) [[2]](diffhunk://#diff-0dd73e14818b55120e653268df1c4bc44367a18b84821c6418641580e3d76b47L110-R110) [[3]](diffhunk://#diff-0dd73e14818b55120e653268df1c4bc44367a18b84821c6418641580e3d76b47L182-R186) [[4]](diffhunk://#diff-24e5f388bcbc626b2144002ef6a3ab8c25849453349172f1e287a82756bf1a71L68-R68) [[5]](diffhunk://#diff-53209bae0cc403f683dfba167d31dbf56132fe37cca436a436c8723bb9fed7e2L59-R59)

**Test utility refactoring and code deduplication:**

* Extracts common input synthesis and output comparison logic into a new shared module `tests/export/conftest.py`, used by all backend export parity tests (CoreML, ExecuTorch, TensorRT), reducing code duplication and ensuring consistent test structure and numerical comparison. [[1]](diffhunk://#diff-90b17390f15fd630cbcd3431932cebe395193bc9b309ab16bf2986b9a70bd69dR1-R149) [[2]](diffhunk://#diff-1ab04d67ecc0ad534ceffed8142e7ddc6ed03bb905813116410fec42c9c41d48L30-L106) [[3]](diffhunk://#diff-1ab04d67ecc0ad534ceffed8142e7ddc6ed03bb905813116410fec42c9c41d48L132-R73) [[4]](diffhunk://#diff-1ab04d67ecc0ad534ceffed8142e7ddc6ed03bb905813116410fec42c9c41d48L146-R83) [[5]](diffhunk://#diff-6cc9c2a2378b20d75cfebd62670fcddab9a0f7f1010f83712a04b51a7fcf8160R37-R61)

**CoreML and ExecuTorch test suite improvements:**

* Updates CoreML and ExecuTorch export parity tests to use the shared utilities, improves clarity of test markers and docstrings, and ensures parity tests are opt-in and robust to backend output shape/count mismatches. [[1]](diffhunk://#diff-1ab04d67ecc0ad534ceffed8142e7ddc6ed03bb905813116410fec42c9c41d48L11-R14) [[2]](diffhunk://#diff-1ab04d67ecc0ad534ceffed8142e7ddc6ed03bb905813116410fec42c9c41d48L445-R374) [[3]](diffhunk://#diff-6cc9c2a2378b20d75cfebd62670fcddab9a0f7f1010f83712a04b51a7fcf8160R37-R61)

**TensorRT backend detection:**

* Adds an explicit `_IS_TENSORRT_AVAILABLE` flag to `src/rfdetr/export/_tensorrt.py` to reliably detect and guard TensorRT backend availability in tests and runtime.