### PR TITLE
perf(postprocess): skip redundant CUDA presence checks in keypoint decode

### DIFF
--- a/src/rfdetr/models/postprocess.py
+++ b/src/rfdetr/models/postprocess.py
@@ -401,14 +401,18 @@ class PostProcess(nn.Module):
         # Iterate over the (small) set of keypoint classes rather than per detection.
         # Avoids `num_select` GPU->CPU stream syncs from `.item()`; loop bound is
         # `num_keypoint_classes` (typically 1-20) instead of `num_select` (up to 300).
+        # Read the static schema before checking a device mask: zero-keypoint classes
+        # need no work, and evaluating `class_mask.any()` would synchronize CUDA. A
+        # one-class schema also needs no per-class check: the global valid-class guard
+        # above guarantees the selected group is non-empty.
         for class_idx in range(num_keypoint_classes):
-            class_mask = selected_labels == class_idx
-            if not class_mask.any():
-                continue
             num_active_keypoints = self.num_keypoints_per_class[class_idx]
             if num_active_keypoints <= 0:
                 continue
 
+            class_mask = selected_labels == class_idx
+            if num_keypoint_classes > 1 and not class_mask.any():
+                continue
             out_idx = valid_indices[class_mask]
             active_keypoints = selected_keypoints[class_mask, :num_active_keypoints]
             output_keypoints[out_idx, :num_active_keypoints, 0] = active_keypoints[..., 0] * img_w
@@ -451,16 +455,18 @@ class PostProcess(nn.Module):
         # stream sync) and a final `torch.stack` over a Python list. Grouping by
         # class lets us call `_keypoint_log_mean_trace` once on a batched tensor
         # whose `num_active_keypoints` is constant within the class.
+        # As above, skip zero-keypoint classes from static schema metadata and avoid
+        # checking the only class of a one-class schema through a Python condition.
         for class_idx in range(num_keypoint_classes):
-            class_mask = selected_labels == class_idx
-            if not class_mask.any():
-                continue
             num_active_keypoints = self.num_keypoints_per_class[class_idx]
             if num_active_keypoints <= 0:
                 # Defaults to 0.0 from `new_zeros` above — matches the legacy
                 # per-detection branch that appended a 0 tensor.
                 continue
 
+            class_mask = selected_labels == class_idx
+            if num_keypoint_classes > 1 and not class_mask.any():
+                continue
             active_keypoints = selected_keypoints[class_mask, :num_active_keypoints]
             log_mean_traces[class_mask] = self._keypoint_log_mean_trace(active_keypoints)
 

--- a/tests/models/test_postprocess_keypoints.py
+++ b/tests/models/test_postprocess_keypoints.py
@@ -26,10 +26,9 @@ def test_static_keypoint_schema_avoids_redundant_device_presence_checks(
 ) -> None:
     """Zero-keypoint slots and a lone valid class must not trigger scalar tensor reads.
 
-    The remaining reads are one global valid-class guard plus one presence guard in
-    each of the decode and trace-fusion loops for every active class in a multi-class
-    schema. Calling ``Tensor.__bool__`` on the scalar returned by ``class_mask.any()``
-    synchronizes CUDA, so the count must depend on active rather than padded classes.
+    The remaining reads are one global valid-class guard plus one presence guard in each of the decode and trace-fusion
+    loops for every active class in a multi-class schema. Calling ``Tensor.__bool__`` on the scalar returned by
+    ``class_mask.any()`` synchronizes CUDA, so the count must depend on active rather than padded classes.
     """
     num_classes = len(schema)
     max_keypoints = max(schema)
@@ -58,11 +57,11 @@ def test_static_keypoint_schema_avoids_redundant_device_presence_checks(
 def test_static_keypoint_schema_skips_absent_active_class_without_stale_output() -> None:
     """An active keypoint class fully absent from an image's detections must still decode to zeros.
 
-    The parametrized test above always builds ``pred_logits`` with ``arange``, which picks the single
-    active class every time, so it never exercises the ``class_mask.any()`` branch actually returning
-    ``False`` for a present-in-schema class. This drives the real checkpoint schema ``[0, 17]`` with
-    every detection classified as the zero-keypoint background class, so the active class (1) has zero
-    matches and the presence check must still run once per loop and correctly skip.
+    The parametrized test above always builds ``pred_logits`` with ``arange``, which picks the single active class every
+    time, so it never exercises the ``class_mask.any()`` branch actually returning ``False`` for a present-in-schema
+    class. This drives the real checkpoint schema ``[0, 17]`` with every detection classified as the zero-keypoint
+    background class, so the active class (1) has zero matches and the presence check must still run once per loop and
+    correctly skip.
     """
     postprocess = PostProcess(num_select=2, num_keypoints_per_class=[0, 17])
     outputs = {

--- a/tests/models/test_postprocess_keypoints.py
+++ b/tests/models/test_postprocess_keypoints.py
@@ -5,10 +5,87 @@
 # ------------------------------------------------------------------------
 """Unit tests for keypoint decoding in PostProcess."""
 
+from unittest.mock import patch
+
 import pytest
 import torch
 
 from rfdetr.models.postprocess import PostProcess
+
+
+@pytest.mark.parametrize(
+    ("schema", "expected_scalar_reads"),
+    [
+        pytest.param([17], 1, id="single-active-class"),
+        pytest.param([0, 17], 3, id="legacy-background-first"),
+        pytest.param([0, 3, 0, 5], 5, id="mixed-detection-and-keypoint-classes"),
+    ],
+)
+def test_static_keypoint_schema_avoids_redundant_device_presence_checks(
+    schema: list[int], expected_scalar_reads: int
+) -> None:
+    """Zero-keypoint slots and a lone valid class must not trigger scalar tensor reads.
+
+    The remaining reads are one global valid-class guard plus one presence guard in
+    each of the decode and trace-fusion loops for every active class in a multi-class
+    schema. Calling ``Tensor.__bool__`` on the scalar returned by ``class_mask.any()``
+    synchronizes CUDA, so the count must depend on active rather than padded classes.
+    """
+    num_classes = len(schema)
+    max_keypoints = max(schema)
+    postprocess = PostProcess(num_select=num_classes, num_keypoints_per_class=schema)
+    outputs = {
+        "pred_logits": torch.arange(num_classes, dtype=torch.float32).view(1, 1, num_classes),
+        "pred_boxes": torch.full((1, 1, 4), 0.5),
+        "pred_keypoints": torch.randn(1, 1, num_classes * max_keypoints, 8),
+    }
+    target_sizes = torch.tensor([[100, 200]])
+    original_bool = torch.Tensor.__bool__
+    scalar_reads = 0
+
+    def counting_bool(tensor: torch.Tensor) -> bool:
+        nonlocal scalar_reads
+        scalar_reads += 1
+        return original_bool(tensor)
+
+    with patch.object(torch.Tensor, "__bool__", counting_bool):
+        results = postprocess(outputs, target_sizes)
+
+    assert scalar_reads == expected_scalar_reads
+    assert results[0]["keypoints"].shape == (num_classes, max_keypoints, 3)
+
+
+def test_static_keypoint_schema_skips_absent_active_class_without_stale_output() -> None:
+    """An active keypoint class fully absent from an image's detections must still decode to zeros.
+
+    The parametrized test above always builds ``pred_logits`` with ``arange``, which picks the single
+    active class every time, so it never exercises the ``class_mask.any()`` branch actually returning
+    ``False`` for a present-in-schema class. This drives the real checkpoint schema ``[0, 17]`` with
+    every detection classified as the zero-keypoint background class, so the active class (1) has zero
+    matches and the presence check must still run once per loop and correctly skip.
+    """
+    postprocess = PostProcess(num_select=2, num_keypoints_per_class=[0, 17])
+    outputs = {
+        "pred_logits": torch.tensor([[[10.0, -10.0], [10.0, -10.0]]], dtype=torch.float32),
+        "pred_boxes": torch.full((1, 2, 4), 0.5),
+        "pred_keypoints": torch.randn(1, 2, 34, 8),
+    }
+    target_sizes = torch.tensor([[100, 200]])
+    original_bool = torch.Tensor.__bool__
+    scalar_reads = 0
+
+    def counting_bool(tensor: torch.Tensor) -> bool:
+        nonlocal scalar_reads
+        scalar_reads += 1
+        return original_bool(tensor)
+
+    with patch.object(torch.Tensor, "__bool__", counting_bool):
+        results = postprocess(outputs, target_sizes)
+
+    assert scalar_reads == 3
+    keypoints = results[0]["keypoints"]
+    assert keypoints.shape == (2, 17, 3)
+    assert torch.equal(keypoints, torch.zeros_like(keypoints))
 
 
 def test_postprocess_keypoints_shape_and_scores() -> None:


### PR DESCRIPTION
## What does this PR do?

Both keypoint-decode loops in `PostProcess` build `class_mask = selected_labels == class_idx` and check `class_mask.any()` before looking at how many keypoints that class actually has. `.any()` followed by the Python bool conversion is a GPU→CPU stream sync, and for a class with zero keypoints it runs for nothing — the `num_active_keypoints <= 0` guard right after throws the result away anyway. The official published `RFDETRKeypointPreview` XLarge checkpoint loads the schema `[0, 17]` (class 0 has no keypoints, class 1 is the 17-keypoint person class), so this useless sync happens on every image in production. A one-class schema has the same problem from the other side: the global valid-class guard above the loop already guarantees the selected group is non-empty, so the per-class presence check is redundant there too.

The fix reads `num_active_keypoints` from the static per-class schema first and skips zero-keypoint classes before `class_mask` ever gets built, and only evaluates `class_mask.any()` when the schema has more than one class. The presence check still runs for every active class in a genuine multi-class schema. It's only the classes that never have keypoints, or don't need the check, that skip it now.

This guard came in with `e072f53f` (Borda, "fix(keypoints): remap gate + vectorize inference hot paths"), which replaced up to 300 `.item()` calls per image (one per detection) with this class-grouped loop — a much bigger win, documented there as 15-60 ms/image. What this PR fixes is a small leftover of that optimisation, not a reversal of it. It stayed hidden behind a much larger saving, the CPU functional tests check results rather than how many CUDA scalar reads happen, and `#1160` changed the keypoint *default* from `[0,17]` to `[17]`.. but the already-published checkpoint still ships `[0,17]`, so the redundant zero-class slot is still live with the real weights people download.

Searched PRs/issues for `class_mask.any`, `zero-keypoint`, `keypoint GPU sync`: no results. `#1160` changed the default but didn't touch these guards; `#1268` optimised box/mask/keypoint gathers with `expand()`/`index_select`, which is CPU/allocation work and doesn't touch these CUDA guards. No other spot in the codebase has this same pattern either.

**Related Issue(s):** none, found while profiling the keypoint postprocess path.

## Type of Change

- Performance improvement (no behaviour change)

## Testing

Measured on the official checkpoint, `rf-detr-keypoint-preview-xlarge.pth` (SHA-256 `2b70ddf5...`), A100-SXM4-40GB, PyTorch 2.9.1+cu128, real COCO val2017 images at 576 resolution, warmup + alternating baseline/candidate order + CUDA sync before and after, median and range:

| scope | batch | rounds | baseline | candidate | change |
| --- | ---: | ---: | ---: | ---: | ---: |
| postprocess on fixed official outputs | 1 | 301 | 1.980814 ms (1.936399–2.097695) | 1.900042 ms (1.858733–1.993522) | **4.08%** |
| postprocess on fixed official outputs | 8 | 301 | 12.156625 ms (12.074282–12.649434) | 11.483703 ms (11.393517–12.511209) | **5.54%** |
| forward XLarge + postprocess, run 1 | 8 | 61 | 68.723124 ms (68.328967–76.782766) | 68.121369 ms (67.655122–78.033078) | 0.88% |
| forward XLarge + postprocess, run 2 | 8 | 61 | 68.226184 ms (67.652623–78.246585) | 67.658077 ms (67.079022–72.325110) | 0.83% |

Batch-8 end-to-end (forward + postprocess) showed 0.83-0.88% across two independent processes, but I'm not claiming that number as signal. Each run's own min-max range (8.3-10.6 ms) is more than 10x wider than the 0.6 ms delta between medians, and run 1's candidate max (78.03 ms) is above run 1's baseline max (76.78 ms). Two runs landing close by chance is possible at that noise level, and I didn't keep per-round paired samples or compute a confidence interval. So there's nothing here I can defend as a real end-to-end win, only the isolated-postprocess numbers below, where the delta is comparable to or larger than the spread. Batch 1 end-to-end showed 0.45% with the same overlap problem, so neither end-to-end row is a claim, just a number I'm logging.

Every benchmark hashes `pred_logits`/`pred_boxes`/`pred_keypoints`/boxes/labels/scores/keypoints/Cholesky precision byte-for-byte, baseline-against-itself and candidate-against-baseline — exact on all four runs above. On top of that, 160 GPU cases (float32/float64/float16/bfloat16 x 8 layouts x 5 seeds) and 80 CPU cases (float32/float64) all came back exact.

I tried removing every `class_mask.any()` and letting the empty-tensor ops be no-ops. Bit-identical, but a lot slower once an active class is genuinely absent: 26.98% slower on the legacy `[0,17]` schema with the active class missing, 207.20% slower with 20 active classes and only one present — launching kernels on empty tensors inside a loop that can run up to 20 times gets expensive. So the final version keeps the guard for real multi-class scenarios and only drops what's actually redundant.

`test_static_keypoint_schema_avoids_redundant_device_presence_checks` (new, parametrised over three schemas: single-class `[17]`, legacy `[0,17]`, mixed `[0,3,0,5]`) patches `torch.Tensor.__bool__` to count the scalar bool conversions that would synchronize CUDA on a device tensor — the same technique already used in this repo's `tests/evaluation/test_evaluation.py::test_does_not_sync_a_tensor_per_class`, on CPU tensors, without a `gpu` marker, since the read count doesn't depend on device. On `develop` it fails with 3/5/9 reads against 1/3/5 expected; with the fix it passes. That parametrised test always resolves the highest-logit class, so it never exercises `class_mask.any()` actually returning `False` for a class present in the schema. `test_static_keypoint_schema_skips_absent_active_class_without_stale_output` (new) covers that case on the real `[0,17]` schema — every detection forced to the zero-keypoint class, so the active class is fully absent. It asserts both the read count (3) and that the output stays exactly zero. On `develop` this second test fails (5 reads instead of 3); it doesn't fail on correctness because the pre-fix code already zeroed correctly, it was just wasting a sync to get there.

Full `test_postprocess_keypoints.py`: 13 passed (12 before this round of review plus the new absent-active-class test). Both new regression tests fail on unpatched `develop` (3/5/9 reads instead of 1/3/5; 5 instead of 3) and pass with the fix — confirmed by reverting just `postprocess.py` and re-running each in isolation. `ruff check`/`ruff format` clean, `mypy` clean on both touched files. `tests/models` on the patched tree (`PYTHONPATH=src`, matching the src-layout package so the suite actually exercises this tree instead of the pip-installed `rfdetr` release): 639 passed, 1 deselected (`-m "not gpu"`), 0 failed, 0 errors. An earlier local run without `PYTHONPATH=src` silently fell back to the installed `rfdetr` package and produced 25 failed/9 errors that had nothing to do with this change or with missing dependencies — that number was wrong and I'm retracting it.

One thing I found but didn't chase here: the official checkpoint has no `num_queries`/`group_detr` metadata, and the loader warns that its fallback could change the group structure. I don't know yet if that's a real bug — keeping it as a separate lead, not mixing it into this PR. Also didn't check ONNX/TensorRT/ExecuTorch export or `torch.compile` on this path.
