### PR TITLE
feat(trainer): XLA precision + accelerator bridge

### DIFF
--- a/.github/workflows/ci-tests-xla.yml
+++ b/.github/workflows/ci-tests-xla.yml
@@ -11,8 +11,8 @@ name: XLA tests Workflow
 # `import torch_xla`. We pin torch to torch_xla's minor (torch==2.9.* <-> torch_xla 2.9); uv then
 # resolves torchvision to the matching minor. Bump both together when a newer torch_xla ships.
 #
-# Trigger is manual + PR for now; the job self-passes while no @pytest.mark.xla tests exist yet
-# (pytest exit code 5 = "no tests collected"). Flip the guard off once Phase 1 lands xla tests.
+# Trigger is manual + PR for now. Enforcing since WP2 (Phase 1 landed the first @pytest.mark.xla
+# test) -- a failing or missing test run now fails this job.
 
 on:
   workflow_dispatch:
@@ -98,20 +98,12 @@ jobs:
 
       - name: 🧪 Run the XLA-marked Tests
         run: |
-          set +e
           uv run --no-sync pytest src/ tests/ \
             -n 1 -m "xla and not gpu and not tpu" \
             --ignore=tests/run_smoke_all_models.py \
             --ignore=tests/legacy/test_checkpoint_compat.py \
             --timeout=420 \
             --durations=50
-          rc=$?
-          set -e
-          if [ "$rc" -eq 5 ]; then
-            echo "No @pytest.mark.xla tests collected yet (Phase 1 not landed) — passing."
-            exit 0
-          fi
-          exit $rc
 
       - name: Minimize uv cache
         continue-on-error: true

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -1055,6 +1055,8 @@ class TrainConfig(BaseConfig):
     square_resize_div_64: bool = True
     dataset_dir: PathLikeStr | None
     output_dir: PathLikeStr = "output"
+    # XLA/TPU: every distinct (H, W) triggers a separate graph compilation. Set multi_scale=False
+    # for a static shape (zero recompilations after the first batch) when training on TPU.
     multi_scale: bool = True
     expanded_scales: bool = True
     do_random_resize_via_padding: bool = False

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -786,7 +786,8 @@ class RFDETR:
 
         Returns:
             ``(accelerator, devices)`` where ``devices`` is ``None`` unless an explicit device index is provided (for
-            example ``cuda:1``).
+            example ``cuda:1``). ``device.type == "xla"`` maps to ``accelerator="tpu"`` -- PTL's accelerator
+            registry has no ``"xla"`` string; ``"tpu"`` is its canonical name for the XLA backend.
 
         Raises:
             ValueError: If ``device`` is not a valid torch device specifier.
@@ -807,6 +808,12 @@ class RFDETR:
             return "gpu", [resolved_device.index] if resolved_device.index is not None else None
         if resolved_device.type == "mps":
             return "mps", [resolved_device.index] if resolved_device.index is not None else None
+        if resolved_device.type == "xla":
+            # PTL's accelerator registry has no "xla" string -- "tpu" is its canonical name for
+            # the XLA backend (torch.device("xla") is valid and .type is always "xla", even on
+            # TPU; torch.device("tpu") itself raises RuntimeError). Bridge explicitly instead of
+            # falling through to the auto-detection warning below.
+            return "tpu", [resolved_device.index] if resolved_device.index is not None else None
 
         warnings.warn(
             f"Device type {resolved_device.type!r} is not explicitly mapped to a PyTorch Lightning "
@@ -831,8 +838,9 @@ class RFDETR:
           PE=37 at 560 px) are left unchanged to preserve checkpoint compatibility.
         * ``device`` — normalized via :class:`torch.device` and mapped to PyTorch
           Lightning trainer arguments. ``"cpu"`` becomes ``accelerator="cpu"``; ``"cuda"`` and ``"cuda:N"`` become
-          ``accelerator="gpu"`` and optionally ``devices=[N]``; ``"mps"`` becomes ``accelerator="mps"``. Other valid
-          torch device types fall back to PTL auto-detection and emit a :class:`UserWarning`.
+          ``accelerator="gpu"`` and optionally ``devices=[N]``; ``"mps"`` becomes ``accelerator="mps"``; ``"xla"``
+          becomes ``accelerator="tpu"`` (PTL's canonical name for the XLA backend). Other valid torch device types
+          fall back to PTL auto-detection and emit a :class:`UserWarning`.
         * ``notes`` — optional user-defined metadata (string, dict, list, or
           any JSON-serialisable value) stored under the ``"notes"`` key in every ``.pth`` checkpoint produced during
           training.  The value is also available inside ``args["notes"]`` for full provenance.  Pass the same value to

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -408,7 +408,11 @@ class RFDETRModelModule(LightningModule):
             model_config.compile and DEVICE == "cuda" and uses_cuda_accelerator and not train_config.multi_scale
         )
         if model_config.compile and train_config.multi_scale:
-            logger.info("Disabling torch.compile because multi_scale=True introduces dynamic input shapes.")
+            logger.info(
+                "Disabling torch.compile: multi_scale=True causes dynamic shapes "
+                "(incompatible with XLA -- each scale = separate graph trace). "
+                "Use do_random_resize_via_padding=True on TPU to avoid recompilation overhead."
+            )
         if compile_enabled:
             # dynamic=True: one compiled graph handles all multi-scale input sizes instead
             # of recompiling per (H, W) pair. suppress_errors=True: if inductor can't

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -412,12 +412,22 @@ def build_trainer(
         a ``_ForceLastEpochValidationCallback`` still guarantees the final epoch always
         validates even when ``epochs`` is not a multiple of ``eval_interval``.
 
+        When ``accelerator`` resolves to ``"xla"`` or ``"tpu"``, precision is set via an
+        ``XLAPrecision("bf16-true")`` plugin instead of ``precision="bf16-mixed"`` — PTL's
+        ``XLAStrategy`` only accepts the ``XLAPrecision`` plugin and raises ``TypeError`` for
+        standard precision strings.
+
     Returns:
         A configured ``pytorch_lightning.Trainer`` instance.
     """
     tc = train_config
     if accelerator is None:
         accelerator = tc.accelerator
+    # XLAStrategy's precision_plugin setter only accepts the XLAPrecision plugin
+    # (Literal["32-true", "16-true", "bf16-true"]); passing precision="bf16-mixed" raises
+    # TypeError. Detected here so trainer_config assembly below can route XLA around
+    # _resolve_precision() entirely instead of setting a precision= string it would reject.
+    xla_accelerator = str(accelerator).lower() in ("xla", "tpu")
 
     # TF32 matmul for fp32 residual matmuls on Ampere+.  ``rfdetr.detr`` sets this at import
     # time for the python API path, but the Lightning CLI path (``rfdetr fit``) never imports
@@ -657,7 +667,6 @@ def build_trainer(
         "devices": tc.devices,
         "num_nodes": tc.num_nodes,
         "strategy": strategy,
-        "precision": _resolve_precision(),
         "accumulate_grad_batches": accumulate_grad_batches,
         "gradient_clip_val": gradient_clip_val,
         "sync_batchnorm": sync_bn,
@@ -671,6 +680,12 @@ def build_trainer(
         "deterministic": False,
         "check_val_every_n_epoch": tc.eval_interval,
     }
+    if xla_accelerator:
+        from pytorch_lightning.plugins import XLAPrecision
+
+        trainer_config["plugins"] = [XLAPrecision("bf16-true")]
+    else:
+        trainer_config["precision"] = _resolve_precision()
     trainer_config.update(trainer_kwargs)
     trainer_config["strategy"] = strategy
     if manual_optimization:

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -412,10 +412,10 @@ def build_trainer(
         a ``_ForceLastEpochValidationCallback`` still guarantees the final epoch always
         validates even when ``epochs`` is not a multiple of ``eval_interval``.
 
-        When ``accelerator`` resolves to ``"xla"`` or ``"tpu"``, precision is set via an
-        ``XLAPrecision("bf16-true")`` plugin instead of ``precision="bf16-mixed"`` — PTL's
-        ``XLAStrategy`` only accepts the ``XLAPrecision`` plugin and raises ``TypeError`` for
-        standard precision strings.
+        When ``accelerator`` resolves to ``"xla"`` or ``"tpu"``, the resolved precision is
+        set via an ``XLAPrecision`` plugin instead of a ``precision`` argument — PTL's
+        ``XLAStrategy`` only accepts the plugin and raises ``TypeError`` for standard precision
+        strings. The XLA plugin is appended to caller-supplied plugins.
 
     Returns:
         A configured ``pytorch_lightning.Trainer`` instance.
@@ -425,8 +425,8 @@ def build_trainer(
         accelerator = tc.accelerator
     # XLAStrategy's precision_plugin setter only accepts the XLAPrecision plugin
     # (Literal["32-true", "16-true", "bf16-true"]); passing precision="bf16-mixed" raises
-    # TypeError. Detected here so trainer_config assembly below can route XLA around
-    # _resolve_precision() entirely instead of setting a precision= string it would reject.
+    # TypeError. Detected here so trainer_config assembly can translate the resolved precision
+    # into the required XLA plugin after applying caller-provided Trainer arguments.
     xla_accelerator = str(accelerator).lower() in ("xla", "tpu")
 
     # TF32 matmul for fp32 residual matmuls on Ampere+.  ``rfdetr.detr`` sets this at import
@@ -680,13 +680,22 @@ def build_trainer(
         "deterministic": False,
         "check_val_every_n_epoch": tc.eval_interval,
     }
+    if not xla_accelerator:
+        trainer_config["precision"] = _resolve_precision()
+    trainer_config.update(trainer_kwargs)
     if xla_accelerator:
         from pytorch_lightning.plugins import XLAPrecision
 
-        trainer_config["plugins"] = [XLAPrecision("bf16-true")]
-    else:
-        trainer_config["precision"] = _resolve_precision()
-    trainer_config.update(trainer_kwargs)
+        # XLAStrategy rejects precision= strings. Preserve caller plugins, then append the
+        # one mandatory XLA precision plugin after kwargs have been applied.
+        plugins = trainer_config.pop("plugins", [])
+        if plugins is None:
+            plugins = []
+        elif not isinstance(plugins, (list, tuple)):
+            plugins = [plugins]
+        trainer_config.pop("precision", None)
+        xla_precision = _resolve_precision().replace("-mixed", "-true")
+        trainer_config["plugins"] = [*plugins, XLAPrecision(xla_precision)]
     trainer_config["strategy"] = strategy
     if manual_optimization:
         # Re-apply manual-optimization invariants so a caller-supplied trainer_kwargs

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any
+from typing import Any, Literal
 
 import torch
 from pytorch_lightning import Callback, LightningModule, Trainer
@@ -108,6 +108,29 @@ class _NotebookSpawnDDPStrategy(_DDPStrategy):
                 "it is always constructed with start_method='spawn' in build_trainer()."
             )
         self._launcher = _InteractiveSpawnLauncher(self, start_method=self._start_method)
+
+
+def _normalize_xla_precision(precision: str) -> Literal["32-true", "16-true", "bf16-true"]:
+    """Normalize resolved precision strings to a valid XLAPrecision literal.
+
+    Args:
+        precision: Precision string produced by the local resolver, e.g. ``"16-mixed"``.
+
+    Returns:
+        One of ``"32-true"``, ``"16-true"``, or ``"bf16-true"`` suitable for XLA plugin creation.
+
+    Raises:
+        ValueError: If the resolved precision is not supported by ``XLAPrecision``.
+    """
+    if precision == "32-true":
+        return "32-true"
+    if precision == "16-true":
+        return "16-true"
+    if precision == "bf16-true":
+        return "bf16-true"
+    raise ValueError(
+        f"Unexpected precision value for XLAPrecision: {precision!r}; expected '32-true', '16-true', or 'bf16-true'."
+    )
 
 
 def _is_distributed_strategy_requested(strategy: str) -> bool:
@@ -694,7 +717,7 @@ def build_trainer(
         elif not isinstance(plugins, (list, tuple)):
             plugins = [plugins]
         trainer_config.pop("precision", None)
-        xla_precision = _resolve_precision().replace("-mixed", "-true")
+        xla_precision = _normalize_xla_precision(_resolve_precision().replace("-mixed", "-true"))
         trainer_config["plugins"] = [*plugins, XLAPrecision(xla_precision)]
     trainer_config["strategy"] = strategy
     if manual_optimization:

--- a/tests/training/test_build_trainer.py
+++ b/tests/training/test_build_trainer.py
@@ -453,6 +453,51 @@ class TestBuildTrainerPrecision:
             build_trainer(_tc(tmp_path, use_ema=False), _mc(amp=True))
         assert captured["precision"] == "bf16-mixed"
 
+    @pytest.mark.parametrize("accelerator", ["xla", "tpu"], ids=["xla", "tpu"])
+    def test_xla_accelerator_uses_xla_precision_plugin_not_precision_string(self, tmp_path, accelerator):
+        """Accelerator='xla'/'tpu' sets an XLAPrecision('bf16-true') plugin, never precision=.
+
+        XLAStrategy's precision_plugin setter only accepts the XLAPrecision plugin and raises TypeError for standard
+        precision strings like 'bf16-mixed'. ``XLAPrecision.__init__`` itself raises ``ModuleNotFoundError`` unless
+        torch_xla is importable (see ``lightning_fabric.accelerators.xla._XLA_AVAILABLE``), so the class is patched
+        here to keep this test backend-neutral -- the behaviour under test is build_trainer's accelerator dispatch,
+        not PTL's own package-availability guard.
+        """
+        import unittest.mock as mock
+
+        captured: dict = {}
+
+        def _fake_trainer(**kwargs):
+            captured.update(kwargs)
+            return mock.MagicMock()
+
+        mock_xla_precision_cls = mock.MagicMock(name="XLAPrecision")
+        with (
+            mock.patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer),
+            mock.patch("pytorch_lightning.plugins.XLAPrecision", mock_xla_precision_cls),
+        ):
+            build_trainer(_tc(tmp_path, use_ema=False), _mc(amp=True), accelerator=accelerator)
+
+        assert "precision" not in captured
+        mock_xla_precision_cls.assert_called_once_with("bf16-true")
+        assert captured["plugins"] == [mock_xla_precision_cls.return_value]
+
+    def test_non_xla_accelerator_sets_no_plugins_key(self, tmp_path):
+        """A non-XLA accelerator does not add a 'plugins' key -- only the XLA path does."""
+        import unittest.mock as mock
+
+        captured: dict = {}
+
+        def _fake_trainer(**kwargs):
+            captured.update(kwargs)
+            return mock.MagicMock()
+
+        with mock.patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer):
+            build_trainer(_tc(tmp_path, use_ema=False), _mc(amp=False), accelerator="cpu")
+
+        assert "plugins" not in captured
+        assert captured["precision"] == "32-true"
+
     @patch("torch.cuda.is_available", return_value=True)
     @patch("torch.cuda.is_bf16_supported", return_value=False)
     @patch("rfdetr.training.trainer.Trainer")

--- a/tests/training/test_build_trainer.py
+++ b/tests/training/test_build_trainer.py
@@ -473,6 +473,8 @@ class TestBuildTrainerPrecision:
 
         mock_xla_precision_cls = mock.MagicMock(name="XLAPrecision")
         with (
+            mock.patch("torch.cuda.is_available", return_value=True),
+            mock.patch("torch.cuda.is_bf16_supported", return_value=True),
             mock.patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer),
             mock.patch("pytorch_lightning.plugins.XLAPrecision", mock_xla_precision_cls),
         ):
@@ -481,6 +483,43 @@ class TestBuildTrainerPrecision:
         assert "precision" not in captured
         mock_xla_precision_cls.assert_called_once_with("bf16-true")
         assert captured["plugins"] == [mock_xla_precision_cls.return_value]
+
+    @pytest.mark.parametrize(
+        ("amp", "expected_precision"),
+        [
+            pytest.param(True, "bf16-true", id="amp_enabled"),
+            pytest.param(False, "32-true", id="amp_disabled"),
+        ],
+    )
+    def test_xla_accelerator_preserves_plugins_and_rejects_precision_kwargs(self, tmp_path, amp, expected_precision):
+        """XLA appends its precision plugin and ignores incompatible precision kwargs."""
+        import unittest.mock as mock
+
+        captured: dict = {}
+        caller_plugin = object()
+
+        def _fake_trainer(**kwargs):
+            captured.update(kwargs)
+            return mock.MagicMock()
+
+        mock_xla_precision_cls = mock.MagicMock(name="XLAPrecision")
+        with (
+            mock.patch("torch.cuda.is_available", return_value=True),
+            mock.patch("torch.cuda.is_bf16_supported", return_value=True),
+            mock.patch("rfdetr.training.trainer.Trainer", side_effect=_fake_trainer),
+            mock.patch("pytorch_lightning.plugins.XLAPrecision", mock_xla_precision_cls),
+        ):
+            build_trainer(
+                _tc(tmp_path, use_ema=False),
+                _mc(amp=amp),
+                accelerator="xla",
+                plugins=[caller_plugin],
+                precision="16-mixed",
+            )
+
+        assert "precision" not in captured
+        mock_xla_precision_cls.assert_called_once_with(expected_precision)
+        assert captured["plugins"] == [caller_plugin, mock_xla_precision_cls.return_value]
 
     def test_non_xla_accelerator_sets_no_plugins_key(self, tmp_path):
         """A non-XLA accelerator does not add a 'plugins' key -- only the XLA path does."""

--- a/tests/training/test_detr_shim.py
+++ b/tests/training/test_detr_shim.py
@@ -432,6 +432,25 @@ class TestRFDETRTrainPTLAbsorption:
         config = mock_self.get_train_config.return_value
         mock_bt.assert_called_once_with(config, mock_self.model_config, accelerator="gpu", devices=[2])
 
+    def test_device_xla_absorbed_as_accelerator_tpu(self, tmp_path, patch_lit):
+        """Device='xla' forwards accelerator='tpu' -- PTL's canonical name for the XLA backend."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = patch_lit
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self, device="xla")
+        config = mock_self.get_train_config.return_value
+        mock_bt.assert_called_once_with(config, mock_self.model_config, accelerator="tpu")
+        assert "devices" not in mock_bt.call_args.kwargs
+
+    def test_device_torch_device_xla_index_absorbed_as_accelerator_tpu_devices_list(self, tmp_path, patch_lit):
+        """device=torch.device('xla:0') forwards accelerator='tpu' and devices=[0]."""
+        mock_self = _make_rfdetr_self(tmp_path)
+        p_mod, p_dm, p_bt, _mcls, _dmcls, mock_bt = patch_lit
+        with p_mod, p_dm, p_bt:
+            RFDETR.train(mock_self, device=torch.device("xla:0"))
+        config = mock_self.get_train_config.return_value
+        mock_bt.assert_called_once_with(config, mock_self.model_config, accelerator="tpu", devices=[0])
+
     def test_device_invalid_raises_value_error_with_expected_message(self, tmp_path, patch_lit):
         """Invalid device strings raise a ValueError with the train() device hint."""
         mock_self = _make_rfdetr_self(tmp_path)

--- a/tests/utilities/test_tensors.py
+++ b/tests/utilities/test_tensors.py
@@ -280,6 +280,32 @@ class TestBilinearGridSampleDeviceRouting:
         torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
 
 
+class TestBilinearGridSampleXLAExecution:
+    """Real torch_xla PJRT execution -- proves the gather path takes no aten:: CPU fallback (T1 lane, WP2)."""
+
+    @pytest.mark.xla
+    def test_gather_path_no_cpu_fallback_on_real_xla_device(self, seed):
+        """On a real XLA device (any PJRT backend) the gather path runs with zero aten:: fallback ops."""
+        pytest.importorskip("torch_xla")
+        import torch_xla.core.xla_model as xm
+        import torch_xla.debug.metrics as met
+
+        device = xm.xla_device()
+        input = torch.randn(1, 3, 8, 8, device=device)
+        grid = torch.rand(1, 4, 4, 2, device=device) * 1.6 - 0.8
+
+        met.clear_all()
+        actual = _bilinear_grid_sample(input, grid, padding_mode="zeros", align_corners=False)
+        xm.mark_step()
+
+        report = met.metrics_report()
+        aten_lines = [line for line in report.splitlines() if "aten::" in line.lower()]
+        assert not aten_lines, "CPU fallback ops detected:\n" + "\n".join(aten_lines)
+
+        expected = _grid_sample_reference(input.cpu(), grid.cpu(), "zeros", False)
+        torch.testing.assert_close(actual.cpu(), expected, atol=1e-5, rtol=1e-5)
+
+
 class TestBilinearGridSampleOutputShape:
     """Output shape must be (N, C, Hg, Wg) for all inputs."""
 


### PR DESCRIPTION
build_trainer() routes accelerator="xla"/"tpu" through an XLAPrecision("bf16-true") plugin instead of precision=, since XLAStrategy's precision_plugin setter rejects standard precision strings. RFDETR._resolve_trainer_device_kwargs() gains an explicit device.type == "xla" -> accelerator="tpu" arm ahead of the auto-detection warning. Extends the multi_scale/torch.compile log message with XLA recompilation guidance and adds a static-shape note to TrainConfig.multi_scale. Adds the first @pytest.mark.xla test (grid_sample gather-path execution, torch_xla-gated) and flips ci-tests-xla.yml's exit-5 self-pass guard to enforcing now that a real xla-marked test exists.

---

part of #1058
