### PR TITLE
perf(postprocess): pick selected rows without materialising repeated index tensors

### DIFF
--- a/src/rfdetr/export/benchmark.py
+++ b/src/rfdetr/export/benchmark.py
@@ -158,7 +158,7 @@ def post_process(
     topk_boxes = topk_indexes // out_logits.shape[2]
     labels = topk_indexes % out_logits.shape[2]
     boxes = box_cxcywh_to_xyxy(out_bbox)
-    boxes = torch.gather(boxes, 1, topk_boxes.unsqueeze(-1).repeat(1, 1, 4))
+    boxes = torch.gather(boxes, 1, topk_boxes.unsqueeze(-1).expand(-1, -1, 4))
 
     # and from relative [0, 1] to absolute [0, height] coordinates
     img_h, img_w = target_sizes.unbind(1)

--- a/src/rfdetr/models/postprocess.py
+++ b/src/rfdetr/models/postprocess.py
@@ -155,7 +155,7 @@ class PostProcess(nn.Module):
             clamped to ``[0, width]`` for x-coordinates and ``[0, height]`` for y-coordinates.
         """
         boxes = box_ops.box_cxcywh_to_xyxy(out_bbox)
-        boxes = torch.gather(boxes, 1, topk_boxes.unsqueeze(-1).repeat(1, 1, 4))
+        boxes = torch.gather(boxes, 1, topk_boxes.unsqueeze(-1).expand(-1, -1, 4))
         img_h, img_w = target_sizes.unbind(1)
         scale_fct = torch.stack([img_w, img_h, img_w, img_h], dim=1).to(boxes.dtype)
         boxes = boxes * scale_fct[:, None, :]
@@ -215,11 +215,9 @@ class PostProcess(nn.Module):
                 scores_i, labels_i = scores_i[sel], labels_i[sel]
                 boxes_i, k_idx = boxes_i[sel], k_idx[sel]
             res_i = {"scores": scores_i, "labels": labels_i, "boxes": boxes_i}
-            masks_i = torch.gather(
-                out_masks[i],
-                0,
-                k_idx.unsqueeze(-1).unsqueeze(-1).repeat(1, out_masks.shape[-2], out_masks.shape[-1]),
-            )  # [K, Hm, Wm]
+            # `index_select` picks whole mask planes without materialising the [K, Hm, Wm] int64
+            # index tensor a `gather` needs (84 MiB at K=300, 192x192 masks).
+            masks_i = out_masks[i].index_select(0, k_idx)  # [K, Hm, Wm]
             if not upsample_masks_to_image_size:
                 res_i["masks"] = (masks_i > 0.0).unsqueeze(1)  # [K,1,Hm,Wm] bool, native resolution
                 results.append(res_i)
@@ -321,11 +319,9 @@ class PostProcess(nn.Module):
         Returns:
             Keypoint predictions aligned with the selected detections.
         """
-        return torch.gather(
-            out_keypoints_i,
-            0,
-            query_indices.unsqueeze(-1).unsqueeze(-1).repeat(1, out_keypoints_i.shape[-2], out_keypoints_i.shape[-1]),
-        )
+        # `index_select` picks whole query rows without materialising the [K, C*max(K_c), D]
+        # int64 index tensor a `gather` needs.
+        return out_keypoints_i.index_select(0, query_indices)
 
     @staticmethod
     def _empty_keypoint_outputs(

--- a/tests/inference/test_trt_inference.py
+++ b/tests/inference/test_trt_inference.py
@@ -108,3 +108,27 @@ class TestBenchmarkShapeParameterization:
         results = post_process(outputs, target_sizes, num_queries=num_queries)
 
         assert results[0]["scores"].shape == (num_queries,)
+
+    def test_post_process_repeats_boxes_for_duplicated_topk_queries(self) -> None:
+        """Top-k over the flattened [Q, C] scores can pick the same query under two classes.
+
+        Each pick must reproduce that query's exact box, so duplicated and out-of-order query indices have to copy
+        the source row verbatim for every occurrence.
+        """
+        from rfdetr.export.benchmark import box_cxcywh_to_xyxy, post_process
+
+        logits = torch.full((1, 4, 3), -10.0)
+        logits[0, 2, 0] = 3.0  # query 2, class 0 -> rank 1
+        logits[0, 2, 1] = 2.0  # query 2, class 1 -> rank 2 (same query twice)
+        logits[0, 1, 2] = 1.0  # query 1, class 2 -> rank 3
+        dets = torch.rand(1, 4, 4)
+        target_sizes = torch.tensor([[480, 640]])
+
+        results = post_process({"labels": logits, "dets": dets}, target_sizes, num_queries=3)
+
+        scale = torch.tensor([640.0, 480.0, 640.0, 480.0])
+        expected = box_cxcywh_to_xyxy(dets[0]) * scale
+        assert torch.equal(results[0]["labels"], torch.tensor([0, 1, 2]))
+        assert torch.equal(results[0]["boxes"][0], expected[2])
+        assert torch.equal(results[0]["boxes"][1], expected[2])
+        assert torch.equal(results[0]["boxes"][2], expected[1])

--- a/tests/inference/test_trt_inference.py
+++ b/tests/inference/test_trt_inference.py
@@ -112,8 +112,8 @@ class TestBenchmarkShapeParameterization:
     def test_post_process_repeats_boxes_for_duplicated_topk_queries(self) -> None:
         """Top-k over the flattened [Q, C] scores can pick the same query under two classes.
 
-        Each pick must reproduce that query's exact box, so duplicated and out-of-order query indices have to copy
-        the source row verbatim for every occurrence.
+        Each pick must reproduce that query's exact box, so duplicated and out-of-order query indices have to copy the
+        source row verbatim for every occurrence.
         """
         from rfdetr.export.benchmark import box_cxcywh_to_xyxy, post_process
 

--- a/tests/models/test_postprocess.py
+++ b/tests/models/test_postprocess.py
@@ -207,6 +207,29 @@ class TestPostProcessMasks:
         expected = torch.tensor([[True, False], [False, True]])
         assert torch.equal(results[0]["masks"].squeeze(1)[0], expected)
 
+    def test_duplicate_query_selection_repeats_the_same_mask_rows(self):
+        """Top-k can pick the same query under two classes; each pick must yield that query's exact mask.
+
+        The mask gather selects whole planes by query index, so duplicated and out-of-order indices must reproduce the
+        source plane verbatim for every occurrence.
+        """
+        out_masks = torch.randn(1, 4, 8, 8)
+        scores = torch.rand(1, 3)
+        labels = torch.tensor([[0, 1, 0]])
+        boxes = torch.zeros(1, 3, 4)
+        topk_boxes = torch.tensor([[2, 2, 1]])  # query 2 selected twice (two classes), then query 1
+        target_sizes = torch.tensor([[256, 256]])
+
+        results = PostProcess._postprocess_masks(
+            out_masks, scores, labels, boxes, topk_boxes, target_sizes, upsample_masks_to_image_size=False
+        )
+
+        masks = results[0]["masks"].squeeze(1)
+        expected = out_masks[0] > 0.0
+        assert torch.equal(masks[0], expected[2])
+        assert torch.equal(masks[1], expected[2])
+        assert torch.equal(masks[2], expected[1])
+
     def test_forward_threads_upsample_flag_from_constructor(self):
         """PostProcess.forward() must respect the constructor's upsample_masks_to_image_size setting."""
         batch, num_queries, mask_h, mask_w = 1, 4, 8, 8

--- a/tests/models/test_postprocess.py
+++ b/tests/models/test_postprocess.py
@@ -11,6 +11,7 @@ import pytest
 import torch
 
 from rfdetr.models.postprocess import PostProcess
+from rfdetr.utilities import box_ops
 
 
 class TestGatherAndScaleBoxes:
@@ -130,6 +131,55 @@ class TestGatherAndScaleBoxes:
         assert (boxes[1, :, 3] >= 0).all(), "img1 y2: expected >= 0"
         assert (boxes[1, :, 3] <= 600).all(), "img1 y2: expected <= img_h (600)"
 
+    def test_gathers_duplicate_and_out_of_order_indices(self):
+        """Top-k can pick the same query under two classes; each pick must reproduce that query's exact scaled box.
+
+        The box gather selects whole rows by query index, so duplicated and out-of-order indices must copy the source
+        box verbatim for every occurrence. Mirrors the TRT-benchmark twin on the shipped PostProcess path.
+        """
+        out_bbox = torch.tensor(
+            [
+                [
+                    [0.20, 0.30, 0.10, 0.10],
+                    [0.50, 0.50, 0.20, 0.20],
+                    [0.70, 0.40, 0.15, 0.25],
+                ]
+            ]
+        )  # (B=1, Q=3, 4); all in-bounds so clamping is a no-op and the copy is exact
+        topk_boxes = torch.tensor([[2, 2, 1]])  # query 2 selected twice, then query 1 (out of order)
+        target_sizes = torch.tensor([[480, 640]])  # (h, w)
+
+        boxes = PostProcess._gather_and_scale_boxes(out_bbox, topk_boxes, target_sizes)
+
+        # Expected computed independently from raw input, not by re-invoking the function under test.
+        scale = torch.tensor([640.0, 480.0, 640.0, 480.0])
+        expected = box_ops.box_cxcywh_to_xyxy(out_bbox[0]) * scale
+        assert torch.equal(boxes[0, 0], expected[2])
+        assert torch.equal(boxes[0, 1], expected[2])
+        assert torch.equal(boxes[0, 2], expected[1])
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_gather_and_scale_boxes_cuda_matches_cpu_for_duplicated_indices(self):
+        """Box selection is an arithmetic-free row copy, so CUDA must reproduce the CPU result bit-for-bit even with
+        duplicated and out-of-order indices."""
+        out_bbox = torch.tensor(
+            [
+                [
+                    [0.20, 0.30, 0.10, 0.10],
+                    [0.50, 0.50, 0.20, 0.20],
+                    [0.70, 0.40, 0.15, 0.25],
+                ]
+            ]
+        )
+        topk_boxes = torch.tensor([[2, 2, 1]])
+        target_sizes = torch.tensor([[480, 640]])
+
+        cpu_boxes = PostProcess._gather_and_scale_boxes(out_bbox, topk_boxes, target_sizes)
+        cuda_boxes = PostProcess._gather_and_scale_boxes(out_bbox.cuda(), topk_boxes.cuda(), target_sizes.cuda())
+
+        assert torch.equal(cpu_boxes, cuda_boxes.cpu())
+
 
 class TestPostProcessForward:
     """Integration tests for :meth:`PostProcess.forward`."""
@@ -229,6 +279,40 @@ class TestPostProcessMasks:
         assert torch.equal(masks[0], expected[2])
         assert torch.equal(masks[1], expected[2])
         assert torch.equal(masks[2], expected[1])
+
+    def test_duplicate_query_selection_repeats_upsampled_masks_across_chunk_boundary(self):
+        """With upsampling on (production default), duplicated query indices must yield identical resized masks even
+        when the two occurrences fall in different _MASK_CHUNK interpolation chunks.
+
+        The gather runs once before the chunked resize, so a duplicate straddling the 32-row chunk boundary exercises
+        that the per-chunk interpolation stays row-independent and reproduces the source plane for every occurrence.
+        """
+        num_queries, num_select = 4, 48  # > _MASK_CHUNK (32) so the resize loop spans two chunks
+        out_masks = torch.randn(1, num_queries, 8, 8)
+        idx = [0] * num_select
+        idx[0] = 2  # query 2 in chunk 0
+        idx[40] = 2  # same query in chunk 1 (straddles the 32-row boundary)
+        topk_boxes = torch.tensor([idx])
+        scores = torch.rand(1, num_select)
+        labels = torch.zeros(1, num_select, dtype=torch.long)
+        boxes = torch.zeros(1, num_select, 4)
+        target_sizes = torch.tensor([[64, 64]])
+
+        results = PostProcess._postprocess_masks(
+            out_masks, scores, labels, boxes, topk_boxes, target_sizes, upsample_masks_to_image_size=True
+        )
+
+        masks = results[0]["masks"]  # [K, 1, 64, 64] bool
+        assert masks.shape == (num_select, 1, 64, 64)
+        # Independent reference: resize query 2's source plane the same way the production path does.
+        expected = (
+            torch.nn.functional.interpolate(
+                out_masks[0, 2][None, None], size=(64, 64), mode="bilinear", align_corners=False
+            )
+            > 0.0
+        )[0]
+        assert torch.equal(masks[0], masks[40])  # both occurrences identical across the chunk boundary
+        assert torch.equal(masks[0], expected)  # and each maps to the correct source query, not query 0
 
     def test_forward_threads_upsample_flag_from_constructor(self):
         """PostProcess.forward() must respect the constructor's upsample_masks_to_image_size setting."""

--- a/tests/models/test_postprocess_keypoints.py
+++ b/tests/models/test_postprocess_keypoints.py
@@ -41,6 +41,23 @@ def test_postprocess_keypoints_shape_and_scores() -> None:
     torch.testing.assert_close(keypoint_precision[:, :, 2], torch.full((2, 17), -0.25))
 
 
+def test_gather_keypoints_for_queries_repeats_duplicated_indices() -> None:
+    """Duplicated and out-of-order query indices must each reproduce that query's exact keypoint rows.
+
+    Top-k selection can pick the same query under two classes, so the gather has to copy the full per-query keypoint
+    block verbatim for every occurrence.
+    """
+    out_keypoints_i = torch.randn(4, 17, 8)
+    query_indices = torch.tensor([3, 1, 3])  # query 3 selected twice, out of order
+
+    gathered = PostProcess._gather_keypoints_for_queries(out_keypoints_i, query_indices)
+
+    assert gathered.shape == (3, 17, 8)
+    assert torch.equal(gathered[0], out_keypoints_i[3])
+    assert torch.equal(gathered[1], out_keypoints_i[1])
+    assert torch.equal(gathered[2], out_keypoints_i[3])
+
+
 def test_postprocess_keypoints_class_filtering() -> None:
     """Class-specific keypoint slots should be selected from padded per-class keypoint tensors."""
     postprocess = PostProcess(num_select=1, num_keypoints_per_class=[2, 1])

--- a/tests/models/test_postprocess_keypoints.py
+++ b/tests/models/test_postprocess_keypoints.py
@@ -58,6 +58,33 @@ def test_gather_keypoints_for_queries_repeats_duplicated_indices() -> None:
     assert torch.equal(gathered[2], out_keypoints_i[3])
 
 
+def test_postprocess_keypoints_decodes_duplicated_and_out_of_order_queries() -> None:
+    """Duplicated and out-of-order query selection must decode each occurrence from the correct source query.
+
+    Drives dupe/out-of-order ``topk_boxes`` through the full class-filtering path (``_decode_keypoints_for_image``)
+    rather than the raw gather helper: two detections that select the same query under the same class must produce
+    identical decoded keypoints, while an interleaved detection must decode a different query's block.
+    """
+    postprocess = PostProcess(num_keypoints_per_class=[2, 2])
+    out_keypoints = torch.randn(1, 4, 4, 8)  # (B, Q, num_classes * max_kpts, D); D >= 7 for precision cols
+    topk_boxes = torch.tensor([[2, 1, 2]])  # query 2 selected twice, query 1 interleaved (out of order)
+    labels = torch.zeros(1, 3, dtype=torch.long)  # all class 0 so the two query-2 picks decode identically
+    scores = torch.rand(1, 3)
+    boxes = torch.zeros(1, 3, 4)
+    target_sizes = torch.tensor([[100, 200]])  # (h, w)
+
+    results = postprocess._postprocess_keypoints(out_keypoints, scores, labels, boxes, topk_boxes, target_sizes)
+    keypoints = results[0]["keypoints"]  # (3, max_num_keypoints=2, 3)
+
+    assert keypoints.shape == (3, 2, 3)
+    assert torch.equal(keypoints[0], keypoints[2])  # same query + class → identical decoded keypoints
+    # Independent decode of query 1's class-0 block (flat slots 0,1) confirms out-of-order gather picks the right query.
+    img_h, img_w = 100, 200
+    q1_class0 = out_keypoints[0, 1, 0:2]
+    expected1 = torch.stack([q1_class0[:, 0] * img_w, q1_class0[:, 1] * img_h, q1_class0[:, 2].sigmoid()], dim=-1)
+    torch.testing.assert_close(keypoints[1], expected1)
+
+
 def test_postprocess_keypoints_class_filtering() -> None:
     """Class-specific keypoint slots should be selected from padded per-class keypoint tensors."""
     postprocess = PostProcess(num_select=1, num_keypoints_per_class=[2, 1])


### PR DESCRIPTION
## What does this PR do?

The three query selections in `PostProcess` build their gather index with `repeat()`, so the index tensor gets materialised at the full size of the data it selects. For masks this is an int64 tensor of shape `[K, Hm, Wm]` — at `num_select=300` that is 21 MiB per image for `rfdetr-seg-small` (96×96 mask head) and 84 MiB for `rfdetr-seg-2xlarge` (192×192), allocated and filled on every image just to pick 300 rows.

`index_select` picks the same whole rows without building any index tensor, and `expand` on the box path replaces the materialised `[B, K, 4]` index with a stride-0 view. The output does not change — bit for bit (see below).

The ONNX benchmark keeps its own copy of the box selection (`post_process` in `src/rfdetr/export/benchmark.py`) with the same `repeat()`, so it gets the same one-line change.

Measured on CPU (torch 2.13, single thread, pinned to one core, median of interleaved A/B runs of the full `PostProcess.forward`):

| path | before | after | change |
| --- | --- | --- | --- |
| masks at head resolution, 96², K=300 | 8.79 ms | 3.40 ms | **2.6×** |
| masks at head resolution, 192², K=300 | 79.99 ms | 27.09 ms | **3.0×** |
| keypoints, 17 kpts, K=300 | 1.07 ms | 0.95 ms | 1.12× |
| boxes only, K=300 | 0.44 ms | 0.41 ms | 1.07× |
| masks upsampled to 1080p, K=300 | 3192.9 ms | 3172.0 ms | ~neutral |

A few notes on where this matters:

- The big win is the mask path when masks stay at head resolution (`upsample_masks_to_image_size=False`, the `eval_masks_head_resolution` cost lever), where the gather is most of the postprocess. That path runs with K=300 on every validation image.
- On the normal predict path the upsample to image size dominates, so this is time-neutral there — what it removes is the 21–84 MiB index allocation per image before the resize.
- With a `score_threshold` (#1265) K is small and everything is already cheap, nothing changes there.
- The two-stage query selection in `src/rfdetr/models/transformer.py` (L381, L389) builds its gather indices with the same `repeat()` pattern. I left it alone on purpose: it sits in the model forward under autograd, and its indices top out at `[B, K, d_model]` — a fraction of the mask case. Happy to cover it here or in a follow-up if you want it.

**Related Issue(s):** none, follow-up of #1265 on the same function.

## Type of Change

- Performance improvement (no behaviour change)

## Testing

- Bit-identical outputs: old vs new `forward()` compared over the three heads (masks / keypoints / boxes) on CPU and CUDA — 198 output tensors compared byte for byte, including duplicated top-k query indices, `Q < num_select`, a threshold that keeps zero rows, and both `upsample_masks_to_image_size` branches. All equal.
- Three new tests pin the contract the change relies on: top-k can select the same query under two classes, and each occurrence must reproduce the source row verbatim (`test_duplicate_query_selection_repeats_the_same_mask_rows`, `test_gather_keypoints_for_queries_repeats_duplicated_indices`, `test_post_process_repeats_boxes_for_duplicated_topk_queries` for the benchmark copy). All pass before and after the change — they test the equivalence, not the implementation.
- The benchmark copy was verified the same way: old vs new `post_process` bit-compared (int32 view) over 50 randomised shapes, including `k` clamped below and above `Q*C`. All equal.
- `tests/models` plus `tests/inference/test_trt_inference.py` pass with the patch (643 passed, 5 skipped) and `ruff check`/`ruff format` are clean on the touched files .. let me know if you want numbers for any other case.
