### PR TITLE
docs: add SAM 3's reported RF100-VL result to the detection benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pip install https://github.com/roboflow/rf-detr/archive/refs/heads/develop.zip
 
 ## Benchmarks
 
-RF-DETR achieves state-of-the-art results in both object detection and instance segmentation, with benchmarks reported on Microsoft COCO and RF100-VL (RF100-VL for detection only). The charts and tables below compare RF-DETR against other top real-time models across accuracy and latency for detection and segmentation. All COCO accuracy numbers are measured in-house for every model shown, computed with pycocotools in SAB over the full 5,000-image `val2017` split, so every row is directly comparable and may differ from vendor-reported figures. All latency numbers were measured on an NVIDIA T4 using TensorRT, FP16, and batch size 1. Parameter counts are deployment (fused) values. For full benchmarking methodology and reproducibility details, see [roboflow/sab](https://github.com/roboflow/single_artifact_benchmarking).
+RF-DETR achieves state-of-the-art results in both object detection and instance segmentation, with benchmarks reported on Microsoft COCO and RF100-VL (RF100-VL for detection only). The charts and tables below compare RF-DETR against other top real-time models across accuracy and latency for detection and segmentation. All COCO accuracy numbers are measured in-house for every model shown, computed with pycocotools in SAB over the full 5,000-image `val2017` split, so every row is directly comparable and may differ from vendor-reported figures. The sole exception is rows marked †, which are quoted from the original authors' paper and were not measured in SAB. All latency numbers were measured on an NVIDIA T4 using TensorRT, FP16, and batch size 1. Parameter counts are deployment (fused) values. For full benchmarking methodology and reproducibility details, see [roboflow/sab](https://github.com/roboflow/single_artifact_benchmarking).
 
 ### Detection
 
@@ -92,6 +92,9 @@ RF-DETR achieves state-of-the-art results in both object detection and instance 
 |   D-FINE-M    |         72.6         |          55.0           |          85.5           |            60.6            |     5.4      |    19.2    |  640x640   | Apache 2.0 |
 |   D-FINE-L    |         74.9         |          57.2           |          86.4           |            61.6            |     7.5      |    31.0    |  640x640   | Apache 2.0 |
 |   D-FINE-X    |         76.8         |          59.3           |          86.9           |            62.2            |     11.5     |    62.0    |  640x640   | Apache 2.0 |
+|    SAM 3 †    |          —           |            —            |            —            |            61.6            |      —       |    ~850    | 1008x1008  |    SAM     |
+
+> † Reported by the SAM 3 authors ([arXiv:2511.16719](https://arxiv.org/abs/2511.16719), Table 36), **not** measured by us in SAB. The value is SAM 3 fine-tuned on the full RF100-VL training set, which is the same setting as the RF100VL columns above — SAM 3's paper reports LW-DETR-m at 59.8 on this benchmark, matching our own measurement, so the numbers line up. Dashes mark results SAM 3 does not report under this protocol. Parameter count is the paper's stated ~850 M (~450 M vision + ~300 M text encoders + ~100 M detector/tracker).
 
 </details>
 

--- a/docs/learn/benchmarks.md
+++ b/docs/learn/benchmarks.md
@@ -17,7 +17,7 @@ This page reports RF-DETR benchmark results for object detection, instance segme
 
 ## Methodology
 
-Accuracy is reported using standard COCO metrics computed with pycocotools. For object detection, we report COCO AP50 and COCO AP50:95, and the same metrics are also reported for RF100-VL. COCO results are evaluated on the validation split, following common practice in detector benchmarking. Every model on this page — including third-party models — is re-evaluated in-house with pycocotools in [roboflow/sab](https://github.com/roboflow/single_artifact_benchmarking) under this same protocol, scored over the full 5,000-image `val2017` split, so all rows are directly comparable; numbers may therefore differ from vendor-reported figures. RF100-VL results are averaged across all 100 datasets to reflect performance under diverse real-world data distributions.
+Accuracy is reported using standard COCO metrics computed with pycocotools. For object detection, we report COCO AP50 and COCO AP50:95, and the same metrics are also reported for RF100-VL. COCO results are evaluated on the validation split, following common practice in detector benchmarking. Every model on this page — including third-party models — is re-evaluated in-house with pycocotools in [roboflow/sab](https://github.com/roboflow/single_artifact_benchmarking) under this same protocol, scored over the full 5,000-image `val2017` split, so all rows are directly comparable; numbers may therefore differ from vendor-reported figures. The sole exception is rows marked †, which are quoted from the original authors' paper and were not run through SAB; these are flagged in the table footnote and should be read as author-reported rather than independently reproduced. RF100-VL results are averaged across all 100 datasets to reflect performance under diverse real-world data distributions.
 
 Latency is measured as single-image inference latency rather than sustained throughput. All latency numbers are obtained on an NVIDIA T4 GPU using TensorRT 10.4 and CUDA 12.4 with FP16 inference and batch size 1. To reduce variance caused by GPU power throttling and thermal effects, a 200 ms buffer is inserted between consecutive forward passes. This procedure improves reproducibility of latency measurements but is not intended to measure maximum throughput.
 
@@ -64,6 +64,9 @@ Accuracy and latency are always measured using the same model artifact and the s
 |   D-FINE-M   |         72.6         |          55.0           |          85.5           |            60.6            |     5.4      |    19.2    |  640x640   |
 |   D-FINE-L   |         74.9         |          57.2           |          86.4           |            61.6            |     7.5      |    31.0    |  640x640   |
 |   D-FINE-X   |         76.8         |          59.3           |          86.9           |            62.2            |     11.5     |    62.0    |  640x640   |
+|   SAM 3 †    |          —           |            —            |            —            |            61.6            |      —       |    ~850    | 1008x1008  |
+
+> † Reported by the SAM 3 authors ([arXiv:2511.16719](https://arxiv.org/abs/2511.16719), Table 36), **not** measured by us in SAB. The value is SAM 3 fine-tuned on the full RF100-VL training set — the same fully-supervised setting as the RF100VL columns above, and distinct from the 15.2 zero-shot / 36.5 10-shot numbers in the paper's main table. SAM 3's paper independently reports LW-DETR-m at 59.8 on this benchmark, matching our own measurement, which confirms the protocols align. Dashes mark results SAM 3 does not report under this protocol. Parameter count is the paper's stated ~850 M (~450 M vision + ~300 M text encoders + ~100 M detector/tracker).
 
 ## Segmentation
 


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #1258** — base is `docs/keypoint-params-fix`, not `develop`. This PR needs to amend the benchmark-methodology sentence that #1258 introduces, so it is stacked rather than branched off develop. Review/merge #1258 first; this diff then shows only the SAM 3 changes.

## Summary

SAM 3 reports a **fully fine-tuned RF100-VL result of 61.6 AP** in Table 36 of its appendix ([arXiv:2511.16719](https://arxiv.org/abs/2511.16719)). This PR adds it to the detection benchmark tables.

```
Table 36 — Comparison on Roboflow100-VL
                Zero-Shot   10-Shot   All
Grounding Dino     15.7      33.7      —
LW-DETRm            —         —       59.8
SAM 3              15.2      36.5     61.6
```

The `All` column is full fine-tuning on the RF100-VL training set — the same fully-supervised setting as our `RF100VL` columns, and **not** the 15.2 zero-shot / 36.5 10-shot numbers from the paper's main few-shot table (Table 2), which are not comparable to ours.

## Why the numbers are comparable

Verified via a shared anchor rather than assumption. **LW-DETR-m = 59.8 on RF100-VL in three independent places:**

| source | LW-DETR-m |
| --- | --- |
| SAM 3 paper, Table 36 | 59.8 |
| RF100-VL paper ([arXiv:2505.20612](https://arxiv.org/abs/2505.20612)), Table 7 | 59.8 |
| our own measurement (this repo) | 59.8 |

Same metric (bbox AP50:95, pycocotools, `maxDets=500`), same protocol. SAM 3's `All` therefore drops straight into our `RF100VL AP50:95` column.

## Resulting standing

| model | RF100-VL AP | params |
| --- | --- | --- |
| RF-DETR-2XL | 63.2 | 126.9 M |
| RF-DETR-XL | 62.9 | 126.4 M |
| **RF-DETR-L** | **62.2** | **33.9 M** |
| **SAM 3** | **61.6** | **~850 M** |
| RF-DETR-M | 61.2 | 33.7 M |
| LW-DETR-m | 59.8 | 28.2 M |

RF-DETR-L edges out SAM 3 at roughly **25× fewer parameters**.

## Provenance — this row is *not* ours

Unlike every other row in these tables, SAM 3's number is quoted from the authors' paper and was **not run through SAB**. That is called out in three places:

1. A **†** marker on the row (mirroring the existing `△` convention).
2. A **footnote** under each table: source + table number, the fully-fine-tuned setting, the LW-DETR-m cross-check, why the dashes are there, and the parameter-count provenance.
3. The **methodology statements** are amended so the "measured in-house in SAB" claim stays true — it now names † rows as the sole exception.

Dashes mark COCO AP50, COCO AP50:95, RF100VL AP50, and latency, which SAM 3 does not report under this protocol. Parameter count (~850 M = ~450 M vision + ~300 M text encoders + ~100 M detector/tracker) is stated in the paper (§C.1); it is not a third-party estimate.

## Literature review — who else has fine-tuned on RF100-VL

Requested alongside the change. Searching for published RF100-VL results:

**Fully supervised (comparable to our columns):**

| source | results |
| --- | --- |
| RF100-VL paper, Table 7 | LW-DETR-m 59.8, LW-DETR-s 57.4, YOLOv11m 57.0, YOLOv11s 57.0, YOLOv8m 56.9, YOLOv8s 56.5, YOLOv11n 56.1, YOLOv8n 55.4 |
| RF-DETR paper ([arXiv:2511.09554](https://arxiv.org/abs/2511.09554)) | RF-DETR N 57.7 → 2XL 63.2 (already in our tables) |
| SAM 3 | 61.6 (this PR) |

**Other regimes, not comparable** — recorded so nobody mistakes them for fine-tuned numbers: 10-shot GroundingDINO 33.6, YOLOv8s+FedLoss 23.6, Detic+FedLoss 22.8, MQ-GLIP 12.2; zero-shot gDino-T 15.7, SAM 3 15.2, Gemini 2.5 Pro 11.6, Qwen2.5-VL-72B 7.6; semi-supervised (10% labels) YOLOv8 39.3–43.3. The CVPR 2025 Foundational FSOD competition winner beat the baseline by ~17 mAP, also few-shot.

Beyond those three papers I found no other published RF100-VL full-fine-tune results — the benchmark is recent (May 2025), so SAM 3 is currently the only external model with a directly comparable number.

## Test plan

- [x] Numbers extracted from the SAM 3 PDF directly (78 pages, appendix Tables 36/37), not from secondary summaries
- [x] Protocol alignment confirmed via the LW-DETR-m = 59.8 three-way anchor
- [x] Parameter count taken from the paper's own §C.1 statement
- [x] Table column counts verified consistent in both files
- [x] `pre-commit` passes (`mdformat`, `codespell`, whitespace/EOF/line-endings)

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
