### PR TITLE
fix(detr): use the resolution-override config when building evaluate()'s datamodule

### DIFF
--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -1073,7 +1073,10 @@ class RFDETR:
         finally:
             if _moved_to_cpu:
                 _move_model_context_to_device(self.model)
-        datamodule = RFDETRDataModule(self.model_config, config)
+        # `self.model_config` was already restored to its pre-call values by the `finally` block above; a
+        # `resolution` override only survives on `eval_model_config`, which is what actually built `module`.
+        # The datamodule must use the same config so the dataloader resizes to the resolution being evaluated.
+        datamodule = RFDETRDataModule(eval_model_config, config)
 
         # Warn (do not adapt) when the dataset class count differs from the model's head.
         stage = "test" if split == "test" else "validate"

--- a/tests/models/test_evaluate.py
+++ b/tests/models/test_evaluate.py
@@ -327,6 +327,71 @@ class TestEvaluateResolutionOverride:
         assert model.model_config.resolution == original_resolution
         assert model.model_config.positional_encoding_size == original_pe
 
+    def test_resolution_override_resizes_real_batches(self, synthetic_shape_dataset_dir: Path, tmp_path: Path) -> None:
+        """evaluate(resolution=...) must actually feed the model images resized to the override, repeatably.
+
+        Unlike ``test_resolution_override_evaluates`` above, the PTL trainer is NOT mocked here: this runs a real
+        ``trainer.test`` pass and inspects the pixel tensor shape ``RFDETRModelModule.test_step`` receives, which is
+        what the datamodule (not the PE-interpolated model) actually controls. A datamodule built from the wrong config
+        would silently keep evaluating at the original resolution while the model's positional embeddings were
+        interpolated for the override, invalidating any resolution-vs-mAP comparison.
+
+        Runs three sequential calls on the same model instance: a first override, a second and distinct override, then
+        a call with no override at all. This checks that the fix isn't specific to the first transition and that it
+        releases the datamodule back to the model's original resolution afterwards, not just to the previous override.
+        """
+        from rfdetr.training import RFDETRModelModule
+
+        model = RFDETRNano(
+            pretrain_weights=None,
+            num_classes=_num_classes(synthetic_shape_dataset_dir),
+            device="cpu",
+        )
+        original_resolution = model.model_config.resolution
+        block_size = model.model_config.patch_size * model.model_config.num_windows
+        first_override = block_size * (original_resolution // block_size + 1)
+        second_override = block_size * (original_resolution // block_size + 2)
+
+        observed_shapes: list[tuple[int, int]] = []
+        original_test_step = RFDETRModelModule.test_step
+
+        def recording_test_step(self: RFDETRModelModule, batch: Any, batch_idx: int) -> Any:
+            """Spy on ``test_step`` and record the pixel shape of each batch it actually receives."""
+            observed_shapes.append(tuple(batch[0].tensors.shape[-2:]))
+            return original_test_step(self, batch, batch_idx)
+
+        def run_and_get_shape(resolution: int | None, output_dir: Path) -> tuple[int, int]:
+            """Run one evaluate() call, spying on test_step, and return the single uniform batch shape it saw."""
+            observed_shapes.clear()
+            kwargs: dict[str, Any] = {"resolution": resolution} if resolution is not None else {}
+            with patch.object(RFDETRModelModule, "test_step", recording_test_step):
+                model.evaluate(
+                    dataset_dir=str(synthetic_shape_dataset_dir),
+                    split="test",
+                    device="cpu",
+                    output_dir=str(output_dir),
+                    batch_size=4,
+                    num_workers=0,
+                    tensorboard=False,
+                    **kwargs,
+                )
+            assert observed_shapes, "test_step was never called"
+            shapes = set(observed_shapes)
+            assert len(shapes) == 1, f"evaluate(resolution={resolution}) fed inconsistently shaped batches: {shapes}"
+            return next(iter(shapes))
+
+        assert run_and_get_shape(first_override, tmp_path / "o1") == (first_override, first_override), (
+            f"evaluate(resolution={first_override}) did not resize batches to the override."
+        )
+        assert run_and_get_shape(second_override, tmp_path / "o2") == (second_override, second_override), (
+            f"evaluate(resolution={second_override}) did not resize batches to the override on a second, distinct "
+            "call — the datamodule fix must not be specific to the first transition."
+        )
+        assert run_and_get_shape(None, tmp_path / "o3") == (original_resolution, original_resolution), (
+            "evaluate() without a resolution override did not return to the model's original resolution after "
+            "two prior overrides — the datamodule must not stay pinned to the last override."
+        )
+
 
 def test_auto_batch_probe_not_invoked(nano_model: RFDETRNano, tmp_path: Path) -> None:
     """``evaluate(batch_size="auto")`` skips the forward+backward prober and uses the default micro-batch.


### PR DESCRIPTION
`evaluate(resolution=...)` documents that the override does not persist — `model_config` gets restored once the eval-only config copy has captured it (`detr.py:1024-1049`). The eval model itself is built from that captured copy, `eval_model_config` (`detr.py:1038`, used at `detr.py:1050`), so the positional embeddings do get interpolated to the requested resolution.

The datamodule doesn't. `RFDETRDataModule(self.model_config, config)` is built at `detr.py:1076`, after the `finally` block already restored `self.model_config` to its pre-call values. So the dataloader keeps resizing images to the original resolution while the model is evaluated at a different one — the override never reaches the data.

I found this while auditing the eval path, not from a reported issue. To confirm it, I wrapped a real photo from the repo (`docs/assets/keypoints/bridge-1.jpg`, 760x428) in a minimal COCO dataset and monkeypatched `RFDETRModelModule.test_step` to record the actual pixel tensor shape the model receives. Before the fix, `baseline`, `resolution=416` and `resolution=448` all produce `384x384` batches — the requested size never shows up. A control build (a config copy with the override, built the same way `eval_model_config` is) gives the correct `416x416`/`448x448`. That rules out the dataloader or the collate function — it comes down to which config object gets passed to `RFDETRDataModule`.

**Changes**
- `src/rfdetr/detr.py`: pass `eval_model_config` instead of `self.model_config` when building the datamodule at line 1076. `eval_model_config` was already being used earlier in the same method to build the eval model itself (`module = RFDETRModelModule(eval_model_config, config)`, line 1050), so this isn't a new object, just the one that should have gone there in the first place.
- `tests/models/test_evaluate.py`: added `test_resolution_override_resizes_real_batches`. Unlike the existing `test_resolution_override_evaluates`, it doesn't mock the trainer — it runs a real `trainer.test` pass and spies on `test_step` the same way the repro above does, so it checks the actual pixel shape, not just that `model_config` gets restored afterwards. It runs three `evaluate()` calls in a row on the same model instance (`resolution=416`, then `resolution=448`, then no override), so it also checks a second override and that the datamodule goes back to the original resolution after, not just the first switch. I ran it against the pre-fix code first (reverting only the `detr.py` line), and it fails at the first override with `AssertionError: evaluate(resolution=416) did not resize batches to the override.`, then passes with the fix.

**Validation**
- `pytest tests/models/test_evaluate.py` — 25 passed.
- `ruff check` / `ruff format --check` / `docformatter --diff` on the two touched files — clean.
- `mypy src/rfdetr/` — no new errors versus `develop` HEAD (the same two pre-existing errors in `coco_eval.py`/`trainer.py`, neither touched by this PR).
- Patch applies cleanly on `develop` at `2222eabf`.

I'm happy to adjust anything, let me know ..
