### PR TITLE
fix(utilities): route XLA through `grid_sample` gather path

### DIFF
--- a/src/rfdetr/utilities/distributed.py
+++ b/src/rfdetr/utilities/distributed.py
@@ -63,11 +63,15 @@ def save_on_master(obj: Any, f: Any, *args: Any, **kwargs: Any) -> None:
         torch.save(obj, f, *args, **kwargs)
 
 
-def all_gather(data: Any) -> list[Any]:
+def all_gather(data: Any, device: torch.device | None = None) -> list[Any]:
     """Run all_gather on arbitrary picklable data (not necessarily tensors).
 
     Args:
         data: Any picklable object.
+        device: Device for the intermediate byte tensors. If ``None``, derived from the process group
+            backend (``cuda`` for NCCL, ``cpu`` otherwise). XLA callers must pass their local XLA device
+            explicitly — XLA has no dedicated ``dist`` backend name to probe, and defaulting to CPU would
+            place gather buffers on the wrong device.
 
     Returns:
         List of data gathered from each rank.
@@ -77,7 +81,9 @@ def all_gather(data: Any) -> list[Any]:
         return [data]
 
     # Serialize to a byte tensor on the active device.
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if device is None:
+        backend = dist.get_backend() if is_dist_avail_and_initialized() else "cpu"
+        device = torch.device("cuda" if backend == "nccl" else "cpu")
     buffer = pickle.dumps(data)
     tensor = torch.tensor(bytearray(buffer), dtype=torch.uint8, device=device)
 

--- a/src/rfdetr/utilities/tensors.py
+++ b/src/rfdetr/utilities/tensors.py
@@ -215,13 +215,14 @@ def _bilinear_grid_sample(
     padding_mode: str = "zeros",
     align_corners: bool = False,
 ) -> Tensor:
-    """Bilinear grid sampling compatible with all PyTorch backends including MPS.
+    """Bilinear grid sampling compatible with all PyTorch backends including MPS and XLA.
 
     Drop-in replacement for ``F.grid_sample(input, grid, mode='bilinear', ...)``. On MPS, ``F.grid_sample`` backward
-    (``grid_sampler_2d_backward``) is not yet implemented and silently falls back to CPU.  This function uses
-    gather-based index arithmetic — natively supported on every backend — for the MPS path, while delegating to
-    ``F.grid_sample`` on CUDA/CPU where its fused kernel is faster.  The two paths are numerically identical, so model
-    accuracy is unaffected.
+    (``grid_sampler_2d_backward``) is not yet implemented and silently falls back to CPU. On XLA, routing through the
+    gather path avoids relying on ``F.grid_sample``'s XLA decomposition (host-fallback risk on older torch_xla).  This
+    function uses gather-based index arithmetic — natively supported on every backend — for the MPS/XLA path, while
+    delegating to ``F.grid_sample`` on CUDA/CPU where its fused kernel is faster.  The two paths are numerically
+    identical, so model accuracy is unaffected.
 
     Args:
         input: Feature map of shape ``(N, C, H, W)``.
@@ -234,7 +235,7 @@ def _bilinear_grid_sample(
     """
     import torch.nn.functional as F  # noqa: N812
 
-    if input.device.type != "mps":
+    if input.device.type not in ("mps", "xla"):
         return F.grid_sample(input, grid, mode="bilinear", padding_mode=padding_mode, align_corners=align_corners)
 
     if padding_mode not in ("zeros", "border"):

--- a/tests/utilities/test_distributed.py
+++ b/tests/utilities/test_distributed.py
@@ -7,21 +7,38 @@
 
 from unittest.mock import patch
 
+import torch
+
 from rfdetr.utilities.distributed import all_gather
 
 
+def _fake_all_gather(output_tensors, input_tensor) -> None:
+    """Stand-in for dist.all_gather: broadcast the local tensor to every output slot."""
+    for out in output_tensors:
+        out.copy_(input_tensor)
+
+
 def test_all_gather_supports_cpu_without_tensor_truthiness_error() -> None:
-    """all_gather should work on CPU-only setups and return gathered objects."""
-
-    def _fake_all_gather(output_tensors, input_tensor) -> None:
-        for out in output_tensors:
-            out.copy_(input_tensor)
-
+    """all_gather derives a cpu device and works when the backend is not nccl (e.g. gloo)."""
     with (
         patch("rfdetr.utilities.distributed.get_world_size", return_value=2),
         patch("rfdetr.utilities.distributed.dist.all_gather", side_effect=_fake_all_gather),
-        patch("rfdetr.utilities.distributed.torch.cuda.is_available", return_value=False),
+        patch("rfdetr.utilities.distributed.is_dist_avail_and_initialized", return_value=True),
+        patch("rfdetr.utilities.distributed.dist.get_backend", return_value="gloo"),
     ):
         result = all_gather({"value": 7})
 
+    assert result == [{"value": 7}, {"value": 7}]
+
+
+def test_all_gather_explicit_device_bypasses_backend_probe() -> None:
+    """A caller-supplied device (e.g. an XLA device) is used as-is; no backend derivation runs."""
+    with (
+        patch("rfdetr.utilities.distributed.get_world_size", return_value=2),
+        patch("rfdetr.utilities.distributed.dist.all_gather", side_effect=_fake_all_gather),
+        patch("rfdetr.utilities.distributed.dist.get_backend") as mock_get_backend,
+    ):
+        result = all_gather({"value": 7}, device=torch.device("cpu"))
+
+    mock_get_backend.assert_not_called()
     assert result == [{"value": 7}, {"value": 7}]

--- a/tests/utilities/test_distributed.py
+++ b/tests/utilities/test_distributed.py
@@ -35,10 +35,30 @@ def test_all_gather_explicit_device_bypasses_backend_probe() -> None:
     """A caller-supplied device (e.g. an XLA device) is used as-is; no backend derivation runs."""
     with (
         patch("rfdetr.utilities.distributed.get_world_size", return_value=2),
-        patch("rfdetr.utilities.distributed.dist.all_gather", side_effect=_fake_all_gather),
+        patch("rfdetr.utilities.distributed.dist.all_gather", side_effect=_fake_all_gather) as mock_all_gather,
         patch("rfdetr.utilities.distributed.dist.get_backend") as mock_get_backend,
     ):
         result = all_gather({"value": 7}, device=torch.device("cpu"))
 
     mock_get_backend.assert_not_called()
+    input_tensor = mock_all_gather.call_args.args[1]
+    assert input_tensor.device == torch.device("cpu")
     assert result == [{"value": 7}, {"value": 7}]
+
+
+def test_all_gather_explicit_device_wins_over_cuda_heuristic() -> None:
+    """Explicit device= is still honored when the cuda-available heuristic would otherwise pick cuda.
+
+    Guards against a regression that silently ignores ``device=`` and falls back to the cuda-if-available-else-cpu
+    heuristic -- such a bug would coincidentally pass on CPU-only CI (where cuda is never available) without this
+    explicit ``is_available=True`` override.
+    """
+    with (
+        patch("rfdetr.utilities.distributed.get_world_size", return_value=2),
+        patch("rfdetr.utilities.distributed.dist.all_gather", side_effect=_fake_all_gather) as mock_all_gather,
+        patch("rfdetr.utilities.distributed.torch.cuda.is_available", return_value=True),
+    ):
+        all_gather({"value": 7}, device=torch.device("cpu"))
+
+    input_tensor = mock_all_gather.call_args.args[1]
+    assert input_tensor.device == torch.device("cpu")

--- a/tests/utilities/test_tensors.py
+++ b/tests/utilities/test_tensors.py
@@ -47,23 +47,25 @@ def _call_manual_path(
     grid: torch.Tensor,
     padding_mode: str = "zeros",
     align_corners: bool = False,
+    device_type: str = "mps",
 ) -> torch.Tensor:
     """Force the manual gather-based code path by mocking input.device.type.
 
-    The function checks ``input.device.type != "mps"`` to decide which branch to take.  We patch ``torch.Tensor.device``
-    to return an object whose ``.type`` is ``"mps"`` so the manual path runs on a normal CPU tensor.
+    The function checks ``input.device.type not in ("mps", "xla")`` to decide which branch to take.  We patch
+    ``torch.Tensor.device`` to return an object whose ``.type`` is *device_type* so the manual path runs on a normal CPU
+    tensor without needing real MPS/XLA hardware.
     """
 
-    class _FakeMPSDevice:
-        type = "mps"
+    class _FakeDevice:
+        type = device_type
 
         def __eq__(self, other):
             return False
 
         def __repr__(self):
-            return "device(type='mps')"
+            return f"device(type='{device_type}')"
 
-    with patch.object(torch.Tensor, "device", new_callable=lambda: property(lambda self: _FakeMPSDevice())):
+    with patch.object(torch.Tensor, "device", new_callable=lambda: property(lambda self: _FakeDevice())):
         return _bilinear_grid_sample(input, grid, padding_mode=padding_mode, align_corners=align_corners)
 
 
@@ -256,6 +258,24 @@ class TestBilinearGridSampleDelegation:
         actual = _bilinear_grid_sample(input, grid, padding_mode="border", align_corners=False)
 
         torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+class TestBilinearGridSampleDeviceRouting:
+    """Both MPS and XLA route through the manual gather path (WP1 Task 1.1)."""
+
+    @pytest.mark.parametrize(
+        "device_type",
+        [pytest.param("mps", id="mps"), pytest.param("xla", id="xla")],
+    )
+    def test_gather_path_taken_and_matches_reference(self, seed, device_type):
+        """Manual gather path is taken for mps/xla and matches F.grid_sample."""
+        input = torch.randn(1, 3, 8, 8)
+        grid = torch.rand(1, 4, 4, 2) * 1.6 - 0.8
+
+        expected = _grid_sample_reference(input, grid, "zeros", False)
+        actual = _call_manual_path(input, grid, "zeros", False, device_type=device_type)
+
+        torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
 
 
 class TestBilinearGridSampleOutputShape:

--- a/tests/utilities/test_tensors.py
+++ b/tests/utilities/test_tensors.py
@@ -268,13 +268,15 @@ class TestBilinearGridSampleDeviceRouting:
         [pytest.param("mps", id="mps"), pytest.param("xla", id="xla")],
     )
     def test_gather_path_taken_and_matches_reference(self, seed, device_type):
-        """Manual gather path is taken for mps/xla and matches F.grid_sample."""
+        """Manual gather path is taken for mps/xla -- F.grid_sample itself is never called -- and matches it."""
         input = torch.randn(1, 3, 8, 8)
         grid = torch.rand(1, 4, 4, 2) * 1.6 - 0.8
 
         expected = _grid_sample_reference(input, grid, "zeros", False)
-        actual = _call_manual_path(input, grid, "zeros", False, device_type=device_type)
+        with patch.object(F, "grid_sample", wraps=F.grid_sample) as mock_grid_sample:
+            actual = _call_manual_path(input, grid, "zeros", False, device_type=device_type)
 
+        mock_grid_sample.assert_not_called()
         torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
 
 


### PR DESCRIPTION
This pull request extends support for XLA devices in distributed utilities and tensor operations, improving compatibility and correctness when running on TPU hardware. The main changes include updating device routing logic and tests to explicitly handle XLA, and enhancing documentation for clarity.

**Distributed utilities:**

* `all_gather` now accepts an optional `device` argument, allowing explicit device selection (e.g., XLA). If not provided, the device is inferred from the backend, defaulting to CUDA for NCCL and CPU otherwise. This prevents incorrect device placement and improves XLA compatibility. [[1]](diffhunk://#diff-0347faf8e4c99633c81cd0245e24ceda401c1630c647413aef9979d8adbdf414L66-R74) [[2]](diffhunk://#diff-0347faf8e4c99633c81cd0245e24ceda401c1630c647413aef9979d8adbdf414L80-R86)
* Tests for `all_gather` have been updated and expanded to verify correct device inference and explicit device handling, including a new test ensuring backend probing is bypassed when a device is supplied.

**Tensor operations:**

* The `_bilinear_grid_sample` function and its documentation are updated to support both MPS and XLA backends, ensuring the manual gather-based path is used for these devices to avoid host-fallback issues and improve reliability on XLA. [[1]](diffhunk://#diff-427028e1d1c06ccc0fd8b2cb139c16c02ba89c14bd12bac7f51830aabf0d1036L218-R225) [[2]](diffhunk://#diff-427028e1d1c06ccc0fd8b2cb139c16c02ba89c14bd12bac7f51830aabf0d1036L237-R238)
* Tests for `_bilinear_grid_sample` now parameterize device type to cover both MPS and XLA, verifying that the correct code path is taken and output matches the reference implementation. [[1]](diffhunk://#diff-6033a699e0a6b416a1ac6c31e531d733f2435074b25eb53efb88f5247dea8fb0R50-R68) [[2]](diffhunk://#diff-6033a699e0a6b416a1ac6c31e531d733f2435074b25eb53efb88f5247dea8fb0R263-R280)

---

part of #1058