### PR TITLE
feat(assets): add `ROBOFLOW_HOME` cache-dir alias

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -33,6 +33,37 @@ No. `RFDETR.from_checkpoint(...)` infers `num_classes` from the checkpoint's cla
 
 No. Fine-tuning on a custom dataset retrains the classification head for that dataset's classes; the pretrained COCO classes are not retained. To detect both your classes and some COCO classes, include those COCO classes in your training data.
 
+## How do I load my own weights or a checkpoint from a specific path?
+
+Pass `pretrain_weights=` when you build any model — it accepts a fine-tuned checkpoint, a pretrained backbone, or one of the published names:
+
+```python
+from rfdetr import RFDETRSmall
+
+# A checkpoint anywhere on disk (absolute or relative path)
+model = RFDETRSmall(pretrain_weights="/data/runs/exp1/checkpoint_best_total.pth")
+
+# A published checkpoint by name — downloaded into the cache dir if missing
+model = RFDETRSmall(pretrain_weights="rf-detr-small.pth")
+```
+
+Resolution rules:
+
+- **Bare filename** (no directory, e.g. `rf-detr-small.pth`) → resolved to the model cache directory (see below) and downloaded there if not already present.
+- **Path with a directory** (e.g. `./my.pth`, `/abs/my.pth`, `~/models/my.pth`) → used as-is.
+- **`None`** → train from randomly initialized weights (no pretrained checkpoint).
+
+## Where does RF-DETR store downloaded weights, and how do I change it?
+
+Published checkpoints are cached in `~/.roboflow/models` by default. Override the location for all models by setting an environment variable — `RF_HOME` (canonical) or its alias `ROBOFLOW_HOME`:
+
+```bash
+export RF_HOME=/mnt/shared/models
+# ROBOFLOW_HOME=/mnt/shared/models works too
+```
+
+If both are set, `RF_HOME` wins. This only affects where **bare-filename** weights are cached; an explicit path in `pretrain_weights=` is always honored as given.
+
 ## What input resolutions are allowed?
 
 `resolution` must be a positive integer divisible by `patch_size × num_windows` for the selected variant (for example, current detection checkpoints use a block size of 32). A non-divisible value raises `ValueError` indicating the required divisor. Input is square; each variant ships a sensible default resolution.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -59,7 +59,8 @@ Published checkpoints are cached in `~/.roboflow/models` by default. Override th
 
 ```bash
 export RF_HOME=/mnt/shared/models
-# ROBOFLOW_HOME=/mnt/shared/models works too
+# or, equivalently, use the alias instead:
+export ROBOFLOW_HOME=/mnt/shared/models
 ```
 
 If both are set, `RF_HOME` wins. This only affects where **bare-filename** weights are cached; an explicit path in `pretrain_weights=` is always honored as given.

--- a/src/rfdetr/assets/model_weights.py
+++ b/src/rfdetr/assets/model_weights.py
@@ -34,6 +34,7 @@ from rfdetr.utilities.logger import get_logger
 logger = get_logger()
 
 _RF_HOME_ENV_VAR = "RF_HOME"
+_ROBOFLOW_HOME_ENV_VAR = "ROBOFLOW_HOME"
 _DEFAULT_CACHE_DIR = "~/.roboflow/models"
 
 
@@ -272,13 +273,16 @@ class ModelWeights(ModelWeightsBase):
 def get_model_cache_dir() -> str:
     """Return the directory where RF-DETR caches downloaded model weights.
 
-    Reads the ``RF_HOME`` environment variable; defaults to ``~/.roboflow/models`` when the variable is not set.
+    Reads the ``RF_HOME`` environment variable, falling back to its alias ``ROBOFLOW_HOME``; defaults to
+    ``~/.roboflow/models`` when neither is set.  ``RF_HOME`` is canonical — when both variables are set it wins, so
+    existing configurations keep their behavior.  An empty value is treated as unset.
 
-    Set ``RF_HOME`` to override the cache location for all RF-DETR models:
+    Set either variable to override the cache location for all RF-DETR models:
 
     .. code-block:: bash
 
-        export RF_HOME=/mnt/shared/models
+        export RF_HOME=/mnt/shared/models       # canonical
+        export ROBOFLOW_HOME=/mnt/shared/models  # accepted alias
 
     Args: None
 
@@ -289,6 +293,7 @@ def get_model_cache_dir() -> str:
     Examples:
         >>> import os
         >>> _ = os.environ.pop("RF_HOME", None)  # ensure default
+        >>> _ = os.environ.pop("ROBOFLOW_HOME", None)
         >>> expected = os.path.normpath(os.path.expanduser("~/.roboflow/models"))
         >>> get_model_cache_dir() == expected
         True
@@ -297,8 +302,15 @@ def get_model_cache_dir() -> str:
         >>> get_model_cache_dir() == expected
         True
         >>> del os.environ["RF_HOME"]
+        >>> os.environ["ROBOFLOW_HOME"] = "~/roboflow_cache"
+        >>> expected = os.path.normpath(os.path.expanduser("~/roboflow_cache"))
+        >>> get_model_cache_dir() == expected
+        True
+        >>> del os.environ["ROBOFLOW_HOME"]
     """
-    cache_dir = os.environ.get(_RF_HOME_ENV_VAR, _DEFAULT_CACHE_DIR)
+    # `RF_HOME` is canonical; `ROBOFLOW_HOME` is an accepted alias. An empty value is
+    # treated as unset so it falls through to the alias and then the default.
+    cache_dir = os.environ.get(_RF_HOME_ENV_VAR) or os.environ.get(_ROBOFLOW_HOME_ENV_VAR) or _DEFAULT_CACHE_DIR
     return os.path.abspath(os.path.expanduser(cache_dir))
 
 

--- a/tests/assets/test_model_weights.py
+++ b/tests/assets/test_model_weights.py
@@ -20,6 +20,7 @@ class TestGetModelCacheDir:
     def test_default_when_rf_home_not_set(self, monkeypatch):
         """Returns ~/.roboflow/models when RF_HOME env var is absent."""
         monkeypatch.delenv("RF_HOME", raising=False)
+        monkeypatch.delenv("ROBOFLOW_HOME", raising=False)
         expected = os.path.normpath(os.path.expanduser("~/.roboflow/models"))
         assert get_model_cache_dir() == expected
 
@@ -38,7 +39,34 @@ class TestGetModelCacheDir:
     def test_returns_string(self, monkeypatch):
         """Return value is always a str, not a Path."""
         monkeypatch.delenv("RF_HOME", raising=False)
+        monkeypatch.delenv("ROBOFLOW_HOME", raising=False)
         assert isinstance(get_model_cache_dir(), str)
+
+    def test_roboflow_home_alias_used_when_rf_home_absent(self, monkeypatch, tmp_path):
+        """ROBOFLOW_HOME acts as an alias for RF_HOME when RF_HOME is unset."""
+        monkeypatch.delenv("RF_HOME", raising=False)
+        monkeypatch.setenv("ROBOFLOW_HOME", str(tmp_path))
+        assert get_model_cache_dir() == str(tmp_path)
+
+    def test_rf_home_wins_when_both_set(self, monkeypatch, tmp_path):
+        """RF_HOME is canonical and takes precedence over ROBOFLOW_HOME when both are set."""
+        rf_home = tmp_path / "rf_home"
+        monkeypatch.setenv("RF_HOME", str(rf_home))
+        monkeypatch.setenv("ROBOFLOW_HOME", str(tmp_path / "roboflow_home"))
+        assert get_model_cache_dir() == str(rf_home)
+
+    def test_empty_rf_home_falls_through_to_roboflow_home(self, monkeypatch, tmp_path):
+        """An empty RF_HOME is treated as unset and falls through to ROBOFLOW_HOME."""
+        monkeypatch.setenv("RF_HOME", "")
+        monkeypatch.setenv("ROBOFLOW_HOME", str(tmp_path))
+        assert get_model_cache_dir() == str(tmp_path)
+
+    def test_default_when_neither_var_set(self, monkeypatch):
+        """Returns ~/.roboflow/models when neither RF_HOME nor ROBOFLOW_HOME is set."""
+        monkeypatch.delenv("RF_HOME", raising=False)
+        monkeypatch.delenv("ROBOFLOW_HOME", raising=False)
+        expected = os.path.normpath(os.path.expanduser("~/.roboflow/models"))
+        assert get_model_cache_dir() == expected
 
 
 def test_from_filename_found():

--- a/tests/assets/test_model_weights.py
+++ b/tests/assets/test_model_weights.py
@@ -61,10 +61,10 @@ class TestGetModelCacheDir:
         monkeypatch.setenv("ROBOFLOW_HOME", str(tmp_path))
         assert get_model_cache_dir() == str(tmp_path)
 
-    def test_default_when_neither_var_set(self, monkeypatch):
-        """Returns ~/.roboflow/models when neither RF_HOME nor ROBOFLOW_HOME is set."""
+    def test_empty_roboflow_home_falls_through_to_default(self, monkeypatch):
+        """An empty ROBOFLOW_HOME is treated as unset and falls back to the default."""
         monkeypatch.delenv("RF_HOME", raising=False)
-        monkeypatch.delenv("ROBOFLOW_HOME", raising=False)
+        monkeypatch.setenv("ROBOFLOW_HOME", "")
         expected = os.path.normpath(os.path.expanduser("~/.roboflow/models"))
         assert get_model_cache_dir() == expected
 


### PR DESCRIPTION
This pull request improves the handling and documentation of model weight cache directories for RF-DETR, making it easier to control where downloaded weights are stored and clarifying the use of environment variables. The changes add support for the `ROBOFLOW_HOME` environment variable as an alias for `RF_HOME`, update documentation accordingly, and expand test coverage to ensure correct behavior.

**Environment variable support and cache directory resolution:**

* Added support for the `ROBOFLOW_HOME` environment variable as an alias for `RF_HOME` in `get_model_cache_dir()`, with `RF_HOME` taking precedence if both are set; empty values are treated as unset and fall through to the next option or the default (`~/.roboflow/models`). (`src/rfdetr/assets/model_weights.py`, [[1]](diffhunk://#diff-0bab15a4f7088d723e0bcf7ea6c8daec6f7a63418b80f53f5b489d330e18a43cR37) [[2]](diffhunk://#diff-0bab15a4f7088d723e0bcf7ea6c8daec6f7a63418b80f53f5b489d330e18a43cL275-R285) [[3]](diffhunk://#diff-0bab15a4f7088d723e0bcf7ea6c8daec6f7a63418b80f53f5b489d330e18a43cR305-R313)
* Updated docstrings and inline documentation to reflect the new environment variable behavior, including examples and explanations of precedence and fallback logic. (`src/rfdetr/assets/model_weights.py`, [[1]](diffhunk://#diff-0bab15a4f7088d723e0bcf7ea6c8daec6f7a63418b80f53f5b489d330e18a43cL275-R285) [[2]](diffhunk://#diff-0bab15a4f7088d723e0bcf7ea6c8daec6f7a63418b80f53f5b489d330e18a43cR296) [[3]](diffhunk://#diff-0bab15a4f7088d723e0bcf7ea6c8daec6f7a63418b80f53f5b489d330e18a43cR305-R313)

**Documentation updates:**

* Added a new FAQ entry explaining how to load custom weights or checkpoints and clarifying the cache directory resolution rules, including the use of `RF_HOME` and `ROBOFLOW_HOME`. (`docs/faq.md`, [docs/faq.mdR36-R66](diffhunk://#diff-57cdcc6b6701a7ce3b3a8f8c0366e0e611e6fb1a1b8dd7cd29e3263b3e064c8bR36-R66))

**Testing improvements:**

* Expanded test coverage in `tests/assets/test_model_weights.py` to verify correct behavior when using `ROBOFLOW_HOME`, when both environment variables are set, when one or both are empty, and when neither is set. (`tests/assets/test_model_weights.py`, [[1]](diffhunk://#diff-0e7805805e644f6e6aea3b4f11b7279ea8102e6fc02ed5002cf866b2ed429e2eR23) [[2]](diffhunk://#diff-0e7805805e644f6e6aea3b4f11b7279ea8102e6fc02ed5002cf866b2ed429e2eR42-R70)