### PR TITLE
feat(augment): support ToGray on the Kornia backend

### DIFF
--- a/src/rfdetr/datasets/aug_configs.py
+++ b/src/rfdetr/datasets/aug_configs.py
@@ -79,7 +79,7 @@ or torchvision defaults. Install it with ``pip install 'rfdetr[augment]'``.
 | ``Rotate`` | ``K.RandomRotation`` | ``limit`` may be scalar or tuple |
 | ``Affine`` | ``K.RandomAffine`` | ``translate_percent`` treated as fraction |
 | ``ColorJitter`` | ``K.ColorJiggle`` | Same multiplicative semantics |
-| ``ToGray`` | ``K.RandomGrayscale`` | Grayscale, kept at three channels |
+| ``ToGray`` | ``K.RandomGrayscale`` | Grayscale, 3 channels; only ``p`` honored, method/num_output_channels ignored |
 | ``RandomBrightnessContrast`` | ``K.ColorJiggle`` | ``brightness_limit`` / ``contrast_limit`` direct |
 | ``GaussianBlur`` | ``K.RandomGaussianBlur`` | ``blur_limit`` rounded up to odd; ``sigma=(0.1, 2.0)`` |
 | ``GaussNoise`` | ``K.RandomGaussianNoise`` | Upper bound of ``std_range`` used as fixed std |

--- a/src/rfdetr/datasets/aug_configs.py
+++ b/src/rfdetr/datasets/aug_configs.py
@@ -41,7 +41,7 @@ model.train(dataset_dir="...", aug_config={"HorizontalFlip": {"p": 0.5}})
 - Perspective: Perspective, ElasticTransform, GridDistortion
 
 **Pixel-level transforms** (preserve bounding boxes):
-- Color: ColorJitter, HueSaturationValue, RandomBrightnessContrast
+- Color: ColorJitter, HueSaturationValue, RandomBrightnessContrast, ToGray
 - Blur/Noise: GaussianBlur, GaussNoise, Blur
 - Enhancement: CLAHE, Sharpen, Equalize
 
@@ -79,6 +79,7 @@ or torchvision defaults. Install it with ``pip install 'rfdetr[augment]'``.
 | ``Rotate`` | ``K.RandomRotation`` | ``limit`` may be scalar or tuple |
 | ``Affine`` | ``K.RandomAffine`` | ``translate_percent`` treated as fraction |
 | ``ColorJitter`` | ``K.ColorJiggle`` | Same multiplicative semantics |
+| ``ToGray`` | ``K.RandomGrayscale`` | Grayscale, kept at three channels |
 | ``RandomBrightnessContrast`` | ``K.ColorJiggle`` | ``brightness_limit`` / ``contrast_limit`` direct |
 | ``GaussianBlur`` | ``K.RandomGaussianBlur`` | ``blur_limit`` rounded up to odd; ``sigma=(0.1, 2.0)`` |
 | ``GaussNoise`` | ``K.RandomGaussianNoise`` | Upper bound of ``std_range`` used as fixed std |

--- a/src/rfdetr/datasets/kornia_transforms.py
+++ b/src/rfdetr/datasets/kornia_transforms.py
@@ -346,6 +346,17 @@ def _make_color_jitter(params: dict[str, Any]) -> Any:
     )
 
 
+def _make_to_gray(params: dict[str, Any]) -> Any:
+    """Build a ``K.RandomGrayscale`` from aug_config ``ToGray`` params.
+
+    Matches Albumentations' ``ToGray``: the image is converted to grayscale and
+    kept at three channels, so it stays a drop-in for an RGB pipeline.
+    """
+    from kornia.augmentation import RandomGrayscale
+
+    return RandomGrayscale(p=params.get("p", 0.5))
+
+
 def _make_random_brightness_contrast(params: dict[str, Any]) -> Any:
     """Build a ``K.ColorJiggle`` from ``RandomBrightnessContrast`` params."""
     from kornia.augmentation import ColorJiggle
@@ -410,6 +421,7 @@ _REGISTRY: dict[str, Callable[[dict[str, Any]], Any]] = {
     "Rotate": _make_rotate,
     "Affine": _make_affine,
     "ColorJitter": _make_color_jitter,
+    "ToGray": _make_to_gray,
     "RandomBrightnessContrast": _make_random_brightness_contrast,
     "GaussianBlur": _make_gaussian_blur,
     "GaussNoise": _make_gauss_noise,

--- a/src/rfdetr/datasets/kornia_transforms.py
+++ b/src/rfdetr/datasets/kornia_transforms.py
@@ -349,8 +349,8 @@ def _make_color_jitter(params: dict[str, Any]) -> Any:
 def _make_to_gray(params: dict[str, Any]) -> Any:
     """Build a ``K.RandomGrayscale`` from aug_config ``ToGray`` params.
 
-    Matches Albumentations' ``ToGray``: the image is converted to grayscale and
-    kept at three channels, so it stays a drop-in for an RGB pipeline.
+    Matches Albumentations' ``ToGray``: the image is converted to grayscale and kept at three channels, so it stays a
+    drop-in for an RGB pipeline.
     """
     from kornia.augmentation import RandomGrayscale
 

--- a/src/rfdetr/datasets/kornia_transforms.py
+++ b/src/rfdetr/datasets/kornia_transforms.py
@@ -350,10 +350,17 @@ def _make_to_gray(params: dict[str, Any]) -> Any:
     """Build a ``K.RandomGrayscale`` from aug_config ``ToGray`` params.
 
     Matches Albumentations' ``ToGray``: the image is converted to grayscale and kept at three channels, so it stays a
-    drop-in for an RGB pipeline.
+    drop-in for an RGB pipeline. Only ``p`` is honored on this (Kornia) backend: ``method`` and ``num_output_channels``
+    are accepted by the CPU (albumentations) path but have no Kornia equivalent, so they are silently ignored here.
     """
     from kornia.augmentation import RandomGrayscale
 
+    if "method" in params or "num_output_channels" in params:
+        logger.warning(
+            "GPU augmentation (Kornia) ToGray ignores 'method' and 'num_output_channels' "
+            "(Kornia's RandomGrayscale always uses BT.601 weights and returns 3 channels). "
+            "CPU augmentation (albumentations) honors both."
+        )
     return RandomGrayscale(p=params.get("p", 0.5))
 
 

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -113,6 +113,42 @@ class TestBuildKorniaPipeline:
         built_names = [t.__class__.__name__ for t in wrappers[0].transform.transforms]
         assert "ToGray" in built_names, f"expected a ToGray transform, got {built_names}"
 
+    def test_to_gray_defaults_p_to_point_five_when_omitted(self):
+        """Omitting p resolves to 0.5, matching Albumentations (not Kornia's native 0.1 default)."""
+        from rfdetr.datasets.kornia_transforms import build_kornia_pipeline
+
+        pipeline = build_kornia_pipeline({"ToGray": {}}, 560)
+        to_gray = next(child for child in pipeline.children() if child.__class__.__name__ == "RandomGrayscale")
+        assert to_gray.p == pytest.approx(0.5)
+
+    def test_to_gray_p_zero_is_a_no_op(self):
+        """p=0.0 never applies: forward pass returns the input unchanged."""
+        from rfdetr.datasets.kornia_transforms import build_kornia_pipeline
+
+        pipeline = build_kornia_pipeline({"ToGray": {"p": 0.0}}, 560)
+        image = torch.rand(1, 3, 32, 32)
+        boxes = torch.tensor([[[0.0, 0.0, 10.0, 10.0]]])
+        out, _ = pipeline(image, boxes)
+
+        assert torch.equal(out, image), "p=0.0 must never apply ToGray"
+
+    def test_to_gray_ignores_method_and_num_output_channels_on_kornia(self):
+        """method/num_output_channels have no Kornia equivalent and are currently ignored there.
+
+        Pins the divergence documented on ``_make_to_gray``: Albumentations honors both, Kornia always uses BT.601
+        weights and returns 3 channels. If this is ever fixed, this test should be updated to assert the new (parity)
+        behavior instead.
+        """
+        from rfdetr.datasets.kornia_transforms import build_kornia_pipeline
+
+        pipeline = build_kornia_pipeline({"ToGray": {"method": "max", "num_output_channels": 1, "p": 1.0}}, 560)
+        image = torch.rand(1, 3, 32, 32)
+        boxes = torch.tensor([[[0.0, 0.0, 10.0, 10.0]]])
+        out, _ = pipeline(image, boxes)
+
+        assert out.shape == image.shape, "num_output_channels=1 is currently ignored -- output stays 3-channel"
+        assert torch.allclose(out[:, 0], out[:, 1], atol=1e-5), "method='max' is currently ignored on Kornia"
+
     def test_hflip_disabled_for_keypoint_pipeline(self):
         """Keypoint-mode Kornia augmentation drops hflip transforms with a warning."""
         from unittest import mock

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -96,8 +96,8 @@ class TestBuildKorniaPipeline:
     def test_to_gray_accepted_by_both_backends(self):
         """The same config is readable by the Albumentations backend too (issue #1227).
 
-        ``ToGray`` resolved on Albumentations via ``getattr`` long before it was a Kornia
-        built-in, so a config that worked on one backend raised on the other.
+        ``ToGray`` resolved on Albumentations via ``getattr`` long before it was a Kornia built-in, so a config that
+        worked on one backend raised on the other.
         """
         pytest.importorskip("albumentations")
         from rfdetr.datasets.kornia_transforms import build_kornia_pipeline

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -105,7 +105,13 @@ class TestBuildKorniaPipeline:
 
         config = {"ToGray": {"p": 0.5}}
         assert build_kornia_pipeline(config, 560) is not None
-        assert AlbumentationsWrapper.from_config(config) is not None
+
+        wrappers = AlbumentationsWrapper.from_config(config)
+        assert len(wrappers) == 1, (
+            "from_config(strict=False) silently drops unresolved transforms, so length must be checked"
+        )
+        built_names = [t.__class__.__name__ for t in wrappers[0].transform.transforms]
+        assert "ToGray" in built_names, f"expected a ToGray transform, got {built_names}"
 
     def test_hflip_disabled_for_keypoint_pipeline(self):
         """Keypoint-mode Kornia augmentation drops hflip transforms with a warning."""

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -71,6 +71,42 @@ class TestBuildKorniaPipeline:
         with pytest.raises(ValueError, match="BogusTransform"):
             build_kornia_pipeline(mixed, 560)
 
+    def test_to_gray_builds_random_grayscale(self):
+        """``ToGray`` maps onto ``K.RandomGrayscale`` (issue #1227)."""
+        from rfdetr.datasets.kornia_transforms import build_kornia_pipeline
+
+        pipeline = build_kornia_pipeline({"ToGray": {"p": 0.5}}, 560)
+        transform_names = [child.__class__.__name__ for child in pipeline.children()]
+        assert "RandomGrayscale" in transform_names
+
+    def test_to_gray_keeps_three_channels_and_greys(self):
+        """``ToGray`` matches Albumentations: grayscale content, still three channels."""
+        from rfdetr.datasets.kornia_transforms import build_kornia_pipeline
+
+        pipeline = build_kornia_pipeline({"ToGray": {"p": 1.0}}, 560)
+        image = torch.rand(1, 3, 32, 32)
+        boxes = torch.tensor([[[0.0, 0.0, 10.0, 10.0]]])
+        out, _ = pipeline(image, boxes)
+
+        assert out.shape == image.shape, "ToGray must preserve the three-channel shape"
+        # A greyscale image has identical values across the channel axis.
+        assert torch.allclose(out[:, 0], out[:, 1], atol=1e-5)
+        assert torch.allclose(out[:, 1], out[:, 2], atol=1e-5)
+
+    def test_to_gray_accepted_by_both_backends(self):
+        """The same config is readable by the Albumentations backend too (issue #1227).
+
+        ``ToGray`` resolved on Albumentations via ``getattr`` long before it was a Kornia
+        built-in, so a config that worked on one backend raised on the other.
+        """
+        pytest.importorskip("albumentations")
+        from rfdetr.datasets.kornia_transforms import build_kornia_pipeline
+        from rfdetr.datasets.transforms import AlbumentationsWrapper
+
+        config = {"ToGray": {"p": 0.5}}
+        assert build_kornia_pipeline(config, 560) is not None
+        assert AlbumentationsWrapper.from_config(config) is not None
+
     def test_hflip_disabled_for_keypoint_pipeline(self):
         """Keypoint-mode Kornia augmentation drops hflip transforms with a warning."""
         from unittest import mock

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -808,6 +808,47 @@ class TestGaussNoiseStdRangeWarning:
         mock_warning.assert_not_called()
 
 
+class TestToGrayDroppedParamsWarning:
+    """_make_to_gray warns when passed method/num_output_channels, which have no Kornia equivalent."""
+
+    @pytest.fixture(autouse=True)
+    def _require_kornia(self):
+        pytest.importorskip("kornia")
+
+    def test_warns_for_method(self):
+        """A non-default method emits a dropped-param warning at build time."""
+        from unittest import mock
+
+        from rfdetr.datasets import kornia_transforms
+
+        with mock.patch.object(kornia_transforms.logger, "warning") as mock_warning:
+            kornia_transforms._make_to_gray({"method": "max", "p": 0.5})
+
+        mock_warning.assert_called_once()
+
+    def test_warns_for_num_output_channels(self):
+        """A non-default num_output_channels emits a dropped-param warning at build time."""
+        from unittest import mock
+
+        from rfdetr.datasets import kornia_transforms
+
+        with mock.patch.object(kornia_transforms.logger, "warning") as mock_warning:
+            kornia_transforms._make_to_gray({"num_output_channels": 1, "p": 0.5})
+
+        mock_warning.assert_called_once()
+
+    def test_no_warning_for_p_only(self):
+        """A config using only p matches the CPU path's default behavior and stays silent."""
+        from unittest import mock
+
+        from rfdetr.datasets import kornia_transforms
+
+        with mock.patch.object(kornia_transforms.logger, "warning") as mock_warning:
+            kornia_transforms._make_to_gray({"p": 0.5})
+
+        mock_warning.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # TestResolveAugmentationBackend — the single resolution seam that maps backend
 # strings (incl. sentinels/legacy aliases) to concrete AugmentationBackend members.


### PR DESCRIPTION
## Description

Closes #1227.

`ToGray` was requested as a built-in augmentation. It turns out it already works on one backend and not the other, so this is really a parity gap rather than a new feature.

The Albumentations backend resolves names dynamically (`getattr(alb, name, None)` in [transforms.py](src/rfdetr/datasets/transforms.py)), so `ToGray` has always resolved there. The Kornia backend resolves from a fixed `_REGISTRY` in [kornia_transforms.py](src/rfdetr/datasets/kornia_transforms.py), which did not list it. The same `aug_config` therefore behaves differently depending on which backend `augmentation_backend` resolves to:

```text
kornia ToGray -> ValueError: Unknown augmentation key 'ToGray' for Kornia GPU backend
albu   ToGray -> OK
```

That is easy to hit without noticing, because `"auto"` picks Kornia when CUDA is present and a CPU-installed environment resolves elsewhere, so the same config can work locally and fail on a GPU box.

This maps `ToGray` onto `K.RandomGrayscale`, which matches Albumentations' semantics: the image is converted to greyscale and kept at three channels, so it stays a drop-in for an RGB pipeline. The `p` parameter passes through, defaulting to `0.5` like the other builders.

Also adds the row to the Kornia equivalence table and the colour list in `aug_configs.py`, so the documented built-ins stay in step with the registry.

## Testing

Three tests in `tests/datasets/test_kornia_transforms.py`, CPU-only like the rest of that module:

- `test_to_gray_builds_random_grayscale`: the key maps onto `RandomGrayscale`.
- `test_to_gray_keeps_three_channels_and_greys`: with `p=1.0`, the output keeps its three-channel shape and the channels are equal, which is the property that makes it a drop-in.
- `test_to_gray_accepted_by_both_backends`: the same config builds on Kornia and on Albumentations, so the parity gap stays closed.

All three fail on `a700efc` with `ValueError: Unknown augmentation key 'ToGray'` and pass here.

```text
$ pytest tests/datasets/test_kornia_transforms.py tests/datasets/test_augmentations.py
215 passed

$ ruff check src/rfdetr/datasets/kornia_transforms.py src/rfdetr/datasets/aug_configs.py tests/datasets/test_kornia_transforms.py
All checks passed!

$ ruff format --check ...
3 files already formatted
```

Ran on Windows, CPU only, `kornia 0.8.3` / `albumentations 2.0.8` / `torch 2.13.0+cpu`. No GPU-only paths are touched, so no `@pytest.mark.gpu` is needed.
