### PR TITLE
fix(deps): declare the `executorch`/`xla` conflict so `uv sync` resolves

### DIFF
--- a/.github/workflows/ci-deps-resolution.yml
+++ b/.github/workflows/ci-deps-resolution.yml
@@ -3,10 +3,10 @@ name: Dependency resolution
 on:
   push:
     branches: ["main", "release/*", "develop"]
-    paths: ["pyproject.toml"]
+    paths: ["pyproject.toml", ".github/workflows/ci-deps-resolution.yml"]
   pull_request:
     branches: ["main", "release/*", "develop"]
-    paths: ["pyproject.toml"]
+    paths: ["pyproject.toml", ".github/workflows/ci-deps-resolution.yml"]
 
 permissions:
   contents: read
@@ -48,6 +48,33 @@ jobs:
             --python-version ${{ matrix.python-version }} \
             --no-header \
             --quiet
+
+      - name: Minimize uv cache
+        continue-on-error: true
+        run: uv cache prune --ci
+
+  universal-resolution:
+    name: Resolve every extra and group together (uv lock)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: 📥 Checkout the repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: 🐍 Install uv and set Python version 3.11
+        uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
+        with:
+          version: "0.9.26"
+          python-version: "3.11"
+
+      - name: 🔍 Resolve the whole dependency universe
+        # `uv pip compile --extra <one>` resolves a single extra at a time, so it cannot see a pair
+        # of extras/groups whose pins are unsatisfiable together. `uv lock` runs the universal
+        # resolution that `uv sync --all-groups` (the setup step in AGENTS.md and CONTRIBUTING.md)
+        # needs, so a new extra with a pin that conflicts with an existing one fails here instead of
+        # on a contributor's machine. No CI job runs `uv sync`, so nothing else covers this path.
+        # A genuine conflict is declared in [tool.uv.conflicts] to let the resolver fork.
+        run: uv lock --quiet
 
       - name: Minimize uv cache
         continue-on-error: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,6 +242,12 @@ conflicts = [
         { extra = "executorch" },
         { extra = "tflite" },
     ],
+    # xla (torch==2.9.*, pinned to torch_xla's companion release) and executorch
+    # (torch>=2.12.0a0) are likewise unsatisfiable together -- same fork rationale.
+    [
+        { extra = "executorch" },
+        { extra = "xla" },
+    ],
 ]
 
 


### PR DESCRIPTION
## What does this PR do?

`uv sync --all-groups` fails on `develop`, so a fresh dev environment cannot be created:

```
$ uv sync --all-groups
  Because rfdetr[executorch] depends on executorch>=1.3 and only the following versions
  of executorch are available: executorch<1.3, executorch==1.3.1
  we can conclude that rfdetr[executorch] depends on executorch==1.3.1.
  And because executorch==1.3.1 depends on torch>=2.12.0a0 and rfdetr[xla] depends on
  torch{sys_platform == 'linux'}==2.9.*, we can conclude that rfdetr[xla] and
  rfdetr[executorch] are incompatible.
  And because your project requires rfdetr[executorch] and rfdetr[xla], we can conclude
  that your project's requirements are unsatisfiable.
```

`[tool.uv.conflicts]` already declares three pairs so the universal resolver can fork instead of giving up, but the `xla` extra is missing from that list. It pins `torch==2.9.*` (line 145) while `executorch` pulls `torch>=2.12.0a0`, which is the same situation as the pairs already there. This adds that fourth pair.

The other file adds the CI job that would have caught it. `ci-deps-resolution.yml` already runs on every `pyproject.toml` change, but its only job is `uv pip compile --extra tflite`, which resolves one extra at a time and so can never see a pair that is unsatisfiable together. No CI job runs `uv sync` either — `ci-tests-gpu.yml` deliberately uses `uv pip install` instead (line 51) — so nothing in CI runs the universal resolution that `AGENTS.md` and `CONTRIBUTING.md` tell contributors to use. The new job runs `uv lock`, which does. It is red on `develop` today and green with the one-pair fix, so it works as a real regression test. I'm happy to split it into its own PR if you prefer to keep this one to the single line ..

**Related Issue(s):** none open that I could find. Same symptom as #1253, which added the `executorch`/`tflite` pair.

## Type of Change

- Bug fix

## Testing

Checked on `develop` at `695dd8f1`, on Linux with Python 3.11, using both uv 0.9.26 (the version the workflows pin) and uv 0.10.4. Identical results on both:

| command | before | after |
| --- | --- | --- |
| `uv lock --no-cache` | exit 1, `requirements are unsatisfiable` | exit 0, `Resolved 374 packages` |
| `uv sync --extra xla --extra executorch` | exit 1, resolution fails | exit 1, `Extras executorch and xla are incompatible with the declared conflicts` |
| `uv sync --extra xla` | exit 1 (the whole lock fails) | resolves and installs |

The middle row is what this does not fix, to be explicit about it: the two extras still cannot be installed together, because their `torch` pins genuinely do not intersect. Declaring the conflict only lets the resolver fork them, so the failure becomes a clear message about that one combination instead of breaking every other combination with it. Same outcome with `--python-platform macos`, where the `xla` extra is a no-op: the lock is universal, so it failed there too before this change.

**Test details:** the regression test is the new `universal-resolution` job, since the change is a resolver declaration and there is no Python code path to exercise. The relevant hooks on the touched files are clean: `check-toml`, `check-yaml`, `trailing-whitespace`, `end-of-file-fixer`, `mixed-line-ending`, `codespell` and `prettier` all pass. `uv.lock` is gitignored, so there is nothing to regenerate.

I also went through the other extras and groups to check whether more pairs were missing. These are the `torch` constraints declared today:

| extra / group | torch constraint |
| --- | --- |
| base | `>=2.2.0` |
| `coreml` | `<2.12` |
| `xla` | `==2.9.*` (linux) |
| `executorch` | `>=2.12.0a0` (via `executorch==1.3.1`) |
| `ci-gpu-pin` | `<2.11` |
| `ci-executorch-pin` | `<2.13` |

Every other combination has a non-empty intersection, so `executorch`/`xla` is the only undeclared conflict. The practical confirmation is that `uv lock` resolves the whole universe after adding this single pair.

I also considered collapsing the four pairs into one conflict set, since `executorch` appears in all of them. I kept them as pairs: a conflict set means at most one of its members can be active, so merging them would also make `coreml`, `tflite` and `xla` mutually exclusive, and they are not.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code where necessary, particularly in hard-to-understand areas
- [X] My changes generate no new warnings or errors
- [X] I have updated the documentation accordingly (if applicable)

## Additional Context

Two PRs from 30 Jul crossed each other. #1253 was opened at 09:56 UTC, before the `xla` extra existed, and merged at 19:02 — 47 minutes after #1254 added it at 18:15. So #1253 fixed this class of failure for `tflite` against a tree that did not have `xla` in it yet. Neither change is wrong, this one just fell in the gap between the two.
