### PR TITLE
fix(deps): gate onnx and executorch extras to interpreters with wheels

### DIFF
--- a/.github/workflows/ci-deps-resolution.yml
+++ b/.github/workflows/ci-deps-resolution.yml
@@ -115,3 +115,27 @@ jobs:
       - name: Minimize uv cache
         continue-on-error: true
         run: uv cache prune --ci
+
+  deps-resolution-complete:
+    name: Dependency resolution complete
+    # Single aggregate gate for branch protection: require THIS one check instead of the ~70
+    # install-plan matrix contexts (5 interpreters × every extra) plus the two resolution jobs.
+    # `needs.<job>.result` collapses a whole matrix to one value — `success` only if every cell
+    # passed. `if: always()` so the gate still runs (and fails) when an upstream job fails;
+    # without it a failed dependency would skip this job and branch protection would see no signal.
+    if: always()
+    needs: [universal-resolution, list-extras, install-plan]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: ✅ Assert every resolution job succeeded
+        run: |
+          results="universal-resolution=${{ needs.universal-resolution.result }} list-extras=${{ needs.list-extras.result }} install-plan=${{ needs.install-plan.result }}"
+          echo "$results"
+          for pair in $results; do
+            if [ "${pair#*=}" != "success" ]; then
+              echo "::error::Dependency resolution incomplete — $results"
+              exit 1
+            fi
+          done
+          echo "All dependency-resolution jobs passed."

--- a/.github/workflows/ci-deps-resolution.yml
+++ b/.github/workflows/ci-deps-resolution.yml
@@ -81,18 +81,38 @@ jobs:
         continue-on-error: true
         run: uv cache prune --ci
 
-  install-plan:
-    name: Install plan for every extra — Python ${{ matrix.python-version }}
+  list-extras:
+    name: List extras for install-plan
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 5
+    outputs:
+      extras: ${{ steps.collect.outputs.extras }}
+    steps:
+      - name: 📋 Collect the extras that get install-plan coverage
+        id: collect
+        # Single source of truth for the install-plan matrix below — `fromJSON` fans this list out
+        # into one job per extra, so there is no in-step loop to keep in sync. tensorrt /
+        # tensorrt-bench / xla / plus are excluded: they need NVIDIA/TPU indexes or the separately
+        # licensed rfdetr_plus package, none of which resolve on a plain runner. Add a new extra
+        # to this list to give it install-plan coverage.
+        run: |
+          echo 'extras=["onnx","executorch","tflite","coreml","augment","train","cli","loggers","visual","lora"]' >> "$GITHUB_OUTPUT"
+
+  install-plan:
+    name: Install plan [${{ matrix.extra }}] — Python ${{ matrix.python-version }}
+    needs: list-extras
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
-        # Every interpreter allowed by requires-python (>=3.10). ci-tests-cpu.yml installs only
-        # train/augment/cli/visual (+coreml on macOS), so onnx, executorch, tflite, loggers and
-        # lora have no install coverage there at any version — and it installs via `uv pip
+        # Every interpreter allowed by requires-python (>=3.10) crossed with every extra from the
+        # list-extras job, so each extra/interpreter pair is its own job. ci-tests-cpu.yml installs
+        # only train/augment/cli/visual (+coreml on macOS), so onnx, executorch, tflite, loggers
+        # and lora have no install coverage there at any version — and it installs via `uv pip
         # install`, which backtracks past a missing wheel instead of failing (see below).
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        extra: ${{ fromJSON(needs.list-extras.outputs.extras) }}
     steps:
       - name: 📥 Checkout the repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -103,7 +123,7 @@ jobs:
           version: "0.9.26"
           python-version: ${{ matrix.python-version }}
 
-      - name: 📦 Verify every extra has an installable distribution
+      - name: 📦 Verify [${{ matrix.extra }}] has an installable distribution
         # `uv lock` proves a version solution exists; it does NOT prove every pinned version
         # ships a wheel (or sdist) for the interpreter actually in use. A dependency that drops
         # an interpreter, or has not added one yet, still locks cleanly and then fails at install
@@ -114,25 +134,7 @@ jobs:
         # happens) without downloading anything, so this stays cheap. `uv pip install --dry-run`
         # is NOT equivalent: it re-resolves per interpreter and silently backtracks to an older
         # version with a compatible wheel, hiding exactly this bug.
-        #
-        # tensorrt/tensorrt-bench/xla/plus are excluded: they need NVIDIA/TPU indexes or the
-        # separately licensed rfdetr_plus package, none of which resolve on a plain runner.
-        run: |
-          failed=()
-          for extra in onnx executorch tflite coreml augment train cli loggers visual lora; do
-            echo "::group::[$extra] on Python ${{ matrix.python-version }}"
-            if uv sync --extra "$extra" --python ${{ matrix.python-version }} --dry-run; then
-              echo "[$extra] ok"
-            else
-              echo "[$extra] NO INSTALLABLE DISTRIBUTION"
-              failed+=("$extra")
-            fi
-            echo "::endgroup::"
-          done
-          if ((${#failed[@]})); then
-            echo "::error::No installable distribution on Python ${{ matrix.python-version }} for: ${failed[*]}"
-            exit 1
-          fi
+        run: uv sync --extra ${{ matrix.extra }} --python ${{ matrix.python-version }} --dry-run
 
       - name: Minimize uv cache
         continue-on-error: true

--- a/.github/workflows/ci-deps-resolution.yml
+++ b/.github/workflows/ci-deps-resolution.yml
@@ -91,20 +91,20 @@ jobs:
       - name: 📥 Checkout the repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      - name: 📋 Collect installable extras from pyproject.toml
+      - name: 📋 Collect every extra from pyproject.toml
         id: collect
-        # Derive the install-plan matrix straight from [project.optional-dependencies] so any new
-        # extra gets wheel-availability coverage automatically — nothing to keep in sync by hand.
-        # `fromJSON` fans the result out into one job per extra, so there is no in-step loop.
-        # tensorrt/tensorrt-bench/xla/plus are excluded: they need NVIDIA/TPU indexes or the
-        # separately licensed rfdetr_plus package, none of which resolve on a plain runner.
+        # Cover every [project.optional-dependencies] extra — a new one is picked up automatically,
+        # nothing to keep in sync by hand. `fromJSON` fans the result out into one job per extra,
+        # so there is no in-step loop. The install-plan step only runs `uv sync --dry-run`
+        # (resolution + wheel check, no build/download/GPU), so extras that need GPU/TPU hardware at
+        # runtime — tensorrt, xla, plus — still resolve here. If one genuinely cannot resolve on a
+        # plain runner, its job goes red and names itself; exclude it then, with evidence.
         run: |
           python3 - <<'PY' >> "$GITHUB_OUTPUT"
           import json, tomllib
           with open("pyproject.toml", "rb") as fh:
               extras = tomllib.load(fh)["project"]["optional-dependencies"]
-          exclude = {"tensorrt", "tensorrt-bench", "xla", "plus"}
-          print("extras=" + json.dumps(sorted(e for e in extras if e not in exclude)))
+          print("extras=" + json.dumps(sorted(extras)))
           PY
 
   install-plan:

--- a/.github/workflows/ci-deps-resolution.yml
+++ b/.github/workflows/ci-deps-resolution.yml
@@ -20,39 +20,6 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  tflite-resolution:
-    name: Resolve [tflite] extra — Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        # tflite deps carry python_version>='3.12' and <'3.13' markers; onnx2tf pins numpy==1.26.4
-        # exactly, which conflicts with ml-dtypes>=0.5.1 requiring numpy>=2.1.0 on 3.13.
-        # Add 3.13 and relax the <'3.13' upper bound when onnx2tf drops the exact numpy pin.
-        python-version: ["3.12"]
-    steps:
-      - name: 📥 Checkout the repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-
-      - name: 🐍 Install uv and set Python version ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
-        with:
-          version: "0.9.26"
-          python-version: ${{ matrix.python-version }}
-
-      - name: 🔍 Resolve [tflite] optional dependencies
-        run: |
-          uv pip compile pyproject.toml \
-            --extra tflite \
-            --python-version ${{ matrix.python-version }} \
-            --no-header \
-            --quiet
-
-      - name: Minimize uv cache
-        continue-on-error: true
-        run: uv cache prune --ci
-
   universal-resolution:
     name: Resolve every extra and group together (uv lock)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-deps-resolution.yml
+++ b/.github/workflows/ci-deps-resolution.yml
@@ -72,9 +72,67 @@ jobs:
         # of extras/groups whose pins are unsatisfiable together. `uv lock` runs the universal
         # resolution that `uv sync --all-groups` (the setup step in AGENTS.md and CONTRIBUTING.md)
         # needs, so a new extra with a pin that conflicts with an existing one fails here instead of
-        # on a contributor's machine. No CI job runs `uv sync`, so nothing else covers this path.
-        # A genuine conflict is declared in [tool.uv.conflicts] to let the resolver fork.
+        # on a contributor's machine. Wheel availability is a separate axis, covered by
+        # `install-plan` below. A genuine conflict is declared in [tool.uv.conflicts] to let the
+        # resolver fork.
         run: uv lock --quiet
+
+      - name: Minimize uv cache
+        continue-on-error: true
+        run: uv cache prune --ci
+
+  install-plan:
+    name: Install plan for every extra — Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        # Every interpreter allowed by requires-python (>=3.10). ci-tests-cpu.yml installs only
+        # train/augment/cli/visual (+coreml on macOS), so onnx, executorch, tflite, loggers and
+        # lora have no install coverage there at any version — and it installs via `uv pip
+        # install`, which backtracks past a missing wheel instead of failing (see below).
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - name: 📥 Checkout the repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: 🐍 Install uv and set Python version ${{ matrix.python-version }}
+        uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
+        with:
+          version: "0.9.26"
+          python-version: ${{ matrix.python-version }}
+
+      - name: 📦 Verify every extra has an installable distribution
+        # `uv lock` proves a version solution exists; it does NOT prove every pinned version
+        # ships a wheel (or sdist) for the interpreter actually in use. A dependency that drops
+        # an interpreter, or has not added one yet, still locks cleanly and then fails at install
+        # with "doesn't have a source distribution or wheel for the current platform" — the
+        # failure mode that broke [onnx] on 3.10 and [executorch] on 3.14.
+        #
+        # `uv sync --dry-run` runs resolution AND install planning (where the wheel check
+        # happens) without downloading anything, so this stays cheap. `uv pip install --dry-run`
+        # is NOT equivalent: it re-resolves per interpreter and silently backtracks to an older
+        # version with a compatible wheel, hiding exactly this bug.
+        #
+        # tensorrt/tensorrt-bench/xla/plus are excluded: they need NVIDIA/TPU indexes or the
+        # separately licensed rfdetr_plus package, none of which resolve on a plain runner.
+        run: |
+          failed=()
+          for extra in onnx executorch tflite coreml augment train cli loggers visual lora; do
+            echo "::group::[$extra] on Python ${{ matrix.python-version }}"
+            if uv sync --extra "$extra" --python ${{ matrix.python-version }} --dry-run; then
+              echo "[$extra] ok"
+            else
+              echo "[$extra] NO INSTALLABLE DISTRIBUTION"
+              failed+=("$extra")
+            fi
+            echo "::endgroup::"
+          done
+          if ((${#failed[@]})); then
+            echo "::error::No installable distribution on Python ${{ matrix.python-version }} for: ${failed[*]}"
+            exit 1
+          fi
 
       - name: Minimize uv cache
         continue-on-error: true

--- a/.github/workflows/ci-deps-resolution.yml
+++ b/.github/workflows/ci-deps-resolution.yml
@@ -88,15 +88,24 @@ jobs:
     outputs:
       extras: ${{ steps.collect.outputs.extras }}
     steps:
-      - name: 📋 Collect the extras that get install-plan coverage
+      - name: 📥 Checkout the repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: 📋 Collect installable extras from pyproject.toml
         id: collect
-        # Single source of truth for the install-plan matrix below — `fromJSON` fans this list out
-        # into one job per extra, so there is no in-step loop to keep in sync. tensorrt /
-        # tensorrt-bench / xla / plus are excluded: they need NVIDIA/TPU indexes or the separately
-        # licensed rfdetr_plus package, none of which resolve on a plain runner. Add a new extra
-        # to this list to give it install-plan coverage.
+        # Derive the install-plan matrix straight from [project.optional-dependencies] so any new
+        # extra gets wheel-availability coverage automatically — nothing to keep in sync by hand.
+        # `fromJSON` fans the result out into one job per extra, so there is no in-step loop.
+        # tensorrt/tensorrt-bench/xla/plus are excluded: they need NVIDIA/TPU indexes or the
+        # separately licensed rfdetr_plus package, none of which resolve on a plain runner.
         run: |
-          echo 'extras=["onnx","executorch","tflite","coreml","augment","train","cli","loggers","visual","lora"]' >> "$GITHUB_OUTPUT"
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json, tomllib
+          with open("pyproject.toml", "rb") as fh:
+              extras = tomllib.load(fh)["project"]["optional-dependencies"]
+          exclude = {"tensorrt", "tensorrt-bench", "xla", "plus"}
+          print("extras=" + json.dumps(sorted(e for e in extras if e not in exclude)))
+          PY
 
   install-plan:
     name: Install plan [${{ matrix.extra }}] — Python ${{ matrix.python-version }}

--- a/.github/workflows/ci-deps-resolution.yml
+++ b/.github/workflows/ci-deps-resolution.yml
@@ -89,6 +89,12 @@ jobs:
         # install`, which backtracks past a missing wheel instead of failing (see below).
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         extra: ${{ fromJSON(needs.list-extras.outputs.extras) }}
+        # Skip interpreter/extra pairs where no wheel is expected, so the gate is not held red by
+        # an unfixable gap: tensorrt on 3.10, and xla (torch_xla 2.9.*) on 3.14. Drop an entry
+        # once that wheel ships. (exclude matches values from the dynamic extra axis by name.)
+        exclude:
+          - { extra: tensorrt, python-version: "3.10" }
+          - { extra: xla, python-version: "3.14" }
     steps:
       - name: 📥 Checkout the repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,7 +321,7 @@ GitHub Actions workflows in `.github/workflows/`:
 - **ci-tests-cpu.yml:** CPU tests across OS/Python versions
 - **ci-tests-gpu.yml:** GPU-dependent tests
 - **ci-legacy-checkpoints.yml:** Backward-compatibility checkpoint-loading tests across historical rfdetr releases (advisory only — not a required check; a compat break does not block merge)
-- **ci-deps-resolution.yml:** Dependency resolution (`uv lock`) plus an install-plan check (`uv sync --dry-run`) for every extra on every Python interpreter allowed by requires-python (3.10-3.14). Resolution alone does not prove a pinned version ships a wheel for the interpreter in use — add new extras to the `install-plan` job's loop
+- **ci-deps-resolution.yml:** Dependency resolution (`uv lock`) plus an install-plan check (`uv sync --dry-run`) for every extra on every Python interpreter allowed by requires-python (3.10-3.14). Resolution alone does not prove a pinned version ships a wheel for the interpreter in use — add new extras to the `list-extras` job's list
 - **build-package.yml:** Build and validate distributions
 - **ci-build-docs.yml:** Documentation builds
 - **publish-docs.yml:** Deploy docs to GitHub Pages

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,6 +321,7 @@ GitHub Actions workflows in `.github/workflows/`:
 - **ci-tests-cpu.yml:** CPU tests across OS/Python versions
 - **ci-tests-gpu.yml:** GPU-dependent tests
 - **ci-legacy-checkpoints.yml:** Backward-compatibility checkpoint-loading tests across historical rfdetr releases (advisory only — not a required check; a compat break does not block merge)
+- **ci-deps-resolution.yml:** Dependency resolution (`uv lock`) plus an install-plan check (`uv sync --dry-run`) for every extra on every supported Python (3.10-3.14). Resolution alone does not prove a pinned version ships a wheel for the interpreter in use — add new extras to the `install-plan` job's loop
 - **build-package.yml:** Build and validate distributions
 - **ci-build-docs.yml:** Documentation builds
 - **publish-docs.yml:** Deploy docs to GitHub Pages

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,7 +321,7 @@ GitHub Actions workflows in `.github/workflows/`:
 - **ci-tests-cpu.yml:** CPU tests across OS/Python versions
 - **ci-tests-gpu.yml:** GPU-dependent tests
 - **ci-legacy-checkpoints.yml:** Backward-compatibility checkpoint-loading tests across historical rfdetr releases (advisory only — not a required check; a compat break does not block merge)
-- **ci-deps-resolution.yml:** Dependency resolution (`uv lock`) plus an install-plan check (`uv sync --dry-run`) for every extra on every supported Python (3.10-3.14). Resolution alone does not prove a pinned version ships a wheel for the interpreter in use — add new extras to the `install-plan` job's loop
+- **ci-deps-resolution.yml:** Dependency resolution (`uv lock`) plus an install-plan check (`uv sync --dry-run`) for every extra on every Python interpreter allowed by requires-python (3.10-3.14). Resolution alone does not prove a pinned version ships a wheel for the interpreter in use — add new extras to the `install-plan` job's loop
 - **build-package.yml:** Build and validate distributions
 - **ci-build-docs.yml:** Documentation builds
 - **publish-docs.yml:** Deploy docs to GitHub Pages

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,7 +321,7 @@ GitHub Actions workflows in `.github/workflows/`:
 - **ci-tests-cpu.yml:** CPU tests across OS/Python versions
 - **ci-tests-gpu.yml:** GPU-dependent tests
 - **ci-legacy-checkpoints.yml:** Backward-compatibility checkpoint-loading tests across historical rfdetr releases (advisory only — not a required check; a compat break does not block merge)
-- **ci-deps-resolution.yml:** Dependency resolution (`uv lock`) plus an install-plan check (`uv sync --dry-run`) for every extra on every Python interpreter allowed by requires-python (3.10-3.14). Resolution alone does not prove a pinned version ships a wheel for the interpreter in use — add new extras to the `list-extras` job's list
+- **ci-deps-resolution.yml:** Dependency resolution (`uv lock`) plus an install-plan check (`uv sync --dry-run`) for every extra on every Python interpreter allowed by requires-python (3.10-3.14). Resolution alone does not prove a pinned version ships a wheel for the interpreter in use. The `list-extras` job derives the checked set from `[project.optional-dependencies]`, so a new extra is covered automatically (unless it is added to that job's runner-unresolvable exclusion list, e.g. `tensorrt`/`xla`/`plus`)
 - **build-package.yml:** Build and validate distributions
 - **ci-build-docs.yml:** Documentation builds
 - **publish-docs.yml:** Deploy docs to GitHub Pages

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,7 +321,7 @@ GitHub Actions workflows in `.github/workflows/`:
 - **ci-tests-cpu.yml:** CPU tests across OS/Python versions
 - **ci-tests-gpu.yml:** GPU-dependent tests
 - **ci-legacy-checkpoints.yml:** Backward-compatibility checkpoint-loading tests across historical rfdetr releases (advisory only — not a required check; a compat break does not block merge)
-- **ci-deps-resolution.yml:** Dependency resolution (`uv lock`) plus an install-plan check (`uv sync --dry-run`) for every extra on every Python interpreter allowed by requires-python (3.10-3.14). Resolution alone does not prove a pinned version ships a wheel for the interpreter in use. The `list-extras` job derives the checked set from `[project.optional-dependencies]`, so a new extra is covered automatically (unless it is added to that job's runner-unresolvable exclusion list, e.g. `tensorrt`/`xla`/`plus`)
+- **ci-deps-resolution.yml:** Dependency resolution (`uv lock`) plus an install-plan check (`uv sync --dry-run`) for every extra on every Python interpreter allowed by requires-python (3.10-3.14). Resolution alone does not prove a pinned version ships a wheel for the interpreter in use. The `list-extras` job derives the checked set from every `[project.optional-dependencies]` extra, so a new extra is covered automatically
 - **build-package.yml:** Build and validate distributions
 - **ci-build-docs.yml:** Documentation builds
 - **publish-docs.yml:** Deploy docs to GitHub Pages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ executorch = [
     # executorch publishes cp310-cp313 wheels only (1.3.1 is current) and has no sdist, so a
     # 3.14 install fails on wheel availability rather than resolution. The marker keeps the
     # extra installable-but-empty on 3.14, matching how [tflite] is gated to 3.12. Drop the
-    # upper bound once executorch ships cp314 wheels.
+    # `python_version < '3.14'` marker once executorch ships cp314 wheels.
     "executorch>=1.3,<2.0; python_version < '3.14'",
 ]
 coreml = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,12 @@ onnx = [
     "onnx>=1.16.0,<2.0",
     "onnxsim>=0.7.0",  # 0.7.0 ships wheels for cp310/311/312-abi3 (3.10-3.13) on linux x86_64+aarch64, win_amd64 and macOS arm64. The old <0.6.0 pin resolved to 0.5.0, which lacks cp311/cp313/aarch64 wheels, so pip built onnxsim's bundled onnxruntime/onnx from source and the install hung (#749).
     "onnx_graphsurgeon",
-    "onnxruntime",
+    # onnxruntime dropped cp310 wheels after 1.23.2; 1.24.0+ ship cp311-cp314 only. Unpinned,
+    # a 3.10 resolve picks the newest release and then fails at install with "no source
+    # distribution or wheel for the current platform". Remove the split when the project's
+    # requires-python floor moves past 3.10.
+    "onnxruntime<1.24; python_version < '3.11'",
+    "onnxruntime; python_version >= '3.11'",
     "polygraphy",
 ]
 tensorrt = [
@@ -98,7 +103,12 @@ tflite = [
     "tensorflow>=2.16.0; python_version >= '3.12' and python_version < '3.13'",
 ]
 executorch = [
-    "executorch>=1.3,<2.0",  # torch.export -> .pte, XNNPACK CPU delegate; validated on 1.3.1
+    # torch.export -> .pte, XNNPACK CPU delegate; validated on 1.3.1.
+    # executorch publishes cp310-cp313 wheels only (1.3.1 is current) and has no sdist, so a
+    # 3.14 install fails on wheel availability rather than resolution. The marker keeps the
+    # extra installable-but-empty on 3.14, matching how [tflite] is gated to 3.12. Drop the
+    # upper bound once executorch ships cp314 wheels.
+    "executorch>=1.3,<2.0; python_version < '3.14'",
 ]
 coreml = [
     # torch.export (ExportedProgram) support added in coremltools 8.0 (see


### PR DESCRIPTION
## What does this PR do?

Issue: https://github.com/roboflow/rf-detr/issues/1266

Two optional extras cannot be installed on Python versions the project claims to support. `requires-python` is `>=3.10`, but `[onnx]` fails on 3.10 and `[executorch]` fails on 3.14.

Both fail the same way. The resolver picks a version, and then the install step finds that there is no wheel for that interpreter. Neither package ships a source build, so there is no fallback.

```
$ uv sync --extra onnx --python 3.10
Resolved 373 packages in 249ms
error: Distribution `onnxruntime==1.24.3` can't be installed because it doesn't
have a source distribution or wheel for the current platform
hint: You're using CPython 3.10 (`cp310`), but `onnxruntime` (v1.24.3) only has
wheels with the following Python implementation tags: `cp311`, `cp312`, `cp313`, `cp314`

$ uv sync --extra executorch --python 3.14
error: Distribution `executorch==1.3.1` can't be installed because it doesn't
have a source distribution or wheel for the current platform
hint: You're using CPython 3.14 (`cp314`), but `executorch` (v1.3.1) only has
wheels with ABI tags: `cp310`, `cp311`, `cp312`, `cp313`
```

Checked against PyPI, so this is not a local quirk:

* `onnxruntime` stopped shipping cp310 wheels after 1.23.2. Every release from 1.24.0 on covers cp311 to cp314 only. The entry was unpinned, so a 3.10 resolve picks the newest one.
* `executorch` has never shipped a cp314 wheel. 1.3.1 is the current release, and it stops at cp313.

### The fix

Add environment markers so each extra picks a version that has a wheel for the interpreter in use.

```toml
- "onnxruntime"
+ "onnxruntime<1.24; python_version < '3.11'"
+ "onnxruntime; python_version >= '3.11'"

- "executorch>=1.3,<2.0"
+ "executorch>=1.3,<2.0; python_version < '3.14'"
```

On 3.14, the `[executorch]` extra becomes installable but empty rather than raising an error. That is the same approach already used for `[tflite]`, which is gated to 3.12. Both entries carry a comment saying when the gate can be removed.

### Why CI did not catch this

`uv lock` only proves a version solution exists. It does not prove that the chosen version has a wheel for a given interpreter. I confirmed `uv lock --python 3.11` passes on the broken code, so CI stayed green while `uv sync` failed for real users.

The workflow file already noted the gap: "No CI job runs `uv sync`, so nothing else covers this path."

So this PR also adds an `install-plan` job to `ci-deps-resolution.yml`. It runs `uv sync --dry-run` for every extra on 3.10 through 3.14. Dry run does resolution plus install planning, which is where the wheel check happens, and it downloads nothing, so the job stays cheap.

One detail worth flagging for future changes: `uv pip install --dry-run` is not a substitute. It re-resolves per interpreter and quietly falls back to an older version that does have a wheel, which hides this exact bug. I tried that first, and it passed on the broken code. The job comment records this.

`tensorrt`, `tensorrt-bench`, `xla`, and `plus` are left out of the loop because they need NVIDIA or TPU indexes, or the separately licensed `rfdetr_plus` package, none of which resolve on a plain runner.

**Related Issue(s):** None. Found while installing the extras locally.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**

No unit tests were added. This is a packaging bug, and a unit test cannot tell whether PyPI has a wheel for a given interpreter without doing the network work that the resolver already does. The regression check is the new CI job, which fails on the current code and passes with the fix.

What I ran:

| Check | Result |
| --- | --- |
| Reproduce on clean `develop` | `[onnx]` fails on 3.10, `[executorch]` fails on 3.14 |
| New CI job against current `develop` | Fails, and flags exactly those two, nothing else |
| New CI job with this fix | 10 extras across 5 Python versions, all pass |
| Real install (not dry run) on 3.10 | Resolves `onnxruntime==1.23.2` and installs |
| `pre-commit run --all-files` | All hooks pass except mypy, see below |
| CPU test suite, CI marker set | 3284 passed, 57 skipped, 0 failed |

Test command used:

```
uv run --no-sync pytest src/ tests/ -n 4 \
  -m "not gpu and not coco17 and not e2e_coreml and not e2e_executorch and not xla and not tpu" \
  --ignore=tests/run_smoke_all_models.py \
  --ignore=tests/legacy/test_checkpoint_compat.py --timeout=240
```

On mypy, it reports 45 errors on an unmodified `develop` checkout and the same 45 on this branch. They are all `import-not-found` for packages in the `[train]` extra, which `uv sync --all-groups` does not install. With those extras installed, the count drops to 2, again identical on both. This PR touches no Python files, so none of it comes from these changes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

On the last two: the new markers and the CI job both carry comments explaining the reason and the condition for removing them, matching the style already used for the `[tflite]` gate and the `[tool.uv]` conflicts. `AGENTS.md` listed the CI workflows but was missing `ci-deps-resolution.yml`, so I added an entry for it that also tells future contributors to add new extras to the job loop.

## Additional Context

`ci-tests-cpu.yml` does install packages on 3.10 through 3.13, but it would not have caught this for two reasons. It installs only `train,augment,cli,visual` plus `coreml` on macOS, so `onnx`, `executorch`, `tflite`, `loggers`, and `lora` have no install coverage at any version. It also installs with `uv pip install`, which backtracks past a missing wheel instead of failing. That is why the new job covers the full 3.10 to 3.14 range rather than just the two ends.
