### PR TITLE
fix(export): match predict()'s antialias=False resize in ONNX/TFLite inference, benchmark and INT8 calibration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `keypoint_flip_pairs` no longer silently disables horizontal-flip augmentations (`HorizontalFlip`, `Flip`, `D4`) on detection-only datasets when a custom `aug_config` is supplied. `AlbumentationsWrapper.from_config` treats an empty `keypoint_flip_pairs` as "keypoint pipeline with no flip pairs defined" and drops flip transforms for annotation safety; detection pipelines must pass `None` instead of `[]` to keep flips enabled. ([#1243](https://github.com/roboflow/rf-detr/pull/1243))
+- Export inference and INT8 calibration now resize with `RFDETR.predict()`'s exact convention (bilinear, half-pixel centers, `antialias=False`) across the ONNX inference, TFLite inference, INT8 TFLite calibration, and benchmark/traced-example paths. These paths previously resized through PIL's antialiased BILINEAR/BICUBIC filters, which diverge from `predict()` on downscale and shift exported-model confidence scores and INT8 calibration ranges. A shared torch-free `_bilinear_resize_half_pixel` NumPy kernel (`rfdetr/export/_resize.py`) mirrors the convention wherever torchvision is unavailable. Re-export any INT8 TFLite model to recalibrate against the corrected pixel distribution. ([#1269](https://github.com/roboflow/rf-detr/pull/1269))
 
 ## [1.9.0] — 2026-07-27
 

--- a/docs/getting-started/migration.md
+++ b/docs/getting-started/migration.md
@@ -55,7 +55,9 @@ See the [Changelog](../changelog.md) for the full list of changes in each releas
     The default resize backend changed from Albumentations (cv2 `INTER_LINEAR`, no antialias) to
     torchvision (`BILINEAR` + `antialias=True`). Resized pixel values differ slightly from previous
     versions, and mAP may drift on existing benchmarks. **This affects training as well as
-    validation, test, and export preprocessing** — not just the training split.
+    validation and test preprocessing** — not just the training split. `predict()` and the
+    exported-model inference paths (ONNX, TFLite, benchmark, INT8 calibration) are the exception:
+    they resize with `antialias=False` to match the released checkpoints.
 
     To restore the previous pixel-exact behaviour:
 

--- a/src/rfdetr/export/_onnx/inference.py
+++ b/src/rfdetr/export/_onnx/inference.py
@@ -11,6 +11,7 @@ RF-DETR training stack — only ``onnxruntime``, ``numpy``, ``supervision``, and
 
 from __future__ import annotations
 
+import contextlib
 from pathlib import Path
 from typing import Any
 
@@ -114,7 +115,7 @@ def _preprocess_pil_to_nchw(
     mean_list = [_imagenet_mean[i % 3] for i in range(channels)]
     std_list = [_imagenet_std[i % 3] for i in range(channels)]
 
-    try:
+    with contextlib.suppress(ImportError):
         # Match predict() exactly: torchvision to_tensor -> resize(antialias=False) -> normalize.
         # antialias=False mirrors detr.py's predict(); torchvision's float-tensor default is True.
         import torch
@@ -125,8 +126,6 @@ def _preprocess_pil_to_nchw(
             t = _F.resize(t, [height, width], antialias=False)
             t = _F.normalize(t, mean_list, std_list)
         return np.asarray(t.unsqueeze(0).cpu().numpy(), dtype=np.float32)
-    except ImportError:
-        pass
 
     # Torch-free fallback: same antialias-free half-pixel bilinear as predict(), in NumPy.
     arr = np.asarray(pil_img, dtype=np.float32) / 255.0

--- a/src/rfdetr/export/_onnx/inference.py
+++ b/src/rfdetr/export/_onnx/inference.py
@@ -152,11 +152,14 @@ def _run_inference(
 
     **Input contract** (must match ``RFDETR.predict()`` preprocessing exactly):
 
-    - Image is opened as-is and converted to ``"RGB"`` (3-channel) or ``"L"``
-      (1-channel greyscale) depending on the model's channel count.
-    - Resize uses ``PIL.Image.Resampling.BILINEAR`` — matching
-      ``torchvision.transforms.functional.resize()`` which defaults to ``InterpolationMode.BILINEAR``.  Using PIL's
-      default (``BICUBIC``) would produce slightly different pixel values and can degrade confidence.
+    - Image is opened with Pillow and converted to ``"RGB"`` (3-channel) or ``"L"``
+      (1-channel greyscale) depending on the model's channel count. PIL is used only to decode and
+      convert — never to resize.
+    - Resize follows ``RFDETR.predict()``'s exact convention — bilinear, half-pixel centers,
+      ``antialias=False`` — applied by :func:`_preprocess_pil_to_nchw` via ``torchvision`` when importable
+      (bit-exact) or the pure-NumPy ``_bilinear_resize_half_pixel`` fallback. PIL's own BILINEAR/BICUBIC
+      filters apply adaptive antialiasing when downscaling and would shift pixel values away from predict(),
+      degrading confidence.
     - Pixel values are scaled to ``[0, 1]`` then normalised with ImageNet
       statistics: ``mean=[0.485, 0.456, 0.406]``, ``std=[0.229, 0.224, 0.225]``.
     - The tensor is kept as ``[1, C, H, W]`` (NCHW) — unlike the TFLite helper

--- a/src/rfdetr/export/_onnx/inference.py
+++ b/src/rfdetr/export/_onnx/inference.py
@@ -19,6 +19,7 @@ from numpy.typing import NDArray
 from PIL import Image as PILImage
 from supervision import Detections
 
+from rfdetr.export._resize import _bilinear_resize_half_pixel
 from rfdetr.utilities.logger import get_logger
 
 logger = get_logger()
@@ -85,8 +86,11 @@ def _preprocess_pil_to_nchw(
 ) -> NDArray[np.float32]:
     """Resize and normalise a PIL image to an ``(1, C, H, W)`` float32 NCHW tensor.
 
-    Resizes using ``BILINEAR`` to match ``torchvision.transforms.functional.resize()`` (PIL's default is ``BICUBIC``
-    which produces slightly different values and can lower confidence scores).  Normalises with ImageNet statistics:
+    Resizes with ``RFDETR.predict()``'s exact convention — bilinear, half-pixel centers,
+    ``antialias=False`` — via ``torchvision`` when importable (bit-exact parity) or the pure-NumPy
+    ``_bilinear_resize_half_pixel`` otherwise (float32 op-order noise only). PIL resize is not used:
+    both its BILINEAR and BICUBIC filters apply adaptive antialiasing when downscaling and diverge
+    from predict(), shifting confidence scores. Normalises with ImageNet statistics:
     ``mean=[0.485, 0.456, 0.406]``, ``std=[0.229, 0.224, 0.225]``.
 
     Args:
@@ -105,22 +109,34 @@ def _preprocess_pil_to_nchw(
     """
     _imagenet_mean = [0.485, 0.456, 0.406]
     _imagenet_std = [0.229, 0.224, 0.225]
-    mean = np.array([_imagenet_mean[i % 3] for i in range(channels)], dtype=np.float32)
-    std = np.array([_imagenet_std[i % 3] for i in range(channels)], dtype=np.float32)
     pil_mode = "L" if channels == 1 else "RGB"
-    # BILINEAR matches torchvision default; PIL default (BICUBIC) causes confidence drop
-    arr = (
-        np.array(
-            image.convert(pil_mode).resize((width, height), PILImage.Resampling.BILINEAR),
-            dtype=np.float32,
-        )
-        / 255.0
-    )
+    pil_img = image.convert(pil_mode)
+    mean_list = [_imagenet_mean[i % 3] for i in range(channels)]
+    std_list = [_imagenet_std[i % 3] for i in range(channels)]
+
+    try:
+        # Match predict() exactly: torchvision to_tensor -> resize(antialias=False) -> normalize.
+        # antialias=False mirrors detr.py's predict(); torchvision's float-tensor default is True.
+        import torch
+        import torchvision.transforms.functional as _F  # noqa: N812
+
+        with torch.no_grad():
+            t = _F.to_tensor(pil_img)
+            t = _F.resize(t, [height, width], antialias=False)
+            t = _F.normalize(t, mean_list, std_list)
+        return np.asarray(t.unsqueeze(0).cpu().numpy(), dtype=np.float32)
+    except ImportError:
+        pass
+
+    # Torch-free fallback: same antialias-free half-pixel bilinear as predict(), in NumPy.
+    arr = np.asarray(pil_img, dtype=np.float32) / 255.0
     if arr.ndim == 2:  # "L" → (H, W); needs (H, W, 1)
         arr = arr[:, :, np.newaxis]
-    arr = (arr - mean) / std
-    arr = arr.transpose(2, 0, 1)  # HWC → CHW
-    return np.expand_dims(arr, axis=0).astype(np.float32)  # (1, C, H, W)
+    chw = _bilinear_resize_half_pixel(arr.transpose(2, 0, 1), height, width)
+    mean = np.array(mean_list, dtype=np.float32)[:, np.newaxis, np.newaxis]
+    std = np.array(std_list, dtype=np.float32)[:, np.newaxis, np.newaxis]
+    chw = (chw - mean) / std
+    return np.expand_dims(chw, axis=0).astype(np.float32)  # (1, C, H, W)
 
 
 def _run_inference(

--- a/src/rfdetr/export/_resize.py
+++ b/src/rfdetr/export/_resize.py
@@ -1,0 +1,57 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Torch-free bilinear resize shared by the export inference helpers.
+
+``RFDETR.predict()`` resizes with ``torchvision`` ``antialias=False`` bilinear (half-pixel centers, no low-pass filter).
+The export inference paths must reproduce that exact convention so exported models score images the same way the PyTorch
+model does. When ``torch`` is importable they call torchvision directly; this module provides the NumPy equivalent for
+torch-free deployments.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def _bilinear_resize_half_pixel(src: NDArray[np.float32], out_h: int, out_w: int) -> NDArray[np.float32]:
+    """Numpy bilinear resize matching ``F.interpolate(mode="bilinear", align_corners=False)``.
+
+    Half-pixel center convention with no antialias filter — the same convention
+    ``torchvision.transforms.functional.resize(..., antialias=False)`` and
+    ``RFDETR.predict()`` use. Serves as the torch-free fallback for both image
+    preprocessing and mask decoding.
+
+    Args:
+        src: Source array of shape ``(K, src_h, src_w)``.
+        out_h: Target height in pixels.
+        out_w: Target width in pixels.
+
+    Returns:
+        Float32 array of shape ``(K, out_h, out_w)``.
+
+    Note:
+        Replaces ``PIL.Image.resize(BILINEAR)``, which applies an adaptive
+        antialias filter when downscaling and a corner-aligned half-pixel
+        convention, both of which diverge from ``F.interpolate``.
+    """
+    src_h, src_w = src.shape[-2], src.shape[-1]
+    src_y = (np.arange(out_h, dtype=np.float32) + 0.5) * (src_h / out_h) - 0.5
+    src_x = (np.arange(out_w, dtype=np.float32) + 0.5) * (src_w / out_w) - 0.5
+    src_y = np.clip(src_y, 0.0, src_h - 1)
+    src_x = np.clip(src_x, 0.0, src_w - 1)
+    y0 = np.floor(src_y).astype(np.int64)
+    x0 = np.floor(src_x).astype(np.int64)
+    y1 = np.minimum(y0 + 1, src_h - 1)
+    x1 = np.minimum(x0 + 1, src_w - 1)
+    dy = (src_y - y0)[:, None]
+    dx = (src_x - x0)[None, :]
+    a = src[..., y0[:, None], x0[None, :]]
+    b = src[..., y0[:, None], x1[None, :]]
+    c = src[..., y1[:, None], x0[None, :]]
+    d = src[..., y1[:, None], x1[None, :]]
+    out = (1 - dy) * ((1 - dx) * a + dx * b) + dy * ((1 - dx) * c + dx * d)
+    return np.asarray(out, dtype=np.float32)

--- a/src/rfdetr/export/_tflite/converter.py
+++ b/src/rfdetr/export/_tflite/converter.py
@@ -637,7 +637,8 @@ def _load_calibration_images(
     arrays: list[NDArray[np.float32]] = []
     for img_path in image_paths:
         try:
-            img = Image.open(img_path).convert("RGB")
+            with Image.open(img_path) as _img:
+                img = _img.convert("RGB")
             # Resize with predict()'s convention (bilinear, half-pixel, no antialias) so the INT8
             # calibration ranges come from the same pixel distribution the model sees at inference.
             # PIL's default resize (BICUBIC + adaptive antialias) diverges from that distribution.

--- a/src/rfdetr/export/_tflite/converter.py
+++ b/src/rfdetr/export/_tflite/converter.py
@@ -71,6 +71,7 @@ from typing import Any, Generator, cast
 import numpy as np
 from numpy.typing import NDArray
 
+from rfdetr.export._resize import _bilinear_resize_half_pixel
 from rfdetr.utilities.logger import get_logger
 
 logger = get_logger()
@@ -636,9 +637,12 @@ def _load_calibration_images(
     arrays: list[NDArray[np.float32]] = []
     for img_path in image_paths:
         try:
-            img = Image.open(img_path).convert("RGB").resize((width, height))
-            image_array = np.asarray(img, dtype=np.float32)
-            image_array /= np.float32(255.0)
+            img = Image.open(img_path).convert("RGB")
+            # Resize with predict()'s convention (bilinear, half-pixel, no antialias) so the INT8
+            # calibration ranges come from the same pixel distribution the model sees at inference.
+            # PIL's default resize (BICUBIC + adaptive antialias) diverges from that distribution.
+            chw = np.asarray(img, dtype=np.float32).transpose(2, 0, 1) / np.float32(255.0)
+            image_array = _bilinear_resize_half_pixel(chw, height, width).transpose(1, 2, 0)
             arrays.append(image_array)
         except Exception:
             logger.debug(f"Skipping unreadable image: {img_path}")

--- a/src/rfdetr/export/_tflite/inference.py
+++ b/src/rfdetr/export/_tflite/inference.py
@@ -22,12 +22,10 @@ from numpy.typing import NDArray
 from PIL import Image as PILImage
 from supervision import Detections
 
+from rfdetr.export._resize import _bilinear_resize_half_pixel
 from rfdetr.utilities.logger import get_logger
 
 logger = get_logger()
-
-# PILImage.Resampling was introduced in Pillow 9.1; fall back to the legacy constant.
-_PIL_BILINEAR = getattr(PILImage, "Resampling", PILImage).BILINEAR
 
 _IMAGENET_MEAN: list[float] = [0.485, 0.456, 0.406]
 _IMAGENET_STD: list[float] = [0.229, 0.224, 0.225]
@@ -72,42 +70,6 @@ def _create_interpreter(model_path: str | Path) -> Any:
     for od in out_det:
         logger.debug("Output : %s  name=%s", od["shape"], od.get("name", "<unnamed>"))
     return interp
-
-
-def _bilinear_resize_half_pixel(src: NDArray[np.float32], out_h: int, out_w: int) -> NDArray[np.float32]:
-    """Numpy bilinear resize matching ``F.interpolate(mode="bilinear", align_corners=False)``.
-
-    Half-pixel center convention. Used by ``_decode_masks`` only when ``torch`` is not importable.
-
-    Args:
-        src: Source array of shape ``(K, src_h, src_w)``.
-        out_h: Target height in pixels.
-        out_w: Target width in pixels.
-
-    Returns:
-        Float32 array of shape ``(K, out_h, out_w)``.
-
-    Note:
-        Replaces ``PIL.Image.resize(BILINEAR)``, which uses a corner-aligned half-pixel convention and
-        produced border-pixel discrepancies vs ``F.interpolate``.
-    """
-    src_h, src_w = src.shape[-2], src.shape[-1]
-    src_y = (np.arange(out_h, dtype=np.float32) + 0.5) * (src_h / out_h) - 0.5
-    src_x = (np.arange(out_w, dtype=np.float32) + 0.5) * (src_w / out_w) - 0.5
-    src_y = np.clip(src_y, 0.0, src_h - 1)
-    src_x = np.clip(src_x, 0.0, src_w - 1)
-    y0 = np.floor(src_y).astype(np.int64)
-    x0 = np.floor(src_x).astype(np.int64)
-    y1 = np.minimum(y0 + 1, src_h - 1)
-    x1 = np.minimum(x0 + 1, src_w - 1)
-    dy = (src_y - y0)[:, None]
-    dx = (src_x - x0)[None, :]
-    a = src[..., y0[:, None], x0[None, :]]
-    b = src[..., y0[:, None], x1[None, :]]
-    c = src[..., y1[:, None], x0[None, :]]
-    d = src[..., y1[:, None], x1[None, :]]
-    out = (1 - dy) * ((1 - dx) * a + dx * b) + dy * ((1 - dx) * c + dx * d)
-    return np.asarray(out, dtype=np.float32)
 
 
 def _decode_masks(mask_logits: NDArray[np.floating[Any]], out_size: tuple[int, int]) -> NDArray[np.bool_]:
@@ -160,7 +122,8 @@ def _preprocess_image(
     """Resize and ImageNet-normalise an image to match ``RFDETR.predict()``.
 
     Uses ``torchvision.transforms.functional`` when importable for bit-exact parity, and falls back
-    to ``PIL.Image.resize`` with BILINEAR for torch-free deployments.
+    to the pure-NumPy ``_bilinear_resize_half_pixel`` for torch-free deployments. Both paths resize
+    with predict()'s convention: bilinear, half-pixel centers, ``antialias=False``.
 
     Args:
         pil_img: Source PIL image at native resolution.
@@ -171,9 +134,9 @@ def _preprocess_image(
         Float32 array of shape ``(1, height, width, channels)`` in NHWC.
 
     Note:
-        The PIL fallback uses BILINEAR resize, which does not perfectly match PyTorch's ``F.resize``
-        (different coordinate conventions). For bit-exact parity with ``RFDETR.predict()``, ensure
-        ``torch`` and ``torchvision`` are importable.
+        The NumPy fallback matches the torchvision path up to float32 op-order noise (~5e-5 in
+        normalised space). For bit-exact parity with ``RFDETR.predict()``, ensure ``torch`` and
+        ``torchvision`` are importable.
     """
     height, width = hw
     pil_mode = "L" if channels == 1 else "RGB"
@@ -181,13 +144,14 @@ def _preprocess_image(
 
     nchw_float: NDArray[np.float32] | None = None
     try:
-        # Match PyTorch.predict() exactly: torchvision to_tensor -> resize -> normalize.
+        # Match PyTorch.predict() exactly: torchvision to_tensor -> resize(antialias=False) -> normalize.
+        # antialias=False mirrors detr.py's predict(); torchvision's float-tensor default is True.
         import torch
         import torchvision.transforms.functional as _F  # noqa: N812
 
         with torch.no_grad():
             t = _F.to_tensor(pil_rgb)
-            t = _F.resize(t, list(hw))
+            t = _F.resize(t, list(hw), antialias=False)
             mean_list = [_IMAGENET_MEAN[i % 3] for i in range(channels)]
             std_list = [_IMAGENET_STD[i % 3] for i in range(channels)]
             t = _F.normalize(t, mean_list, std_list)
@@ -199,15 +163,18 @@ def _preprocess_image(
         # NCHW -> NHWC for the TFLite interpreter.
         return np.asarray(nchw_float.transpose(0, 2, 3, 1), dtype=np.float32)
 
-    # Torch-free fallback: PIL BILINEAR. PIL's default is BICUBIC, which diverges from PyTorch.
-    arr = np.array(pil_rgb.resize((width, height), _PIL_BILINEAR), dtype=np.float32) / 255.0
+    # Torch-free fallback: same antialias-free half-pixel bilinear as predict(), in NumPy.
+    # PIL resize is not an option here: both BILINEAR and BICUBIC apply an adaptive antialias
+    # filter when downscaling and diverge from predict() by up to ~1.7 in normalised space.
+    arr = np.asarray(pil_rgb, dtype=np.float32) / 255.0
     if arr.ndim == 2:  # "L" -> (height, width); TFLite needs (height, width, 1).
         arr = arr[:, :, np.newaxis]
+    arr = _bilinear_resize_half_pixel(arr.transpose(2, 0, 1), height, width).transpose(1, 2, 0)
 
     mean = np.array([_IMAGENET_MEAN[i % 3] for i in range(channels)], dtype=np.float32)
     std = np.array([_IMAGENET_STD[i % 3] for i in range(channels)], dtype=np.float32)
 
-    return ((arr - mean) / std)[np.newaxis]
+    return np.asarray(((arr - mean) / std)[np.newaxis], dtype=np.float32)
 
 
 def _run_inference(

--- a/src/rfdetr/export/_tflite/inference.py
+++ b/src/rfdetr/export/_tflite/inference.py
@@ -142,8 +142,7 @@ def _preprocess_image(
     pil_mode = "L" if channels == 1 else "RGB"
     pil_rgb = pil_img.convert(pil_mode)
 
-    nchw_float: NDArray[np.float32] | None = None
-    try:
+    with contextlib.suppress(ImportError):
         # Match PyTorch.predict() exactly: torchvision to_tensor -> resize(antialias=False) -> normalize.
         # antialias=False mirrors detr.py's predict(); torchvision's float-tensor default is True.
         import torch
@@ -156,10 +155,6 @@ def _preprocess_image(
             std_list = [_IMAGENET_STD[i % 3] for i in range(channels)]
             t = _F.normalize(t, mean_list, std_list)
         nchw_float = np.asarray(t.unsqueeze(0).cpu().numpy(), dtype=np.float32)
-    except ImportError:
-        pass
-
-    if nchw_float is not None:
         # NCHW -> NHWC for the TFLite interpreter.
         return np.asarray(nchw_float.transpose(0, 2, 3, 1), dtype=np.float32)
 

--- a/src/rfdetr/export/benchmark.py
+++ b/src/rfdetr/export/benchmark.py
@@ -111,8 +111,13 @@ def infer_transforms(size: tuple[int, int] = _DEFAULT_INPUT_SIZE) -> Any:
             :data:`_DEFAULT_INPUT_SIZE` for dynamic-axis models where a static size cannot be read.
 
     Returns:
-        A ``torchvision.transforms.v2.Compose`` that resizes, tensorizes, normalizes, and returns
+        A ``torchvision.transforms.v2.Compose`` that tensorizes, resizes, normalizes, and returns
         the image as a contiguous tensor.
+
+    Note:
+        Tensorize-then-resize with ``antialias=False`` mirrors ``RFDETR.predict()``'s preprocessing
+        (``detr.py``): resizing the PIL image first would apply PIL's adaptive antialias filter and
+        benchmark the model on inputs predict() never produces.
     """
     from torchvision.transforms.v2 import Compose, Resize, ToDtype, ToImage
 
@@ -120,9 +125,9 @@ def infer_transforms(size: tuple[int, int] = _DEFAULT_INPUT_SIZE) -> Any:
 
     return Compose(
         [
-            Resize(size),
             ToImage(),
             ToDtype(torch.float32, scale=True),
+            Resize(size, antialias=False),
             Normalize(),
             _ensure_contiguous,
         ]

--- a/src/rfdetr/export/main.py
+++ b/src/rfdetr/export/main.py
@@ -145,11 +145,13 @@ def make_infer_image(
             )
         image = Image.open(infer_dir).convert("RGB")
 
+    # Tensorize-then-resize with antialias=False mirrors RFDETR.predict()'s preprocessing, so the
+    # traced example input (and any export sanity check run on it) sees production-domain tensors.
     transforms = Compose(
         [
-            Resize((shape[0], shape[1])),
             ToImage(),
             ToDtype(torch.float32, scale=True),
+            Resize((shape[0], shape[1]), antialias=False),
             Normalize(),
         ]
     )

--- a/src/rfdetr/export/main.py
+++ b/src/rfdetr/export/main.py
@@ -143,7 +143,8 @@ def make_infer_image(
                 "Providing `infer_dir` is only supported for RGB models (num_channels=3). "
                 "For non-RGB models, omit `infer_dir` to use a synthetic dummy input."
             )
-        image = Image.open(infer_dir).convert("RGB")
+        with Image.open(infer_dir) as _img:
+            image = _img.convert("RGB")
 
     # Tensorize-then-resize with antialias=False mirrors RFDETR.predict()'s preprocessing, so the
     # traced example input (and any export sanity check run on it) sees production-domain tensors.

--- a/tests/export/test_infer_preprocess_parity.py
+++ b/tests/export/test_infer_preprocess_parity.py
@@ -1,0 +1,97 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Preprocessing parity tests for the benchmark and export example-input pipelines.
+
+``infer_transforms`` (ONNX/TensorRT benchmark) and ``make_infer_image`` (traced example input for export) must feed the
+model the same tensors ``RFDETR.predict()`` produces. History: both pipelines resized the PIL image before tensorising,
+going through PIL's adaptive antialias filter; after predict() switched to ``antialias=False`` (#1206) they benchmarked
+and traced on inputs predict() never produces. They now tensorise first and resize with ``antialias=False``; the only
+residual versus predict()'s ``to_tensor`` chain is 1 ULP from v2's uint8->float scaling.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import torchvision.transforms.functional as F  # noqa: N812
+from PIL import Image as PILImage
+
+from rfdetr.export.benchmark import infer_transforms
+from rfdetr.export.main import make_infer_image
+
+IMAGENET_MEAN = [0.485, 0.456, 0.406]
+IMAGENET_STD = [0.229, 0.224, 0.225]
+
+# v2's ToDtype(scale=True) and to_tensor may round the uint8->float conversion 1 ULP apart, which
+# propagates through resize+normalize to ~1e-6 in normalised space. The old resize-then-tensorise
+# pipelines (PIL antialiased filter) diverged by ~1.6 and would blow far past this bound.
+MAX_ABS_DIFF_BOUND = 1e-4
+
+
+def _pytorch_preprocess(pil_img: PILImage.Image, hw: tuple[int, int]) -> np.ndarray:
+    """Mirror of the PyTorch predict() preprocessing: to_tensor -> resize(antialias=False) -> normalize."""
+    img = F.to_tensor(pil_img)
+    img = F.resize(img, list(hw), antialias=False)
+    img = F.normalize(img, IMAGENET_MEAN, IMAGENET_STD)
+    return img.unsqueeze(0).numpy()
+
+
+def _make_synthetic_rgb(seed: int, size: tuple[int, int]) -> PILImage.Image:
+    """Deterministic synthetic RGB image with structure (not pure noise) so resize filtering matters."""
+    rng = np.random.default_rng(seed)
+    height, width = size
+    base = rng.integers(0, 256, size=(height // 8, width // 8, 3), dtype=np.uint8)
+    pil_small = PILImage.fromarray(base, mode="RGB")
+    return pil_small.resize((width, height), getattr(PILImage, "Resampling", PILImage).NEAREST)
+
+
+def test_infer_transforms_matches_predict_preprocessing() -> None:
+    """The benchmark pipeline must resize with predict()'s convention (bilinear, half-pixel, antialias-free)."""
+    pil = _make_synthetic_rgb(seed=3, size=(720, 1280))
+    tgt = (384, 384)
+
+    pt = _pytorch_preprocess(pil, tgt)
+    tensor, _ = infer_transforms(tgt)(pil, None)
+    bench = tensor.unsqueeze(0).numpy()
+
+    assert bench.shape == pt.shape, f"shape mismatch: predict {pt.shape} vs benchmark {bench.shape}"
+    max_diff = float(np.abs(pt - bench).max())
+    assert max_diff < MAX_ABS_DIFF_BOUND, (
+        f"Benchmark preprocessing diverged from predict(): max|diff|={max_diff:.4f}. infer_transforms "
+        f"must tensorise before resizing and pass antialias=False, matching detr.py's predict()."
+    )
+
+    # The antialiased variant (what a Resize without the flag, or a PIL-first pipeline, produces)
+    # must stay far away, proving the assertion discriminates on the resize convention.
+    img = F.to_tensor(pil)
+    img = F.resize(img, list(tgt), antialias=True)
+    img = F.normalize(img, IMAGENET_MEAN, IMAGENET_STD)
+    max_diff_antialias = float(np.abs(pt - img.unsqueeze(0).numpy()).max())
+    assert max_diff_antialias > 0.1, (
+        f"antialias=True variant unexpectedly close to predict() (max|diff|={max_diff_antialias:.4f}); "
+        "this test can no longer discriminate the antialias regression."
+    )
+
+
+def test_make_infer_image_matches_predict_preprocessing(tmp_path: Path) -> None:
+    """The traced example input must go through predict()'s resize convention, batched on the CPU."""
+    pil = _make_synthetic_rgb(seed=4, size=(720, 1280))
+    img_path = tmp_path / "img.png"
+    pil.save(img_path)
+
+    out = make_infer_image(str(img_path), shape=(384, 384), batch_size=2, device="cpu")
+
+    assert out.shape == (2, 3, 384, 384), f"unexpected shape: {tuple(out.shape)}"
+    pt = _pytorch_preprocess(pil, (384, 384))
+    max_diff = float(np.abs(pt[0] - out[0].numpy()).max())
+    assert max_diff < MAX_ABS_DIFF_BOUND, (
+        f"Export example input diverged from predict(): max|diff|={max_diff:.4f}. make_infer_image "
+        f"must tensorise before resizing and pass antialias=False, matching detr.py's predict()."
+    )
+    np.testing.assert_array_equal(
+        out[0].numpy(), out[1].numpy(), err_msg="batch entries must be identical copies of the same image"
+    )

--- a/tests/export/test_onnx_preprocess_parity.py
+++ b/tests/export/test_onnx_preprocess_parity.py
@@ -1,0 +1,102 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Preprocessing parity tests for the ONNX Runtime inference helper.
+
+``_preprocess_pil_to_nchw`` must produce the same input tensor as ``RFDETR.predict()`` for the same source image — the
+ONNX sibling of ``tests/export/test_tflite_inference_parity.py``. History: this path resized with PIL BILINEAR, which
+applies an adaptive antialias filter when downscaling; after predict() switched to ``antialias=False`` (#1206) the ONNX
+inputs diverged on 91%+ of float bits.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+import pytest
+import torchvision.transforms.functional as F  # noqa: N812
+from PIL import Image as PILImage
+
+from rfdetr.export._onnx.inference import _preprocess_pil_to_nchw
+
+IMAGENET_MEAN = [0.485, 0.456, 0.406]
+IMAGENET_STD = [0.229, 0.224, 0.225]
+
+# Same bound as the TFLite parity file: the torch-free NumPy fallback matches the torchvision
+# path up to float32 op-order noise (~5e-5 in normalised space).
+FALLBACK_MAX_ABS_DIFF_BOUND = 1e-3
+
+
+def _pytorch_preprocess(pil_img: PILImage.Image, hw: tuple[int, int]) -> np.ndarray:
+    """Mirror of the PyTorch predict() preprocessing: to_tensor -> resize(antialias=False) -> normalize."""
+    img = F.to_tensor(pil_img)
+    img = F.resize(img, list(hw), antialias=False)
+    img = F.normalize(img, IMAGENET_MEAN, IMAGENET_STD)
+    return img.unsqueeze(0).numpy()
+
+
+def _make_synthetic_rgb(seed: int, size: tuple[int, int]) -> PILImage.Image:
+    """Deterministic synthetic RGB image with structure (not pure noise) so resize filtering matters."""
+    rng = np.random.default_rng(seed)
+    height, width = size
+    base = rng.integers(0, 256, size=(height // 8, width // 8, 3), dtype=np.uint8)
+    pil_small = PILImage.fromarray(base, mode="RGB")
+    return pil_small.resize((width, height), getattr(PILImage, "Resampling", PILImage).NEAREST)
+
+
+class TestOnnxPreprocessingParity:
+    """``_preprocess_pil_to_nchw`` must match predict()'s preprocessing bit-for-bit with torchvision."""
+
+    @pytest.mark.parametrize(
+        ("src_hw", "tgt", "seed"),
+        [
+            pytest.param((720, 1280), (384, 384), 5, id="1280x720_to_384x384"),
+            pytest.param((600, 800), (384, 384), 8, id="800x600_to_384x384"),
+            pytest.param((384, 384), (384, 384), 9, id="identity_384x384"),
+        ],
+    )
+    def test_matches_pytorch_predict_preprocessing_bitwise(
+        self, src_hw: tuple[int, int], tgt: tuple[int, int], seed: int
+    ) -> None:
+        pil = _make_synthetic_rgb(seed=seed, size=src_hw)
+
+        pt = _pytorch_preprocess(pil, tgt)
+        onnx = _preprocess_pil_to_nchw(pil, tgt[0], tgt[1], channels=3)
+
+        assert pt.shape == onnx.shape, f"shape mismatch: PT {pt.shape} vs ONNX {onnx.shape}"
+        pt32 = np.ascontiguousarray(pt, dtype=np.float32).view(np.uint32)
+        on32 = np.ascontiguousarray(onnx, dtype=np.float32).view(np.uint32)
+        n_diff = int((pt32 != on32).sum())
+        assert n_diff == 0, (
+            f"ONNX preprocessing diverged from predict(): {n_diff}/{pt32.size} float bits differ "
+            f"(max|diff|={float(np.abs(pt - onnx).max()):.6f}). With torchvision importable it must "
+            f"run predict()'s exact call chain (to_tensor -> resize(antialias=False) -> normalize)."
+        )
+
+    def test_torch_free_fallback_still_close(self) -> None:
+        """With torch masked out, the NumPy fallback stays within float32 op-order noise of predict()."""
+        from unittest import mock
+
+        pil = _make_synthetic_rgb(seed=6, size=(720, 1280))
+        tgt = (384, 384)
+        pt = _pytorch_preprocess(pil, tgt)
+
+        with mock.patch.dict(sys.modules, {"torch": None}):
+            onnx = _preprocess_pil_to_nchw(pil, tgt[0], tgt[1], channels=3)
+
+        max_diff = float(np.abs(pt - onnx).max())
+        assert max_diff < FALLBACK_MAX_ABS_DIFF_BOUND, (
+            f"Torch-free NumPy fallback diverged: max|diff|={max_diff:.4f} > {FALLBACK_MAX_ABS_DIFF_BOUND}. "
+            "The fallback must use _bilinear_resize_half_pixel (antialias-free, half-pixel centres)."
+        )
+
+    def test_grayscale_channel_handling(self) -> None:
+        """Grayscale (channels=1) path must produce shape (1, 1, H, W) float32."""
+        rng = np.random.default_rng(7)
+        pil = PILImage.fromarray(rng.integers(0, 256, size=(256, 256), dtype=np.uint8), mode="L")
+        onnx = _preprocess_pil_to_nchw(pil, 128, 128, channels=1)
+        assert onnx.shape == (1, 1, 128, 128), f"unexpected shape: {onnx.shape}"
+        assert onnx.dtype == np.float32

--- a/tests/export/test_onnx_preprocess_parity.py
+++ b/tests/export/test_onnx_preprocess_parity.py
@@ -55,6 +55,7 @@ class TestOnnxPreprocessingParity:
         [
             pytest.param((720, 1280), (384, 384), 5, id="1280x720_to_384x384"),
             pytest.param((600, 800), (384, 384), 8, id="800x600_to_384x384"),
+            pytest.param((500, 500), (256, 256), 11, id="500x500_to_256x256"),
             pytest.param((384, 384), (384, 384), 9, id="identity_384x384"),
         ],
     )
@@ -74,6 +75,35 @@ class TestOnnxPreprocessingParity:
             f"ONNX preprocessing diverged from predict(): {n_diff}/{pt32.size} float bits differ "
             f"(max|diff|={float(np.abs(pt - onnx).max()):.6f}). With torchvision importable it must "
             f"run predict()'s exact call chain (to_tensor -> resize(antialias=False) -> normalize)."
+        )
+
+    def test_antialias_true_would_be_much_worse(self) -> None:
+        """Discriminator: torchvision's ``antialias=True`` default must diverge far from predict().
+
+        The regression this file guards against — the ONNX path silently resized with antialiasing after predict()
+        switched to ``antialias=False`` (#1206), flipping 91%+ of float bits. The current code must stay bit-identical
+        to predict() while the antialiased variant stays far away, proving the bitwise parity assertion discriminates on
+        the antialias flag rather than passing vacuously.
+        """
+        pil = _make_synthetic_rgb(seed=13, size=(720, 1280))
+        tgt = (384, 384)
+
+        pt = _pytorch_preprocess(pil, tgt)
+        onnx = _preprocess_pil_to_nchw(pil, tgt[0], tgt[1], channels=3)
+
+        img = F.to_tensor(pil.convert("RGB"))
+        img = F.resize(img, list(tgt), antialias=True)
+        img = F.normalize(img, IMAGENET_MEAN, IMAGENET_STD)
+        antialias = img.unsqueeze(0).numpy()
+
+        pt32 = np.ascontiguousarray(pt, dtype=np.float32).view(np.uint32)
+        on32 = np.ascontiguousarray(onnx, dtype=np.float32).view(np.uint32)
+        assert int((pt32 != on32).sum()) == 0, "current ONNX code must stay bit-identical to predict()"
+
+        max_diff_antialias = float(np.abs(pt - antialias).max())
+        assert max_diff_antialias > 0.1, (
+            f"antialias=True variant unexpectedly close to predict() (max|diff|={max_diff_antialias:.4f}); "
+            "this test can no longer discriminate the antialias regression."
         )
 
     def test_torch_free_fallback_still_close(self) -> None:

--- a/tests/export/test_tflite_export.py
+++ b/tests/export/test_tflite_export.py
@@ -947,6 +947,38 @@ class TestLoadCalibrationImages:
         assert result.min() >= 0.0
         assert result.max() <= 1.0
 
+    def test_resize_matches_predict_convention(self, tmp_path: Path) -> None:
+        """The calibration resize must follow predict()'s convention: bilinear, half-pixel, antialias-free.
+
+        Guards the #1206 alignment: PIL's default resize (BICUBIC + adaptive antialias when downscaling) produces a
+        pixel distribution the model never sees at inference and would skew the INT8 ranges.
+        """
+        import torchvision.transforms.functional as F  # noqa: N812
+        from PIL import Image
+
+        rng = np.random.default_rng(11)
+        base = rng.integers(0, 256, size=(40, 50, 3), dtype=np.uint8)
+        nearest = getattr(Image, "Resampling", Image).NEAREST
+        pil = Image.fromarray(base, mode="RGB").resize((400, 320), nearest)
+        pil.save(tmp_path / "img.png")
+
+        result = _load_calibration_images(tmp_path, height=128, width=160)
+
+        ref = F.resize(F.to_tensor(pil), [128, 160], antialias=False).numpy().transpose(1, 2, 0)
+        max_diff = float(np.abs(result[0] - ref).max())
+        assert max_diff < 1e-3, (
+            f"Calibration resize diverged from predict()'s antialias-free convention: "
+            f"max|diff|={max_diff:.4f}. _load_calibration_images must resize with "
+            f"_bilinear_resize_half_pixel, not PIL."
+        )
+
+        # PIL's default resample (the old behaviour) must stay far from the reference,
+        # proving this assertion actually discriminates on the resize convention.
+        pil_default = np.asarray(pil.resize((160, 128)), dtype=np.float32) / np.float32(255.0)
+        assert float(np.abs(pil_default - ref).max()) > 0.05, (
+            "PIL's default resize unexpectedly matches the reference; this test no longer discriminates."
+        )
+
     def test_respects_max_images(self, tmp_path: Path) -> None:
         self._make_images(tmp_path, count=10)
         result = _load_calibration_images(tmp_path, height=64, width=64, max_images=4)

--- a/tests/export/test_tflite_inference.py
+++ b/tests/export/test_tflite_inference.py
@@ -22,8 +22,8 @@ import pytest
 import supervision as sv
 from PIL import Image as PILImage
 
+from rfdetr.export._resize import _bilinear_resize_half_pixel
 from rfdetr.export._tflite.inference import (
-    _bilinear_resize_half_pixel,
     _create_interpreter,
     _decode_masks,
     _preprocess_image,
@@ -767,8 +767,8 @@ class TestPreprocessImage:
         # pixel 0 → 0.0 → (0.0 - 0.485) / 0.229 ≈ -2.12
         assert out.min() < -1.0
 
-    def test_pil_fallback_when_torch_unavailable(self) -> None:
-        """PIL path is used when torch is masked from sys.modules."""
+    def test_numpy_fallback_when_torch_unavailable(self) -> None:
+        """The NumPy resize path is used when torch is masked from sys.modules."""
         pil_img = PILImage.new("RGB", (100, 80))
         with mock.patch.dict(
             sys.modules,

--- a/tests/export/test_tflite_inference_parity.py
+++ b/tests/export/test_tflite_inference_parity.py
@@ -10,8 +10,11 @@ drift.
 History: an earlier version of ``_run_inference`` called ``PIL.Image.resize`` without a filter argument, picking up
 PIL's default (BICUBIC since Pillow 9.1.0). PyTorch's predict() path uses torchvision ``F.resize`` (BILINEAR). The
 mismatch caused IoU drift up to 0.36 on detail-rich images and a 2-class-mismatch FP16 disaster on the ``dog`` test
-image. This test exists to keep ``_preprocess_image`` locked to BILINEAR -- any regression that re-introduces BICUBIC or
-otherwise shifts the resize filter will surface here.
+image. Later, predict() switched to ``antialias=False`` (#1206) to match the antialias-free resize the released
+checkpoints were trained with, and the export paths silently kept torchvision's ``antialias=True`` default -- 83-97% of
+float bits differed and RFDETRNano detection counts shifted at threshold 0.3. This test locks ``_preprocess_image`` to
+predict()'s exact resize convention: the torchvision path must match bit-for-bit, and any regression in the filter
+(BICUBIC) or the antialias flag will surface here.
 """
 
 from __future__ import annotations
@@ -23,29 +26,38 @@ import pytest
 import torchvision.transforms.functional as F  # noqa: N812
 from PIL import Image as PILImage
 
-from rfdetr.export._tflite.inference import _bilinear_resize_half_pixel, _preprocess_image
+from rfdetr.export._resize import _bilinear_resize_half_pixel
+from rfdetr.export._tflite.inference import _preprocess_image
 
 IMAGENET_MEAN = [0.485, 0.456, 0.406]
 IMAGENET_STD = [0.229, 0.224, 0.225]
 
-# Bound for max abs diff in normalised space between the PyTorch and TFLite preprocessing pipelines.
-# With torchvision available (which is always the case in this repo's CI -- it's a hard rfdetr
-# dependency) _preprocess_image runs the same torchvision call PyTorch's predict() uses, so the
-# tensors are bit-exact. The 0.05 bound is generous so the torch-free fallback path (which uses
-# PIL.BILINEAR and shows ~0.016 max diff) also passes; the BICUBIC regression would push max diff
-# to ~0.5, well above the bound.
-MAX_ABS_DIFF_BOUND = 0.05
-# When torchvision is available the inference path matches torchvision-resize byte-for-byte, so
-# the diff is effectively zero modulo floating-point noise.
-BIT_EXACT_BOUND = 1e-5
+# Bound for max abs diff in normalised space for the torch-free fallback path, which reimplements
+# predict()'s antialias-free bilinear resize in pure NumPy (`_bilinear_resize_half_pixel`). The
+# residual is float32 op-order noise only, measured ~5e-5; the old PIL.BILINEAR fallback (adaptive
+# antialias filter) diverged by ~1.6 and would blow far past this bound.
+FALLBACK_MAX_ABS_DIFF_BOUND = 1e-3
 
 
 def _pytorch_preprocess(pil_img: PILImage.Image, hw: tuple[int, int]) -> np.ndarray:
-    """Mirror of the PyTorch predict() preprocessing: to_tensor -> resize -> normalize."""
+    """Mirror of the PyTorch predict() preprocessing: to_tensor -> resize(antialias=False) -> normalize."""
     img = F.to_tensor(pil_img)
-    img = F.resize(img, list(hw))
+    img = F.resize(img, list(hw), antialias=False)
     img = F.normalize(img, IMAGENET_MEAN, IMAGENET_STD)
     return img.unsqueeze(0).numpy()
+
+
+def _assert_bit_identical(pt: np.ndarray, tf: np.ndarray, context: str) -> None:
+    """Assert two float32 arrays are identical at the bit level (uint32 view, no tolerance)."""
+    pt32 = np.ascontiguousarray(pt, dtype=np.float32).view(np.uint32)
+    tf32 = np.ascontiguousarray(tf, dtype=np.float32).view(np.uint32)
+    n_diff = int((pt32 != tf32).sum())
+    assert n_diff == 0, (
+        f"{context}: {n_diff}/{pt32.size} float bits differ from predict()'s preprocessing "
+        f"(max|diff|={float(np.abs(pt - tf).max()):.6f}). With torchvision importable, "
+        f"_preprocess_image must run the exact predict() call chain "
+        f"(to_tensor -> resize(antialias=False) -> normalize) and match bit-for-bit."
+    )
 
 
 def _tflite_preprocess_to_nchw(pil_img: PILImage.Image, hw: tuple[int, int]) -> np.ndarray:
@@ -88,17 +100,10 @@ class TestPreprocessingParity:
         tf = _tflite_preprocess_to_nchw(pil, tgt_size)
 
         assert pt.shape == tf.shape, f"shape mismatch: PT {pt.shape} vs TF {tf.shape}"
-        max_diff = float(np.abs(pt - tf).max())
         # torchvision is a hard rfdetr dependency, so in this test environment _preprocess_image
-        # uses the torchvision path and matches PyTorch byte-for-byte. The torch-free fallback is
+        # uses the torchvision path and matches PyTorch bit-for-bit. The torch-free fallback is
         # exercised separately by test_torch_free_fallback_still_close.
-        assert max_diff < BIT_EXACT_BOUND, (
-            f"PyTorch vs TFLite preprocessing diverged: max|diff|={max_diff:.6f} exceeds "
-            f"{BIT_EXACT_BOUND}. With torchvision available, _preprocess_image should be using "
-            f"torchvision.transforms.functional.resize and the diff should be effectively zero. "
-            f"If this fires, check that the torch/torchvision import path inside _preprocess_image "
-            f"hasn't been broken."
-        )
+        _assert_bit_identical(pt, tf, f"{src_size} -> {tgt_size}")
 
     def test_grayscale_channel_handling(self) -> None:
         """Grayscale (channels=1) path must produce shape (1, H, W, 1)."""
@@ -130,11 +135,11 @@ class TestPreprocessingParity:
         np.testing.assert_allclose(per_channel_mean, expected, atol=1e-3)
 
     def test_torch_free_fallback_still_close(self) -> None:
-        """Simulate the torch-free environment by masking torch imports; assert the PIL fallback still stays within the
-        looser MAX_ABS_DIFF_BOUND.
+        """Simulate the torch-free environment by masking torch imports; assert the NumPy fallback stays within
+        FALLBACK_MAX_ABS_DIFF_BOUND.
 
-        This documents the gap users on edge deployments without torch installed will see (versus the bit-exact
-        torchvision path).
+        The fallback runs ``_bilinear_resize_half_pixel`` -- the same antialias-free half-pixel convention predict()
+        uses -- so the residual versus the torchvision path is float32 op-order noise only.
         """
         from unittest import mock
 
@@ -142,15 +147,15 @@ class TestPreprocessingParity:
         tgt = (384, 384)
         pt = _pytorch_preprocess(pil, tgt)
 
-        # Hide torch from _preprocess_image's lazy import, forcing the PIL fallback.
+        # Hide torch from _preprocess_image's lazy import, forcing the NumPy fallback.
         with mock.patch.dict(sys.modules, {"torch": None}):
             tf = _tflite_preprocess_to_nchw(pil, tgt)
 
         max_diff = float(np.abs(pt - tf).max())
-        assert max_diff < MAX_ABS_DIFF_BOUND, (
-            f"Torch-free PIL fallback diverged: max|diff|={max_diff:.4f} > {MAX_ABS_DIFF_BOUND}. "
-            "The fallback uses PIL.BILINEAR which should keep diff ~0.016; a regression to "
-            "BICUBIC would push it ~30x larger."
+        assert max_diff < FALLBACK_MAX_ABS_DIFF_BOUND, (
+            f"Torch-free NumPy fallback diverged: max|diff|={max_diff:.4f} > {FALLBACK_MAX_ABS_DIFF_BOUND}. "
+            "The fallback must use _bilinear_resize_half_pixel (antialias-free, half-pixel centers); "
+            "a regression to PIL resize (BILINEAR or BICUBIC, both antialiased) pushes the diff above 0.4."
         )
 
 
@@ -183,7 +188,33 @@ class TestPreprocessingFilterRegression:
         assert max_diff_current * 5 < max_diff_bicubic, (
             f"_preprocess_image is too close to BICUBIC behaviour: "
             f"current max|diff|={max_diff_current:.4f}, BICUBIC max|diff|={max_diff_bicubic:.4f}. "
-            f"Check that _PIL_BILINEAR is being passed to .resize()."
+            f"Check that the resize path is not falling back to PIL's default filter."
+        )
+
+    def test_antialias_true_would_be_much_worse(self) -> None:
+        """The regression this file guards against: resizing with torchvision's ``antialias=True`` default.
+
+        This is what the export paths silently did after predict() switched to ``antialias=False`` (#1206): calling
+        ``F.resize`` without the flag flips 83-97% of float bits versus predict()'s tensors. The current code must stay
+        bit-identical while the antialiased variant stays far away -- proving the parity assertion actually
+        discriminates on the antialias flag.
+        """
+        pil = _make_synthetic_rgb(seed=13, size=(720, 1280))
+        tgt = (384, 384)
+
+        pt = _pytorch_preprocess(pil, tgt)
+        tf_current = _tflite_preprocess_to_nchw(pil, tgt)
+
+        img = F.to_tensor(pil.convert("RGB"))
+        img = F.resize(img, list(tgt), antialias=True)
+        img = F.normalize(img, IMAGENET_MEAN, IMAGENET_STD)
+        tf_antialias = img.unsqueeze(0).numpy()
+
+        _assert_bit_identical(pt, tf_current, "current code vs predict()")
+        max_diff_antialias = float(np.abs(pt - tf_antialias).max())
+        assert max_diff_antialias > 0.1, (
+            f"antialias=True variant unexpectedly close to predict() (max|diff|={max_diff_antialias:.4f}); "
+            "this test can no longer discriminate the antialias regression."
         )
 
 


### PR DESCRIPTION
Follow-up to #1203 and #1206. #1206 switched `predict()` to `antialias=False` so inference matches the resize the released checkpoints were trained with, but the export-side preprocessing paths kept their old conventions, so exported models no longer see the same tensors as `predict()`:

1. TFLite inference (`_preprocess_image`) calls `F.resize` with no flag, and torchvision defaults to `antialias=True` for float tensors. This path was made bit-exact against the old `predict()` in #1131 and nobody updated it after #1206.
2. ONNX inference (`_preprocess_pil_to_nchw`) resizes with PIL BILINEAR, which applies an adaptive antialias filter when downscaling.
3. The ONNX/TensorRT benchmark and the export example-input pipeline resize the PIL image before tensorising, so they also go through PIL's antialiased filter.
4. INT8 calibration resizes with PIL's default resample, which is BICUBIC since Pillow 9.1.

I measured the divergence on 25 COCO images, comparing float32 bits through a `uint32` view (baseline first checked against itself: 0 bits differ):

| resolution | path | max abs diff (normalised space) | bits differing |
|---|---|---|---|
| 384 | TFLite current | 1.603 | 96.41% |
| 512 | TFLite current | 0.695 | 86.76% |
| 576 | TFLite current | 0.423 | 83.35% |
| 384 | ONNX current | 1.602 | 91.64% |

End to end it moves detections, not just pixels. Released RFDETRNano at 384, threshold 0.3, 10 COCO images: the canonical preprocessing gives 50 detections, the current TFLite preprocessing gives 47. Hungarian matching restricted to the same class leaves 47 pairs, mean IoU 0.951, and a max score difference of 0.153 — detections appear and disappear around the threshold just from the resize flag.

The parity test did not catch it because its baseline omits `antialias=False` too, and its "bit exact" assertion was a 1e-5 tolerance.

**Changes**

- Every export path now resizes with `predict()`'s exact convention: bilinear, half-pixel centres, `antialias=False`. With torchvision importable, TFLite and ONNX preprocessing are bit-identical to `predict()` — 0 differing bits on the same 25 images at the three resolutions.
- `_bilinear_resize_half_pixel` moved from `_tflite/inference.py` to a shared `rfdetr/export/_resize.py`, and it now also backs the torch-free fallback of both inference helpers. It implements the same antialias-free half-pixel convention, so the fallback gap drops from ~1.6 to ~5e-5 in normalised space. The old PIL BILINEAR fallback cannot get closer, its filter is antialiased by design.
- The benchmark and export example-input pipelines tensorise before resizing (`ToImage → ToDtype → Resize(antialias=False)`). The only remaining difference with `predict()` there is 1 ULP from v2's uint8→float scaling.
- INT8 calibration resizes with the same convention, so the calibration ranges come from the pixel distribution the model actually sees at inference. Existing INT8 exports keep working, and re-exporting picks up the aligned calibration.
- The TFLite parity test now asserts bit-identity (uint32 view, no tolerance) on the torchvision path, and a new test checks the antialiased variant stays far away, so the assertion really discriminates on the flag. The ONNX helper gets its own parity file (`test_onnx_preprocess_parity.py`), it had no preprocessing test before. Same for the two remaining consumers: `test_infer_preprocess_parity.py` locks `infer_transforms` and `make_infer_image` to `predict()`'s convention, and `test_tflite_export.py` adds a calibration-resize test. Each of these embeds a discriminator assertion (the old antialiased behaviour must stay far from the reference), so none of them can become vacuous like the previous parity test did.
- One sentence in the migration guide updated to reflect that `predict()` and the export inference paths are antialias-free since #1206.

**Validation**

- Every new or hardened test fails on current `develop` and passes with this change: the TFLite parity cases (389600/442368 bits differ on the 1280x720 → 384 case), the ONNX bitwise and fallback cases, both benchmark/example-input cases, and the calibration-resize case. Verified by reverting each touched source file individually with the tests in place.
- `pytest tests/export/` — 303 passed, 63 skipped, 0 failed.
- Full CPU suite — same result as `develop`, the only failures are pre-existing environment ones in `tests/cli` (missing `jsonargparse` locally), unrelated to this change.
- `pre-commit run` clean on the touched files; mypy on `src/rfdetr/export/` clean.
