### PR TITLE
docs(llms): add keypoint coverage to llms.txt and llms-full.txt

### DIFF
--- a/docs/root-static/llms-full.txt
+++ b/docs/root-static/llms-full.txt
@@ -1,6 +1,6 @@
 # RF-DETR — Full Documentation
 
-> RF-DETR is a real-time transformer architecture for object detection and instance segmentation by Roboflow.
+> RF-DETR is a real-time transformer architecture for object detection, instance segmentation, and keypoint detection (preview) by Roboflow.
 > DINOv2 vision transformer backbone. ICLR 2026. SOTA on COCO (60.1 AP50:95, RF-DETR-2XL).
 > Apache 2.0 license for core models (Nano through Large). Python 3.10+.
 > Source: https://github.com/roboflow/rf-detr | Paper: https://arxiv.org/abs/2511.09554
@@ -9,7 +9,7 @@
 
 ## Overview
 
-RF-DETR (Roboflow Detection Transformer) is a real-time object detection and instance segmentation model from Roboflow, accepted at ICLR 2026. It uses a DINOv2 vision transformer backbone and achieves state-of-the-art accuracy–latency trade-offs on Microsoft COCO and RF100-VL.
+RF-DETR (Roboflow Detection Transformer) is a real-time object detection, instance segmentation, and keypoint detection (preview) model from Roboflow, accepted at ICLR 2026. It uses a DINOv2 vision transformer backbone and achieves state-of-the-art accuracy–latency trade-offs on Microsoft COCO and RF100-VL.
 
 RF-DETR is the first real-time model to exceed 60 mean Average Precision (mAP) when benchmarked on the COCO dataset. RF-DETR-2XL achieves 60.1 AP50:95 at 17.2 ms latency on NVIDIA T4 (TensorRT FP16, batch 1).
 
@@ -17,6 +17,7 @@ RF-DETR is the first real-time model to exceed 60 mean Average Precision (mAP) w
 - Core models (Nano, Small, Medium, Large) and all code: Apache 2.0
 - XLarge and 2XLarge detection models: PML 1.0 (requires rfdetr[plus])
 - Segmentation models follow the same tier structure
+- Keypoint model (preview): Apache 2.0
 
 ---
 
@@ -85,6 +86,24 @@ detections = model.predict("image.jpg", threshold=0.5)
 - `RFDETRSeg2XLarge` — 21.8 ms, 73.1 AP50 (49.9 AP50:95), 38.6M params, 768×768
 
 Segmentation models output instance masks in addition to bounding boxes. Masks are returned as a `torch.Tensor` or dict with `spatial_features`, `query_features`, and `bias` keys.
+
+---
+
+## Run Keypoints
+
+```python
+from rfdetr import RFDETRKeypointPreview
+
+model = RFDETRKeypointPreview()
+key_points = model.predict("image.jpg", threshold=0.5)
+```
+
+**Available keypoint model classes:**
+- `RFDETRKeypointPreview` — 9.7 ms, 71.8 AP50:95, 40.7M params, 576×576
+
+Keypoint detection is a preview feature. The model is pretrained on COCO person keypoints and predicts 17 body keypoints per detected person, in addition to bounding boxes. Accuracy is reported as OKS-based AP50:95, the standard COCO keypoint metric.
+
+The keypoint model is available in the `rfdetr` package only; it is not yet available via the `inference` package.
 
 ---
 
@@ -265,6 +284,24 @@ model.deploy_to_roboflow(
 | RF-DETR-Seg-L | 70.5 | 47.1 | 8.8 | 36.2 | 504×504 |
 | RF-DETR-Seg-XL | 72.2 | 48.8 | 13.5 | 38.1 | 624×624 |
 | RF-DETR-Seg-2XL | 73.1 | 49.9 | 21.8 | 38.6 | 768×768 |
+
+### Keypoint Results
+
+COCO person keypoints, OKS-based AP50:95. Params are deployment (fused) counts.
+
+| Architecture | COCO AP50:95 | Latency (ms) | Params (M) | License |
+|---|---|---|---|---|
+| RF-DETR Keypoint (Preview) | 71.8 | 9.7 | 40.7 | Apache 2.0 |
+| YOLO11-pose N | 48.9 | 3.2 | 2.9 | AGPL-3.0 |
+| YOLO11-pose S | 57.5 | 3.4 | 9.9 | AGPL-3.0 |
+| YOLO11-pose M | 64.2 | 5.2 | 20.9 | AGPL-3.0 |
+| YOLO11-pose L | 65.2 | 6.6 | 26.2 | AGPL-3.0 |
+| YOLO11-pose X | 68.6 | 10.6 | 58.8 | AGPL-3.0 |
+| YOLO26-pose N | 55.9 | 1.9 | 2.9 | AGPL-3.0 |
+| YOLO26-pose S | 62.0 | 2.7 | 10.4 | AGPL-3.0 |
+| YOLO26-pose M | 68.0 | 4.6 | 21.5 | AGPL-3.0 |
+| YOLO26-pose L | 69.2 | 5.9 | 25.9 | AGPL-3.0 |
+| YOLO26-pose X | 71.0 | 9.8 | 57.6 | AGPL-3.0 |
 
 ---
 

--- a/docs/root-static/llms.txt
+++ b/docs/root-static/llms.txt
@@ -1,5 +1,5 @@
 # RF-DETR
-> RF-DETR is a real-time object detection and instance segmentation transformer by Roboflow.
+> RF-DETR is a real-time object detection, instance segmentation, and keypoint detection (preview) transformer by Roboflow.
 > DINOv2 backbone. ICLR 2026. SOTA on COCO (60.1 AP50:95, RF-DETR-2XL).
 > Apache 2.0 for base models (Nano-Large). Install: pip install rfdetr.
 
@@ -11,7 +11,7 @@
 - Source repository: https://github.com/roboflow/rf-detr
 - Paper: https://arxiv.org/abs/2511.09554
 - Runtime: Python 3.10+, torch >=2.2.0, torchvision >=0.17.0, transformers >=5.1.0 and <6.0.0
-- Tasks: object detection and instance segmentation
+- Tasks: object detection, instance segmentation, and keypoint detection (preview)
 - Backbone: DINOv2 vision transformer
 - Dataset formats: COCO JSON and YOLO
 - Export targets: ONNX, TensorRT, and TFLite
@@ -21,6 +21,7 @@
 - [Install](https://rfdetr.roboflow.com/latest/getting-started/install/): pip install rfdetr
 - [Run Detection](https://rfdetr.roboflow.com/latest/learn/run/detection/): Run RF-DETR detection on images, video, webcam, and streams
 - [Run Segmentation](https://rfdetr.roboflow.com/latest/learn/run/segmentation/): Run RF-DETR Seg instance segmentation on images and video
+- [Run Keypoints](https://rfdetr.roboflow.com/latest/learn/run/keypoints/): Run RF-DETR Keypoint (preview) person keypoint detection on images, video, webcam, and streams
 - [Pretrained Models](https://rfdetr.roboflow.com/latest/learn/pretrained/): Nano, Small, Medium, Large, XLarge, and 2XLarge checkpoints
 
 ## Train
@@ -40,6 +41,7 @@
 - [COCO and RF100-VL Results](https://rfdetr.roboflow.com/latest/learn/benchmarks/): T4 TensorRT FP16, batch 1
 - Detection model range: RF-DETR-Nano 2.3 ms and 48.4 COCO AP50:95 through RF-DETR-2XLarge 17.2 ms and 60.1 COCO AP50:95
 - Segmentation model range: RF-DETR-Seg-Nano 3.4 ms and 40.3 COCO AP50:95 through RF-DETR-Seg-2XLarge 21.8 ms and 49.9 COCO AP50:95
+- Keypoint model (preview): RF-DETR Keypoint 9.7 ms and 71.8 COCO AP50:95 (OKS-based) on COCO person keypoints
 
 ## Model Selection Answers
 - Use RF-DETR-Nano for lowest latency edge detection: 2.3 ms on T4 TensorRT FP16, 48.4 AP50:95 on COCO, 30.5 M params.
@@ -47,13 +49,16 @@
 - Use RF-DETR-Large for the best open Apache 2.0 accuracy-latency trade-off: 6.8 ms, 56.5 AP50:95 on COCO.
 - Use RF-DETR-XLarge (11.5 ms, 58.6 AP50:95) or RF-DETR-2XLarge (17.2 ms, 60.1 AP50:95) when maximum accuracy matters; requires rfdetr[plus] and PML 1.0 license.
 - Use RF-DETR-Seg-Large (8.8 ms, 47.1 AP50:95) or RF-DETR-Seg-2XLarge (21.8 ms, 49.9 AP50:95) when instance masks are required; detection-only models return bounding boxes only.
+- Use RF-DETR Keypoint Preview (9.7 ms, 71.8 AP50:95, 40.7 M params) for person keypoint detection: 17 body keypoints per detected person, Apache 2.0. Preview feature, `rfdetr` package only.
 
 ## API Reference
 - [RFDETR base class](https://rfdetr.roboflow.com/latest/reference/rfdetr/): train(), predict(), export(), deploy_to_roboflow()
 - [Detection models](https://rfdetr.roboflow.com/latest/reference/nano/): RFDETRNano through RFDETR2XLarge
 - [Segmentation models](https://rfdetr.roboflow.com/latest/reference/seg_nano/): RFDETRSegNano through RFDETRSeg2XLarge
+- [Keypoint models](https://rfdetr.roboflow.com/latest/reference/kp_preview/): RFDETRKeypointPreview
 - [TrainConfig](https://rfdetr.roboflow.com/latest/reference/train_config/): Detection training configuration schema
 - [SegmentationTrainConfig](https://rfdetr.roboflow.com/latest/reference/segmentation_train_config/): Segmentation training configuration schema
+- [KeypointTrainConfig](https://rfdetr.roboflow.com/latest/reference/keypoint_train_config/): Keypoint training configuration schema
 - [Lightning Training](https://rfdetr.roboflow.com/latest/reference/training/): PyTorch Lightning training module, datamodule, callbacks, and trainer builder
 
 ## Migration


### PR DESCRIPTION
## Summary

`docs/root-static/llms.txt` and `docs/root-static/llms-full.txt` describe RF-DETR as an object detection **and instance segmentation** model only. Neither contains any keypoint content — no task listing, no usage snippet, no benchmark row, no API-reference link:

```
before:
  llms.txt       detection ✓  segmentation ✓  keypoint ✗
  llms-full.txt  detection ✓  segmentation ✓  keypoint ✗
after:
  llms.txt       detection ✓  segmentation ✓  keypoint ✓
  llms-full.txt  detection ✓  segmentation ✓  keypoint ✓
```

These files are served at `/llms.txt` and `/llms-full.txt` specifically so assistants can ingest them. As written, an assistant asked *"does RF-DETR support keypoint detection?"* would answer **no** — while the project's own title is "Real-Time SOTA Object Detection, Instance Segmentation, **and Keypoint Detection**".

Neither file is generated. `.github/workflows/publish-docs.yml:144` copies them verbatim to the gh-pages root, so they silently drifted when keypoint support was added.

## Changes

**`llms.txt`** — keypoints added to the summary line, `Tasks:` list, Getting Started, Benchmarks, Model Selection Answers, and API Reference (model class + train config).

**`llms-full.txt`** — keypoints added to the summary line, Overview, and licensing list, plus:

- a new **`## Run Keypoints`** section (usage snippet, model class, preview caveat, `rfdetr`-package-only note), mirroring the existing Run Detection / Run Segmentation sections
- a new **`### Keypoint Results`** benchmark table matching the one in `docs/learn/benchmarks.md`

## Verification

- [x] Every numeric cell cross-checked against the README tables. The 12 pre-existing detection/segmentation rows already matched **exactly** and are untouched — this PR adds rows, it does not change any existing number.
- [x] All three new documentation URLs verified to resolve to real pages (`docs/learn/run/keypoints.md`, `docs/reference/kp_preview.md`, `docs/reference/keypoint_train_config.md`).
- [x] `pre-commit` passes on both files (whitespace, EOF, line endings, codespell).

## Merge order

Uses **40.7 M** for keypoint params — the corrected value from #1258. Until that lands, `README.md` still shows `126.4 M` (which is RF-DETR-XL's count, copied by mistake). Merging #1258 first avoids a window where the two disagree; there are no file conflicts between the PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
