### PR TITLE
perf(matcher): copy only the diagonal cost blocks to CPU before assignment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -312,13 +312,12 @@ addopts = [
     "--color=yes",          # colored output
     "--doctest-plus",       # run doctests from all modules (pytest-doctestplus)
 ]
-# Skip doctest COLLECTION for test modules (they are not doc sources; src/ doctests unaffected).
-# Without this, doctestplus walks every test module's attributes; when the TF/ai_edge_litert
-# stack has been imported by the tflite export tests, scanning a module that exposes
-# `unittest.mock.call` (a `_Call` that auto-creates and caches child mocks on attribute access)
-# grows the object graph unboundedly — observed 38 GB RSS and a silent SIGKILL during
-# collection. The value must be a glob ("tests/*"): matching is per-file via fnmatch.
-doctest_norecursedirs = ["tests/*"]
+# Doctest collection is intentionally enabled across tests/ (no doctest_norecursedirs exclusion) so
+# helper-function doctests in test modules run. This previously blanket-excluded tests/* because
+# doctestplus walking every test module's attributes after the TF/ai_edge_litert stack is imported by
+# the tflite export tests grows unittest.mock.call's cached child-mock graph unboundedly — observed
+# 38 GB RSS and a silent SIGKILL during collection. If that recurs, reintroduce
+# `doctest_norecursedirs = ["tests/*"]` or scope it to `tests/export/test_tflite_inference.py`.
 pythonpath = ["src", "."]
 markers = [
     "gpu: tests that require GPU or are slow on CPU",

--- a/src/rfdetr/models/matcher.py
+++ b/src/rfdetr/models/matcher.py
@@ -264,7 +264,7 @@ class HungarianMatcher(nn.Module):
             cost_nll = cost_nll.flatten(0, 1)
 
         # Final cost matrix
-        cost_matrix = self.cost_bbox * cost_bbox + self.cost_class * cost_class + self.cost_giou * cost_giou
+        cost_matrix: Tensor = self.cost_bbox * cost_bbox + self.cost_class * cost_class + self.cost_giou * cost_giou
         if masks_present:
             cost_matrix = cost_matrix + self.cost_mask_ce * cost_mask_ce + self.cost_mask_dice * cost_mask_dice
         if keypoints_present:
@@ -275,14 +275,13 @@ class HungarianMatcher(nn.Module):
                 + self.keypoint_visible_loss_coef * cost_visible
                 + self.keypoint_nll_loss_coef * cost_nll
             )
-        cost_matrix = (
-            cost_matrix.view(bs, num_queries, -1).float().cpu()
-        )  # convert to float because bfloat16 doesn't play nicely with CPU
+        cost_matrix = cost_matrix.view(bs, num_queries, -1).float()
 
         # We assume any good match will not cause NaN or Inf, so replace invalid
         # entries with a finite value that is larger than every valid cost.
         finite_mask = torch.isfinite(cost_matrix)
         if not finite_mask.all():
+            cost_matrix = cost_matrix.cpu()
             if not self._warned_non_finite_costs:
                 logger.warning(
                     "Non-finite values detected in matcher cost matrix; "
@@ -293,14 +292,24 @@ class HungarianMatcher(nn.Module):
             cost_matrix = self._sanitize_cost_matrix(cost_matrix)
 
         sizes = [len(v["boxes"]) for v in targets]
+        target_offsets = [0]
+        for size in sizes:
+            target_offsets.append(target_offsets[-1] + size)
+        diagonal_cost_matrix: Tensor = torch.cat(
+            [cost_matrix[i, :, target_offsets[i] : target_offsets[i + 1]] for i in range(bs)], dim=-1
+        ).cpu()
+
         indices = []
         if num_queries % group_detr != 0:
             raise ValueError(f"num_queries ({num_queries}) must be divisible by group_detr ({group_detr})")
         g_num_queries = num_queries // group_detr
-        cost_matrix_list = cost_matrix.split(g_num_queries, dim=1)
         for g_i in range(group_detr):
-            grouped_cost_matrix = cost_matrix_list[g_i]
-            indices_g = [linear_sum_assignment(c[i]) for i, c in enumerate(grouped_cost_matrix.split(sizes, -1))]
+            group_start = g_i * g_num_queries
+            grouped_cost_matrix = diagonal_cost_matrix[group_start : group_start + g_num_queries]
+            indices_g = [
+                linear_sum_assignment(grouped_cost_matrix[:, target_offsets[i] : target_offsets[i + 1]])
+                for i in range(bs)
+            ]
             if g_i == 0:
                 indices = indices_g
             else:

--- a/src/rfdetr/models/matcher.py
+++ b/src/rfdetr/models/matcher.py
@@ -279,9 +279,9 @@ class HungarianMatcher(nn.Module):
 
         # We assume any good match will not cause NaN or Inf, so replace invalid
         # entries with a finite value that is larger than every valid cost.
-all_finite = torch.isfinite(cost_matrix).all().item()
-if not all_finite:
-    cost_matrix = cost_matrix.cpu()
+        all_finite = torch.isfinite(cost_matrix).all().item()
+        if not all_finite:
+            cost_matrix = cost_matrix.cpu()
             if not self._warned_non_finite_costs:
                 logger.warning(
                     "Non-finite values detected in matcher cost matrix; "

--- a/src/rfdetr/models/matcher.py
+++ b/src/rfdetr/models/matcher.py
@@ -279,9 +279,9 @@ class HungarianMatcher(nn.Module):
 
         # We assume any good match will not cause NaN or Inf, so replace invalid
         # entries with a finite value that is larger than every valid cost.
-        finite_mask = torch.isfinite(cost_matrix)
-        if not finite_mask.all():
-            cost_matrix = cost_matrix.cpu()
+all_finite = torch.isfinite(cost_matrix).all().item()
+if not all_finite:
+    cost_matrix = cost_matrix.cpu()
             if not self._warned_non_finite_costs:
                 logger.warning(
                     "Non-finite values detected in matcher cost matrix; "

--- a/tests/models/test_matcher.py
+++ b/tests/models/test_matcher.py
@@ -503,12 +503,12 @@ def _reference_indices_pre_diagonal_extraction(
     targets: list[dict[str, torch.Tensor]],
     group_detr: int = 1,
 ) -> list[tuple[torch.Tensor, torch.Tensor]]:
-    """Reference matching using the pre-PR extraction: materialize the full
-    ``[bs, num_queries, total_targets]`` cost matrix, then slice per image with
-    ``cost_matrix.split(sizes, -1)`` and ``c[i]`` (the code in ``matcher.py`` before the
-    diagonal-block candidate). Reuses the matcher's current gather-first class cost so this
-    isolates only the extraction-step change under test, not the unrelated class-cost refactor
-    already covered by ``_reference_indices_full_class_materialization``.
+    """Reference matching using the pre-PR extraction: materialize the full ``[bs, num_queries, total_targets]`` cost
+    matrix, then slice per image with ``cost_matrix.split(sizes, -1)`` and ``c[i]`` (the code in ``matcher.py`` before
+    the diagonal-block candidate).
+
+    Reuses the matcher's current gather-first class cost so this isolates only the extraction-step change under test,
+    not the unrelated class-cost refactor already covered by ``_reference_indices_full_class_materialization``.
     """
     from scipy.optimize import linear_sum_assignment
 
@@ -554,16 +554,14 @@ def _reference_indices_pre_diagonal_extraction(
 
 
 class TestDiagonalBlockExtraction:
-    """The ``target_offsets`` diagonal-block extraction in ``matcher.py`` must reproduce the
-    pre-PR ``cost_matrix.split(sizes, -1)`` + ``c[i]`` extraction for every batch element,
-    across heterogeneous target counts and zero-target elements in any position.
-    """
+    """The ``target_offsets`` diagonal-block extraction in ``matcher.py`` must reproduce the pre-PR
+    ``cost_matrix.split(sizes, -1)`` + ``c[i]`` extraction for every batch element, across heterogeneous target counts
+    and zero-target elements in any position."""
 
     def test_heterogeneous_sizes_with_zero_in_the_middle(self, matcher: HungarianMatcher) -> None:
-        """Batch of 4 images with sizes [2, 0, 3, 1]: the zero-target element sits between two
-        non-zero elements, so an off-by-one in the cumulative ``target_offsets`` would leak
-        columns from a neighboring image into the wrong diagonal block.
-        """
+        """Batch of 4 images with sizes [2, 0, 3, 1]: the zero-target element sits between two non-zero elements, so an
+        off-by-one in the cumulative ``target_offsets`` would leak columns from a neighboring image into the wrong
+        diagonal block."""
         torch.manual_seed(23)
         bs, num_queries, num_classes = 4, 6, 5
         outputs = {
@@ -602,11 +600,9 @@ class TestDiagonalBlockExtraction:
         assert actual[1][1].shape == (0,)
 
     def test_heterogeneous_sizes_with_group_detr(self, matcher: HungarianMatcher) -> None:
-        """With ``group_detr > 1`` the diagonal block is additionally sliced by
-        ``group_start:group_start + g_num_queries`` before being sliced by target offsets; a bug
-        in either slice would corrupt the group-combination step that concatenates indices across
-        groups.
-        """
+        """With ``group_detr > 1`` the diagonal block is additionally sliced by ``group_start:group_start +
+        g_num_queries`` before being sliced by target offsets; a bug in either slice would corrupt the group-combination
+        step that concatenates indices across groups."""
         torch.manual_seed(29)
         bs, num_queries, num_classes, group_detr = 3, 8, 6, 2
         outputs = {
@@ -644,12 +640,13 @@ class TestDiagonalBlockExtraction:
         assert actual[1][0].shape == (0,)
 
     def test_all_batch_elements_have_zero_targets(self, matcher: HungarianMatcher) -> None:
-        """Degenerate case: every image in the batch has zero targets, so ``target_offsets``
-        collapses to all-zero and every diagonal block is empty. Must not raise and must return an
-        empty assignment for every image, and must agree with the pre-PR extraction on that (both
-        return the same trivially-empty indices here, but the comparison is kept so this test
-        actually exercises ``_reference_indices_pre_diagonal_extraction`` like its two siblings,
-        instead of only asserting the shape of the new code's own output).
+        """Degenerate case: every image in the batch has zero targets, so ``target_offsets`` collapses to all-zero and
+        every diagonal block is empty.
+
+        Must not raise and must return an empty assignment for every image, and must agree with the pre-PR extraction on
+        that (both return the same trivially-empty indices here, but the comparison is kept so this test actually
+        exercises ``_reference_indices_pre_diagonal_extraction`` like its two siblings, instead of only asserting the
+        shape of the new code's own output).
         """
         torch.manual_seed(31)
         bs, num_queries, num_classes = 3, 4, 5
@@ -677,11 +674,10 @@ class TestDiagonalBlockExtraction:
 def _new_extraction_indices(
     cost_matrix: torch.Tensor, sizes: list[int], group_detr: int = 1
 ) -> list[tuple[torch.Tensor, torch.Tensor]]:
-    """Mirrors the post-PR extraction in ``matcher.py`` (``target_offsets`` + ``torch.cat``),
-    decoupled from cost computation so it can be property-tested against arbitrary cost-matrix
-    content — including whatever values the mask/keypoint cost terms (``matcher.py:266-277``,
-    untouched by this PR) would fold in, without duplicating those formulas here.
-    """
+    """Mirrors the post-PR extraction in ``matcher.py`` (``target_offsets`` + ``torch.cat``), decoupled from cost
+    computation so it can be property-tested against arbitrary cost-matrix content — including whatever values the
+    mask/keypoint cost terms (``matcher.py:266-277``, untouched by this PR) would fold in, without duplicating those
+    formulas here."""
     from scipy.optimize import linear_sum_assignment
 
     bs, num_queries = cost_matrix.shape[:2]
@@ -733,8 +729,10 @@ def _old_extraction_indices(
 
 
 class TestDiagonalExtractionContentAgnostic:
-    """``TestDiagonalBlockExtraction`` above only feeds detection-shaped costs (bbox+class+giou)
-    through the real ``matcher.forward``. But the extraction step it exercises has no notion of
+    """``TestDiagonalBlockExtraction`` above only feeds detection-shaped costs (bbox+class+giou) through the real
+    ``matcher.forward``.
+
+    But the extraction step it exercises has no notion of
     where the cost values came from: it slices ``cost_matrix`` by ``sizes``/``target_offsets``
     after the mask (``cost_mask_ce``/``cost_mask_dice``) and keypoint
     (``cost_l1``/``cost_findable``/``cost_visible``/``cost_nll``) terms are already summed into it

--- a/tests/models/test_matcher.py
+++ b/tests/models/test_matcher.py
@@ -4,6 +4,7 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
+import numpy as np
 import pytest
 import torch
 
@@ -494,3 +495,271 @@ class TestClassCostGatherFirst:
             assert torch.equal(act_t, exp_t)
         assert actual[1][0].shape == (0,)
         assert actual[1][1].shape == (0,)
+
+
+def _reference_indices_pre_diagonal_extraction(
+    matcher: HungarianMatcher,
+    outputs: dict[str, torch.Tensor],
+    targets: list[dict[str, torch.Tensor]],
+    group_detr: int = 1,
+) -> list[tuple[torch.Tensor, torch.Tensor]]:
+    """Reference matching using the pre-PR extraction: materialize the full
+    ``[bs, num_queries, total_targets]`` cost matrix, then slice per image with
+    ``cost_matrix.split(sizes, -1)`` and ``c[i]`` (the code in ``matcher.py`` before the
+    diagonal-block candidate). Reuses the matcher's current gather-first class cost so this
+    isolates only the extraction-step change under test, not the unrelated class-cost refactor
+    already covered by ``_reference_indices_full_class_materialization``.
+    """
+    from scipy.optimize import linear_sum_assignment
+
+    from rfdetr.utilities.box_ops import box_cxcywh_to_xyxy, generalized_box_iou
+
+    bs, num_queries = outputs["pred_logits"].shape[:2]
+    flat_pred_logits = outputs["pred_logits"].flatten(0, 1)
+    out_bbox = outputs["pred_boxes"].flatten(0, 1)
+    tgt_ids = torch.cat([t["labels"] for t in targets])
+    tgt_bbox = torch.cat([t["boxes"] for t in targets])
+    alpha = matcher.focal_alpha
+    gamma = matcher_module._FOCAL_LOSS_GAMMA
+    tgt_logits = flat_pred_logits[:, tgt_ids]
+    tgt_prob = tgt_logits.sigmoid()
+    neg_cost_class = (1 - alpha) * (tgt_prob**gamma) * (-torch.nn.functional.logsigmoid(-tgt_logits))
+    pos_cost_class = alpha * ((1 - tgt_prob) ** gamma) * (-torch.nn.functional.logsigmoid(tgt_logits))
+    cost_class = pos_cost_class - neg_cost_class
+    cost_bbox = torch.cdist(out_bbox, tgt_bbox, p=1)
+    cost_giou = -generalized_box_iou(box_cxcywh_to_xyxy(out_bbox), box_cxcywh_to_xyxy(tgt_bbox))
+    cost_matrix = matcher.cost_bbox * cost_bbox + matcher.cost_class * cost_class + matcher.cost_giou * cost_giou
+    cost_matrix = cost_matrix.view(bs, num_queries, -1).float().cpu()
+
+    sizes = [len(t["boxes"]) for t in targets]
+    if num_queries % group_detr != 0:
+        raise ValueError(f"num_queries ({num_queries}) must be divisible by group_detr ({group_detr})")
+    g_num_queries = num_queries // group_detr
+    cost_matrix_list = cost_matrix.split(g_num_queries, dim=1)
+    indices = []
+    for g_i in range(group_detr):
+        grouped_cost_matrix = cost_matrix_list[g_i]
+        indices_g = [linear_sum_assignment(c[i]) for i, c in enumerate(grouped_cost_matrix.split(sizes, -1))]
+        if g_i == 0:
+            indices = indices_g
+        else:
+            indices = [
+                (
+                    np.concatenate([indice1[0], indice2[0] + g_num_queries * g_i]),
+                    np.concatenate([indice1[1], indice2[1]]),
+                )
+                for indice1, indice2 in zip(indices, indices_g)
+            ]
+    return [(torch.as_tensor(i, dtype=torch.int64), torch.as_tensor(j, dtype=torch.int64)) for i, j in indices]
+
+
+class TestDiagonalBlockExtraction:
+    """The ``target_offsets`` diagonal-block extraction in ``matcher.py`` must reproduce the
+    pre-PR ``cost_matrix.split(sizes, -1)`` + ``c[i]`` extraction for every batch element,
+    across heterogeneous target counts and zero-target elements in any position.
+    """
+
+    def test_heterogeneous_sizes_with_zero_in_the_middle(self, matcher: HungarianMatcher) -> None:
+        """Batch of 4 images with sizes [2, 0, 3, 1]: the zero-target element sits between two
+        non-zero elements, so an off-by-one in the cumulative ``target_offsets`` would leak
+        columns from a neighboring image into the wrong diagonal block.
+        """
+        torch.manual_seed(23)
+        bs, num_queries, num_classes = 4, 6, 5
+        outputs = {
+            "pred_logits": torch.randn(bs, num_queries, num_classes),
+            "pred_boxes": torch.rand(bs, num_queries, 4) * 0.4 + 0.3,
+        }
+        targets = [
+            {
+                "labels": torch.tensor([1, 3], dtype=torch.int64),
+                "boxes": torch.tensor([[0.3, 0.3, 0.2, 0.2], [0.6, 0.6, 0.1, 0.1]], dtype=torch.float32),
+            },
+            {
+                "labels": torch.zeros(0, dtype=torch.int64),
+                "boxes": torch.zeros(0, 4, dtype=torch.float32),
+            },
+            {
+                "labels": torch.tensor([0, 2, 4], dtype=torch.int64),
+                "boxes": torch.tensor(
+                    [[0.4, 0.4, 0.2, 0.2], [0.5, 0.5, 0.3, 0.3], [0.6, 0.3, 0.1, 0.2]], dtype=torch.float32
+                ),
+            },
+            {
+                "labels": torch.tensor([1], dtype=torch.int64),
+                "boxes": torch.tensor([[0.5, 0.5, 0.2, 0.2]], dtype=torch.float32),
+            },
+        ]
+
+        actual = matcher(outputs, targets)
+        expected = _reference_indices_pre_diagonal_extraction(matcher, outputs, targets)
+
+        assert len(actual) == bs
+        for image_idx, ((act_q, act_t), (exp_q, exp_t)) in enumerate(zip(actual, expected)):
+            assert torch.equal(act_q, exp_q), f"query indices diverged for image {image_idx}"
+            assert torch.equal(act_t, exp_t), f"target indices diverged for image {image_idx}"
+        assert actual[1][0].shape == (0,)
+        assert actual[1][1].shape == (0,)
+
+    def test_heterogeneous_sizes_with_group_detr(self, matcher: HungarianMatcher) -> None:
+        """With ``group_detr > 1`` the diagonal block is additionally sliced by
+        ``group_start:group_start + g_num_queries`` before being sliced by target offsets; a bug
+        in either slice would corrupt the group-combination step that concatenates indices across
+        groups.
+        """
+        torch.manual_seed(29)
+        bs, num_queries, num_classes, group_detr = 3, 8, 6, 2
+        outputs = {
+            "pred_logits": torch.randn(bs, num_queries, num_classes),
+            "pred_boxes": torch.rand(bs, num_queries, 4) * 0.4 + 0.3,
+        }
+        targets = [
+            {
+                "labels": torch.tensor([2, 5, 0], dtype=torch.int64),
+                "boxes": torch.tensor(
+                    [[0.3, 0.3, 0.2, 0.2], [0.6, 0.6, 0.1, 0.1], [0.4, 0.5, 0.2, 0.3]], dtype=torch.float32
+                ),
+            },
+            {
+                "labels": torch.zeros(0, dtype=torch.int64),
+                "boxes": torch.zeros(0, 4, dtype=torch.float32),
+            },
+            {
+                "labels": torch.tensor([1, 4], dtype=torch.int64),
+                "boxes": torch.tensor([[0.5, 0.5, 0.3, 0.3], [0.2, 0.7, 0.1, 0.1]], dtype=torch.float32),
+            },
+        ]
+
+        actual = matcher(outputs, targets, group_detr=group_detr)
+        expected = _reference_indices_pre_diagonal_extraction(matcher, outputs, targets, group_detr=group_detr)
+
+        assert len(actual) == bs
+        for image_idx, ((act_q, act_t), (exp_q, exp_t)) in enumerate(zip(actual, expected)):
+            assert torch.equal(act_q, exp_q), f"query indices diverged for image {image_idx}"
+            assert torch.equal(act_t, exp_t), f"target indices diverged for image {image_idx}"
+        # Each group matches min(g_num_queries, size) queries per image (g_num_queries=4):
+        # image 0 has 3 targets -> 3 per group x 2 groups; image 2 has 2 targets -> 2 per group x 2 groups.
+        assert actual[0][0].shape == (6,)
+        assert actual[2][0].shape == (4,)
+        assert actual[1][0].shape == (0,)
+
+    def test_all_batch_elements_have_zero_targets(self, matcher: HungarianMatcher) -> None:
+        """Degenerate case: every image in the batch has zero targets, so ``target_offsets``
+        collapses to all-zero and every diagonal block is empty. Must not raise and must return an
+        empty assignment for every image, and must agree with the pre-PR extraction on that (both
+        return the same trivially-empty indices here, but the comparison is kept so this test
+        actually exercises ``_reference_indices_pre_diagonal_extraction`` like its two siblings,
+        instead of only asserting the shape of the new code's own output).
+        """
+        torch.manual_seed(31)
+        bs, num_queries, num_classes = 3, 4, 5
+        outputs = {
+            "pred_logits": torch.randn(bs, num_queries, num_classes),
+            "pred_boxes": torch.rand(bs, num_queries, 4) * 0.4 + 0.3,
+        }
+        targets = [
+            {"labels": torch.zeros(0, dtype=torch.int64), "boxes": torch.zeros(0, 4, dtype=torch.float32)}
+            for _ in range(bs)
+        ]
+
+        actual = matcher(outputs, targets)
+        expected = _reference_indices_pre_diagonal_extraction(matcher, outputs, targets)
+
+        assert len(actual) == bs
+        for image_idx, ((act_q, act_t), (exp_q, exp_t)) in enumerate(zip(actual, expected)):
+            assert torch.equal(act_q, exp_q), f"query indices diverged for image {image_idx}"
+            assert torch.equal(act_t, exp_t), f"target indices diverged for image {image_idx}"
+        for matched_queries, matched_targets in actual:
+            assert matched_queries.shape == (0,)
+            assert matched_targets.shape == (0,)
+
+
+def _new_extraction_indices(
+    cost_matrix: torch.Tensor, sizes: list[int], group_detr: int = 1
+) -> list[tuple[torch.Tensor, torch.Tensor]]:
+    """Mirrors the post-PR extraction in ``matcher.py`` (``target_offsets`` + ``torch.cat``),
+    decoupled from cost computation so it can be property-tested against arbitrary cost-matrix
+    content — including whatever values the mask/keypoint cost terms (``matcher.py:266-277``,
+    untouched by this PR) would fold in, without duplicating those formulas here.
+    """
+    from scipy.optimize import linear_sum_assignment
+
+    bs, num_queries = cost_matrix.shape[:2]
+    target_offsets = [0]
+    for size in sizes:
+        target_offsets.append(target_offsets[-1] + size)
+    diagonal_cost_matrix = torch.cat(
+        [cost_matrix[i, :, target_offsets[i] : target_offsets[i + 1]] for i in range(bs)], dim=-1
+    )
+    g_num_queries = num_queries // group_detr
+    indices = []
+    for g_i in range(group_detr):
+        group_start = g_i * g_num_queries
+        grouped_cost_matrix = diagonal_cost_matrix[group_start : group_start + g_num_queries]
+        indices_g = [
+            linear_sum_assignment(grouped_cost_matrix[:, target_offsets[i] : target_offsets[i + 1]]) for i in range(bs)
+        ]
+        if g_i == 0:
+            indices = indices_g
+        else:
+            indices = [
+                (np.concatenate([i1[0], i2[0] + g_num_queries * g_i]), np.concatenate([i1[1], i2[1]]))
+                for i1, i2 in zip(indices, indices_g)
+            ]
+    return [(torch.as_tensor(i, dtype=torch.int64), torch.as_tensor(j, dtype=torch.int64)) for i, j in indices]
+
+
+def _old_extraction_indices(
+    cost_matrix: torch.Tensor, sizes: list[int], group_detr: int = 1
+) -> list[tuple[torch.Tensor, torch.Tensor]]:
+    """Mirrors the pre-PR extraction (``cost_matrix.split(sizes, -1)`` + ``c[i]``)."""
+    from scipy.optimize import linear_sum_assignment
+
+    bs, num_queries = cost_matrix.shape[:2]
+    g_num_queries = num_queries // group_detr
+    cost_matrix_list = cost_matrix.split(g_num_queries, dim=1)
+    indices = []
+    for g_i in range(group_detr):
+        grouped_cost_matrix = cost_matrix_list[g_i]
+        indices_g = [linear_sum_assignment(c[i]) for i, c in enumerate(grouped_cost_matrix.split(sizes, -1))]
+        if g_i == 0:
+            indices = indices_g
+        else:
+            indices = [
+                (np.concatenate([i1[0], i2[0] + g_num_queries * g_i]), np.concatenate([i1[1], i2[1]]))
+                for i1, i2 in zip(indices, indices_g)
+            ]
+    return [(torch.as_tensor(i, dtype=torch.int64), torch.as_tensor(j, dtype=torch.int64)) for i, j in indices]
+
+
+class TestDiagonalExtractionContentAgnostic:
+    """``TestDiagonalBlockExtraction`` above only feeds detection-shaped costs (bbox+class+giou)
+    through the real ``matcher.forward``. But the extraction step it exercises has no notion of
+    where the cost values came from: it slices ``cost_matrix`` by ``sizes``/``target_offsets``
+    after the mask (``cost_mask_ce``/``cost_mask_dice``) and keypoint
+    (``cost_l1``/``cost_findable``/``cost_visible``/``cost_nll``) terms are already summed into it
+    (``matcher.py:266-278``, all untouched by this PR). Property-testing the old and new extraction
+    directly on arbitrary cost tensors therefore also covers segmentation and keypoint batches,
+    without re-deriving their cost formulas in this test file.
+    """
+
+    @pytest.mark.parametrize("group_detr", [1, 2, 3])
+    @pytest.mark.parametrize("seed", [41, 42, 43, 44, 45])
+    def test_matches_old_extraction_for_arbitrary_cost_content(self, seed: int, group_detr: int) -> None:
+        torch.manual_seed(seed)
+        sizes = [3, 0, 5, 2]
+        bs = len(sizes)
+        num_queries = 12
+        total_targets = sum(sizes)
+        # Wide range and an offset so the sentinel-adjacent negative-cost edge case (see
+        # TestHungarianMatcherNonFiniteCosts.test_negative_costs_with_nan_selects_valid_query)
+        # is also exercised by some seeds, not just small positive costs.
+        cost_matrix = torch.randn(bs, num_queries, total_targets, dtype=torch.float32) * 10 - 3
+
+        actual = _new_extraction_indices(cost_matrix, sizes, group_detr=group_detr)
+        expected = _old_extraction_indices(cost_matrix, sizes, group_detr=group_detr)
+
+        assert len(actual) == bs
+        for image_idx, ((act_q, act_t), (exp_q, exp_t)) in enumerate(zip(actual, expected)):
+            assert torch.equal(act_q, exp_q), f"query indices diverged for image {image_idx}"
+            assert torch.equal(act_t, exp_t), f"target indices diverged for image {image_idx}"

--- a/tests/models/test_matcher.py
+++ b/tests/models/test_matcher.py
@@ -509,6 +509,23 @@ def _reference_indices_pre_diagonal_extraction(
 
     Reuses the matcher's current gather-first class cost so this isolates only the extraction-step change under test,
     not the unrelated class-cost refactor already covered by ``_reference_indices_full_class_materialization``.
+
+    One image, two queries, one target: query 0's box exactly equals the target box (cost_bbox=0,
+    cost_giou=-1, the minimum possible), query 1's box is far away. Both queries share identical
+    logits, so cost_class is equal for both — bbox/giou alone decide the winner.
+
+    >>> import torch
+    >>> from rfdetr.models.matcher import HungarianMatcher
+    >>> matcher = HungarianMatcher()
+    >>> target_box = [0.5, 0.5, 0.2, 0.2]
+    >>> outputs = {
+    ...     "pred_logits": torch.zeros(1, 2, 3),
+    ...     "pred_boxes": torch.tensor([[target_box, [0.05, 0.05, 0.05, 0.05]]]),
+    ... }
+    >>> targets = [{"labels": torch.tensor([0]), "boxes": torch.tensor([target_box])}]
+    >>> indices = _reference_indices_pre_diagonal_extraction(matcher, outputs, targets)
+    >>> [(q.tolist(), t.tolist()) for q, t in indices]
+    [([0], [0])]
     """
     from scipy.optimize import linear_sum_assignment
 
@@ -677,7 +694,21 @@ def _new_extraction_indices(
     """Mirrors the post-PR extraction in ``matcher.py`` (``target_offsets`` + ``torch.cat``), decoupled from cost
     computation so it can be property-tested against arbitrary cost-matrix content — including whatever values the
     mask/keypoint cost terms (``matcher.py:266-277``, untouched by this PR) would fold in, without duplicating those
-    formulas here."""
+    formulas here.
+
+    Two images, two queries each, one target each: image 0's own column (0) is cheapest at query 1
+    (cost 1.0); image 1's own column (1) is cheapest at query 0 (cost 2.0). The other column in each
+    row belongs to the other image and must be ignored.
+
+    >>> import torch
+    >>> cost_matrix = torch.tensor([
+    ...     [[5.0, 100.0], [1.0, 100.0]],
+    ...     [[50.0, 2.0], [60.0, 9.0]],
+    ... ])
+    >>> indices = _new_extraction_indices(cost_matrix, sizes=[1, 1])
+    >>> [(q.tolist(), t.tolist()) for q, t in indices]
+    [([1], [0]), ([0], [0])]
+    """
     from scipy.optimize import linear_sum_assignment
 
     bs, num_queries = cost_matrix.shape[:2]
@@ -708,7 +739,19 @@ def _new_extraction_indices(
 def _old_extraction_indices(
     cost_matrix: torch.Tensor, sizes: list[int], group_detr: int = 1
 ) -> list[tuple[torch.Tensor, torch.Tensor]]:
-    """Mirrors the pre-PR extraction (``cost_matrix.split(sizes, -1)`` + ``c[i]``)."""
+    """Mirrors the pre-PR extraction (``cost_matrix.split(sizes, -1)`` + ``c[i]``).
+
+    Same hand-computed case as ``_new_extraction_indices`` — output must match it exactly.
+
+    >>> import torch
+    >>> cost_matrix = torch.tensor([
+    ...     [[5.0, 100.0], [1.0, 100.0]],
+    ...     [[50.0, 2.0], [60.0, 9.0]],
+    ... ])
+    >>> indices = _old_extraction_indices(cost_matrix, sizes=[1, 1])
+    >>> [(q.tolist(), t.tolist()) for q, t in indices]
+    [([1], [0]), ([0], [0])]
+    """
     from scipy.optimize import linear_sum_assignment
 
     bs, num_queries = cost_matrix.shape[:2]


### PR DESCRIPTION
## What does this PR do?

`HungarianMatcher.forward` copies the full `[batch, num_queries, total_targets]` cost matrix to CPU before calling `linear_sum_assignment`, then splits it per image and keeps only `c[i]`, the diagonal block for that image's own targets. Every column that belongs to another image in the batch gets copied to host and thrown away right after.

This PR extracts the diagonal blocks on-device first (using the cumulative `target_offsets` of each image's target count), and copies only the compact `[num_queries, total_targets]` matrix to CPU instead of the full `[batch, num_queries, total_targets]` one. So the host transfer drops by exactly the batch size on the normal (finite) path. The non-finite path is a bit different: `isfinite` gets checked on-device before any transfer, and if any cost is NaN/Inf the code still falls back to copying the *full* matrix to CPU and running the existing `_sanitize_cost_matrix`, same as before, that part I didn't touch. The diagonal-block extraction that runs afterwards (`target_offsets` + `torch.cat`, replacing the old `cost_matrix.split(sizes, -1)` + `c[i]`) is new code, but it's shared by both branches now instead of duplicated on each side of the `if`. So it doesn't add a new asymmetry between the finite and non-finite paths, it's just relocated.

Measured on real COCO batches, A100-SXM4-40GB, PyTorch 2.9.1+cu128, `RFDETRSmall` at 512 / `RFDETRSegSmall` at 384, batch 16, median of 31 interleaved repeats with warmup (ranges are min–max):

| flow, batch 16 | targets | before | after | change |
| --- | ---: | ---: | ---: | ---: |
| detection, COCO batch 0 | 111 | 45.321 ms (44.386–47.676) | 24.508 ms (24.199–27.420) | **45.9%** |
| detection, COCO batch 2 | 129 | 51.785 ms (50.610–53.274) | 27.750 ms (27.400–28.729) | **46.4%** |
| detection, COCO batch 233 | 205 | 74.014 ms (73.769–74.410) | 40.714 ms (40.528–41.259) | **45.0%** |
| segmentation, COCO batch 0 | 111 | 16.802 ms (16.120–18.512) | 13.853 ms (13.536–16.067) | 17.5% |

The criterion calls the matcher four times per step, so the effect adds up: full criterion on COCO batch 2, 31 reps, goes from 227.711 ms (225.719–234.298) to 129.176 ms (127.482–139.981), 43.3%. `forward + criterion + backward` (no `optimizer.step`), same batch, 9 reps, goes from 391.457 ms (386.566–399.230) to 289.659 ms (288.120–294.566), 26.0%.

CPU-only control (single thread, 11 reps) shows no clear regression, medians moved -0.7%, -9.5% and -3.2% for batches 1/4/16, but the ranges overlap so I'm not calling that an improvement either, just no regression.

**Related Issue(s):** none, this is a candidate I found while profiling the matcher, not a reported bug.

## Type of Change

- Performance improvement (no behaviour change)

## Testing

- During development I ran an ad hoc script (not part of this PR) comparing assignment indices before/after across 10 seeds for both detection and segmentation batches (1/4/16): bit-for-bit identical. That script isn't committed, so it's not independently re-runnable from this diff alone, see the two bullets below for what *is* committed and re-runnable.
- Added `TestDiagonalBlockExtraction` in `tests/models/test_matcher.py`, comparing the new `target_offsets` extraction against a reference that reproduces the previous `cost_matrix.split(sizes, -1)` + `c[i]` extraction, through the real `matcher.forward` on detection-shaped costs. Covers heterogeneous target counts with a zero-target image in the middle of the batch, `group_detr > 1`, and the degenerate case where every image in the batch has zero targets (all three cases assert equality against the reference, not just that the output is empty/well-shaped).
- Added `TestDiagonalExtractionContentAgnostic`, which isolates the extraction step from cost computation and property-tests the old and new extraction algorithms directly against 15 arbitrary cost tensors (5 seeds × `group_detr` in {1, 2, 3}). The mask (`cost_mask_ce`/`cost_mask_dice`) and keypoint (`cost_l1`/`cost_findable`/`cost_visible`/`cost_nll`) cost terms get summed into the same `cost_matrix` before this extraction runs (`matcher.py:266-277`, untouched by this PR), and the extraction has no notion of where its input came from. So this ends up being the committed regression test for segmentation and keypoint batches too, without re-deriving their cost formulas here.
- Exceptional paths (an injected NaN, and the whole cost matrix turned non-finite) still produce identical indices, these are the pre-existing `TestHungarianMatcherNonFiniteCosts`/`TestHungarianMatcherSanitization` tests, which exercise the shared extraction step end-to-end and still pass unmodified.
- The 17 criterion losses have identical bytes before/after, and gradients with respect to every captured model output have the same SHA-256 in both versions, checked with an ad hoc script during development (not committed, same caveat as above; both claims follow from the assignment-index equivalence above plus the fact that `criterion.py` is untouched). I couldn't verify bit-identity for every parameter gradient of the full model though, the CUDA baseline is not deterministic against itself (`grid_sampler_2d_backward_cuda` has no deterministic implementation in PyTorch), so that comparison stops at the boundary that matters here (criterion gradients w.r.t. outputs), not beyond it.
- CUDA peak memory is unchanged: the temporary cost matrices dominate the peak either way. The win is transfer time and volume, not VRAM.
- `tests/models/test_matcher.py` passes in full: 35 passed (17 existing + 3 new in `TestDiagonalBlockExtraction` + 15 new in `TestDiagonalExtractionContentAgnostic`).
- `ruff check` and `ruff format` are clean on the touched files, `mypy` finds no issues in `matcher.py`.

I didn't touch anything else, `HungarianMatcher` is only used from `criterion.py`, and there's no second copy of this splitting logic elsewhere in the codebase (unlike the `postprocess.py` case in #1265/#1268, which had a twin in `export/benchmark.py`).
