### PR TITLE
perf(eval): count labels on host in matching

### DIFF
--- a/src/rfdetr/evaluation/matching.py
+++ b/src/rfdetr/evaluation/matching.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from typing import Any, cast
 
 import numpy as np
@@ -181,6 +182,12 @@ def build_matching_data(
             - ``"matches"``: int ndarray (1 = TP, 0 = FP).
             - ``"ignore"``: bool ndarray (True if matched to a crowd GT).
             - ``"total_gt"``: int, count of non-crowd GT instances.
+
+    Raises:
+        ValueError: If a target's ``iscrowd`` is not a 1-D tensor with one entry per GT label, or if
+            ``iou_type="segm"`` and ``masks`` is missing on either side for a class that has both
+            predictions and ground truth. Classes present on only one side skip the mask lookup, so
+            a missing ``masks`` key is not reported for an image whose classes are all one-sided.
     """
     acc: dict[int, dict[str, list[Any] | int]] = {}
 
@@ -198,19 +205,29 @@ def build_matching_data(
             torch.zeros(len(gt_labels), dtype=torch.long, device=gt_labels.device),
         )
         gt_crowd = raw_crowd.bool()
+        # Checked on the shape, not on len(): a [M, 1] iscrowd has the right len() but its
+        # tolist() rows are all truthy, which would silently drop every GT from total_gt.
+        if gt_crowd.ndim != 1 or gt_crowd.shape[0] != gt_labels.numel():
+            raise ValueError(
+                f"'iscrowd' must be a 1-D tensor with one entry per GT label, got shape "
+                f"{tuple(gt_crowd.shape)} for {gt_labels.numel()} labels"
+            )
 
         gt_label_ids = cast(list[int], gt_labels.tolist())
         pred_label_ids = cast(list[int], pred_labels.tolist())
-        all_class_ids: set[int] = set(gt_label_ids) | set(pred_label_ids)
+        gt_crowd_ids = cast(list[bool], gt_crowd.tolist())
+
+        # Host-side counts, built once per image from the tolist()'d labels above, replace what
+        # used to be a per-class `.sum().item()` device-to-host sync (two or three per class).
+        # The crowd count feeds the `n_pred == 0` branch, which must skip crowd GTs.
+        pred_count = Counter(pred_label_ids)
+        gt_count = Counter(gt_label_ids)
+        gt_noncrowd_count = Counter(label for label, crowd in zip(gt_label_ids, gt_crowd_ids) if not crowd)
+        all_class_ids: set[int] = set(gt_count) | set(pred_count)
 
         for class_id in all_class_ids:
-            pred_mask_c = pred_labels == class_id
-            gt_mask_c = gt_labels == class_id
-
-            p_scores = pred_scores[pred_mask_c]
-            gt_crowd_c = gt_crowd[gt_mask_c]
-            n_pred = int(pred_mask_c.sum().item())
-            n_gt = int(gt_mask_c.sum().item())
+            n_pred = pred_count.get(class_id, 0)
+            n_gt = gt_count.get(class_id, 0)
 
             entry = acc.setdefault(
                 class_id,
@@ -218,8 +235,13 @@ def build_matching_data(
             )
 
             if n_pred == 0:
-                entry["total_gt"] = cast(int, entry["total_gt"]) + int((~gt_crowd_c).sum().item())
+                entry["total_gt"] = cast(int, entry["total_gt"]) + gt_noncrowd_count.get(class_id, 0)
                 continue
+
+            # Only materialize the boolean mask / gather predictions for classes that actually
+            # have detections — gt_mask_c below is deferred further, to classes that also matter.
+            pred_mask_c = pred_labels == class_id
+            p_scores = pred_scores[pred_mask_c]
 
             if n_gt == 0:
                 # TODO: support bfloat16 natively once numpy adds bf16 dtype
@@ -229,6 +251,9 @@ def build_matching_data(
                 cast(list[int], entry["matches"]).extend([0] * n_pred)
                 cast(list[bool], entry["ignore"]).extend([False] * n_pred)
                 continue
+
+            gt_mask_c = gt_labels == class_id
+            gt_crowd_c = gt_crowd[gt_mask_c]
 
             if iou_type == "bbox":
                 p_items: Tensor = pred_boxes[pred_mask_c]  # [n_pred, 4]

--- a/tests/evaluation/test_evaluation.py
+++ b/tests/evaluation/test_evaluation.py
@@ -4,6 +4,8 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
+from collections.abc import Callable
+from contextlib import ExitStack
 from unittest.mock import patch
 
 import numpy as np
@@ -425,6 +427,127 @@ class TestBuildMatchingData:
         assert 99 in result
         assert result[99]["total_gt"] == 0
         assert result[99]["matches"][0] == 0
+
+    def test_crowd_gt_without_predictions_is_not_counted(self) -> None:
+        """Crowd GTs of a class with no predictions must stay out of total_gt."""
+        pred = self._make_pred([[0, 0, 10, 10]], [0.9], [0])
+        target = self._make_target(
+            [[0, 0, 10, 10], [50, 50, 60, 60], [70, 70, 80, 80]],
+            [0, 7, 7],
+            iscrowd=[0, 1, 0],
+        )
+        result = build_matching_data([pred], [target])
+        assert result[7]["total_gt"] == 1
+        assert len(result[7]["scores"]) == 0
+        assert result[0]["total_gt"] == 1
+
+    def test_iscrowd_length_mismatch_raises(self) -> None:
+        """An ``iscrowd`` that does not line up with ``labels`` must be rejected, not counted."""
+        pred = self._make_pred([[0, 0, 10, 10]], [0.9], [0])
+        target = self._make_target([[0, 0, 10, 10], [50, 50, 60, 60]], [0, 7], iscrowd=[0])
+        with pytest.raises(ValueError, match="one entry per GT label"):
+            build_matching_data([pred], [target])
+
+    def test_iscrowd_length_mismatch_raises_on_image_without_classes(self) -> None:
+        """The mismatch is rejected even on an image with no labels and no predictions to loop over."""
+        pred = self._make_pred([], [], [])
+        target = self._make_target([], [], iscrowd=[1])
+        with pytest.raises(ValueError, match="one entry per GT label"):
+            build_matching_data([pred], [target])
+
+    @pytest.mark.parametrize(
+        "iscrowd",
+        [
+            pytest.param(torch.zeros(2, 1, dtype=torch.int64), id="column-vector"),
+            pytest.param(torch.tensor(0, dtype=torch.int64), id="scalar"),
+        ],
+    )
+    def test_iscrowd_with_wrong_rank_raises(self, iscrowd: torch.Tensor) -> None:
+        """An ``iscrowd`` of the right length but the wrong rank must be rejected, not silently applied.
+
+        A ``[M, 1]`` tensor passes a length-only check, and then every row is a non-empty list and therefore truthy, so
+        each GT of a class without predictions would drop out of ``total_gt``.
+        """
+        pred = self._make_pred([[0, 0, 10, 10]], [0.9], [0])
+        target = self._make_target([[0, 0, 10, 10], [50, 50, 60, 60]], [0, 7])
+        target["iscrowd"] = iscrowd
+        with pytest.raises(ValueError, match="one entry per GT label"):
+            build_matching_data([pred], [target])
+
+    @pytest.mark.parametrize("num_classes", [pytest.param(40, id="40-classes"), pytest.param(80, id="80-classes")])
+    @pytest.mark.parametrize(
+        ("with_preds", "with_gts", "expected_matches", "expected_total_gt"),
+        [
+            pytest.param(True, True, [1], 1, id="preds-and-gts"),
+            pytest.param(False, True, [], 1, id="gt-only-classes"),
+            pytest.param(True, False, [0], 0, id="pred-only-classes"),
+        ],
+    )
+    def test_does_not_sync_a_tensor_per_class(
+        self,
+        num_classes: int,
+        with_preds: bool,
+        with_gts: bool,
+        expected_matches: list[int],
+        expected_total_gt: int,
+    ) -> None:
+        """Regression test: the per-class loop must not force a scalar device-to-host read per class per image — that
+        turns an O(1) per-image cost into O(num_classes), which dominates wall time on datasets with hundreds of classes
+        (e.g. COCO's 80). The branch cases cover the three exits of the loop, each of which used to sync: the matcher
+        path, the ``n_pred == 0`` path (which synced a third time on the non-crowd GT count), and ``n_gt == 0``.
+
+        Two properties are asserted, both exact rather than bounds and both at two class counts, so
+        that neither a per-class sync nor a fraction of one can creep back in:
+
+        1. every scalar read out of a tensor (``item``/``__bool__``/``__int__``/``__float__``/
+           ``__index__``) is gone, not just ``item()``;
+        2. the bulk reads that remain (``tolist``) are exactly three per image — the pred labels, the
+           GT labels and ``iscrowd`` — and do not grow with the class count.
+
+        Not covered: ``_match_single_class`` still moves its own scores and IoUs to host with
+        ``.cpu()/.numpy()`` once per class that has detections. That is pre-existing and untouched
+        here; this test fixes the cost of the classes that never reach the matcher.
+        """
+        # One pred and one GT per class, on a per-image diagonal grid so each parametrized case
+        # drives every class down the same branch.
+        boxes = [[i * 20, i * 20, i * 20 + 10, i * 20 + 10] for i in range(num_classes)]
+        labels = list(range(num_classes))
+        pred = self._make_pred(boxes, [0.9] * num_classes, labels) if with_preds else self._make_pred([], [], [])
+        target = self._make_target(boxes, labels) if with_gts else self._make_target([], [])
+
+        scalar_reads = ["item", "__bool__", "__int__", "__float__", "__index__"]
+        counts: dict[str, int] = dict.fromkeys([*scalar_reads, "tolist"], 0)
+        originals = {name: getattr(torch.Tensor, name) for name in counts}
+
+        def make_counter(name: str) -> Callable[..., object]:
+            original = originals[name]
+
+            def counting(self: torch.Tensor, *args: object, **kwargs: object) -> object:
+                counts[name] += 1
+                return original(self, *args, **kwargs)
+
+            return counting
+
+        with ExitStack() as stack:
+            for name in counts:
+                stack.enter_context(patch.object(torch.Tensor, name, make_counter(name)))
+            result = build_matching_data([pred], [target])
+
+        synced = {name: counts[name] for name in scalar_reads if counts[name]}
+        assert not synced, (
+            f"build_matching_data triggered scalar tensor->host reads {synced} for "
+            f"num_classes={num_classes}; the per-class counts come from the host-side label lists, "
+            "so no branch of the loop should read a scalar out of a tensor at all"
+        )
+        assert counts["tolist"] == 3, (
+            f"build_matching_data called Tensor.tolist() {counts['tolist']} times for "
+            f"num_classes={num_classes}; it must be exactly three per image (pred labels, GT labels, "
+            "iscrowd), independent of how many classes the image contains"
+        )
+        assert len(result) == num_classes
+        for class_id in range(num_classes):
+            assert result[class_id]["matches"].tolist() == expected_matches
+            assert result[class_id]["total_gt"] == expected_total_gt
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

`build_matching_data()` in `src/rfdetr/evaluation/matching.py` already converts `gt_labels` and `pred_labels` to host lists (`gt_label_ids` / `pred_label_ids`) to build the set of class ids for the image. But the per-class loop does not use them, it goes back to the device: it rebuilds a boolean mask per class and calls `pred_mask_c.sum().item()` / `gt_mask_c.sum().item()` to get the counts, plus a third `.item()` in the `n_pred == 0` branch. So that is up to three device-to-host syncs per class per image, over data that was already in Python. The loop runs once per class present in the image, and with the default `num_select=300` (`src/rfdetr/config.py:496`) that is 30.7 classes per image on COCO val2017, measured on the real output of `PostProcess` and not assumed.

The fix replaces those counts with `Counter` over the same host lists, and only builds the boolean masks (`pred_mask_c` / `gt_mask_c`) for classes that actually reach the matcher. Classes with `n_pred == 0` do not build a mask any more. `all_class_ids` comes from those counters instead of a second pass over the raw label lists. `_match_single_class` and the greedy matching order are untouched, so the matching output does not change.

`PostProcess` already does the same thing for keypoints (`src/rfdetr/models/postprocess.py:400-402`: *"Avoids `num_select` GPU->CPU stream syncs from `.item()`"*), and this is a follow-up of #1225 (issue #416), which fixed a per-detection sync inside the greedy loop in `_match_single_class`. The regression test of that PR instruments `Tensor.__bool__` inside that function directly, so it never sees these `.item()` calls one level up, in `build_matching_data`.

Two things to make explicit:

- **One deliberate behaviour change, on malformed input.** The non-crowd count now comes from the host lists, so `iscrowd` is no longer indexed with a per-class boolean mask. That indexing was what caught an `iscrowd` that does not match `labels`: it raised `IndexError`, but only for images with at least one class to loop over. An image with no GT labels and no predictions skipped the loop, and the bad `iscrowd` passed unnoticed. This PR validates `iscrowd` once per image, on its shape and not on its length, and raises `ValueError("'iscrowd' must be a 1-D tensor with one entry per GT label, got shape (...) for M labels")`. The shape is the important part here: an `[M, 1]` `iscrowd` has the right `len()`, but each of its `tolist()` rows is a non-empty list, so it is truthy. A check on the length only would let it pass and silently set `total_gt` to zero for every class without predictions. Documented in the docstring's `Raises:` and covered by four tests.
- **Scope of the guarantee.** This removes the *counting* syncs only. `_match_single_class` still copies the IoU matrix and the crowd mask to host once per class that has detections, and the `n_gt == 0` branch still copies the scores. That path was rewritten in #1225 and is left alone here. The gain is on the classes that never reach the matcher.

## Type of Change

- Performance improvement (matching output unchanged; the one behaviour change is the `iscrowd` validation described above)

## Validation

Predictions are **real**, not synthesised: `rfdetr-small` run over 300 real COCO val2017 images, with the output of `PostProcess` at `threshold=0.0` so all `num_select` detections survive, exactly as the evaluation callback feeds them (`coco_eval.py:450` passes the postprocessed `results` straight to `build_matching_data`, with no score filtering in between). Ground truth is the matching real COCO annotation, `iscrowd` included. The rows with a smaller `num_select` are the same dump truncated to the top-K by score, which is what a smaller `num_select` selects.

This matters for the numbers below, so better to say it directly: predicted labels come from a top-K over the flattened query x class sigmoid grid (`postprocess.py:131-137`), and they are **not** uniform over the classes. A first version of this benchmark drew them uniformly and reported 77.5 classes per image, and the real distribution gives 30.7. Both the class count and the speed-ups here come from the real one. The predictions were dumped once and saved to disk (an earlier attempt had a label-space bug, see below, so the valid dump is the second one). The timing benchmark then ran twice against that same saved dump, to check the numbers were not noise: background load on this machine was heavy (load average 15-26), so a single run was not enough to trust.

CPU, 300 images, `torch.set_num_threads(1)`, two full independent runs (11 and 15 interleaved rounds), medians:

| config | classes/img | run 1 | run 2 |
| --- | --- | --- | --- |
| `num_select=300` (default) | 30.7 | -20.26%, 1.254x, paired 1.122-1.316x | -21.47%, 1.273x, paired 1.266-1.292x |
| `num_select=100` | 15.0 | -16.67%, 1.200x, paired 1.180-1.217x | -17.09%, 1.206x, paired 1.194-1.215x |
| `num_select=20` (post-threshold) | 6.0 | -10.89%, 1.122x, paired 1.094-1.144x | -11.37%, 1.128x, paired 1.113-1.142x |
| images with no GT and no preds | 0.0 | +64.00% (0.90 -> 1.48 ms) | +68.58% (0.86 -> 1.44 ms) |

The last row is the one case that gets slower, it is in the table on purpose: the per-image work (one extra `.tolist()`, three `Counter`s) is now paid always, while the per-class work it replaces is skipped when there are no classes. In absolute terms that is under 2 us per empty image, and it does not happen in the callback path, where predictions always carry `num_select` detections.

CUDA (RTX 4060 Laptop), 100 images, two runs (7 and 9 interleaved rounds). This is where the removed `.item()` calls are real stream syncs:

| config | classes/img | run 1 | run 2 |
| --- | --- | --- | --- |
| `num_select=300` (default) | 28.6 | -42.41%, 1.737x, paired 1.713-1.753x | -43.38%, 1.766x, paired 1.757-1.772x |
| `num_select=20` | 5.4 | -21.85%, 1.280x, paired 1.272-1.281x | -22.37%, 1.288x, paired 1.268-1.305x |

Both runs stay in the same range (~1.25-1.27x CPU, ~1.74-1.77x CUDA at the default config), so this is not noise. **This number replaces an earlier, larger claim (1.628x CPU / 2.364x CUDA at 32.4 classes/img) that a review round left in the PR without a reproducible artifact behind it**: no dump script, no `.pt` file, no log. I generated the real predictions myself with the scripts below, and byte-identity is asserted on every configuration before timing anything. A second, independent reproduction against the exact tree of this patch gave 1.268x CPU / 1.787x CUDA, inside the same range. Mine had run against an intermediate commit of my own, functionally the same in the parts that drive this benchmark.

Correctness:

- The benchmark asserts byte-identical output (`scores` / `matches` / `ignore` / `total_gt`) between the pre-fix and patched implementations on every configuration above, CPU and CUDA, before timing anything.
- A separate randomised differential (`diff_base_vs_patch.py`, second script below) compares the two implementations over 300 random `bbox` batches and 100 random `segm` batches, with 1-4 images each, 0-8 preds and 0-8 GTs per image, ~20% crowd, overlapping and disjoint boxes and repeated class ids across images: **2128 class entries, byte-identical, same key order**. The same script prints the declared divergence on malformed `iscrowd`, side by side:
    ```
    short-iscrowd          pre-fix: IndexError                     -> patch: ValueError
    no-classes-to-loop     pre-fix: returned total_gt={  }         -> patch: ValueError
    column-vector-iscrowd  pre-fix: IndexError                     -> patch: ValueError
    column-vector-no-preds pre-fix: returned total_gt={ 7: 2 }     -> patch: ValueError
    scalar-iscrowd         pre-fix: IndexError                     -> patch: ValueError
    ```
- The 40 existing tests in `tests/evaluation/test_evaluation.py` pass unchanged, so the existing coverage (crowd/non-crowd, multi-class, multi-image, segm, class-only-in-predictions) still holds. The file is now 51 tests.
- `test_does_not_sync_a_tensor_per_class` instruments `build_matching_data` from the outside, parametrized over the three exits of the loop and over two class counts, and asserts two exact properties instead of bounds: every *scalar* read out of a tensor (`item`/`__bool__`/`__int__`/`__float__`/`__index__`) is zero, and `Tensor.tolist()` is called exactly three times per image (pred labels, GT labels, `iscrowd`) no matter how many classes the image has. Against the pre-fix code all six cases fail. The docstring says what the test does not cover: the per-class `.cpu()/.numpy()` inside `_match_single_class`, which this PR does not touch.
- `test_crowd_gt_without_predictions_is_not_counted` covers the one combination the suite did not have, a class with crowd GT and no predictions, which is exactly what the new non-crowd `Counter` replaces. It discriminates: dropping the crowd filter keeps the other tests passing and fails only this one.
- Four tests pin the `iscrowd` behaviour change and all four fail against the pre-fix code: `test_iscrowd_length_mismatch_raises`, `test_iscrowd_length_mismatch_raises_on_image_without_classes`, and `test_iscrowd_with_wrong_rank_raises[column-vector|scalar]`.

Checks: `tests/evaluation/` plus `test_coco_eval_callback.py` (202 passed). I tried the full CPU suite twice (`pytest src/ tests/ -m "not gpu and not coco17 and not e2e_coreml and not e2e_executorch and not xla and not tpu"`, 3207 items) and both times it got cut at 96-99% by a 550s timeout on my side, so I am not claiming it green, CI is the one to say that. `ruff check` and `ruff format --check` are clean on both files (ruff 0.15.20 locally, the hook pins 0.16.1), `docformatter` applied, and mypy reports no error in `matching.py` (mypy 2.3.0 rather than the pinned 1.19.1, and the repo does not type-check `tests/`). `pre-commit` itself is not installed in this environment, so of its hooks I could only verify the ones that apply to a two-file Python diff: ruff check/format, docformatter, mypy, license header, trailing whitespace, EOF newline and line endings. `codespell` and `mdformat` I could not run either.

<details> <summary>Scripts: dump the real predictions, then benchmark against them</summary>

Both need the pre-fix `matching.py` saved next to them as `matching_baseline_pre_fix.py` (`git show <base>:src/rfdetr/evaluation/matching.py`).

```python
# dump_real_preds.py -- run the real model over real images once, save what PostProcess emits.
# PYTHONPATH=src python dump_real_preds.py --images /path/to/val2017 --ann /path/to/instances_val2017.json --n 300
import argparse, json, os, statistics
import numpy as np
import torch

parser = argparse.ArgumentParser()
parser.add_argument("--images", required=True)
parser.add_argument("--ann", required=True)
parser.add_argument("--n", type=int, default=300)
parser.add_argument("--out", default="real_preds.pt")
args = parser.parse_args()

from rfdetr import RFDETRSmall

with open(args.ann) as fh:
    coco = json.load(fh)
# NOTE: do NOT remap category_id to a contiguous index here. model.predict()'s det.class_id is in
# COCO's raw (gapped) category-id space -- an earlier version of this script remapped only the GT
# side to a contiguous 0..79 index and left pred labels raw, which silently compared two different
# label spaces (max pred label 90, max GT label 77) and produced a wrong classes/img count.
per_image = {}
for ann in coco["annotations"]:
    per_image.setdefault(ann["image_id"], []).append(ann)
images_by_id = {im["id"]: im for im in coco["images"]}

model = RFDETRSmall()
records, uniq_union = [], []
for img_id in sorted(per_image)[: args.n]:
    path = os.path.join(args.images, images_by_id[img_id]["file_name"])
    if not os.path.exists(path):
        continue
    det = model.predict(path, threshold=0.0, include_source_image=False)  # threshold=0 -> all num_select
    labels = np.asarray(det.class_id, dtype=np.int64)
    anns = per_image[img_id]
    gt_labels = np.array([a["category_id"] for a in anns], dtype=np.int64)  # raw id, matches det.class_id
    gt_boxes = np.array(
        [[a["bbox"][0], a["bbox"][1], a["bbox"][0] + a["bbox"][2], a["bbox"][1] + a["bbox"][3]] for a in anns],
        dtype=np.float32,
    )
    uniq_union.append(len(set(labels.tolist()) | set(gt_labels.tolist())))
    records.append(
        {
            "pred": {
                "boxes": np.asarray(det.xyxy, dtype=np.float32),
                "scores": np.asarray(det.confidence, dtype=np.float32),
                "labels": labels,
            },
            "target": {
                "boxes": gt_boxes,
                "labels": gt_labels,
                "iscrowd": np.array([a.get("iscrowd", 0) for a in anns], dtype=np.int64),
            },
        }
    )

print(f"{len(records)} images, unique classes per image (pred u GT): mean {statistics.mean(uniq_union):.2f}")
torch.save(records, args.out)
```

```python
# bench_matching_real_preds.py -- A/B on the dump above. PYTHONPATH=src python ... --dump real_preds.pt
from __future__ import annotations

import argparse
import importlib.util
import os
import statistics
import time

import numpy as np
import torch

_here = os.path.dirname(os.path.abspath(__file__))
_spec = importlib.util.spec_from_file_location("matching_baseline", os.path.join(_here, "matching_baseline_pre_fix.py"))
baseline_mod = importlib.util.module_from_spec(_spec)
_spec.loader.exec_module(baseline_mod)
baseline_build = baseline_mod.build_matching_data

from rfdetr.evaluation.matching import build_matching_data as candidate_build  # noqa: E402


def truncate(records: list[dict], num_select: int) -> tuple[list[dict], list[dict]]:
    """Keep the top-`num_select` detections per image (PostProcess selects by descending score)."""
    preds, targets = [], []
    for rec in records:
        p = rec["pred"]
        order = np.argsort(-p["scores"])[:num_select]
        preds.append({"boxes": p["boxes"][order], "scores": p["scores"][order], "labels": p["labels"][order]})
        targets.append(rec["target"])
    return preds, targets


def to_torch(items: list[dict], device: str) -> list[dict]:
    return [{k: torch.from_numpy(np.ascontiguousarray(v)).to(device) for k, v in d.items()} for d in items]


def serialize(result: dict) -> dict:
    return {
        cid: (
            np.asarray(d["scores"]).tobytes(),
            np.asarray(d["matches"]).tobytes(),
            np.asarray(d["ignore"]).tobytes(),
            int(d["total_gt"]),
        )
        for cid, d in result.items()
    }


def bench(preds: list[dict], targets: list[dict], device: str, rounds: int, label: str) -> None:
    p, t = to_torch(preds, device), to_torch(targets, device)
    r_base_1, r_base_2, r_cand = serialize(baseline_build(p, t)), serialize(baseline_build(p, t)), serialize(candidate_build(p, t))
    assert r_base_1 == r_base_2, "baseline is not self-deterministic"
    assert r_base_1 == r_cand, "candidate diverges from baseline output"

    classes_per_image = statistics.mean(len(set(x["labels"].tolist()) | set(y["labels"].tolist())) for x, y in zip(preds, targets))

    def timeit(fn) -> float:
        if device == "cuda":
            torch.cuda.synchronize()
        t0 = time.perf_counter()
        fn(p, t)
        if device == "cuda":
            torch.cuda.synchronize()
        return time.perf_counter() - t0

    base_times, cand_times = [], []
    for _ in range(rounds):
        base_times.append(timeit(baseline_build))
        cand_times.append(timeit(candidate_build))
    bm, cm = statistics.median(base_times) * 1000, statistics.median(cand_times) * 1000
    paired = sorted(b / c for b, c in zip(base_times, cand_times))
    print(
        f"{label:34s} {device:4s} n={len(preds):4d} img, {classes_per_image:5.1f} cls/img | "
        f"base {bm:8.2f} ms [{min(base_times) * 1000:8.2f}, {max(base_times) * 1000:8.2f}] | "
        f"patch {cm:8.2f} ms [{min(cand_times) * 1000:8.2f}, {max(cand_times) * 1000:8.2f}] | "
        f"{(cm - bm) / bm * 100:+6.2f}%, {bm / cm:.3f}x | paired {paired[0]:.3f}-{paired[-1]:.3f}x"
    )


def main() -> None:
    ap = argparse.ArgumentParser()
    ap.add_argument("--dump", required=True)
    ap.add_argument("--rounds", type=int, default=11)
    ap.add_argument("--cuda-images", type=int, default=100)
    ap.add_argument("--cuda-rounds", type=int, default=7)
    args = ap.parse_args()

    torch.set_num_threads(1)
    records = torch.load(args.dump, weights_only=False)
    for num_select, name in [(300, "num_select=300 (rf-detr default)"), (100, "num_select=100"), (20, "num_select=20 (post-threshold)")]:
        preds, targets = truncate(records, num_select)
        bench(preds, targets, "cpu", args.rounds, name)

    empty = [{"boxes": np.zeros((0, 4), np.float32), "labels": np.zeros(0, np.int64), "iscrowd": np.zeros(0, np.int64)} for _ in records]
    empty_preds = [{"boxes": np.zeros((0, 4), np.float32), "scores": np.zeros(0, np.float32), "labels": np.zeros(0, np.int64)} for _ in records]
    bench(empty_preds, empty, "cpu", args.rounds, "empty images (worst case)")

    if torch.cuda.is_available():
        for num_select, name in [(300, "num_select=300 (rf-detr default)"), (20, "num_select=20 (post-threshold)")]:
            preds, targets = truncate(records[: args.cuda_images], num_select)
            bench(preds, targets, "cuda", args.cuda_rounds, name)


if __name__ == "__main__":
    main()
```

```python
# diff_base_vs_patch.py -- randomised differential, pre-fix vs patched.
# PYTHONPATH=src python diff_base_vs_patch.py --bbox-batches 300 --segm-batches 100
from __future__ import annotations

import argparse
import importlib.util
import os

import numpy as np
import torch

_here = os.path.dirname(os.path.abspath(__file__))
_spec = importlib.util.spec_from_file_location("matching_baseline", os.path.join(_here, "matching_baseline_pre_fix.py"))
baseline_mod = importlib.util.module_from_spec(_spec)
_spec.loader.exec_module(baseline_mod)
baseline_build = baseline_mod.build_matching_data

from rfdetr.evaluation.matching import build_matching_data as candidate_build  # noqa: E402


def serialize(result: dict) -> list[tuple]:
    """Serialise to a list (not a dict) so key ORDER is part of the comparison."""
    return [
        (cid, np.asarray(d["scores"]).tobytes(), np.asarray(d["matches"]).tobytes(), np.asarray(d["ignore"]).tobytes(), int(d["total_gt"]))
        for cid, d in result.items()
    ]


def random_batch(rng: np.random.Generator, iou_type: str, mask_size: int = 12) -> tuple[list[dict], list[dict]]:
    num_images, num_classes = int(rng.integers(1, 5)), int(rng.integers(1, 12))
    preds, targets = [], []
    for _ in range(num_images):
        n_pred, n_gt = int(rng.integers(0, 9)), int(rng.integers(0, 9))
        p_boxes = rng.uniform(0, 100, size=(n_pred, 4)).astype(np.float32)
        p_boxes[:, 2:] += p_boxes[:, :2] + 1.0
        g_boxes = rng.uniform(0, 100, size=(n_gt, 4)).astype(np.float32)
        g_boxes[:, 2:] += g_boxes[:, :2] + 1.0
        for i in range(min(n_pred, n_gt)):  # overlap some, so the matcher path fires too
            if rng.random() < 0.6:
                g_boxes[i] = p_boxes[i] + rng.normal(0, 2, size=4).astype(np.float32)
        pred = {
            "boxes": torch.from_numpy(p_boxes),
            "scores": torch.from_numpy(rng.uniform(0, 1, size=n_pred).astype(np.float32)),
            "labels": torch.from_numpy(rng.integers(0, num_classes, size=n_pred).astype(np.int64)),
        }
        target = {
            "boxes": torch.from_numpy(g_boxes),
            "labels": torch.from_numpy(rng.integers(0, num_classes, size=n_gt).astype(np.int64)),
            "iscrowd": torch.from_numpy((rng.random(n_gt) < 0.2).astype(np.int64)),
        }
        if iou_type == "segm":
            pred["masks"] = torch.from_numpy(rng.random((n_pred, mask_size, mask_size)) < 0.4)
            target["masks"] = torch.from_numpy(rng.random((n_gt, mask_size, mask_size)) < 0.4)
        preds.append(pred)
        targets.append(target)
    return preds, targets


def main() -> None:
    ap = argparse.ArgumentParser()
    ap.add_argument("--bbox-batches", type=int, default=300)
    ap.add_argument("--segm-batches", type=int, default=100)
    ap.add_argument("--seed", type=int, default=20260803)
    args = ap.parse_args()

    rng = np.random.default_rng(args.seed)
    for iou_type, n_batches in (("bbox", args.bbox_batches), ("segm", args.segm_batches)):
        classes_seen = 0
        for i in range(n_batches):
            preds, targets = random_batch(rng, iou_type)
            base = serialize(baseline_build(preds, targets, iou_type=iou_type))
            cand = serialize(candidate_build(preds, targets, iou_type=iou_type))
            assert base == cand, f"{iou_type} batch {i}: patched output diverges from pre-fix"
            classes_seen += len(base)
        print(f"{iou_type}: {n_batches} random batches byte-identical (same key order), {classes_seen} class entries compared")

    print("\ndeclared behaviour change on misaligned 'iscrowd':")
    cases = {
        "short-iscrowd": (
            [{"boxes": torch.zeros(1, 4), "scores": torch.tensor([0.9]), "labels": torch.tensor([0])}],
            [{"boxes": torch.zeros(2, 4), "labels": torch.tensor([0, 7]), "iscrowd": torch.tensor([0])}],
        ),
        "no-classes-to-loop": (
            [{"boxes": torch.zeros(0, 4), "scores": torch.zeros(0), "labels": torch.zeros(0, dtype=torch.int64)}],
            [{"boxes": torch.zeros(0, 4), "labels": torch.zeros(0, dtype=torch.int64), "iscrowd": torch.tensor([1])}],
        ),
        "column-vector-iscrowd": (
            [{"boxes": torch.zeros(1, 4), "scores": torch.tensor([0.9]), "labels": torch.tensor([0])}],
            [{"boxes": torch.zeros(2, 4), "labels": torch.tensor([0, 7]), "iscrowd": torch.zeros(2, 1, dtype=torch.int64)}],
        ),
        "column-vector-no-preds": (
            [{"boxes": torch.zeros(0, 4), "scores": torch.zeros(0), "labels": torch.zeros(0, dtype=torch.int64)}],
            [{"boxes": torch.zeros(2, 4), "labels": torch.tensor([7, 7]), "iscrowd": torch.zeros(2, 1, dtype=torch.int64)}],
        ),
        "scalar-iscrowd": (
            [{"boxes": torch.zeros(1, 4), "scores": torch.tensor([0.9]), "labels": torch.tensor([0])}],
            [{"boxes": torch.zeros(2, 4), "labels": torch.tensor([0, 7]), "iscrowd": torch.tensor(0)}],
        ),
    }
    for name, (preds, targets) in cases.items():
        outcomes = []
        for tag, fn in (("pre-fix", baseline_build), ("patch", candidate_build)):
            try:
                out = fn(preds, targets)
                inner = ", ".join(f"{c}: {d['total_gt']}" for c, d in out.items())
                outcomes.append(f"{tag}: returned total_gt={{ {inner} }}")
            except Exception as exc:  # noqa: BLE001 - reporting, not handling
                outcomes.append(f"{tag}: {type(exc).__name__}")
        print(f"  {name:22s} {outcomes[0]:52s} -> {outcomes[1]}")


if __name__ == "__main__":
    main()
```

</details>

Let me know what you think ..
