### PR TITLE
fix: guard `ModelContext.reinitialize_detection_head` against cleared weights

### DIFF
--- a/src/rfdetr/inference.py
+++ b/src/rfdetr/inference.py
@@ -65,11 +65,12 @@ class ModelContext:
             num_classes: New number of output classes (including background).
 
         Raises:
-            RuntimeError: If the model weights were already cleared by ``inference(inplace=True)``.
+            RuntimeError: If the model weights were already cleared by ``RFDETR.inference(inplace=True)``.
         """
         if self.model is None:
             raise RuntimeError(
-                "Cannot reinitialize the detection head after inference(inplace=True) cleared the model weights."
+                "Cannot reinitialize the detection head after inplace optimization. "
+                "The original model has been cleared. Create a new RFDETR instance."
             )
         reinitialize_head = cast("Callable[[int], None]", self.model.reinitialize_detection_head)
         reinitialize_head(num_classes)

--- a/src/rfdetr/inference.py
+++ b/src/rfdetr/inference.py
@@ -31,7 +31,9 @@ class ModelContext:
     ``populate_args()`` or the legacy stack.
 
     Args:
-        model: The underlying ``nn.Module`` (LWDETR instance).
+        model: The underlying ``LWDETR`` module. The attribute is cleared to ``None`` by
+            :meth:`RFDETR.inference` when called with ``inplace=True``, which frees the
+            weights from memory.
         postprocess: PostProcess instance for converting raw outputs to boxes.
         device: Device the model lives on.
         resolution: Input resolution (square side length in pixels).
@@ -41,14 +43,14 @@ class ModelContext:
 
     def __init__(
         self,
-        model: torch.nn.Module,
+        model: LWDETR,
         postprocess: PostProcess,
         device: torch.device,
         resolution: int,
         args: Any,
         class_names: list[str] | None = None,
     ) -> None:
-        self.model = model
+        self.model: LWDETR | None = model
         self.postprocess = postprocess
         self.device = device
         self.resolution = resolution
@@ -61,7 +63,14 @@ class ModelContext:
 
         Args:
             num_classes: New number of output classes (including background).
+
+        Raises:
+            RuntimeError: If the model weights were already cleared by ``inference(inplace=True)``.
         """
+        if self.model is None:
+            raise RuntimeError(
+                "Cannot reinitialize the detection head after inference(inplace=True) cleared the model weights."
+            )
         reinitialize_head = cast("Callable[[int], None]", self.model.reinitialize_detection_head)
         reinitialize_head(num_classes)
         self.args.num_classes = num_classes

--- a/tests/inference/test_model_inference.py
+++ b/tests/inference/test_model_inference.py
@@ -12,6 +12,7 @@ import pytest
 import torch
 
 from rfdetr.detr import RFDETR
+from rfdetr.inference import ModelContext
 
 
 class _FakeModel(torch.nn.Module):
@@ -546,3 +547,34 @@ class TestModelInferenceExceptionRecovery:
         assert rfdetr.model.model is original_model
         # The mutation happened and cannot be undone by RFDETR's recovery path
         assert mutated["happened"] is True
+
+
+class TestModelContextClearedWeights:
+    """``ModelContext`` rejects work needing the underlying module once ``inplace=True`` cleared it."""
+
+    @staticmethod
+    def _context() -> ModelContext:
+        """Build a ModelContext whose weights have already been cleared."""
+        context = ModelContext(
+            model=_FakeModel(),
+            postprocess=SimpleNamespace(),
+            device=torch.device("cpu"),
+            resolution=28,
+            args=SimpleNamespace(num_classes=2),
+        )
+        context.model = None
+        return context
+
+    def test_reinitialize_detection_head_raises_runtime_error(self) -> None:
+        """Reinitializing the head after the weights were cleared raises RuntimeError, not AttributeError."""
+        with pytest.raises(RuntimeError, match="cleared the model weights"):
+            self._context().reinitialize_detection_head(5)
+
+    def test_reinitialize_detection_head_leaves_num_classes_untouched(self) -> None:
+        """The guard fires before ``args.num_classes`` is mutated, so the context is not left half-updated."""
+        context = self._context()
+
+        with pytest.raises(RuntimeError):
+            context.reinitialize_detection_head(5)
+
+        assert context.args.num_classes == 2

--- a/tests/inference/test_model_inference.py
+++ b/tests/inference/test_model_inference.py
@@ -567,7 +567,7 @@ class TestModelContextClearedWeights:
 
     def test_reinitialize_detection_head_raises_runtime_error(self) -> None:
         """Reinitializing the head after the weights were cleared raises RuntimeError, not AttributeError."""
-        with pytest.raises(RuntimeError, match="cleared the model weights"):
+        with pytest.raises(RuntimeError, match="Cannot reinitialize the detection head"):
             self._context().reinitialize_detection_head(5)
 
     def test_reinitialize_detection_head_leaves_num_classes_untouched(self) -> None:


### PR DESCRIPTION
## Description

Found while working through #564. Standalone fix, no typing config changes here.

`ModelContext.model` is declared `torch.nn.Module`, and it is neither of those things.

**It is an `LWDETR`.** `inference.py` asserts `isinstance(nn_model, LWDETR)` immediately before the only construction site, and the class docstring already called it an LWDETR instance. Only the declaration stayed loose.

**It is also optional.** `RFDETR.inference(inplace=True)` sets it to `None` to free the weights, and three methods already raise `RuntimeError` when they find it `None`:

- `evaluate()`, detr.py:1062: `"Cannot evaluate: the base model has been cleared by a previous inplace optimization."`
- `export()`, detr.py:1571
- `deploy_to_roboflow()`, detr.py:2540

`reinitialize_detection_head()` is the one that reaches through `self.model` without that check, so calling it after an inplace optimization fails with:

```
AttributeError: 'NoneType' object has no attribute 'reinitialize_detection_head'
```

It now raises `RuntimeError` in the same style as the three existing checks. The guard runs before `args.num_classes` is assigned, so a rejected call cannot leave the context half updated.

Declaring the attribute `LWDETR | None` makes the type say what the code has always done.

## Changes

- `src/rfdetr/inference.py`: declare `ModelContext.model` as `LWDETR | None`, narrow the constructor parameter to `LWDETR`, guard `reinitialize_detection_head`, update the docstring
- `tests/inference/test_model_inference.py`: cover the guard

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Narrowing the constructor parameter from `nn.Module` to `LWDETR` is a type-level tightening only. It matches the `isinstance` assert that already runs on the sole construction path, and nothing in the package passes anything else.

## Testing

`ModelContext.reinitialize_detection_head` had no coverage before this PR. It has no in-package callers, and every existing test matching that method name targets `LWDETR.reinitialize_detection_head` or `RFDETRModule.reinitialize_detection_head` instead, which are different methods.

I checked the two new tests are not vacuous: with the guard removed, both fail on the original `AttributeError`, which is the failure the guard replaces.

- `python -m mypy src/rfdetr/ --no-error-summary` exits 0
- `pre-commit run --all-files` passes, all 19 hooks
- Full CPU suite matching `ci-tests-cpu.yml`: 3301 passed, 59 skipped, 0 failed

## Notes

This also unblocks `rfdetr.detr` for #564. Three of its five strict errors come from this declaration, and with it corrected the rest is a one-line re-export plus two `pyproject.toml` lines. I kept that in a separate PR so this one can be judged as the fix it is. Happy to open it once this lands.
