### PR TITLE
perf: 2.5x faster ExecuTorch XNNPACK inference

### DIFF
--- a/src/rfdetr/export/_executorch/converter.py
+++ b/src/rfdetr/export/_executorch/converter.py
@@ -359,7 +359,6 @@ def export_executorch(
         )
 
     _check_executorch_available()
-    from executorch.backends.transforms.addmm_mm_to_linear import AddmmToLinearTransform
     from executorch.exir import to_edge_transform_and_lower
 
     output_dir = Path(output_dir)
@@ -397,8 +396,18 @@ def export_executorch(
                 # lowering fails. Non-strict keeps those inline and lowers cleanly with verified parity. Revisit
                 # strict=True when that upstream torch.export <-> ExecuTorch interaction is fixed.
                 exported_program = torch.export.export(model, (input_tensors,), strict=False)
-                # AddmmToLinearTransform recombines the addmm/mm ops torch.export decomposes nn.Linear
-                # into back into aten.linear. The handful the partitioner leaves un-delegated (the
+                # Imported in the non-QNN path only: the qnn backend never uses this transform, and
+                # some ExecuTorch installs don't ship it -- a top-level import would raise ImportError
+                # they never needed.
+                try:
+                    from executorch.backends.transforms.addmm_mm_to_linear import AddmmToLinearTransform
+                except ImportError as exc:
+                    raise ImportError(
+                        "AddmmToLinearTransform is unavailable in this ExecuTorch install; upgrade "
+                        "executorch to a version shipping executorch.backends.transforms.addmm_mm_to_linear."
+                    ) from exc
+                # AddmmToLinearTransform recombines the addmm/mm ops that torch.export decomposes
+                # nn.Linear into, back into aten.linear. The handful the partitioner leaves un-delegated (the
                 # two-stage encoder-output projections over the full token sequence) otherwise run on the
                 # portable addmm.out kernel, which is ~2 orders of magnitude slower than linear.out:
                 # 111 ms -> 44 ms end-to-end on RFDETRNano/XNNPACK, outputs identical to ~1e-5.

--- a/src/rfdetr/export/_executorch/converter.py
+++ b/src/rfdetr/export/_executorch/converter.py
@@ -359,6 +359,7 @@ def export_executorch(
         )
 
     _check_executorch_available()
+    from executorch.backends.transforms.addmm_mm_to_linear import AddmmToLinearTransform
     from executorch.exir import to_edge_transform_and_lower
 
     output_dir = Path(output_dir)
@@ -396,8 +397,15 @@ def export_executorch(
                 # lowering fails. Non-strict keeps those inline and lowers cleanly with verified parity. Revisit
                 # strict=True when that upstream torch.export <-> ExecuTorch interaction is fixed.
                 exported_program = torch.export.export(model, (input_tensors,), strict=False)
+                # AddmmToLinearTransform recombines the addmm/mm ops torch.export decomposes nn.Linear
+                # into back into aten.linear. The handful the partitioner leaves un-delegated (the
+                # two-stage encoder-output projections over the full token sequence) otherwise run on the
+                # portable addmm.out kernel, which is ~2 orders of magnitude slower than linear.out:
+                # 111 ms -> 44 ms end-to-end on RFDETRNano/XNNPACK, outputs identical to ~1e-5.
                 edge_program = to_edge_transform_and_lower(
-                    exported_program, partitioner=_build_partitioner(backend_name)
+                    exported_program,
+                    transform_passes=[AddmmToLinearTransform()],
+                    partitioner=_build_partitioner(backend_name),
                 )
                 executorch_program = edge_program.to_executorch()
     except (ImportError, ValueError):

--- a/tests/export/test_executorch_export.py
+++ b/tests/export/test_executorch_export.py
@@ -610,6 +610,7 @@ class TestExportExecutorchBody:
         return _fake_executorch_tree(
             {
                 "executorch.exir": {"to_edge_transform_and_lower": mock.MagicMock(return_value=edge)},
+                "executorch.backends.transforms.addmm_mm_to_linear": {"AddmmToLinearTransform": mock.MagicMock()},
                 "executorch.backends.xnnpack.partition.xnnpack_partitioner": {"XnnpackPartitioner": mock.MagicMock()},
                 "executorch.backends.apple.coreml.partition.coreml_partitioner": {
                     "CoreMLPartitioner": mock.MagicMock()
@@ -628,6 +629,27 @@ class TestExportExecutorchBody:
             )
         assert out.name == f"inference_model_{backend}.pte"
         assert out.read_bytes() == b"PTE"
+
+    @pytest.mark.parametrize("backend", [pytest.param("xnnpack", id="xnnpack"), pytest.param("coreml", id="coreml")])
+    def test_generic_backend_lowers_with_addmm_to_linear_transform(self, tmp_path: Path, backend: str) -> None:
+        """Lowering must recombine addmm/mm into ``aten.linear`` via ``AddmmToLinearTransform``.
+
+        ``torch.export`` decomposes every ``nn.Linear`` into ``addmm``; the ops the XNNPACK partitioner does not
+        delegate then fall back to ExecuTorch's slow portable ``addmm.out`` kernel. Passing ``AddmmToLinearTransform``
+        recombines them into ``aten.linear`` (2.5x faster end-to-end on RFDETRNano, numerically identical -- see PR
+        benchmark).
+        """
+        mods = self._generic_modules()
+        transform_cls = mods["executorch.backends.transforms.addmm_mm_to_linear"].AddmmToLinearTransform
+        with mock.patch.dict(sys.modules, mods), mock.patch("torch.export.export"):
+            export_executorch(
+                model=mock.MagicMock(),
+                input_tensors=torch.zeros(1, 3, 8, 8),
+                output_dir=tmp_path,
+                backend=backend,
+            )
+        lower_kwargs = mods["executorch.exir"].to_edge_transform_and_lower.call_args.kwargs
+        assert lower_kwargs.get("transform_passes") == [transform_cls.return_value]
 
     def test_variant_name_sanitized_to_basename(self, tmp_path: Path) -> None:
         """A path-like ``variant_name`` is reduced to its basename stem (mirrors the ONNX exporter)."""
@@ -844,10 +866,49 @@ def exported(
     return model, example, Path(pte_path), validate_fn
 
 
+def _portable_kernel_call_names(pte_path: Path) -> list[str]:
+    """Return the op name of every non-delegated (portable) kernel call in a ``.pte``, one entry per call.
+
+    Args:
+        pte_path: Path to a serialized ExecuTorch program.
+
+    Returns:
+        Qualified op names (e.g. ``"aten::linear.out"``), repeated per kernel-call instruction; delegate
+        calls (XNNPACK/CoreML subgraphs) are excluded.
+    """
+    from executorch.exir._serialize import _deserialize_pte_binary
+
+    plan = _deserialize_pte_binary(pte_path.read_bytes()).program.execution_plan[0]
+    op_names = [f"{op.name}.{op.overload}" if op.overload else op.name for op in plan.operators]
+    return [
+        op_names[instruction.instr_args.op_index]
+        for chain in plan.chains
+        for instruction in chain.instructions
+        if type(instruction.instr_args).__name__ == "KernelCall"
+    ]
+
+
 @executorch_only
 @pytest.mark.e2e_executorch
 class TestExecutorchEndToEnd:
     """End-to-end export of a real RF-DETR model (detection + segmentation), gated on the executorch package."""
+
+    def test_no_portable_addmm_kernel_calls(self, exported: tuple[Any, torch.Tensor, Path, Any]) -> None:
+        """No ``aten::addmm`` may survive lowering as a portable kernel call.
+
+        ``torch.export`` decomposes ``nn.Linear`` into ``addmm``; any instance the XNNPACK partitioner
+        leaves un-delegated runs on the portable ``addmm.out`` kernel, which is ~2 orders of magnitude
+        slower than ``linear.out`` for RF-DETR's encoder-output projections (111 ms -> 44 ms end-to-end
+        on RFDETRNano). ``AddmmToLinearTransform`` in the lowering call recombines them into
+        ``aten.linear``; this guards that the transform stays wired in.
+        """
+        _, _, pte_path, _ = exported
+        portable_ops = _portable_kernel_call_names(pte_path)
+        addmm_calls = [op for op in portable_ops if "addmm" in op]
+        assert not addmm_calls, (
+            f"{len(addmm_calls)} portable addmm kernel call(s) in {pte_path.name}; "
+            "expected AddmmToLinearTransform to recombine them into aten.linear"
+        )
 
     def test_pte_file_written(self, exported: tuple[Any, torch.Tensor, Path, Any]) -> None:
         """The exported artifact must be a non-empty ``.pte`` file."""


### PR DESCRIPTION
We've been working on the performance of RF-Detr in executorch for the [React Native ExecuTorch](https://executorch.swmansion.com/) project and noticed that your export script could benefit from the following change.
Adds `AddmmToLinearTransform` to the ExecuTorch lowering call. `torch.export` turns every `nn.Linear` into `addmm`; the few the XNNPACK partitioner doesn't delegate run on the slow portable `addmm.out` kernel. The transform recombines them into `aten.linear`, which runs ~100x faster for these shapes.

RFDETRNano / XNNPACK / Apple silicon: **119.9 ms → 48.3 ms median (2.5x)**. Outputs match the previous lowering to ~1e-5 and eager PyTorch to ~1e-4 (same as before).

Test it:

```bash
uv run pytest tests/export/test_executorch_export.py -k addmm
# or e2e parity + kernel check:
uv run pytest tests/export/test_executorch_export.py::TestExecutorchEndToEnd
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)