### PR TITLE
refactor: enable mypy strict checking for rfdetr.assets.model_weights

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -397,7 +397,6 @@ overrides = [
   { module = [
     "rfdetr",
     "rfdetr._namespace",
-    "rfdetr.assets.model_weights",
     "rfdetr.config",
     "rfdetr.datasets._develop",
     "rfdetr.datasets.coco",

--- a/src/rfdetr/assets/model_weights.py
+++ b/src/rfdetr/assets/model_weights.py
@@ -89,6 +89,8 @@ class ModelWeightsBase(Enum):
         'https://storage.googleapis.com/rfdetr/rf-detr-base-coco.pth'
     """
 
+    _value_: ModelWeightAsset
+
     def __new__(cls, asset: ModelWeightAsset) -> ModelWeightsBase:
         obj = object.__new__(cls)
         obj._value_ = asset
@@ -98,17 +100,17 @@ class ModelWeightsBase(Enum):
     @property
     def filename(self) -> str:
         """Get the filename from the underlying ModelWeightAsset."""
-        return self.value.filename
+        return self._value_.filename
 
     @property
     def url(self) -> str:
         """Get the URL from the underlying ModelWeightAsset."""
-        return self.value.url
+        return self._value_.url
 
     @property
     def md5_hash(self) -> str | None:
         """Get the MD5 hash from the underlying ModelWeightAsset."""
-        return self.value.md5_hash
+        return self._value_.md5_hash
 
     @classmethod
     def from_filename(cls, filename: str) -> ModelWeightAsset | None:
@@ -126,8 +128,8 @@ class ModelWeightsBase(Enum):
             'https://storage.googleapis.com/rfdetr/rf-detr-base-coco.pth'
         """
         for member in cls:
-            if member.value.filename == filename:
-                return member.value  # Return the ModelWeightAsset directly
+            if member._value_.filename == filename:
+                return member._value_  # Return the ModelWeightAsset directly
         return None
 
     @classmethod
@@ -163,7 +165,7 @@ class ModelWeightsBase(Enum):
         Returns:
             List of model filenames
         """
-        return [member.value.filename for member in cls]
+        return [member._value_.filename for member in cls]
 
 
 class ModelWeights(ModelWeightsBase):


### PR DESCRIPTION
## Description

Part of #564.

Enables `mypy --strict` for `rfdetr.assets.model_weights` and removes it from the `ignore_errors` list in `pyproject.toml`.

`ModelWeightsBase` is an `Enum` whose members carry a `ModelWeightAsset` payload, assigned via `obj._value_ = asset` in `__new__`. mypy has no way to know that payload type, so `.value` is `Any`, and every accessor reading through it returned `Any` from a function declared to return `str`:

```
model_weights.py:101: error: Returning Any from function declared to return "str"  [no-any-return]
model_weights.py:106: error: Returning Any from function declared to return "str"  [no-any-return]
model_weights.py:111: error: Returning Any from function declared to return "str | None"  [no-any-return]
model_weights.py:130: error: Returning Any from function declared to return "ModelWeightAsset | None"  [no-any-return]
```

The fix declares the payload type once, at the point the class already establishes it:

```python
_value_: ModelWeightAsset
```

This is an annotation with no assignment, so it does not become an enum member and has no runtime effect.

### Why the accessors now read `_value_` rather than `.value`

Declaring `_value_` types `_value_` but does not propagate to `.value` under mypy 1.19.1:

```
reveal_type(ModelWeights.RF_DETR_BASE.value)   # Any
reveal_type(ModelWeights.RF_DETR_BASE._value_) # ModelWeightAsset
```

`Enum.value` is a `DynamicClassAttribute` that returns `self._value_`, so the two are the same object at runtime (verified: `m.value is m._value_`). Reading the annotated name keeps the module honest without scattering four `cast(...)` calls, and `_value_` is already this class's own vocabulary since `__new__` assigns it.

If you would rather keep `.value` at the call sites, the alternative is a `TYPE_CHECKING`-only `value` property declaration. I did not take that route because `.value` is used only inside this module (all six sites are here); every external caller already goes through the `filename` / `url` / `md5_hash` properties, so it would add indirection for no reach.

## Changes

- `src/rfdetr/assets/model_weights.py`: declare `_value_: ModelWeightAsset` on `ModelWeightsBase`, read the accessors through it
- `pyproject.toml`: drop `rfdetr.assets.model_weights` from the "Modules with pre-existing type errors" override block

Note that `list_models` was not one of the four reported errors, but it was building a `list[Any]` that silently satisfied its `list[str]` return type. It is included so the module is genuinely typed rather than passing by accident.

## Type of change

- [x] Refactor / typing (no functional change)

## Testing

No behavioral change, so no new runtime tests. The `mypy` gate is the test: `rfdetr.assets.model_weights` is now checked in CI instead of exempted.

Verified in an environment matching `ci-typing.yml` (Python 3.10, `-e ".[train,cli,visual]" --group typing`):

- `python -m mypy src/rfdetr/ --no-error-summary` exits 0
- `pre-commit run --all-files` passes, all 19 hooks including mypy
- `tests/assets/`, `tests/training/test_load_pretrain_weights.py`, `tests/training/test_module_model.py`: 285 passed, 2 skipped
- Full CPU suite matching `ci-tests-cpu.yml` (`-e ".[train,augment,cli,visual]" --group tests`, CI's marker set): 3282 passed, 59 skipped, 0 failed

Also confirmed at runtime that the annotation changes nothing: 16 enum members before and after, `_value_` does not appear in `__members__`, `m.value is m._value_`, and `from_filename` / `get_url` / `get_md5` / `list_models` all return identical results.

## Notes

While measuring the backlog I noticed `rfdetr._namespace` currently passes `--strict` with no code changes at all, so its entry in the `ignore_errors` block looks stale. I left it alone to keep this PR to one module, but happy to drop that line here or in a separate one-line PR, whichever you prefer.

This leaves 10 modules in the block (9 if `_namespace` goes). Happy to keep working through them.
