### PR TITLE
refactor: enable mypy strict checking for rfdetr.variants

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -406,6 +406,5 @@ overrides = [
     "rfdetr.datasets.transforms",
     "rfdetr.datasets.yolo",
     "rfdetr.detr",
-    "rfdetr.variants",
   ], ignore_errors = true },
 ]

--- a/src/rfdetr/variants.py
+++ b/src/rfdetr/variants.py
@@ -30,6 +30,8 @@ __all__ = [
     "RFDETRSeg2XLarge",
 ]
 
+from typing import Any
+
 from deprecate import deprecated_class
 
 from rfdetr.config import (
@@ -140,7 +142,7 @@ class RFDETRLarge(RFDETR):
 
     size = "rfdetr-large"
 
-    def get_model_config(self, **kwargs) -> ModelConfig:
+    def get_model_config(self, **kwargs: Any) -> ModelConfig:
         return RFDETRLargeConfig(**kwargs)
 
 


### PR DESCRIPTION
## Description

Part of #564.

Enables `mypy --strict` for `rfdetr.variants` and removes it from the `ignore_errors` list in `pyproject.toml`.

`RFDETRLarge.get_model_config` was the only untyped signature in the module. The base class already declares the annotated form:

```python
# src/rfdetr/detr.py:439
def get_model_config(self, **kwargs: Any) -> ModelConfig:
```

The override in `src/rfdetr/variants.py` dropped the `**kwargs` annotation, which tripped `no-untyped-def` under strict mode. This aligns the override with the base class rather than introducing a new convention.

## Changes

- `src/rfdetr/variants.py`: annotate `**kwargs: Any` on `RFDETRLarge.get_model_config`, add the `typing.Any` import
- `pyproject.toml`: drop `rfdetr.variants` from the "Modules with pre-existing type errors" override block

## Type of change

- [x] Refactor / typing (no functional change)

## Testing

No behavioral change, so no new runtime tests. The `mypy` gate is the test: `rfdetr.variants` is now checked in CI instead of exempted, and regressions in this module will fail the hook.

Verified in an environment matching `ci-typing.yml` (Python 3.10, `-e ".[train,cli,visual]" --group typing`):

- `python -m mypy src/rfdetr/ --no-error-summary` exits 0
- `pre-commit run --all-files` passes, mypy hook included
- CPU suite with CI's marker set: 3281 passed, 60 skipped

## Notes

This leaves 11 modules in the `ignore_errors` block. Happy to keep working through them, `rfdetr.datasets.yolo` and `rfdetr.datasets.coco` next if nobody else has claimed those.
