### PR TITLE
perf(inference): skip upsampling masks the caller's threshold discards

### DIFF
--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -2360,7 +2360,7 @@ class RFDETR:
                     return_predictions["pred_masks"] = predictions[2]
             predictions = return_predictions
         target_sizes = torch.tensor(orig_sizes, device=self.model.device)
-        results = self.model.postprocess(predictions, target_sizes=target_sizes)
+        results = self.model.postprocess(predictions, target_sizes=target_sizes, score_threshold=threshold)
 
         model_class_names = self.class_names
         n = len(model_class_names)

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -2403,6 +2403,11 @@ class RFDETR:
             labels = result["labels"]
             boxes = result["boxes"]
 
+            # INVARIANT: this predicate must stay identical (same operator and threshold) to the
+            # pre-filter in PostProcess._postprocess_masks (`scores_i > score_threshold`), which is
+            # fed `score_threshold=threshold` above. The seg path drops below-threshold masks before
+            # upsampling on the strength of that match; diverging here (e.g. `>=`, per-class, top-k)
+            # would make it silently drop rows this filter keeps — a behaviour change with no failing test.
             keep = scores > threshold
             scores = scores[keep]
             labels = labels[keep]

--- a/src/rfdetr/models/postprocess.py
+++ b/src/rfdetr/models/postprocess.py
@@ -42,7 +42,9 @@ class PostProcess(nn.Module):
         self.upsample_masks_to_image_size = upsample_masks_to_image_size
 
     @torch.no_grad()
-    def forward(self, outputs: dict[str, torch.Tensor], target_sizes: torch.Tensor) -> list[dict[str, torch.Tensor]]:
+    def forward(
+        self, outputs: dict[str, torch.Tensor], target_sizes: torch.Tensor, score_threshold: float | None = None
+    ) -> list[dict[str, torch.Tensor]]:
         """Convert raw model tensors into per-image detection dictionaries.
 
         Args:
@@ -50,11 +52,19 @@ class PostProcess(nn.Module):
                 ``pred_masks`` or ``pred_keypoints``.
             target_sizes: Per-image ``(height, width)`` tensor. For inference and evaluation this should be the
                 original image size so normalized boxes and keypoints are returned in source-image pixel coordinates.
+            score_threshold: Optional confidence threshold already known to the caller. Detections scoring at or
+                below it are dropped before masks are resized, so the upsample only runs on detections the caller
+                keeps. Only the segmentation path acts on it: the keypoint path rewrites scores after selection
+                (uncertainty fusion), so filtering on the pre-fusion scores would not match the caller's own filter,
+                and the box-only path has no per-detection work worth skipping. ``None`` (the default) keeps every
+                selected detection, which is what evaluation relies on.
 
         Returns:
             One dictionary per image. Every dictionary contains ``scores``, ``labels``, and ``boxes`` in absolute
             pixel coordinates clamped to the respective image dimensions. Segmentation outputs also contain
-            ``masks``. Keypoint outputs also contain ``keypoints`` and ``keypoint_precision_cholesky``.
+            ``masks``. Keypoint outputs also contain ``keypoints`` and ``keypoint_precision_cholesky``. With
+            ``score_threshold`` set, segmentation dictionaries hold only the detections above it — fewer rows,
+            never different ones.
         """
         out_logits, out_bbox = outputs["pred_logits"], outputs["pred_boxes"]
         out_masks = outputs.get("pred_masks")
@@ -66,7 +76,14 @@ class PostProcess(nn.Module):
 
         if out_masks is not None:
             return self._postprocess_masks(
-                out_masks, scores, labels, boxes, topk_boxes, target_sizes, self.upsample_masks_to_image_size
+                out_masks,
+                scores,
+                labels,
+                boxes,
+                topk_boxes,
+                target_sizes,
+                self.upsample_masks_to_image_size,
+                score_threshold=score_threshold,
             )
         if out_keypoints is not None:
             return self._postprocess_keypoints(out_keypoints, scores, labels, boxes, topk_boxes, target_sizes)
@@ -155,6 +172,8 @@ class PostProcess(nn.Module):
         topk_boxes: torch.Tensor,
         target_sizes: torch.Tensor,
         upsample_masks_to_image_size: bool = True,
+        *,
+        score_threshold: float | None = None,
     ) -> list[dict[str, torch.Tensor]]:
         """Attach segmentation masks for selected detections.
 
@@ -175,6 +194,10 @@ class PostProcess(nn.Module):
                 (e.g. COCO segm mAP) must downsize the other side to match, or the comparison is
                 meaningless. Intended for opt-in, validation-only cost reduction (see
                 ``TrainConfig.eval_masks_head_resolution``), not for inference output.
+            score_threshold: Optional confidence threshold already known to the caller. Detections scoring at or
+                below it are dropped before the gather, so no mask the caller discards is ever gathered, resized or
+                thresholded. Applies to both ``upsample_masks_to_image_size`` branches. ``None`` (the default) keeps
+                every selected detection.
 
         Returns:
             One result dict per image containing scores, labels, boxes, and boolean masks —
@@ -183,8 +206,12 @@ class PostProcess(nn.Module):
         """
         results = []
         for i in range(out_masks.shape[0]):
-            res_i = {"scores": scores[i], "labels": labels[i], "boxes": boxes[i]}
-            k_idx = topk_boxes[i]
+            scores_i, labels_i, boxes_i, k_idx = scores[i], labels[i], boxes[i], topk_boxes[i]
+            if score_threshold is not None:
+                keep = scores_i > score_threshold
+                scores_i, labels_i = scores_i[keep], labels_i[keep]
+                boxes_i, k_idx = boxes_i[keep], k_idx[keep]
+            res_i = {"scores": scores_i, "labels": labels_i, "boxes": boxes_i}
             masks_i = torch.gather(
                 out_masks[i],
                 0,

--- a/src/rfdetr/models/postprocess.py
+++ b/src/rfdetr/models/postprocess.py
@@ -208,9 +208,12 @@ class PostProcess(nn.Module):
         for i in range(out_masks.shape[0]):
             scores_i, labels_i, boxes_i, k_idx = scores[i], labels[i], boxes[i], topk_boxes[i]
             if score_threshold is not None:
-                keep = scores_i > score_threshold
-                scores_i, labels_i = scores_i[keep], labels_i[keep]
-                boxes_i, k_idx = boxes_i[keep], k_idx[keep]
+                # A boolean-mask index (t[mask]) runs `nonzero` internally and forces a device sync
+                # on each use; materialise the kept indices once so the four selections share a single
+                # sync instead of four. Integer indexing preserves row order, so the result is identical.
+                sel = (scores_i > score_threshold).nonzero(as_tuple=True)[0]
+                scores_i, labels_i = scores_i[sel], labels_i[sel]
+                boxes_i, k_idx = boxes_i[sel], k_idx[sel]
             res_i = {"scores": scores_i, "labels": labels_i, "boxes": boxes_i}
             masks_i = torch.gather(
                 out_masks[i],

--- a/tests/inference/helpers.py
+++ b/tests/inference/helpers.py
@@ -65,7 +65,12 @@ class _DummyModel:
         self._include_keypoints = include_keypoints
         self._num_keypoints = num_keypoints
 
-    def postprocess(self, predictions: Any, target_sizes: torch.Tensor) -> list[dict[str, torch.Tensor]]:
+    def postprocess(
+        self,
+        predictions: Any,
+        target_sizes: torch.Tensor,
+        score_threshold: float | None = None,
+    ) -> list[dict[str, torch.Tensor]]:
         """Return fixed scores/boxes (and optional keypoints) for every image in the batch."""
         batch = target_sizes.shape[0]
         results = []

--- a/tests/inference/test_predict.py
+++ b/tests/inference/test_predict.py
@@ -88,7 +88,10 @@ class _TupleOutputModelContext:
         return boxes, logits, keypoints
 
     def postprocess(
-        self, predictions: dict[str, torch.Tensor], target_sizes: torch.Tensor
+        self,
+        predictions: dict[str, torch.Tensor],
+        target_sizes: torch.Tensor,
+        score_threshold: float | None = None,
     ) -> list[dict[str, torch.Tensor]]:
         self.captured_predictions = predictions
         batch = target_sizes.shape[0]

--- a/tests/inference/test_predict.py
+++ b/tests/inference/test_predict.py
@@ -64,6 +64,38 @@ class TestPredictReturnTypes:
         assert all(isinstance(result, sv.KeyPoints) for result in batch)
 
 
+class TestPredictScoreThresholdEquivalence:
+    """The mask pre-filter perf path must not change ``predict()``'s final output."""
+
+    def test_mask_prefilter_output_equivalent_at_predict_boundary(self) -> None:
+        """``predict()`` masks/boxes/scores must be bit-identical whether the mask pre-filter runs or not.
+
+        The optimization forwards ``predict(threshold=...)`` into ``PostProcess`` so below-threshold masks skip
+        upsampling. Disabling the pre-filter (``score_threshold=None``) makes ``PostProcess`` upsample every mask and
+        lets ``predict()``'s own downstream filter drop them instead. The two paths must produce the same
+        ``Detections``, proving the pre-filter drops only rows ``predict()`` itself discards — the equivalence that the
+        unit test at ``_postprocess_masks`` level asserts, now verified end-to-end through the real ``predict()`` path.
+        """
+        img = PIL.Image.new("RGB", (640, 640), color=(128, 128, 128))
+        model = RFDETRSegNano(pretrain_weights=None)
+        threshold = 0.3
+
+        optimized = model.predict(img, threshold=threshold)
+
+        real_postprocess = model.model.postprocess
+
+        def postprocess_without_prefilter(predictions, target_sizes, score_threshold=None):
+            return real_postprocess(predictions, target_sizes, score_threshold=None)
+
+        model.model.postprocess = postprocess_without_prefilter
+        baseline = model.predict(img, threshold=threshold)
+
+        np.testing.assert_array_equal(optimized.xyxy, baseline.xyxy)
+        np.testing.assert_array_equal(optimized.confidence, baseline.confidence)
+        np.testing.assert_array_equal(optimized.class_id, baseline.class_id)
+        np.testing.assert_array_equal(optimized.mask, baseline.mask)
+
+
 class _TupleOutputModelContext:
     """Model context whose forward returns a 3-tuple, mirroring ``forward_export()`` after ``inference()``.
 

--- a/tests/inference/test_predict_eval_mode.py
+++ b/tests/inference/test_predict_eval_mode.py
@@ -125,7 +125,7 @@ class TestUnoptimizedInferenceEvalMode:
         monkeypatch.setattr(
             rfdetr.model,
             "postprocess",
-            lambda preds, target_sizes: [
+            lambda preds, target_sizes, score_threshold=None: [
                 {"scores": torch.zeros(0), "labels": torch.zeros(0, dtype=torch.long), "boxes": torch.zeros(0, 4)}
             ],
             raising=False,

--- a/tests/models/test_postprocess.py
+++ b/tests/models/test_postprocess.py
@@ -5,6 +5,8 @@
 # ------------------------------------------------------------------------
 """Tests for PostProcess box clamping behaviour."""
 
+from unittest.mock import patch
+
 import pytest
 import torch
 
@@ -220,3 +222,113 @@ class TestPostProcessMasks:
         results = pp(outputs, target_sizes)
 
         assert results[0]["masks"].shape[-2:] == (mask_h, mask_w)
+
+    @staticmethod
+    def _mask_case(num_select: int = 16, num_queries: int = 16, mask_hw: int = 8, batch: int = 1):
+        """Return (out_masks, scores, labels, boxes, topk_boxes, target_sizes) with known scores.
+
+        Scores descend within each image so a threshold of 0.5 keeps a known prefix, and each image
+        starts lower than the previous one so a batch keeps a different number of rows per image.
+        """
+        out_masks = torch.randn(batch, num_queries, mask_hw, mask_hw)
+        scores = torch.stack([torch.linspace(0.95 - 0.3 * i, 0.05, num_select) for i in range(batch)])
+        labels = torch.zeros(batch, num_select, dtype=torch.long)
+        boxes = torch.zeros(batch, num_select, 4)
+        topk_boxes = torch.arange(num_select).unsqueeze(0).repeat(batch, 1)
+        target_sizes = torch.tensor([[64, 64]]).repeat(batch, 1)
+        return out_masks, scores, labels, boxes, topk_boxes, target_sizes
+
+    @pytest.mark.parametrize("threshold", [0.5, 1.0])
+    def test_score_threshold_upsamples_only_the_kept_masks(self, threshold):
+        """Masks that the caller's threshold discards must never reach the interpolation.
+
+        The upsample runs at target-image resolution while the kept fraction is small (at
+        ``num_select=100`` a COCO-style image keeps a handful), so resizing the discarded
+        rows is work whose result is dropped a few lines later. Counting the interpolated
+        rows rather than timing them keeps the test deterministic. A threshold of 1.0 keeps
+        nothing and must skip the interpolation altogether rather than resize an empty tensor.
+        """
+        args = self._mask_case()
+        scores = args[1]
+        expected_kept = int((scores[0] > threshold).sum())
+
+        rows = []
+        orig = torch.nn.functional.interpolate
+
+        def counting_interpolate(tensor, *a, **kw):
+            rows.append(tensor.shape[0])
+            return orig(tensor, *a, **kw)
+
+        with patch("rfdetr.models.postprocess.F.interpolate", counting_interpolate):
+            results = PostProcess._postprocess_masks(*args, score_threshold=threshold)
+
+        assert sum(rows) == expected_kept, (
+            f"interpolated {sum(rows)} mask rows but only {expected_kept} survive the "
+            "caller's threshold; masks below it must be dropped before the resize"
+        )
+        assert results[0]["masks"].shape[0] == expected_kept
+
+    @pytest.mark.parametrize("upsample", [True, False])
+    @pytest.mark.parametrize("threshold", [0.5, 1.0])
+    def test_score_threshold_matches_filtering_after_upsampling(self, threshold, upsample):
+        """Filtering before the resize must return exactly what filtering after it returns.
+
+        The filter sits above the ``upsample_masks_to_image_size`` branch, so the native-resolution
+        path has to drop the same rows as the resized one. A threshold of 1.0 keeps nothing and pins
+        the shape and dtype of the empty result on both branches.
+        """
+        args = self._mask_case()
+
+        filtered_early = PostProcess._postprocess_masks(*args, upsample, score_threshold=threshold)[0]
+        full = PostProcess._postprocess_masks(*args, upsample)[0]
+        keep = full["scores"] > threshold
+
+        for key in ("scores", "labels", "boxes"):
+            assert torch.equal(filtered_early[key], full[key][keep])
+        assert torch.equal(filtered_early["masks"], full["masks"][keep])
+
+    def test_score_threshold_filters_each_image_independently(self):
+        """A batch keeps a different number of rows per image, not one count applied to all of them."""
+        args = self._mask_case(batch=2)
+        scores = args[1]
+        threshold = 0.5
+
+        results = PostProcess._postprocess_masks(*args, score_threshold=threshold)
+
+        for i, result in enumerate(results):
+            keep = scores[i] > threshold
+            assert torch.equal(result["scores"], scores[i][keep])
+            assert result["masks"].shape[0] == int(keep.sum())
+        assert results[0]["masks"].shape[0] > results[1]["masks"].shape[0], (
+            "the second image scores lower and must keep fewer masks; equal counts mean the "
+            "threshold was applied batch-wide instead of per image"
+        )
+
+    @pytest.mark.parametrize("head", ["boxes", "keypoints"])
+    def test_score_threshold_is_ignored_outside_the_mask_path(self, head):
+        """The box-only and keypoint heads must return the same thing with and without the argument.
+
+        ``predict()`` passes the threshold for every model, so the two heads that cannot use it have
+        to ignore it rather than fail. The keypoint path rewrites scores after selection (uncertainty
+        fusion), so filtering on the pre-fusion scores would not match the caller's own filter, and
+        the box-only path has no per-detection resize to skip.
+        """
+        batch, num_queries, num_classes = 1, 4, 2
+        outputs = {
+            "pred_logits": torch.randn(batch, num_queries, num_classes),
+            "pred_boxes": torch.rand(batch, num_queries, 4),
+        }
+        kwargs = {}
+        if head == "keypoints":
+            # (B, Q, num_keypoint_classes * max_num_keypoints, D) with D >= 7 so precision is emitted.
+            outputs["pred_keypoints"] = torch.randn(batch, num_queries, 6, 7)
+            kwargs["num_keypoints_per_class"] = [3, 3]
+        postprocess = PostProcess(num_select=num_queries, **kwargs)
+        target_sizes = torch.tensor([[128, 128]])
+
+        baseline = postprocess(outputs, target_sizes)[0]
+        with_threshold = postprocess(outputs, target_sizes, score_threshold=0.9)[0]
+
+        assert baseline.keys() == with_threshold.keys()
+        for key in baseline:
+            torch.testing.assert_close(baseline[key], with_threshold[key], rtol=0.0, atol=0.0, equal_nan=True)

--- a/tests/models/test_postprocess.py
+++ b/tests/models/test_postprocess.py
@@ -227,8 +227,8 @@ class TestPostProcessMasks:
     def _mask_case(num_select: int = 16, num_queries: int = 16, mask_hw: int = 8, batch: int = 1):
         """Return (out_masks, scores, labels, boxes, topk_boxes, target_sizes) with known scores.
 
-        Scores descend within each image so a threshold of 0.5 keeps a known prefix, and each image
-        starts lower than the previous one so a batch keeps a different number of rows per image.
+        Scores descend within each image so a threshold of 0.5 keeps a known prefix, and each image starts lower than
+        the previous one so a batch keeps a different number of rows per image.
         """
         out_masks = torch.randn(batch, num_queries, mask_hw, mask_hw)
         scores = torch.stack([torch.linspace(0.95 - 0.3 * i, 0.05, num_select) for i in range(batch)])
@@ -242,10 +242,9 @@ class TestPostProcessMasks:
     def test_score_threshold_upsamples_only_the_kept_masks(self, threshold):
         """Masks that the caller's threshold discards must never reach the interpolation.
 
-        The upsample runs at target-image resolution while the kept fraction is small (at
-        ``num_select=100`` a COCO-style image keeps a handful), so resizing the discarded
-        rows is work whose result is dropped a few lines later. Counting the interpolated
-        rows rather than timing them keeps the test deterministic. A threshold of 1.0 keeps
+        The upsample runs at target-image resolution while the kept fraction is small (at ``num_select=100`` a COCO-
+        style image keeps a handful), so resizing the discarded rows is work whose result is dropped a few lines later.
+        Counting the interpolated rows rather than timing them keeps the test deterministic. A threshold of 1.0 keeps
         nothing and must skip the interpolation altogether rather than resize an empty tensor.
         """
         args = self._mask_case()
@@ -273,9 +272,9 @@ class TestPostProcessMasks:
     def test_score_threshold_matches_filtering_after_upsampling(self, threshold, upsample):
         """Filtering before the resize must return exactly what filtering after it returns.
 
-        The filter sits above the ``upsample_masks_to_image_size`` branch, so the native-resolution
-        path has to drop the same rows as the resized one. A threshold of 1.0 keeps nothing and pins
-        the shape and dtype of the empty result on both branches.
+        The filter sits above the ``upsample_masks_to_image_size`` branch, so the native-resolution path has to drop the
+        same rows as the resized one. A threshold of 1.0 keeps nothing and pins the shape and dtype of the empty result
+        on both branches.
         """
         args = self._mask_case()
 
@@ -308,10 +307,10 @@ class TestPostProcessMasks:
     def test_score_threshold_is_ignored_outside_the_mask_path(self, head):
         """The box-only and keypoint heads must return the same thing with and without the argument.
 
-        ``predict()`` passes the threshold for every model, so the two heads that cannot use it have
-        to ignore it rather than fail. The keypoint path rewrites scores after selection (uncertainty
-        fusion), so filtering on the pre-fusion scores would not match the caller's own filter, and
-        the box-only path has no per-detection resize to skip.
+        ``predict()`` passes the threshold for every model, so the two heads that cannot use it have to ignore it rather
+        than fail. The keypoint path rewrites scores after selection (uncertainty fusion), so filtering on the pre-
+        fusion scores would not match the caller's own filter, and the box-only path has no per-detection resize to
+        skip.
         """
         batch, num_queries, num_classes = 1, 4, 2
         outputs = {

--- a/tests/models/test_postprocess.py
+++ b/tests/models/test_postprocess.py
@@ -246,8 +246,11 @@ class TestPostProcessMasks:
         style image keeps a handful), so resizing the discarded rows is work whose result is dropped a few lines later.
         Counting the interpolated rows rather than timing them keeps the test deterministic. A threshold of 1.0 keeps
         nothing and must skip the interpolation altogether rather than resize an empty tensor.
+
+        ``num_select=100`` (> ``_MASK_CHUNK`` = 32) keeps enough rows above 0.5 to span several interpolation chunks,
+        so the count also proves the chunked upsample loop stays correct under early filtering.
         """
-        args = self._mask_case()
+        args = self._mask_case(num_select=100, num_queries=100)
         scores = args[1]
         expected_kept = int((scores[0] > threshold).sum())
 


### PR DESCRIPTION
## What does this PR do?

`predict()` on a segmentation model resizes **every** one of the `num_select` masks to the target image size, and then `detr.py` drops the ones below the caller's threshold ~40 lines later. On COCO images a median of **3 of 100** masks survive the default `threshold=0.5`, so around 97 % of that resize is spent on masks that get discarded.

This passes the caller's threshold down, so the masks that will be dropped are never upsampled. The output does not change — bit for bit.

Measured on an RTX 4060 (torch 2.13, `RFDETRSegSmall`, `optimize_for_inference()`), 25 real COCO val2017 images, median of 5 runs. The times are the whole `predict()` call, not just the postprocessing:

| input resolution | before | after | change |
| --- | --- | --- | --- |
| 427x640 (native COCO) | 18.87 ms | 18.45 ms | -2.2 % |
| 1080p | 40.68 ms | 32.39 ms | **-20.4 %** |

Isolating `_postprocess_masks` with K=100 against K=4 shows where the time goes:

| resolution | K=100 | K=4 | wasted |
| --- | --- | --- | --- |
| 640 | 1.40 ms | 0.08 ms | 1.32 ms |
| 1080p | 10.55 ms | 0.39 ms | 10.16 ms |
| 4K | 41.62 ms | 1.94 ms | 39.68 ms |

A few things about these numbers:

- The saving scales with the image area, because the resize does too. It does not scale with
the model, so the relative gain gets bigger as the model gets faster.
- At native COCO resolution the saving is 0.42 ms end to end, and I would not open a PR only
for that number. At 1080p it is a fifth of the whole call, and at 4K the discarded masks cost more than the forward pass of the model.
- So this is useful for video and camera resolutions, and it gives almost nothing at 640.
Detection and keypoint models are not affected either way, the cost is only on the mask path.

**Related Issue(s):** none, found while profiling the inference path.

## Type of Change

- Performance improvement (no behaviour change)

## Testing

All in `TestPostProcessMasks`, `tests/models/test_postprocess.py`:

- `test_score_threshold_upsamples_only_the_kept_masks[0.5, 1.0]` — patches `F.interpolate` and
asserts that the number of interpolated rows equals the number of masks that survive the threshold. Counting the rows instead of measuring the time keeps the test deterministic, in the same way `test_greedy_loop_does_not_sync_a_tensor_per_detection` counts syncs and not seconds. I also checked it against a version that gives the same output but filters *after* the resize: both cases fail there, and that is the regression this test is meant to catch. The `1.0` case keeps nothing and asserts that the interpolation is skipped completely instead of running on an empty tensor.
- `test_score_threshold_matches_filtering_after_upsampling[...]` — filtering before the resize
returns exactly the same as filtering after it, for scores, labels, boxes and masks. Parametrized over both `upsample_masks_to_image_size` branches, because the filter sits above that branch and the native-resolution path has to drop the same rows, and also over a threshold that keeps nothing, so the shape and dtype of the empty result are fixed on both.
- `test_score_threshold_filters_each_image_independently` — in a batch where the second image
scores lower, that image keeps fewer masks. A batch-wide mask would return the same count twice.
- `test_score_threshold_is_ignored_outside_the_mask_path[boxes, keypoints]` — `predict()` passes
the threshold for every model, so the two heads that cannot use it have to ignore it and not fail.

I dropped `test_no_score_threshold_keeps_every_detection` from my first pass: `test_chunked_upsample_preserves_shape_for_large_k` already checks that the argument-free path returns all `num_select` masks, so it was a second copy of the same assertion.

The three test doubles that changed (`tests/inference/helpers.py`, `test_predict.py`, `test_predict_eval_mode.py`) only follow the real signature. No assertion was removed and no coverage was moved.

**Test details:** `pytest src/ tests/ -m "not gpu"` gives the same result as on a clean `develop` on this machine. `ruff-check`, `ruff-format` and `mypy` are clean on the touched files, and `mypy src/rfdetr/` reports exactly the same errors as it does on `develop`. Bit-exactness was also checked outside the suite, end to end, hashing `xyxy`, `confidence`, `class_id` and `mask` of every prediction over the 25 real images at both resolutions: identical in all the cases.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code where necessary, particularly in hard-to-understand areas
- [X] My changes generate no new warnings or errors
- [X] I have updated the documentation accordingly (if applicable)

## Additional Context

**On where the threshold is threaded.** #1225 added `upsample_masks_to_image_size` to the `PostProcess` constructor and read it from `self` inside `forward()`, without touching the signature. I considered doing the same here, but that flag is static configuration and the threshold is per call — `predict(threshold=...)` can change between calls, so a constructor value would have to be mutated before each one, and that is worse. So `forward()` takes an optional keyword instead, with default `None` for exactly the current behaviour. The argument goes last and defaults to `None`, so no existing call changes: `PostProcess` is re-exported from `rfdetr.models` but it has no docs page, and the four training/eval call sites (`module_model.py`, `coco_eval.py`) pass positionally and are untouched. I'm happy to move it to the constructor if you prefer to keep that signature fixed.

**Why it is optional and not always on.** `predict()` passes it unconditionally, so this is not a knob for the user to tune — there is only one caller. It defaults to `None` because evaluation has to keep every selected detection: `coco_eval` scores the full ranked list, and dropping its tail would move mAP.

**What it does not cover.** `forward()` accepts the argument for every head, but only the mask path uses it. `_postprocess_keypoints` (postprocess.py:219 on `develop`) has the same shape — it gathers per-query data for detections that the caller may discard — and I left it alone for two reasons: it rewrites the scores after selection through the keypoint uncertainty fusion, so filtering on the pre-fusion scores would not match the filter the caller applies later; and there is no interpolation there, so the waste is of a different order of magnitude. Both facts are in the `forward()` docstring and covered by a test, so the next reader does not have to figure it out. I'm happy to look at the keypoint gather separately if you want ..
