### PR TITLE
feat(augment): support Blur, Sharpen, Equalize and CLAHE on the Kornia backend

### DIFF
--- a/src/rfdetr/datasets/aug_configs.py
+++ b/src/rfdetr/datasets/aug_configs.py
@@ -83,6 +83,16 @@ or torchvision defaults. Install it with ``pip install 'rfdetr[augment]'``.
 | ``RandomBrightnessContrast`` | ``K.ColorJiggle`` | ``brightness_limit`` / ``contrast_limit`` direct |
 | ``GaussianBlur`` | ``K.RandomGaussianBlur`` | ``blur_limit`` rounded up to odd; ``sigma=(0.1, 2.0)`` |
 | ``GaussNoise`` | ``K.RandomGaussianNoise`` | Upper bound of ``std_range`` used as fixed std |
+| ``Blur`` | ``K.RandomBoxBlur`` | Box blur; ``blur_limit`` rounded up to odd, pair collapses to its upper bound |
+| ``Sharpen`` | ``K.RandomSharpness`` | ``alpha`` maps to ``sharpness``; ``lightness``/``method`` ignored |
+| ``Equalize`` | ``K.RandomEqualize`` | Only ``p`` honored; ``mode``/``by_channels``/``mask`` ignored |
+| ``CLAHE`` | ``K.RandomClahe`` | ``clip_limit`` and ``tile_grid_size`` map directly |
+
+Not yet supported on Kornia: ``HueSaturationValue`` (Albumentations shifts hue/saturation/value additively,
+Kornia's ``ColorJiggle`` scales them multiplicatively, so there is no faithful mapping), and the geometric
+group ``ShiftScaleRotate``, ``RandomCrop``, ``CenterCrop``, ``RandomResizedCrop``, ``Perspective``,
+``ElasticTransform`` and ``GridDistortion``, which move boxes and masks and need the auxiliary-target
+handling settled first. These still work on the Albumentations backend.
 
 Segmentation models are supported by the GPU augmentation path; masks are augmented in sync with images and boxes.
 """

--- a/src/rfdetr/datasets/aug_configs.py
+++ b/src/rfdetr/datasets/aug_configs.py
@@ -84,7 +84,7 @@ or torchvision defaults. Install it with ``pip install 'rfdetr[augment]'``.
 | ``GaussianBlur`` | ``K.RandomGaussianBlur`` | ``blur_limit`` rounded up to odd; ``sigma=(0.1, 2.0)`` |
 | ``GaussNoise`` | ``K.RandomGaussianNoise`` | Upper bound of ``std_range`` used as fixed std |
 | ``Blur`` | ``K.RandomBoxBlur`` | Box blur; ``blur_limit`` rounded up to odd, pair collapses to its upper bound |
-| ``Sharpen`` | ``K.RandomSharpness`` | ``alpha`` maps to ``sharpness``; ``lightness``/``method`` ignored |
+| ``Sharpen`` | ``K.RandomSharpness`` | ``sharpness = 1.0 + alpha`` (1.0-pivoted); ``lightness``/``method`` ignored |
 | ``Equalize`` | ``K.RandomEqualize`` | Only ``p`` honored; ``mode``/``by_channels``/``mask`` ignored |
 | ``CLAHE`` | ``K.RandomClahe`` | ``clip_limit`` and ``tile_grid_size`` map directly |
 

--- a/src/rfdetr/datasets/kornia_transforms.py
+++ b/src/rfdetr/datasets/kornia_transforms.py
@@ -297,6 +297,38 @@ def _as_range(value: Any) -> tuple[float, float]:
     return (float(value), float(value))
 
 
+def _as_odd_kernel(value: Any, transform: str) -> int:
+    """Resolve an Albumentations ``blur_limit`` to a single odd Kornia kernel size.
+
+    Albumentations samples an odd kernel from a ``(min, max)`` range per call; Kornia takes one fixed kernel size, so a
+    non-degenerate pair collapses to its upper bound and logs a warning. The result is forced odd and at least 3, which
+    Kornia requires, and to an ``int``: a float such as ``5.0`` builds but crashes at forward time.
+
+    Args:
+        value: A scalar kernel size or a ``(min, max)`` pair.
+        transform: Name used in the warning, so the log says which augmentation collapsed.
+
+    Returns:
+        An odd ``int`` kernel size of at least 3.
+    """
+    if isinstance(value, (list, tuple)):
+        if len(value) == 2 and value[0] != value[1]:
+            logger.warning(
+                "GPU augmentation (Kornia) uses a fixed kernel_size=%d for %s "
+                "(Kornia does not sample the kernel size per call). "
+                "CPU augmentation (albumentations) samples an odd kernel from [%s, %s].",
+                max(value),
+                transform,
+                value[0],
+                value[1],
+            )
+        value = max(value)
+    kernel = int(value)
+    if kernel % 2 == 0:
+        kernel += 1
+    return max(3, kernel)
+
+
 def _make_horizontal_flip(params: dict[str, Any]) -> Any:
     """Build a ``K.RandomHorizontalFlip`` from aug_config params."""
     from kornia.augmentation import RandomHorizontalFlip
@@ -417,26 +449,8 @@ def _make_gaussian_blur(params: dict[str, Any]) -> Any:
     """
     from kornia.augmentation import RandomGaussianBlur
 
-    # Albumentations allows `blur_limit` as a (min, max) pair; Kornia takes a single kernel size, so use the upper
-    # bound, the same direction the GaussNoise builder below resolves its range.
-    blur_limit = params.get("blur_limit", 3)
-    if isinstance(blur_limit, (list, tuple)):
-        if len(blur_limit) == 2 and blur_limit[0] != blur_limit[1]:
-            logger.warning(
-                "GPU augmentation (Kornia) uses a fixed kernel_size=%d for GaussianBlur "
-                "(Kornia does not sample the kernel size per call). "
-                "CPU augmentation (albumentations) samples an odd kernel from [%s, %s].",
-                max(blur_limit),
-                blur_limit[0],
-                blur_limit[1],
-            )
-        blur_limit = max(blur_limit)
-    # Kornia requires an integer kernel size; a float (e.g. 5.0) builds but crashes at forward time.
-    blur_limit = int(blur_limit)
-    # Ensure blur_limit is odd and at least 3 (Kornia requires kernel_size >= 3)
-    if blur_limit % 2 == 0:
-        blur_limit = blur_limit + 1
-    blur_limit = max(3, blur_limit)
+    # Shared with Blur: a (min, max) pair collapses to its upper bound, forced odd and >= 3.
+    blur_limit = _as_odd_kernel(params.get("blur_limit", 3), "GaussianBlur")
     # Match the CPU albumentations default sigma range while allowing an explicit override via config.
     sigma_range = params.get("sigma", (0.1, 2.0))
     blur_sigma = _as_range(sigma_range)
@@ -472,6 +486,74 @@ def _make_gauss_noise(params: dict[str, Any]) -> Any:
     )
 
 
+def _make_blur(params: dict[str, Any]) -> Any:
+    """Build a ``K.RandomBoxBlur`` from aug_config ``Blur`` params.
+
+    Albumentations' ``Blur`` is a box (average) blur, which is what ``RandomBoxBlur`` applies, so this is a direct
+    mapping. ``blur_limit`` resolves the same way as for ``GaussianBlur``: a non-degenerate pair collapses to its upper
+    bound because Kornia takes a single kernel size.
+    """
+    from kornia.augmentation import RandomBoxBlur
+
+    kernel = _as_odd_kernel(params.get("blur_limit", (3, 7)), "Blur")
+    return RandomBoxBlur(kernel_size=(kernel, kernel), p=params.get("p", 0.5))
+
+
+def _make_sharpen(params: dict[str, Any]) -> Any:
+    """Build a ``K.RandomSharpness`` from aug_config ``Sharpen`` params.
+
+    Albumentations' ``alpha`` is the blend weight between the original and the sharpened image, which is what Kornia's
+    ``sharpness`` factor controls, and Kornia accepts it as a ``(min, max)`` range so it passes through unchanged.
+    ``lightness`` and ``method`` have no Kornia equivalent and are ignored here; the CPU (albumentations) path honors
+    both.
+    """
+    from kornia.augmentation import RandomSharpness
+
+    if "lightness" in params or "method" in params:
+        logger.warning(
+            "GPU augmentation (Kornia) Sharpen ignores 'lightness' and 'method' "
+            "(Kornia's RandomSharpness exposes only a sharpness factor). "
+            "CPU augmentation (albumentations) honors both."
+        )
+    return RandomSharpness(
+        sharpness=_as_range(params.get("alpha", (0.2, 0.5))),
+        p=params.get("p", 0.5),
+    )
+
+
+def _make_equalize(params: dict[str, Any]) -> Any:
+    """Build a ``K.RandomEqualize`` from aug_config ``Equalize`` params.
+
+    Only ``p`` is honored. ``mode``, ``by_channels`` and ``mask`` are accepted by the CPU (albumentations) path but
+    have no Kornia equivalent: ``RandomEqualize`` always equalizes every channel and takes no mask.
+    """
+    from kornia.augmentation import RandomEqualize
+
+    if any(key in params for key in ("mode", "by_channels", "mask")):
+        logger.warning(
+            "GPU augmentation (Kornia) Equalize ignores 'mode', 'by_channels' and 'mask' "
+            "(Kornia's RandomEqualize always equalizes all channels and takes no mask). "
+            "CPU augmentation (albumentations) honors them."
+        )
+    return RandomEqualize(p=params.get("p", 0.5))
+
+
+def _make_clahe(params: dict[str, Any]) -> Any:
+    """Build a ``K.RandomClahe`` from aug_config ``CLAHE`` params.
+
+    Both parameters map directly: Albumentations' ``clip_limit`` (a scalar or a pair) becomes Kornia's ``clip_limit``
+    range, and ``tile_grid_size`` becomes ``grid_size``.
+    """
+    from kornia.augmentation import RandomClahe
+
+    grid = params.get("tile_grid_size", (8, 8))
+    return RandomClahe(
+        clip_limit=_as_range(params.get("clip_limit", 4.0)),
+        grid_size=(int(grid[0]), int(grid[1])),
+        p=params.get("p", 0.5),
+    )
+
+
 _REGISTRY: dict[str, Callable[[dict[str, Any]], Any]] = {
     "HorizontalFlip": _make_horizontal_flip,
     "VerticalFlip": _make_vertical_flip,
@@ -482,6 +564,10 @@ _REGISTRY: dict[str, Callable[[dict[str, Any]], Any]] = {
     "RandomBrightnessContrast": _make_random_brightness_contrast,
     "GaussianBlur": _make_gaussian_blur,
     "GaussNoise": _make_gauss_noise,
+    "Blur": _make_blur,
+    "Sharpen": _make_sharpen,
+    "Equalize": _make_equalize,
+    "CLAHE": _make_clahe,
 }
 
 

--- a/src/rfdetr/datasets/kornia_transforms.py
+++ b/src/rfdetr/datasets/kornia_transforms.py
@@ -59,6 +59,11 @@ IMAGENET_MEAN = (0.485, 0.456, 0.406)
 #: ImageNet channel-wise standard deviation (RGB order).
 IMAGENET_STD = (0.229, 0.224, 0.225)
 
+#: Albumentations' own default ``blur_limit`` for ``A.Blur``, which is a range rather than a single kernel size
+#: (``A.Blur(blur_limit=7).blur_limit`` normalises to this same pair). A configured pair equal to it is the library
+#: default rather than a deliberate user choice, so :func:`_as_odd_kernel` reports its collapse at ``DEBUG``.
+_ALBUMENTATIONS_BLUR_LIMIT_DEFAULT: tuple[int, int] = (3, 7)
+
 #: Threshold applied to float32 mask values produced by Kornia augmentation.
 #: Kornia forces nearest-neighbour resampling for the ``"mask"`` data key, so
 #: output values are already in {0.0, 1.0}; the threshold is a defensive cast.
@@ -297,36 +302,61 @@ def _as_range(value: Any) -> tuple[float, float]:
     return (float(value), float(value))
 
 
-def _as_odd_kernel(value: Any, transform: str) -> int:
+def _as_odd_kernel(value: Any, transform: str, default_pair: tuple[int, int] | None = None) -> int:
     """Resolve an Albumentations ``blur_limit`` to a single odd Kornia kernel size.
 
     Albumentations samples an odd kernel from a ``(min, max)`` range per call; Kornia takes one fixed kernel size, so a
-    non-degenerate pair collapses to its upper bound and logs a warning. The result is forced odd and at least 3, which
-    Kornia requires, and to an ``int``: a float such as ``5.0`` builds but crashes at forward time.
+    non-degenerate pair collapses to its upper bound and the divergence is logged. The result is forced odd and at
+    least 3, which Kornia requires, and to an ``int``: a float such as ``5.0`` builds but crashes at forward time.
 
     Args:
-        value: A scalar kernel size or a ``(min, max)`` pair.
-        transform: Name used in the warning, so the log says which augmentation collapsed.
+        value: A scalar kernel size, a 1-element sequence (a degenerate single kernel size), or a ``(min, max)`` pair.
+        transform: Name used in the log message, so the log says which augmentation collapsed.
+        default_pair: The Albumentations default range for ``transform``, when its default is a range rather than a
+            scalar. A ``value`` equal to it is the library default rather than a deliberate user choice, so its
+            collapse is logged at ``DEBUG``; every other non-degenerate pair is an explicit request the GPU path
+            cannot honor and stays at ``WARNING``.
 
     Returns:
         An odd ``int`` kernel size of at least 3.
+
+    Raises:
+        ValueError: If ``value`` is an empty sequence or has more than two elements, rather than silently dropping
+            trailing elements.
     """
+    collapsed_from: tuple[Any, Any] | None = None
     if isinstance(value, (list, tuple)):
-        if len(value) == 2 and value[0] != value[1]:
-            logger.warning(
-                "GPU augmentation (Kornia) uses a fixed kernel_size=%d for %s "
-                "(Kornia does not sample the kernel size per call). "
-                "CPU augmentation (albumentations) samples an odd kernel from [%s, %s].",
-                max(value),
-                transform,
-                value[0],
-                value[1],
+        if len(value) == 1:
+            value = value[0]
+        elif len(value) == 2:
+            if value[0] != value[1]:
+                collapsed_from = (value[0], value[1])
+            value = max(value)
+        else:
+            raise ValueError(
+                "Kernel size parameter must be a scalar, a 1-element sequence, or a 2-element (min, max) pair; "
+                f"got a {len(value)}-element sequence: {value!r}"
             )
-        value = max(value)
     kernel = int(value)
     if kernel % 2 == 0:
         kernel += 1
-    return max(3, kernel)
+    kernel = max(3, kernel)
+    if collapsed_from is not None:
+        # Report the kernel actually handed to Kornia, not the pre-rounding upper bound: (3, 6) resolves to 7.
+        # A pair matching the library default is an expected, documented divergence, so only a range the user
+        # chose explicitly is worth a warning.
+        is_library_default = default_pair is not None and collapsed_from == tuple(default_pair)
+        log = logger.debug if is_library_default else logger.warning
+        log(
+            "GPU augmentation (Kornia) uses a fixed kernel_size=%d for %s "
+            "(Kornia does not sample the kernel size per call). "
+            "CPU augmentation (albumentations) samples an odd kernel from [%s, %s].",
+            kernel,
+            transform,
+            collapsed_from[0],
+            collapsed_from[1],
+        )
+    return kernel
 
 
 def _make_horizontal_flip(params: dict[str, Any]) -> Any:
@@ -491,11 +521,17 @@ def _make_blur(params: dict[str, Any]) -> Any:
 
     Albumentations' ``Blur`` is a box (average) blur, which is what ``RandomBoxBlur`` applies, so this is a direct
     mapping. ``blur_limit`` resolves the same way as for ``GaussianBlur``: a non-degenerate pair collapses to its upper
-    bound because Kornia takes a single kernel size.
+    bound because Kornia takes a single kernel size. Unlike ``GaussianBlur``, Albumentations' own default here is a
+    range rather than a scalar, so the default collapse is expected rather than a misconfiguration and is reported at
+    ``DEBUG``; a range the user set explicitly still warns.
     """
     from kornia.augmentation import RandomBoxBlur
 
-    kernel = _as_odd_kernel(params.get("blur_limit", (3, 7)), "Blur")
+    kernel = _as_odd_kernel(
+        params.get("blur_limit", _ALBUMENTATIONS_BLUR_LIMIT_DEFAULT),
+        "Blur",
+        default_pair=_ALBUMENTATIONS_BLUR_LIMIT_DEFAULT,
+    )
     return RandomBoxBlur(kernel_size=(kernel, kernel), p=params.get("p", 0.5))
 
 

--- a/src/rfdetr/datasets/kornia_transforms.py
+++ b/src/rfdetr/datasets/kornia_transforms.py
@@ -587,7 +587,9 @@ def _make_clahe(params: dict[str, Any]) -> Any:
     Both parameters map directly: Albumentations' ``clip_limit`` (a scalar or a pair) becomes Kornia's ``clip_limit``
     range, and ``tile_grid_size`` becomes ``grid_size``.
     """
-    from kornia.augmentation import RandomClahe
+    from kornia.augmentation import (  # type: ignore[attr-defined]  # Kornia's stubs don't export RandomClahe yet
+        RandomClahe,
+    )
 
     grid = params.get("tile_grid_size", (8, 8))
     return RandomClahe(

--- a/src/rfdetr/datasets/kornia_transforms.py
+++ b/src/rfdetr/datasets/kornia_transforms.py
@@ -41,7 +41,7 @@ Usage::
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 import torch
 from torch import Tensor
@@ -587,12 +587,11 @@ def _make_clahe(params: dict[str, Any]) -> Any:
     Both parameters map directly: Albumentations' ``clip_limit`` (a scalar or a pair) becomes Kornia's ``clip_limit``
     range, and ``tile_grid_size`` becomes ``grid_size``.
     """
-    from kornia.augmentation import (  # type: ignore[attr-defined]  # Kornia's stubs don't export RandomClahe yet
-        RandomClahe,
-    )
+    import kornia.augmentation as kornia_augmentation
 
+    random_clahe = cast(Any, kornia_augmentation).RandomClahe
     grid = params.get("tile_grid_size", (8, 8))
-    return RandomClahe(
+    return random_clahe(
         clip_limit=_as_range(params.get("clip_limit", 4.0)),
         grid_size=(int(grid[0]), int(grid[1])),
         p=params.get("p", 0.5),

--- a/src/rfdetr/datasets/kornia_transforms.py
+++ b/src/rfdetr/datasets/kornia_transforms.py
@@ -502,8 +502,14 @@ def _make_blur(params: dict[str, Any]) -> Any:
 def _make_sharpen(params: dict[str, Any]) -> Any:
     """Build a ``K.RandomSharpness`` from aug_config ``Sharpen`` params.
 
-    Albumentations' ``alpha`` is the blend weight between the original and the sharpened image, which is what Kornia's
-    ``sharpness`` factor controls, and Kornia accepts it as a ``(min, max)`` range so it passes through unchanged.
+    The two libraries use different origins for the same effect, so ``alpha`` is shifted rather than passed through.
+    Albumentations' ``alpha`` is the visibility of the sharpened image: ``0`` leaves the image unchanged and ``1``
+    shows the fully sharpened version, so it never blurs. Kornia's ``sharpness`` factor is pivoted at ``1.0`` (the
+    PIL ``ImageEnhance.Sharpness`` convention): it blends from a smoothed copy at ``0`` through the untouched image
+    at ``1.0`` and sharpens only above ``1.0``. Passing ``alpha`` through unchanged would therefore blur the image
+    for every value below ``1``, so the resolved range is shifted with ``sharpness = 1.0 + alpha``, which keeps the
+    Albumentations no-op at ``alpha = 0`` mapped to Kornia's no-op at ``sharpness = 1.0``.
+
     ``lightness`` and ``method`` have no Kornia equivalent and are ignored here; the CPU (albumentations) path honors
     both.
     """
@@ -515,8 +521,9 @@ def _make_sharpen(params: dict[str, Any]) -> Any:
             "(Kornia's RandomSharpness exposes only a sharpness factor). "
             "CPU augmentation (albumentations) honors both."
         )
+    alpha_min, alpha_max = _as_range(params.get("alpha", (0.2, 0.5)))
     return RandomSharpness(
-        sharpness=_as_range(params.get("alpha", (0.2, 0.5))),
+        sharpness=(1.0 + alpha_min, 1.0 + alpha_max),
         p=params.get("p", 0.5),
     )
 

--- a/src/rfdetr/training/module_data.py
+++ b/src/rfdetr/training/module_data.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import torch
 import torch.utils.data
@@ -527,10 +527,14 @@ class RFDETRDataModule(LightningDataModule):
                 scene = sv.BoxAnnotator(thickness=1).annotate(scene=scene, detections=detections)
                 # LabelAnnotator.annotate() is typed as PIL-only, but its @ensure_cv2_image_for_class_method
                 # decorator accepts and returns ndarray at runtime too (see its docstring).
-                scene = sv.LabelAnnotator(text_scale=0.4, text_padding=2).annotate(  # type: ignore[assignment]
-                    scene=scene,  # type: ignore[arg-type]
-                    detections=detections,
-                    labels=labels_text,
+                label_annotator = sv.LabelAnnotator(text_scale=0.4, text_padding=2)
+                scene = cast(
+                    np.ndarray[Any, np.dtype[Any]],
+                    label_annotator.annotate(
+                        scene=cast(Any, scene),
+                        detections=detections,
+                        labels=labels_text,
+                    ),
                 )
 
             keypoints = target.get("keypoints")

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -314,6 +314,35 @@ class TestBuildKorniaPipeline:
             kornia_transforms.build_kornia_pipeline({"Blur": {"blur_limit": (5, 5)}}, 560)
         warning.assert_not_called()
 
+    def test_blur_library_default_pair_logs_at_debug_not_warning(self):
+        """(3, 7) is Albumentations' own Blur default, an expected divergence, so it must stay off WARNING."""
+        from unittest import mock
+
+        from rfdetr.datasets import kornia_transforms
+
+        with (
+            mock.patch.object(kornia_transforms.logger, "warning") as warning,
+            mock.patch.object(kornia_transforms.logger, "debug") as debug,
+        ):
+            kornia_transforms.build_kornia_pipeline({"Blur": {"blur_limit": (3, 7)}}, 560)
+        warning.assert_not_called()
+        assert debug.called
+        assert "Blur" in str(debug.call_args)
+
+    @pytest.mark.parametrize(
+        "blur_limit",
+        [
+            pytest.param([], id="empty-sequence"),
+            pytest.param((1, 2, 3), id="three-element-sequence"),
+        ],
+    )
+    def test_blur_kernel_rejects_invalid_sequence_length(self, blur_limit):
+        """A sequence that is neither a scalar nor a (min, max) pair must raise, not silently misresolve."""
+        from rfdetr.datasets.kornia_transforms import build_kornia_pipeline
+
+        with pytest.raises(ValueError, match="Kernel size parameter must be"):
+            build_kornia_pipeline({"Blur": {"blur_limit": blur_limit}}, 560)
+
     def test_sharpen_shifts_alpha_to_kornias_one_pivoted_sharpness_range(self):
         """Albumentations' alpha (0=no-op) is shifted to Kornia's sharpness (1.0=no-op): sharpness = 1.0 + alpha."""
         from rfdetr.datasets.kornia_transforms import build_kornia_pipeline

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -287,15 +287,44 @@ class TestBuildKorniaPipeline:
             kornia_transforms.build_kornia_pipeline({"Blur": {"blur_limit": (5, 5)}}, 560)
         warning.assert_not_called()
 
-    def test_sharpen_passes_alpha_through_as_a_range(self):
-        """Albumentations' alpha is the blend weight, which is Kornia's sharpness factor."""
+    def test_sharpen_shifts_alpha_to_kornias_one_pivoted_sharpness_range(self):
+        """Albumentations' alpha (0=no-op) is shifted to Kornia's sharpness (1.0=no-op): sharpness = 1.0 + alpha."""
         from rfdetr.datasets.kornia_transforms import build_kornia_pipeline
 
         pipeline = build_kornia_pipeline({"Sharpen": {"alpha": (0.1, 0.4)}}, 560)
         transform = next(iter(pipeline.children()))
         # Kornia keeps sampled ranges on the parameter generator rather than in `flags`.
         sampler = transform._param_generator.sampler_dict["sharpness"]
-        assert (float(sampler.low), float(sampler.high)) == pytest.approx((0.1, 0.4))
+        assert (float(sampler.low), float(sampler.high)) == pytest.approx((1.1, 1.4))
+
+    def test_sharpen_default_alpha_actually_sharpens_not_blurs(self):
+        """Regression guard: at the default alpha=(0.2, 0.5), Sharpen must raise edge energy, not lower it.
+
+        Kornia's ``sharpness`` factor is pivoted at 1.0 (0=blur, 1=no-op, >1=sharpen), unlike Albumentations' ``alpha``
+        (pivoted at 0). Passing ``alpha`` straight through as ``sharpness`` (the pre-fix bug) resolves to the range
+        (0.2, 0.5) — below Kornia's no-op point — which blurs a step edge instead of sharpening it, so this test would
+        fail against that code. The fixed mapping resolves to ``sharpness=(1.2, 1.5)``, which sharpens.
+        """
+        from rfdetr.datasets.kornia_transforms import build_kornia_pipeline
+
+        size = 16
+        img = torch.full((1, 3, size, size), 0.3)
+        img[:, :, :, size // 2 :] = 0.7  # a single sharp step edge down the middle column
+        boxes = torch.tensor([[[0.0, 0.0, float(size), float(size)]]], dtype=torch.float32)
+
+        pipeline = build_kornia_pipeline({"Sharpen": {"p": 1.0}}, 560)
+        img_out, _ = pipeline(img, boxes)
+
+        def edge_energy(x: torch.Tensor) -> float:
+            # Exclude the outer 2-pixel ring: Kornia's sharpness leaves border pixels unchanged (see
+            # kornia.enhance.adjust.sharpness), so including them would dilute the interior sharpening signal.
+            interior = x[:, :, 2:-2, 2:-2]
+            return (torch.diff(interior, dim=-1).abs().mean() + torch.diff(interior, dim=-2).abs().mean()).item()
+
+        assert edge_energy(img_out) > edge_energy(img), (
+            "Sharpen at the default alpha=(0.2, 0.5) must increase edge energy (sharpen); an unchanged or lower "
+            "value means the pivot-point bug regressed (sharpness range fell back to (0.2, 0.5), which blurs)."
+        )
 
     def test_sharpen_warns_about_ignored_lightness(self):
         """Lightness has no Kornia equivalent, so dropping it must be announced."""

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -267,13 +267,13 @@ class TestBuildKorniaPipeline:
         assert transform.flags["kernel_size"] == (expected, expected)
 
     def test_blur_pair_warns_about_the_fixed_kernel(self):
-        """A non-degenerate pair collapses to one kernel, so it must say so."""
+        """A non-degenerate pair the user chose explicitly collapses to one kernel, so it must say so."""
         from unittest import mock
 
         from rfdetr.datasets import kornia_transforms
 
         with mock.patch.object(kornia_transforms.logger, "warning") as warning:
-            kornia_transforms.build_kornia_pipeline({"Blur": {"blur_limit": (3, 7)}}, 560)
+            kornia_transforms.build_kornia_pipeline({"Blur": {"blur_limit": (3, 5)}}, 560)
         assert warning.called
         assert "Blur" in str(warning.call_args)
 

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -298,7 +298,7 @@ class TestBuildKorniaPipeline:
         assert (float(sampler.low), float(sampler.high)) == pytest.approx((0.1, 0.4))
 
     def test_sharpen_warns_about_ignored_lightness(self):
-        """lightness has no Kornia equivalent, so dropping it must be announced."""
+        """Lightness has no Kornia equivalent, so dropping it must be announced."""
         from unittest import mock
 
         from rfdetr.datasets import kornia_transforms

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -19,6 +19,33 @@ from rfdetr.datasets.aug_configs import (
     AUG_INDUSTRIAL,
 )
 
+
+def _sharpness_sampler_range(transform: torch.nn.Module) -> tuple[float, float]:
+    """Read the sampled ``sharpness`` range off a Kornia ``RandomSharpness`` transform.
+
+    This intentionally reads a private Kornia implementation detail (``_param_generator.sampler_dict``) because no
+    public equivalent exists: ``RandomSharpness(...).flags`` is empty (verified against the installed Kornia
+    version), so the sampled range isn't reachable through any public attribute. If a future Kornia release
+    renames or removes ``_param_generator``/``sampler_dict``, this raises a clear, actionable failure instead of a
+    raw ``AttributeError``/``KeyError`` deep inside the test body.
+
+    Args:
+        transform: A ``kornia.augmentation.RandomSharpness`` instance (or equivalent) built with a sampled range.
+
+    Returns:
+        The sampled ``(low, high)`` bounds as floats.
+    """
+    try:
+        sampler = transform._param_generator.sampler_dict["sharpness"]
+        return float(sampler.low), float(sampler.high)
+    except (AttributeError, KeyError) as exc:
+        pytest.fail(
+            "Kornia's RandomSharpness no longer exposes the sampled `sharpness` range via the private "
+            f"`_param_generator.sampler_dict['sharpness']` path (no public alternative exists): {exc!r}. Update "
+            "this helper to match Kornia's new internal parameter-generator shape."
+        )
+
+
 # ---------------------------------------------------------------------------
 # TestBuildKorniaPipeline — validates the factory that translates aug_config
 # dicts into a Kornia AugmentationSequential pipeline.
@@ -293,9 +320,9 @@ class TestBuildKorniaPipeline:
 
         pipeline = build_kornia_pipeline({"Sharpen": {"alpha": (0.1, 0.4)}}, 560)
         transform = next(iter(pipeline.children()))
-        # Kornia keeps sampled ranges on the parameter generator rather than in `flags`.
-        sampler = transform._param_generator.sampler_dict["sharpness"]
-        assert (float(sampler.low), float(sampler.high)) == pytest.approx((1.1, 1.4))
+        # Kornia keeps sampled ranges on the parameter generator rather than in `flags`; see
+        # `_sharpness_sampler_range` for why this reads a private attribute.
+        assert _sharpness_sampler_range(transform) == pytest.approx((1.1, 1.4))
 
     def test_sharpen_default_alpha_actually_sharpens_not_blurs(self):
         """Regression guard: at the default alpha=(0.2, 0.5), Sharpen must raise edge energy, not lower it.
@@ -355,9 +382,9 @@ class TestBuildKorniaPipeline:
         pipeline = build_kornia_pipeline({"CLAHE": {"clip_limit": (2.0, 6.0), "tile_grid_size": (4, 4)}}, 560)
         transform = next(iter(pipeline.children()))
         assert tuple(transform.flags["grid_size"]) == (4, 4)
-        # clip_limit is sampled, so it lives on the parameter generator.
-        sampler = transform._param_generator.sampler_dict["clip_limit_factor"]
-        assert (float(sampler.low), float(sampler.high)) == pytest.approx((2.0, 6.0))
+        # Unlike Sharpen's sharpness range, RandomClahe exposes its range on a plain public
+        # `clip_limit` attribute (set directly from the constructor arg), so no private access needed.
+        assert tuple(transform.clip_limit) == pytest.approx((2.0, 6.0))
 
     def test_hue_saturation_value_still_unsupported(self):
         """Deliberately out of scope: albumentations shifts additively, Kornia scales multiplicatively."""

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -214,6 +214,129 @@ class TestBuildKorniaPipeline:
         assert warning.called
         assert "HorizontalFlip" in str(warning.call_args)
 
+    # --- pixel-level transforms added for issue #1252 -------------------
+
+    @pytest.mark.parametrize(
+        ("name", "params", "expected"),
+        [
+            ("Blur", {"blur_limit": 5}, "RandomBoxBlur"),
+            ("Sharpen", {"alpha": (0.2, 0.5)}, "RandomSharpness"),
+            ("Equalize", {}, "RandomEqualize"),
+            ("CLAHE", {"clip_limit": 4.0}, "RandomClahe"),
+        ],
+    )
+    def test_pixel_transforms_map_to_kornia(self, name, params, expected):
+        """Each documented pixel-level name builds its Kornia counterpart (issue #1252)."""
+        from rfdetr.datasets.kornia_transforms import build_kornia_pipeline
+
+        pipeline = build_kornia_pipeline({name: params}, 560)
+        assert expected in [child.__class__.__name__ for child in pipeline.children()]
+
+    @pytest.mark.parametrize(
+        ("name", "params"),
+        [
+            ("Blur", {"blur_limit": (3, 7)}),
+            ("Sharpen", {"alpha": (0.2, 0.5)}),
+            ("Equalize", {"p": 0.5}),
+            ("CLAHE", {"clip_limit": 4.0, "tile_grid_size": (8, 8)}),
+        ],
+    )
+    def test_pixel_transforms_accepted_by_both_backends(self, name, params):
+        """The same config builds on either backend, which is the gap issue #1252 reports."""
+        pytest.importorskip("albumentations")
+        from rfdetr.datasets.kornia_transforms import build_kornia_pipeline
+        from rfdetr.datasets.transforms import AlbumentationsWrapper
+
+        config = {name: params}
+        assert build_kornia_pipeline(config, 560) is not None
+
+        wrappers = AlbumentationsWrapper.from_config(config)
+        assert len(wrappers) == 1, (
+            "from_config(strict=False) silently drops unresolved transforms, so length must be checked"
+        )
+        built = [t.__class__.__name__ for t in wrappers[0].transform.transforms]
+        assert name in built, f"expected {name}, got {built}"
+
+    @pytest.mark.parametrize(("blur_limit", "expected"), [(5, 5), (4, 5), ((3, 7), 7), ((3, 6), 7), (2, 3)])
+    def test_blur_kernel_is_odd_and_at_least_three(self, blur_limit, expected):
+        """Blur resolves its kernel the same way GaussianBlur does: odd, >= 3, upper bound of a pair."""
+        from rfdetr.datasets.kornia_transforms import build_kornia_pipeline
+
+        pipeline = build_kornia_pipeline({"Blur": {"blur_limit": blur_limit}}, 560)
+        transform = next(iter(pipeline.children()))
+        assert transform.flags["kernel_size"] == (expected, expected)
+
+    def test_blur_pair_warns_about_the_fixed_kernel(self):
+        """A non-degenerate pair collapses to one kernel, so it must say so."""
+        from unittest import mock
+
+        from rfdetr.datasets import kornia_transforms
+
+        with mock.patch.object(kornia_transforms.logger, "warning") as warning:
+            kornia_transforms.build_kornia_pipeline({"Blur": {"blur_limit": (3, 7)}}, 560)
+        assert warning.called
+        assert "Blur" in str(warning.call_args)
+
+    def test_blur_degenerate_pair_does_not_warn(self):
+        """(5, 5) loses nothing, so it should stay quiet."""
+        from unittest import mock
+
+        from rfdetr.datasets import kornia_transforms
+
+        with mock.patch.object(kornia_transforms.logger, "warning") as warning:
+            kornia_transforms.build_kornia_pipeline({"Blur": {"blur_limit": (5, 5)}}, 560)
+        warning.assert_not_called()
+
+    def test_sharpen_passes_alpha_through_as_a_range(self):
+        """Albumentations' alpha is the blend weight, which is Kornia's sharpness factor."""
+        from rfdetr.datasets.kornia_transforms import build_kornia_pipeline
+
+        pipeline = build_kornia_pipeline({"Sharpen": {"alpha": (0.1, 0.4)}}, 560)
+        transform = next(iter(pipeline.children()))
+        # Kornia keeps sampled ranges on the parameter generator rather than in `flags`.
+        sampler = transform._param_generator.sampler_dict["sharpness"]
+        assert (float(sampler.low), float(sampler.high)) == pytest.approx((0.1, 0.4))
+
+    def test_sharpen_warns_about_ignored_lightness(self):
+        """lightness has no Kornia equivalent, so dropping it must be announced."""
+        from unittest import mock
+
+        from rfdetr.datasets import kornia_transforms
+
+        with mock.patch.object(kornia_transforms.logger, "warning") as warning:
+            kornia_transforms.build_kornia_pipeline({"Sharpen": {"lightness": (0.5, 1.0)}}, 560)
+        assert warning.called
+        assert "lightness" in str(warning.call_args)
+
+    def test_equalize_warns_about_ignored_options(self):
+        """mode/by_channels/mask are albumentations-only."""
+        from unittest import mock
+
+        from rfdetr.datasets import kornia_transforms
+
+        with mock.patch.object(kornia_transforms.logger, "warning") as warning:
+            kornia_transforms.build_kornia_pipeline({"Equalize": {"by_channels": False}}, 560)
+        assert warning.called
+        assert "by_channels" in str(warning.call_args)
+
+    def test_clahe_maps_both_parameters(self):
+        """clip_limit and tile_grid_size map straight onto Kornia's clip_limit and grid_size."""
+        from rfdetr.datasets.kornia_transforms import build_kornia_pipeline
+
+        pipeline = build_kornia_pipeline({"CLAHE": {"clip_limit": (2.0, 6.0), "tile_grid_size": (4, 4)}}, 560)
+        transform = next(iter(pipeline.children()))
+        assert tuple(transform.flags["grid_size"]) == (4, 4)
+        # clip_limit is sampled, so it lives on the parameter generator.
+        sampler = transform._param_generator.sampler_dict["clip_limit_factor"]
+        assert (float(sampler.low), float(sampler.high)) == pytest.approx((2.0, 6.0))
+
+    def test_hue_saturation_value_still_unsupported(self):
+        """Deliberately out of scope: albumentations shifts additively, Kornia scales multiplicatively."""
+        from rfdetr.datasets.kornia_transforms import build_kornia_pipeline
+
+        with pytest.raises(ValueError, match="HueSaturationValue"):
+            build_kornia_pipeline({"HueSaturationValue": {"hue_shift_limit": 20}}, 560)
+
 
 # ---------------------------------------------------------------------------
 # TestCollateBoxes — validates packing of variable-length per-image boxes


### PR DESCRIPTION
## Description

Makes progress on #1252.

That issue lists twelve documented transform names that raise `ValueError` on the Kornia backend while working on Albumentations. This PR closes four of them, the ones with faithful Kornia equivalents and no open design question:

| preset key | Kornia | note |
|---|---|---|
| `Blur` | `K.RandomBoxBlur` | Albumentations' `Blur` is a box blur, so this is a direct mapping |
| `Sharpen` | `K.RandomSharpness` | `alpha` is the blend weight, which is what Kornia's `sharpness` factor controls |
| `Equalize` | `K.RandomEqualize` | |
| `CLAHE` | `K.RandomClahe` | `clip_limit` and `tile_grid_size` map straight onto `clip_limit` and `grid_size` |

None of the four can move a box, mask or keypoint, so they sidestep the auxiliary-target question raised on the issue entirely. Before:

```text
Blur      kornia=ValueError  albumentations=OK
Sharpen   kornia=ValueError  albumentations=OK
Equalize  kornia=ValueError  albumentations=OK
CLAHE     kornia=ValueError  albumentations=OK
```

After, all four build on both backends.

Parameters Kornia cannot express are logged rather than dropped silently, matching how `ToGray` already handles `method` and `num_output_channels`. `Sharpen` warns about `lightness` and `method`; `Equalize` warns about `mode`, `by_channels` and `mask`.

## One change of scope from what I offered on the issue

On #1252 I said I would send five, including `HueSaturationValue` mapped to `K.ColorJiggle`. Looking at it properly, that mapping is not faithful and I have left it out.

Albumentations shifts hue, saturation and value **additively** (`hue_shift_limit=(-20, 20)` in OpenCV hue units, `sat_shift_limit=(-30, 30)` on a 0-255 scale). Kornia's `ColorJiggle` scales them **multiplicatively** by a factor. Mapping one onto the other would silently change what an existing config means rather than port it, so I would rather leave `HueSaturationValue` raising a clear `ValueError` than quietly do something different on the GPU path. There is a test pinning that it still raises, and the docs now say why.

The geometric group is untouched for the same reason as before: it needs the target-handling decision first.

## Refactor

`Blur` needs the same kernel resolution `GaussianBlur` already had (a `(min, max)` pair collapses to its upper bound, forced odd and at least 3), so that logic moved into a shared `_as_odd_kernel()` helper and `GaussianBlur` now calls it. Behaviour is unchanged and the existing `GaussianBlur` tests cover it, including the `blur_limit` pair cases.

## Testing

Thirteen cases added to `tests/datasets/test_kornia_transforms.py`:

- each of the four builds the expected Kornia class
- each is accepted by **both** backends, which is the parity gap the issue is about
- `Blur` kernel resolution is odd and at least 3 across scalars and pairs, warns on a lossy pair, stays quiet on a degenerate one
- `Sharpen` passes `alpha` through as a range and warns about `lightness`
- `Equalize` warns about ignored options
- `CLAHE` maps both parameters
- `HueSaturationValue` still raises, so the exclusion is deliberate rather than accidental

All thirteen fail on the parent commit with `ValueError: Unknown augmentation key`.

```
$ pytest tests/datasets/test_kornia_transforms.py tests/datasets/test_augmentations.py
248 passed
```

`ruff check` and `ruff format` are clean on the changed files. Tests are CPU-only, like the rest of that module.
