### PR TITLE
fix(eval): log EMA validation metrics under `eval_ema_only` when the base metric is empty

### DIFF
--- a/docs/learn/train/training-parameters.md
+++ b/docs/learn/train/training-parameters.md
@@ -109,9 +109,9 @@ For example, `RFDETRSegXLarge` uses `624x624`, which is valid because `624` is d
 
 ## EMA (Exponential Moving Average)
 
-| Parameter       | Type   | Default | Description                                                                                                                                                                                                                              |
-| --------------- | ------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `use_ema`       | `bool` | `True`  | Enables Exponential Moving Average of weights. Produces a smoothed checkpoint that often improves final performance.                                                                                                                     |
+| Parameter       | Type   | Default | Description                                                                                                                                                                                                                                                                                                            |
+| --------------- | ------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `use_ema`       | `bool` | `True`  | Enables Exponential Moving Average of weights. Produces a smoothed checkpoint that often improves final performance.                                                                                                                                                                                                   |
 | `eval_ema_only` | `bool` | `False` | Validation-only: forward through the EMA model instead of the base model, halving per-batch validation compute. Requires `use_ema=True`. The base model is never evaluated that epoch, so `val/mAP_*` stays unpopulated; the real per-epoch score is logged under `val/ema_mAP_*` instead — see Evaluation Parameters. |
 
 !!! info "What is EMA?"

--- a/docs/learn/train/training-parameters.md
+++ b/docs/learn/train/training-parameters.md
@@ -112,7 +112,7 @@ For example, `RFDETRSegXLarge` uses `624x624`, which is valid because `624` is d
 | Parameter       | Type   | Default | Description                                                                                                                                                                                                                              |
 | --------------- | ------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `use_ema`       | `bool` | `True`  | Enables Exponential Moving Average of weights. Produces a smoothed checkpoint that often improves final performance.                                                                                                                     |
-| `eval_ema_only` | `bool` | `False` | Validation-only: forward through the EMA model instead of the base model, halving per-batch validation compute. Requires `use_ema=True`. `val/mAP_*` then reports EMA-model quality, not base-model quality — see Evaluation Parameters. |
+| `eval_ema_only` | `bool` | `False` | Validation-only: forward through the EMA model instead of the base model, halving per-batch validation compute. Requires `use_ema=True`. The base model is never evaluated that epoch, so `val/mAP_*` stays unpopulated; the real per-epoch score is logged under `val/ema_mAP_*` instead — see Evaluation Parameters. |
 
 !!! info "What is EMA?"
 

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -1065,12 +1065,16 @@ class TrainConfig(BaseConfig):
     # Validation-only: forward through the EMA model instead of the base model, and skip the
     # duplicate base-model forward pass COCOEvalCallback would otherwise also run — halves
     # per-batch validation compute when EMA is enabled. Requires use_ema=True.
-    # Metric-key remap: when active, val/mAP_50_95 (and val/segm_mAP_*) report EMA-model
-    # quality, not base-model quality — the base model is never evaluated this epoch. Best-
-    # checkpoint tracking follows: the "regular" checkpoint track sees no data (safely no-ops)
-    # while the EMA checkpoint track receives the real per-epoch EMA score. val/F1 is not
-    # remapped (no parallel EMA-tracked accumulator) and still reflects EMA-quality predictions
-    # under the regular key.
+    # Metric-key routing: when active, val/mAP_50_95 (and val/segm_mAP_*) stay unpopulated —
+    # the base model is never evaluated this epoch, so there is nothing real to report under
+    # that key. The real per-epoch score is logged under val/ema_mAP_50_95 (and
+    # val/ema_segm_mAP_*) instead (see COCOEvalCallback._compute_and_log_ema_metrics). Best-
+    # checkpoint tracking follows: the "regular" checkpoint track sees no data this epoch
+    # (safely no-ops, see BestModelCallback) while the EMA checkpoint track (monitor_ema) can
+    # be pointed at val/ema_mAP_50_95 to receive it. val/F1 is not remapped (no parallel
+    # EMA-tracked accumulator) and still reflects EMA-quality predictions under the regular key.
+    # Per-class AP follows the mAP routing: logged under val/ema_AP/<class> instead of
+    # val/AP/<class>, and the printed per-epoch summary table is titled "val (ema)".
     eval_ema_only: bool = False
     num_workers: int = 2
     weight_decay: float = 1e-4

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -47,8 +47,10 @@ class BestModelCallback(ModelCheckpoint):
     ``checkpoint_best_ema.pth`` (backfilled with the final EMA weights if the EMA metric never improved) and
     ``last_ema.pth`` (final EMA weights, mirroring ``last.pth`` for the live model).
 
-    Checkpoints are only updated on validation epochs where the monitor metric is actually logged.  On non-eval epochs
-    (when ``eval_interval > 1`` causes COCO evaluation to be skipped) the callback is a no-op.
+    Each track only updates when its own monitor key is actually logged that epoch, and the two tracks are
+    checked independently.  On non-eval epochs (``eval_interval > 1`` skips COCO eval entirely) both keys are
+    absent and the callback is a full no-op.  Under ``eval_ema_only`` (see ``TrainConfig.eval_ema_only``),
+    ``monitor_regular`` is never populated, so only the EMA track ever updates.
 
     ``state_dict()`` and ``load_state_dict()`` are overridden to persist ``_best_ema`` in the Lightning callback state,
     ensuring that ``trainer.fit(ckpt_path=...)`` resumes EMA high-water-mark tracking from the correct value.
@@ -473,38 +475,41 @@ class BestModelCallback(ModelCheckpoint):
             self._smoothed_regular = self._smooth_alpha * self._smoothed_regular + (1.0 - self._smooth_alpha) * raw
         if trainer.current_epoch < self._skip_best_epochs:
             return
-        # Guard: only run checkpoint logic when the monitored metric was actually
-        # logged this epoch (non-eval epochs with eval_interval > 1 skip COCO eval
-        # so the key is absent from callback_metrics).
-        if self.monitor not in trainer.callback_metrics:
-            return
-        # Optional EMA smoothing of the monitored metric before the parent's improvement
-        # check.  The smoothed value is substituted into ``trainer.callback_metrics`` for
-        # the duration of the super() call only; the original raw tensor is always
-        # restored in the ``finally`` block so what gets logged to ``metrics.csv`` and
-        # seen by other callbacks (including EMA tracking below) is unaffected.
-        if self._smooth_alpha > 0.0:
-            # raw was captured in the accumulator update above; smooth_alpha > 0 and monitor
-            # in callback_metrics are both guaranteed here (passed the guard above).
-            current_raw: float = raw if raw is not None else trainer.callback_metrics[self.monitor].item()
-            prev_best_score = self.best_model_score.item() if self.best_model_score is not None else -float("inf")
-            original = trainer.callback_metrics[self.monitor]
-            trainer.callback_metrics[self.monitor] = torch.tensor(
-                self._smoothed_regular, dtype=original.dtype, device=original.device
-            )
-            try:
+        # Guard: only run the REGULAR checkpoint logic when the monitored metric was
+        # actually logged this epoch (non-eval epochs with eval_interval > 1 skip COCO
+        # eval so the key is absent; so does every epoch under `eval_ema_only`, which
+        # routes the epoch's only score to `monitor_ema` instead — see config.py's
+        # `eval_ema_only` docstring). This must NOT also skip the EMA block below: under
+        # `eval_ema_only` that block is the only checkpoint tracking that ever runs (#1285).
+        if self.monitor in trainer.callback_metrics:
+            # Optional EMA smoothing of the monitored metric before the parent's improvement
+            # check.  The smoothed value is substituted into ``trainer.callback_metrics`` for
+            # the duration of the super() call only; the original raw tensor is always
+            # restored in the ``finally`` block so what gets logged to ``metrics.csv`` and
+            # seen by other callbacks (including EMA tracking below) is unaffected.
+            if self._smooth_alpha > 0.0:
+                # raw was captured in the accumulator update above; smooth_alpha > 0 and
+                # monitor in callback_metrics are both guaranteed here (passed the `if` above).
+                current_raw: float = raw if raw is not None else trainer.callback_metrics[self.monitor].item()
+                prev_best_score = self.best_model_score.item() if self.best_model_score is not None else -float("inf")
+                original = trainer.callback_metrics[self.monitor]
+                trainer.callback_metrics[self.monitor] = torch.tensor(
+                    self._smoothed_regular, dtype=original.dtype, device=original.device
+                )
+                try:
+                    super().on_validation_end(trainer, pl_module)
+                finally:
+                    trainer.callback_metrics[self.monitor] = original
+                # Record the raw metric value when parent selected a new best so on_fit_end
+                # compares raw EMA vs raw regular (not raw EMA vs smoothed regular).
+                new_best_score = self.best_model_score.item() if self.best_model_score is not None else -float("inf")
+                if new_best_score > prev_best_score:
+                    self._best_raw_regular = current_raw
+            else:
                 super().on_validation_end(trainer, pl_module)
-            finally:
-                trainer.callback_metrics[self.monitor] = original
-            # Record the raw metric value when parent selected a new best so on_fit_end
-            # compares raw EMA vs raw regular (not raw EMA vs smoothed regular).
-            new_best_score = self.best_model_score.item() if self.best_model_score is not None else -float("inf")
-            if new_best_score > prev_best_score:
-                self._best_raw_regular = current_raw
-        else:
-            super().on_validation_end(trainer, pl_module)
 
-        # EMA model — custom tracking on top of parent.
+        # EMA model — custom tracking on top of parent. Independent of the regular-monitor
+        # guard above: under `eval_ema_only` this is the only track with data this epoch.
         if self._monitor_ema is None or not trainer.is_global_zero:
             return
         ema_val = trainer.callback_metrics.get(self._monitor_ema, torch.tensor(0.0)).item()

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -605,10 +605,12 @@ class COCOEvalCallback(Callback):
                 trainer.callback_metrics[f"{split}/ema_segm_mAP_50_95"] = ema_metrics["segm_map"].detach().cpu()
                 trainer.callback_metrics[f"{split}/ema_segm_mAP_50"] = ema_metrics["segm_map_50"].detach().cpu()
             self.map_metric_ema.reset()
+            self._ema_has_updates = False
         elif self.map_metric_ema is not None:
             # Not all ranks have EMA data this epoch (e.g. EMA not yet warmed up) → skip the
             # sync uniformly on every rank, but clear local state so the next epoch is clean.
             self.map_metric_ema.reset()
+            self._ema_has_updates = False
         return should_compute_ema, ema_metrics
 
     def _compute_and_log_f1_metrics(

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -548,71 +548,37 @@ class COCOEvalCallback(Callback):
     # Private helpers
     # ------------------------------------------------------------------
 
-    def _compute_and_log(self, trainer: Any, pl_module: Any, split: str, *, metric: Any | None = None) -> None:
-        """Shared epoch-end logic for validation and test evaluation loops.
+    def _compute_and_log_ema_metrics(
+        self, trainer: Any, pl_module: Any, split: str, pfx: str, mar_key: str
+    ) -> tuple[bool, dict[str, Any] | None]:
+        """Compute, log, and reset ``map_metric_ema`` if every rank agrees it has data this epoch.
 
-        Computes mAP (via ``self.map_metric``), runs the F1 confidence-threshold sweep, logs all scalar metrics via
-        ``pl_module.log``, prints two summary tables to the terminal, and resets internal accumulators.  When
-        ``self.map_metric_ema`` is set, EMA variants of all metrics (including ``ema_segm_mAP_50_95`` and
-        ``ema_segm_mAP_50`` for segmentation models) are logged under the same ``split/`` namespace.
+        Extracted out of :meth:`_compute_and_log` so its early-return branch (base ``metric`` empty)
+        can call it too — under ``eval_ema_only`` the base metric never accumulates updates (see
+        ``on_validation_batch_end``), so gating EMA logging on the base metric's own guard silently
+        drops the EMA metrics as well, leaving the epoch with no validation output at all (#1285).
+
+        The EMA ``compute()`` triggers a cross-rank metric sync, so it must be issued by EVERY rank
+        or none: a rank whose EMA metric is empty/absent would otherwise skip this collective and
+        desync the DDP collective sequence, deadlocking validation (#931 / #449).
+        ``_should_compute_ema`` makes the decision unanimous across ranks.
 
         Args:
             trainer: The PTL Trainer.
             pl_module: The LightningModule.
             split: Metric namespace — ``"val"`` or ``"test"``.
-            metric: Optional split-specific mAP accumulator. Defaults to the validation/test accumulator.
+            pfx: torchmetrics key prefix (``"bbox_"`` when ``iou_type`` is a list, else ``""``).
+            mar_key: Prefixed AR metric key for ``self._max_dets``.
+
+        Returns:
+            ``(should_compute_ema, ema_metrics)`` — whether the EMA metrics were actually computed
+            and logged this call (callers use this to decide whether the parallel EMA keypoint split
+            should also be logged or reset), and the raw ``compute()`` output when they were, else
+            ``None``. Callers that also need per-class EMA data (see ``_print_ema_only_summary``)
+            reuse this instead of calling ``compute()`` a second time.
         """
-        metric = self.map_metric if metric is None else metric
-        f1_local = self._f1_train_local if split == "train" else self._f1_local
-        if not self._metric_has_updates(metric):
-            metric.reset()
-            self._reset_f1_local(split)
-            self._reset_keypoint_split(split)
-            logger.debug("Skipping %s COCO metric compute because no predictions were accumulated.", split)
-            return
-
-        # Merge per-rank state across ranks ourselves (DDP-safe, fixed-shape gather) before the
-        # metric computes locally — replaces torchmetrics' deadlock-prone internal sync. No-op when
-        # not distributed. Called unconditionally on every rank, so the collectives stay symmetric.
-        self._merge_metric_state_across_ranks(metric)
-        metrics = self._compute_map_metric(trainer, metric)
-
-        # torchmetrics prefixes all keys when iou_type is a list (e.g. "bbox_map")
-        pfx = "bbox_" if self._use_segm_metrics else ""
-        mar_key = f"{pfx}mar_{self._max_dets}"
-
-        overall: dict[str, float] = {
-            "mAP 50:95": float(metrics[f"{pfx}map"]),
-            "mAP 50": float(metrics[f"{pfx}map_50"]),
-            "mAP 75": float(metrics[f"{pfx}map_75"]),
-            f"mAR @{self._max_dets}": float(metrics[mar_key]),
-        }
-
-        pl_module.log(
-            f"{split}/mAP_50_95", metrics[f"{pfx}map"], prog_bar=True, logger=True, on_step=False, on_epoch=True
-        )
-        pl_module.log(
-            f"{split}/mAP_50", metrics[f"{pfx}map_50"], prog_bar=True, logger=True, on_step=False, on_epoch=True
-        )
-        pl_module.log(f"{split}/mAP_75", metrics[f"{pfx}map_75"], logger=True, on_step=False, on_epoch=True)
-        pl_module.log(f"{split}/mAR", metrics[mar_key], logger=True, on_step=False, on_epoch=True)
-
-        # Write directly into callback_metrics so ModelCheckpoint / EarlyStopping
-        # read fresh values each epoch.  pl_module.log() from a callback's
-        # on_*_epoch_end goes only to logged_metrics (external loggers), not to
-        # callback_metrics, so checkpointing would see stale values otherwise.
-        trainer.callback_metrics[f"{split}/mAP_50_95"] = metrics[f"{pfx}map"].detach().cpu()
-        trainer.callback_metrics[f"{split}/mAP_50"] = metrics[f"{pfx}map_50"].detach().cpu()
-        trainer.callback_metrics[f"{split}/mAP_75"] = metrics[f"{pfx}map_75"].detach().cpu()
-        trainer.callback_metrics[f"{split}/mAR"] = metrics[mar_key].detach().cpu()
-
-        # EMA metrics — computed from a separate EMA forward pass accumulated in
-        # on_validation_batch_end, so base and EMA values are independent.  The EMA
-        # compute() triggers a cross-rank metric sync, so it must be issued by EVERY rank
-        # or none: a rank whose EMA metric is empty/absent would otherwise skip this
-        # collective and desync the DDP collective sequence, deadlocking validation
-        # (#931 / #449).  _should_compute_ema makes the decision unanimous across ranks.
         should_compute_ema = self._should_compute_ema(pl_module)
+        ema_metrics: dict[str, Any] | None = None
         if should_compute_ema:
             self._merge_metric_state_across_ranks(self.map_metric_ema)
             ema_metrics = self._compute_map_metric(trainer, self.map_metric_ema)
@@ -643,6 +609,151 @@ class COCOEvalCallback(Callback):
             # Not all ranks have EMA data this epoch (e.g. EMA not yet warmed up) → skip the
             # sync uniformly on every rank, but clear local state so the next epoch is clean.
             self.map_metric_ema.reset()
+        return should_compute_ema, ema_metrics
+
+    def _compute_and_log_f1_metrics(
+        self, trainer: Any, pl_module: Any, split: str, f1_local: dict[int, dict[str, Any]]
+    ) -> tuple[dict[str, float], dict[int, dict[str, float]]]:
+        """Sweep confidence thresholds over ``f1_local``, log ``{split}/F1`` (+precision/recall), return per-class F1.
+
+        Independent of ``self.map_metric``/``self.map_metric_ema``: ``f1_local`` accumulates every batch's matching
+        data via ``merge_matching_data`` in ``on_validation_batch_end`` unconditionally, regardless of which mAP
+        track (base vs EMA) that batch's predictions were routed to. Extracted so the empty-``metric`` early-return
+        branch of :meth:`_compute_and_log` can also call it — under ``eval_ema_only`` ``f1_local`` is the only
+        accumulator with real data this epoch, so discarding it via ``_reset_f1_local`` without computing would
+        silently drop ``val/F1`` too, even though real matching data was collected (#1285).
+
+        Args:
+            trainer: The PTL Trainer.
+            pl_module: The LightningModule.
+            split: Metric namespace — ``"val"``, ``"test"``, or ``"train"``.
+            f1_local: Per-category matching accumulator for this split.
+
+        Returns:
+            ``(overall, f1_by_cid)`` — ``overall`` has keys ``"F1"``, ``"Precision"``, ``"Recall"``; ``f1_by_cid``
+            maps category_id to its per-class ``f1``/``precision``/``recall`` at the best macro-F1 threshold
+            (empty when no matching data was accumulated).
+        """
+        merged = distributed_merge_matching_data(f1_local)
+        f1_by_cid: dict[int, dict[str, float]] = {}
+        if merged:
+            sorted_ids = sorted(merged.keys())
+            per_class_list = [merged[cid] for cid in sorted_ids]
+            classes_with_gt = [i for i, cid in enumerate(sorted_ids) if merged[cid]["total_gt"] > 0]
+            f1_results = sweep_confidence_thresholds(per_class_list, np.linspace(0, 1, 101), classes_with_gt)
+            best = max(f1_results, key=lambda x: x["macro_f1"])
+            overall = {
+                "F1": float(best["macro_f1"]),
+                "Precision": float(best["macro_precision"]),
+                "Recall": float(best["macro_recall"]),
+            }
+            for k, cid in enumerate(sorted_ids):
+                f1_by_cid[cid] = {
+                    "f1": float(best["per_class_f1"][k]),
+                    "precision": float(best["per_class_prec"][k]),
+                    "recall": float(best["per_class_rec"][k]),
+                }
+        else:
+            overall = {"F1": 0.0, "Precision": 0.0, "Recall": 0.0}
+        pl_module.log(f"{split}/F1", overall["F1"], prog_bar=True, logger=True, on_step=False, on_epoch=True)
+        pl_module.log(f"{split}/precision", overall["Precision"], logger=True, on_step=False, on_epoch=True)
+        pl_module.log(f"{split}/recall", overall["Recall"], logger=True, on_step=False, on_epoch=True)
+        trainer.callback_metrics[f"{split}/F1"] = torch.tensor(overall["F1"])
+        trainer.callback_metrics[f"{split}/precision"] = torch.tensor(overall["Precision"])
+        trainer.callback_metrics[f"{split}/recall"] = torch.tensor(overall["Recall"])
+        return overall, f1_by_cid
+
+    def _compute_and_log(self, trainer: Any, pl_module: Any, split: str, *, metric: Any | None = None) -> None:
+        """Shared epoch-end logic for validation and test evaluation loops.
+
+        Computes mAP (via ``self.map_metric``), runs the F1 confidence-threshold sweep, logs all scalar metrics via
+        ``pl_module.log``, prints two summary tables to the terminal, and resets internal accumulators.  When
+        ``self.map_metric_ema`` is set, EMA variants of all metrics (including ``ema_segm_mAP_50_95`` and
+        ``ema_segm_mAP_50`` for segmentation models) are logged under the same ``split/`` namespace.
+
+        Args:
+            trainer: The PTL Trainer.
+            pl_module: The LightningModule.
+            split: Metric namespace — ``"val"`` or ``"test"``.
+            metric: Optional split-specific mAP accumulator. Defaults to the validation/test accumulator.
+        """
+        metric = self.map_metric if metric is None else metric
+        f1_local = self._f1_train_local if split == "train" else self._f1_local
+        # torchmetrics prefixes all keys when iou_type is a list (e.g. "bbox_map"). Computed
+        # up front (pure, independent of `metric`) so the early-return branch below can also
+        # use it to log the EMA-only track under `eval_ema_only` (#1285).
+        pfx = "bbox_" if self._use_segm_metrics else ""
+        mar_key = f"{pfx}mar_{self._max_dets}"
+        if not self._metric_has_updates(metric):
+            metric.reset()
+            self._reset_keypoint_split(split)
+            # Under `eval_ema_only`, on_validation_batch_end routes every prediction to
+            # map_metric_ema instead of `metric` (see its docstring), so `metric` never
+            # accumulates any update this epoch — that must not also suppress the EMA metrics,
+            # or an eval_ema_only run logs no validation output at all (#1285). train/test never
+            # populate map_metric_ema this way (on_test_epoch_start resets _ema_has_updates for
+            # test, and on_train_epoch_end never reaches this branch with stale EMA state from a
+            # prior validation epoch under normal use), so this is scoped to "val" only.
+            if split == "val":
+                should_compute_ema, ema_metrics = self._compute_and_log_ema_metrics(
+                    trainer, pl_module, split, pfx, mar_key
+                )
+                if should_compute_ema:
+                    self._compute_and_log_keypoint_map(
+                        "val_ema", pl_module, trainer, log_split="val", metric_prefix="ema_"
+                    )
+                else:
+                    self._reset_keypoint_split("val_ema")
+                # f1_local accumulates every batch's matching data unconditionally in
+                # on_validation_batch_end (merge_matching_data runs outside the used_ema_forward
+                # branch), independent of which mAP track a batch's predictions were routed to.
+                # Under eval_ema_only `metric` never updates but f1_local does — computing it here
+                # instead of via the unconditional _reset_f1_local below prevents val/F1 from
+                # silently going unlogged even though real matching data was collected (#1285).
+                f1_overall, f1_by_cid = self._compute_and_log_f1_metrics(trainer, pl_module, split, f1_local)
+                # The normal per-class/table path below only ever reads from the base `metric`,
+                # which never has data here — without this, eval_ema_only prints no console table
+                # for the whole run even though ema_metrics has real per-class data (#1285).
+                if should_compute_ema and ema_metrics is not None:
+                    self._print_ema_only_summary(
+                        trainer, pl_module, split, pfx, mar_key, ema_metrics, f1_overall, f1_by_cid
+                    )
+            self._reset_f1_local(split)
+            logger.debug("Skipping %s COCO metric compute because no predictions were accumulated.", split)
+            return
+
+        # Merge per-rank state across ranks ourselves (DDP-safe, fixed-shape gather) before the
+        # metric computes locally — replaces torchmetrics' deadlock-prone internal sync. No-op when
+        # not distributed. Called unconditionally on every rank, so the collectives stay symmetric.
+        self._merge_metric_state_across_ranks(metric)
+        metrics = self._compute_map_metric(trainer, metric)
+
+        overall: dict[str, float] = {
+            "mAP 50:95": float(metrics[f"{pfx}map"]),
+            "mAP 50": float(metrics[f"{pfx}map_50"]),
+            "mAP 75": float(metrics[f"{pfx}map_75"]),
+            f"mAR @{self._max_dets}": float(metrics[mar_key]),
+        }
+
+        pl_module.log(
+            f"{split}/mAP_50_95", metrics[f"{pfx}map"], prog_bar=True, logger=True, on_step=False, on_epoch=True
+        )
+        pl_module.log(
+            f"{split}/mAP_50", metrics[f"{pfx}map_50"], prog_bar=True, logger=True, on_step=False, on_epoch=True
+        )
+        pl_module.log(f"{split}/mAP_75", metrics[f"{pfx}map_75"], logger=True, on_step=False, on_epoch=True)
+        pl_module.log(f"{split}/mAR", metrics[mar_key], logger=True, on_step=False, on_epoch=True)
+
+        # Write directly into callback_metrics so ModelCheckpoint / EarlyStopping
+        # read fresh values each epoch.  pl_module.log() from a callback's
+        # on_*_epoch_end goes only to logged_metrics (external loggers), not to
+        # callback_metrics, so checkpointing would see stale values otherwise.
+        trainer.callback_metrics[f"{split}/mAP_50_95"] = metrics[f"{pfx}map"].detach().cpu()
+        trainer.callback_metrics[f"{split}/mAP_50"] = metrics[f"{pfx}map_50"].detach().cpu()
+        trainer.callback_metrics[f"{split}/mAP_75"] = metrics[f"{pfx}map_75"].detach().cpu()
+        trainer.callback_metrics[f"{split}/mAR"] = metrics[mar_key].detach().cpu()
+
+        should_compute_ema, _ema_metrics = self._compute_and_log_ema_metrics(trainer, pl_module, split, pfx, mar_key)
 
         if self._use_segm_metrics:
             overall["segm mAP 50:95"] = float(metrics["segm_map"])
@@ -654,49 +765,8 @@ class COCOEvalCallback(Callback):
 
         # F1 sweep — run first so per-class F1/prec/rec are available when
         # building the unified per-class table rows below.
-        merged = distributed_merge_matching_data(f1_local)
-        # category_id → {f1, precision, recall} at the best macro-F1 threshold
-        f1_by_cid: dict[int, dict[str, float]] = {}
-        if merged:
-            sorted_ids = sorted(merged.keys())
-            per_class_list = [merged[cid] for cid in sorted_ids]
-            classes_with_gt = [i for i, cid in enumerate(sorted_ids) if merged[cid]["total_gt"] > 0]
-            f1_results = sweep_confidence_thresholds(per_class_list, np.linspace(0, 1, 101), classes_with_gt)
-            best = max(f1_results, key=lambda x: x["macro_f1"])
-            overall["F1"] = float(best["macro_f1"])
-            overall["Precision"] = float(best["macro_precision"])
-            overall["Recall"] = float(best["macro_recall"])
-            pl_module.log(
-                f"{split}/F1",
-                float(best["macro_f1"]),
-                prog_bar=True,
-                logger=True,
-                on_step=False,
-                on_epoch=True,
-            )
-            pl_module.log(
-                f"{split}/precision", float(best["macro_precision"]), logger=True, on_step=False, on_epoch=True
-            )
-            pl_module.log(f"{split}/recall", float(best["macro_recall"]), logger=True, on_step=False, on_epoch=True)
-            trainer.callback_metrics[f"{split}/F1"] = torch.tensor(float(best["macro_f1"]))
-            trainer.callback_metrics[f"{split}/precision"] = torch.tensor(float(best["macro_precision"]))
-            trainer.callback_metrics[f"{split}/recall"] = torch.tensor(float(best["macro_recall"]))
-            for k, cid in enumerate(sorted_ids):
-                f1_by_cid[cid] = {
-                    "f1": float(best["per_class_f1"][k]),
-                    "precision": float(best["per_class_prec"][k]),
-                    "recall": float(best["per_class_rec"][k]),
-                }
-        else:
-            overall["F1"] = 0.0
-            overall["Precision"] = 0.0
-            overall["Recall"] = 0.0
-            pl_module.log(f"{split}/F1", 0.0, prog_bar=True, logger=True, on_step=False, on_epoch=True)
-            pl_module.log(f"{split}/precision", 0.0, logger=True, on_step=False, on_epoch=True)
-            pl_module.log(f"{split}/recall", 0.0, logger=True, on_step=False, on_epoch=True)
-            trainer.callback_metrics[f"{split}/F1"] = torch.tensor(0.0)
-            trainer.callback_metrics[f"{split}/precision"] = torch.tensor(0.0)
-            trainer.callback_metrics[f"{split}/recall"] = torch.tensor(0.0)
+        f1_overall, f1_by_cid = self._compute_and_log_f1_metrics(trainer, pl_module, split, f1_local)
+        overall.update(f1_overall)
 
         # torchmetrics returns `classes` as a 0-d scalar when only one class is
         # present in the batch.  Ensure it is always 1-d before iterating.
@@ -1033,6 +1103,77 @@ class COCOEvalCallback(Callback):
         finally:
             metric.reset()
 
+    def _print_ema_only_summary(
+        self,
+        trainer: Any,
+        pl_module: Any,
+        split: str,
+        pfx: str,
+        mar_key: str,
+        ema_metrics: dict[str, Any],
+        f1_overall: dict[str, float],
+        f1_by_cid: dict[int, dict[str, float]],
+    ) -> None:
+        """Print the Rich summary table from ``ema_metrics`` when it is the epoch's only track with data.
+
+        The normal table/per-class path in :meth:`_compute_and_log` only ever reads from the base
+        ``metric`` — under ``eval_ema_only`` that metric never accumulates a single update (see the
+        early-return branch), so that path never runs and no table is ever printed for the entire run,
+        even though ``map_metric_ema`` has real per-class data (built with the same ``class_metrics``
+        setting as the base metric). Without this, fixing the logged scalars alone leaves the console
+        table half of the original "no validation output at all" complaint (#1285) unfixed. Per-class
+        AP is logged under ``ema_`` keys (via ``_build_per_class_rows``'s ``metric_prefix``) so it never
+        collides with a base-track ``{split}/AP/{name}`` key — consistent with ``val/ema_mAP_50_95``
+        staying separate from ``val/mAP_50_95`` elsewhere in this callback.
+
+        Args:
+            trainer: The PTL Trainer.
+            pl_module: The LightningModule.
+            split: Metric namespace — ``"val"`` (the only split that reaches this method).
+            pfx: torchmetrics key prefix (``"bbox_"`` when ``iou_type`` is a list, else ``""``).
+            mar_key: Prefixed AR metric key for ``self._max_dets``.
+            ema_metrics: Raw ``map_metric_ema.compute()`` output, from ``_compute_and_log_ema_metrics``.
+            f1_overall: ``{"F1", "Precision", "Recall"}`` from ``_compute_and_log_f1_metrics``; not
+                EMA-prefixed by existing design (see ``TrainConfig.eval_ema_only`` docstring) since
+                ``f1_local`` has no parallel EMA-tracked accumulator.
+            f1_by_cid: Per-class F1/precision/recall keyed by ``category_id``, from the same call.
+        """
+        if "classes" in ema_metrics and ema_metrics["classes"].ndim == 0:
+            ema_metrics = dict(ema_metrics)
+            ema_metrics["classes"] = ema_metrics["classes"].unsqueeze(0)
+            for metric_key in list(ema_metrics):
+                value = ema_metrics[metric_key]
+                if isinstance(value, Tensor) and value.ndim == 0 and "per_class" in metric_key:
+                    ema_metrics[metric_key] = value.unsqueeze(0)
+
+        overall_ema: dict[str, float] = {
+            "mAP 50:95": float(ema_metrics[f"{pfx}map"]),
+            "mAP 50": float(ema_metrics[f"{pfx}map_50"]),
+            "mAP 75": float(ema_metrics[f"{pfx}map_75"]),
+            f"mAR @{self._max_dets}": float(ema_metrics[mar_key]),
+        }
+        if self._use_segm_metrics and "segm_map" in ema_metrics:
+            overall_ema["segm mAP 50:95"] = float(ema_metrics["segm_map"])
+            overall_ema["segm mAP 50"] = float(ema_metrics["segm_map_50"])
+        overall_ema.update(f1_overall)
+
+        ar_pc_key = f"{pfx}mar_{self._max_dets}_per_class"
+        ar_by_cid: dict[int, float] = {}
+        if self._log_per_class_metrics and ar_pc_key in ema_metrics and "classes" in ema_metrics:
+            for class_id, ar in zip(ema_metrics["classes"], ema_metrics[ar_pc_key]):
+                ar_by_cid[int(class_id)] = float(ar)
+
+        per_class_ema = self._build_per_class_rows(
+            metrics=ema_metrics,
+            pfx=pfx,
+            split=split,
+            pl_module=pl_module,
+            ar_by_cid=ar_by_cid,
+            f1_by_cid=f1_by_cid,
+            metric_prefix="ema_",
+        )
+        self._print_metrics_tables(trainer, "val (ema)", overall_ema, per_class_ema)
+
     def _build_per_class_rows(
         self,
         metrics: dict[str, Any],
@@ -1041,6 +1182,7 @@ class COCOEvalCallback(Callback):
         pl_module: Any,
         ar_by_cid: dict[int, float],
         f1_by_cid: dict[int, dict[str, float]],
+        metric_prefix: str = "",
     ) -> list[dict[str, Any]]:
         """Build per-class rows and emit per-class AP metrics.
 
@@ -1051,6 +1193,9 @@ class COCOEvalCallback(Callback):
             pl_module: LightningModule used for metric logging.
             ar_by_cid: Per-class AR keyed by ``category_id``.
             f1_by_cid: Per-class F1/precision/recall keyed by ``category_id``.
+            metric_prefix: Prepended to the logged key (``f"{split}/{metric_prefix}AP/{name}"``), e.g.
+                ``"ema_"`` so per-class EMA AP (see ``_print_ema_only_summary``) never collides with
+                the regular track's ``{split}/AP/{name}`` keys.
 
         Returns:
             Per-class rows for table rendering.
@@ -1070,7 +1215,7 @@ class COCOEvalCallback(Callback):
                 continue
             idx = int(class_id)
             name = self._cat_id_to_name.get(idx, str(idx))
-            pl_module.log(f"{split}/AP/{name}", ap)
+            pl_module.log(f"{split}/{metric_prefix}AP/{name}", ap)
             row: dict[str, Any] = {"name": name, "ap": ap_f, "ar": ar_f}
             row.update(f1_by_cid.get(idx, {"f1": float("nan"), "precision": float("nan"), "recall": float("nan")}))
             per_class.append(row)

--- a/tests/training/callbacks/test_best_model_callback.py
+++ b/tests/training/callbacks/test_best_model_callback.py
@@ -311,6 +311,26 @@ class TestBestModelCallback:
 
         assert (tmp_path / "checkpoint_best_ema.pth").exists()
 
+    def test_ema_checkpoint_saved_when_regular_monitor_absent(self, tmp_path: Path) -> None:
+        """Under `eval_ema_only`, val/mAP_50_95 is never logged — only val/ema_mAP_50_95 is.
+
+        Regression test for #1285: the regular-monitor guard in on_validation_end used to
+        `return` before reaching the EMA block, so checkpoint_best_ema.pth was never written
+        in this mode even though the EMA metric had real data every epoch.
+        """
+        cb = BestModelCallback(
+            output_dir=str(tmp_path),
+            monitor_ema="val/ema_mAP_50_95",
+        )
+        # No "val/mAP_50_95" key at all — matches eval_ema_only routing (config.py:1068-1074).
+        trainer = _make_trainer({"val/ema_mAP_50_95": 0.6})
+        pl_module = _make_pl_module()
+
+        cb.on_validation_end(trainer, pl_module)
+
+        assert (tmp_path / "checkpoint_best_ema.pth").exists()
+        assert not (tmp_path / "checkpoint_best_regular.pth").exists()
+
     def test_ema_checkpoint_saves_ema_callback_weights(self, tmp_path: Path) -> None:
         """EMA checkpoint must store EMA callback weights, not live model weights."""
         cb = BestModelCallback(
@@ -1206,6 +1226,24 @@ class TestRFDETREarlyStopping:
         cb.on_validation_end(trainer, pl_module)
 
         assert cb.best_score.item() == pytest.approx(0.45)
+        assert cb.wait_count == 0
+
+    def test_only_ema_available(self) -> None:
+        """When the regular monitor key is absent, falls back to EMA without error.
+
+        Mirrors `test_only_regular_available`; this is the exact shape `eval_ema_only` produces
+        (`val/mAP_50_95` never populated, see #1285) and was previously untested here, unlike
+        `BestModelCallback.on_validation_end`'s sibling guard where the same input shape was an
+        outright bug (see `test_ema_checkpoint_saved_when_regular_monitor_absent`). This callback's
+        `regular_val is None` branching already handled it correctly; this test locks that in.
+        """
+        cb = RFDETREarlyStopping(patience=5, min_delta=0.001)
+        pl_module = _make_pl_module()
+
+        trainer = _make_trainer({"val/ema_mAP_50_95": 0.55})
+        cb.on_validation_end(trainer, pl_module)
+
+        assert cb.best_score.item() == pytest.approx(0.55)
         assert cb.wait_count == 0
 
     def test_neither_available_is_noop(self) -> None:

--- a/tests/training/callbacks/test_best_model_callback.py
+++ b/tests/training/callbacks/test_best_model_callback.py
@@ -314,9 +314,9 @@ class TestBestModelCallback:
     def test_ema_checkpoint_saved_when_regular_monitor_absent(self, tmp_path: Path) -> None:
         """Under `eval_ema_only`, val/mAP_50_95 is never logged — only val/ema_mAP_50_95 is.
 
-        Regression test for #1285: the regular-monitor guard in on_validation_end used to
-        `return` before reaching the EMA block, so checkpoint_best_ema.pth was never written
-        in this mode even though the EMA metric had real data every epoch.
+        Regression test for #1285: the regular-monitor guard in on_validation_end used to `return` before reaching the
+        EMA block, so checkpoint_best_ema.pth was never written in this mode even though the EMA metric had real data
+        every epoch.
         """
         cb = BestModelCallback(
             output_dir=str(tmp_path),

--- a/tests/training/callbacks/test_coco_eval_callback.py
+++ b/tests/training/callbacks/test_coco_eval_callback.py
@@ -951,10 +951,11 @@ class TestOnValidationEpochEnd:
         cb.map_metric_ema.reset.assert_called_once()
 
     def test_eval_ema_only_still_logs_ema_metrics_when_base_metric_is_empty(self) -> None:
-        """Regression for #1285: under eval_ema_only, on_validation_batch_end routes every prediction to
-        map_metric_ema and map_metric never accumulates a single update this epoch. The empty-state guard in
-        _compute_and_log must not also suppress the EMA metrics — before the fix it returned before ever reaching
-        the EMA compute block, so eval_ema_only runs logged no validation output at all.
+        """Regression for #1285: under eval_ema_only, on_validation_batch_end routes every prediction to map_metric_ema
+        and map_metric never accumulates a single update this epoch.
+
+        The empty-state guard in _compute_and_log must not also suppress the EMA metrics — before the fix it returned
+        before ever reaching the EMA compute block, so eval_ema_only runs logged no validation output at all.
         """
         cb = COCOEvalCallback(max_dets=500, eval_ema_only=True)
         cb.setup(_make_trainer(), _make_pl_module(), stage="fit")
@@ -977,12 +978,12 @@ class TestOnValidationEpochEnd:
         cb.map_metric.reset.assert_called_once()
 
     def test_eval_ema_only_computes_f1_from_accumulated_matches_when_base_metric_is_empty(self) -> None:
-        """Regression for #1285: on_validation_batch_end merges matching data into f1_local
-        unconditionally (outside the used_ema_forward branch), independent of which mAP track a
-        batch's predictions were routed to. Under eval_ema_only, map_metric never accumulates, so
-        the empty-state guard in _compute_and_log used to discard f1_local via _reset_f1_local
-        before ever computing val/F1 — silently dropping it even though real matching data (from
-        the EMA-quality predictions) had been collected.
+        """Regression for #1285: on_validation_batch_end merges matching data into f1_local unconditionally (outside the
+        used_ema_forward branch), independent of which mAP track a batch's predictions were routed to.
+
+        Under eval_ema_only, map_metric never accumulates, so the empty-state guard in _compute_and_log used to discard
+        f1_local via _reset_f1_local before ever computing val/F1 — silently dropping it even though real matching data
+        (from the EMA-quality predictions) had been collected.
         """
         cb = COCOEvalCallback(max_dets=500, eval_ema_only=True)
         cb.setup(_make_trainer(), _make_pl_module(), stage="fit")
@@ -1012,11 +1013,11 @@ class TestOnValidationEpochEnd:
     def test_eval_ema_only_prints_summary_table_when_base_metric_is_empty(self) -> None:
         """Regression for #1285: the console summary table is also part of "validation output".
 
-        Before this fix, ``_print_metrics_tables`` was only ever called from the branch that reads
-        the base ``metric`` — which never has data under ``eval_ema_only`` — so no table was ever
-        printed for the entire run, even after the scalar/F1 logging gaps were closed. Per-class AP
-        must be logged under ``ema_``-prefixed keys, mirroring ``val/ema_mAP_50_95`` staying separate
-        from ``val/mAP_50_95`` elsewhere, so it never collides with a base-track key.
+        Before this fix, ``_print_metrics_tables`` was only ever called from the branch that reads the base ``metric`` —
+        which never has data under ``eval_ema_only`` — so no table was ever printed for the entire run, even after the
+        scalar/F1 logging gaps were closed. Per-class AP must be logged under ``ema_``-prefixed keys, mirroring
+        ``val/ema_mAP_50_95`` staying separate from ``val/mAP_50_95`` elsewhere, so it never collides with a base-track
+        key.
         """
         cb = COCOEvalCallback(max_dets=500, eval_ema_only=True)
         cb.setup(_make_trainer(), _make_pl_module(), stage="fit")
@@ -1495,13 +1496,12 @@ class TestValidationBatchEndEvalEmaOnly:
 class TestEvalEmaOnlyBatchToEpochEndToEnd:
     """Full batch -> epoch pipeline for eval_ema_only, with real (non-mocked) accumulators (#1285).
 
-    TestValidationBatchEndEvalEmaOnly and TestOnValidationEpochEnd each replace map_metric /
-    map_metric_ema with MagicMock and drive a single hook in isolation. Neither would catch a
-    wiring bug between the two (e.g. `_ema_has_updates` set by batch-time routing never reaching
-    epoch-end, or `_prepare_ema_metric` creating a `map_metric_ema` that batch-time routing never
-    populates). This test keeps the real MeanAveragePrecision instances created by setup() /
-    on_validation_epoch_start() and drives on_validation_batch_end then on_validation_epoch_end
-    in sequence on the same callback instance.
+    TestValidationBatchEndEvalEmaOnly and TestOnValidationEpochEnd each replace map_metric / map_metric_ema with
+    MagicMock and drive a single hook in isolation. Neither would catch a wiring bug between the two (e.g.
+    `_ema_has_updates` set by batch-time routing never reaching epoch-end, or `_prepare_ema_metric` creating a
+    `map_metric_ema` that batch-time routing never populates). This test keeps the real MeanAveragePrecision instances
+    created by setup() / on_validation_epoch_start() and drives on_validation_batch_end then on_validation_epoch_end in
+    sequence on the same callback instance.
     """
 
     def test_eval_ema_only_real_batch_then_epoch_end_logs_ema_metrics(self) -> None:

--- a/tests/training/callbacks/test_coco_eval_callback.py
+++ b/tests/training/callbacks/test_coco_eval_callback.py
@@ -13,6 +13,7 @@ import numpy as np
 import pytest
 import torch
 
+from rfdetr.evaluation.matching import build_matching_data, merge_matching_data
 from rfdetr.training.callbacks.coco_eval import COCOEvalCallback
 
 # ---------------------------------------------------------------------------
@@ -949,6 +950,104 @@ class TestOnValidationEpochEnd:
         assert "val/ema_mAR" in logged_keys
         cb.map_metric_ema.reset.assert_called_once()
 
+    def test_eval_ema_only_still_logs_ema_metrics_when_base_metric_is_empty(self) -> None:
+        """Regression for #1285: under eval_ema_only, on_validation_batch_end routes every prediction to
+        map_metric_ema and map_metric never accumulates a single update this epoch. The empty-state guard in
+        _compute_and_log must not also suppress the EMA metrics — before the fix it returned before ever reaching
+        the EMA compute block, so eval_ema_only runs logged no validation output at all.
+        """
+        cb = COCOEvalCallback(max_dets=500, eval_ema_only=True)
+        cb.setup(_make_trainer(), _make_pl_module(), stage="fit")
+        cb.map_metric = MagicMock(name="map_metric")
+        cb.map_metric._update_count = 0  # genuinely empty: eval_ema_only never routes here
+        cb.map_metric_ema = MagicMock(name="map_metric_ema")
+        cb.map_metric_ema.compute.return_value = _minimal_metrics()
+        cb._ema_has_updates = True
+        module = _make_pl_module()
+
+        cb.on_validation_epoch_end(_make_trainer(), module)
+
+        cb.map_metric.compute.assert_not_called()
+        logged_keys = {c.args[0] for c in module.log.call_args_list}
+        assert "val/ema_mAP_50_95" in logged_keys
+        assert "val/ema_mAP_50" in logged_keys
+        assert "val/ema_mAR" in logged_keys
+        assert not any(k in {"val/mAP_50_95", "val/mAP_50", "val/mAP_75", "val/mAR"} for k in logged_keys)
+        cb.map_metric_ema.reset.assert_called_once()
+        cb.map_metric.reset.assert_called_once()
+
+    def test_eval_ema_only_computes_f1_from_accumulated_matches_when_base_metric_is_empty(self) -> None:
+        """Regression for #1285: on_validation_batch_end merges matching data into f1_local
+        unconditionally (outside the used_ema_forward branch), independent of which mAP track a
+        batch's predictions were routed to. Under eval_ema_only, map_metric never accumulates, so
+        the empty-state guard in _compute_and_log used to discard f1_local via _reset_f1_local
+        before ever computing val/F1 — silently dropping it even though real matching data (from
+        the EMA-quality predictions) had been collected.
+        """
+        cb = COCOEvalCallback(max_dets=500, eval_ema_only=True)
+        cb.setup(_make_trainer(), _make_pl_module(), stage="fit")
+        cb.map_metric = MagicMock(name="map_metric")
+        cb.map_metric._update_count = 0  # genuinely empty: eval_ema_only never routes here
+        cb.map_metric_ema = MagicMock(name="map_metric_ema")
+        cb.map_metric_ema.compute.return_value = _minimal_metrics()
+        cb._ema_has_updates = True
+        # A perfect match (pred == target box/label), mirroring what the unconditional
+        # merge_matching_data call in on_validation_batch_end accumulates every batch.
+        preds = [
+            {
+                "boxes": torch.tensor([[0.0, 0.0, 10.0, 10.0]]),
+                "scores": torch.tensor([0.9]),
+                "labels": torch.tensor([1]),
+            }
+        ]
+        targets = [{"boxes": torch.tensor([[0.0, 0.0, 10.0, 10.0]]), "labels": torch.tensor([1])}]
+        merge_matching_data(cb._f1_local, build_matching_data(preds, targets))
+        module = _make_pl_module()
+
+        cb.on_validation_epoch_end(_make_trainer(), module)
+
+        f1_call = next(c for c in module.log.call_args_list if c.args[0] == "val/F1")
+        assert f1_call.args[1] == pytest.approx(1.0)
+
+    def test_eval_ema_only_prints_summary_table_when_base_metric_is_empty(self) -> None:
+        """Regression for #1285: the console summary table is also part of "validation output".
+
+        Before this fix, ``_print_metrics_tables`` was only ever called from the branch that reads
+        the base ``metric`` — which never has data under ``eval_ema_only`` — so no table was ever
+        printed for the entire run, even after the scalar/F1 logging gaps were closed. Per-class AP
+        must be logged under ``ema_``-prefixed keys, mirroring ``val/ema_mAP_50_95`` staying separate
+        from ``val/mAP_50_95`` elsewhere, so it never collides with a base-track key.
+        """
+        cb = COCOEvalCallback(max_dets=500, eval_ema_only=True)
+        cb.setup(_make_trainer(), _make_pl_module(), stage="fit")
+        cb._class_names = ["cat", "dog"]
+        cb._cat_id_to_name = {0: "cat", 1: "dog"}
+        cb.map_metric = MagicMock(name="map_metric")
+        cb.map_metric._update_count = 0  # genuinely empty: eval_ema_only never routes here
+        cb.map_metric_ema = MagicMock(name="map_metric_ema")
+        ema_metrics = _minimal_metrics()
+        ema_metrics["map_per_class"] = torch.tensor([0.5, 0.4])
+        ema_metrics["mar_500_per_class"] = torch.tensor([0.6, 0.3])
+        ema_metrics["classes"] = torch.tensor([0, 1])
+        cb.map_metric_ema.compute.return_value = ema_metrics
+        cb._ema_has_updates = True
+        module = _make_pl_module()
+
+        with patch.object(cb, "_print_metrics_tables") as print_metrics_tables:
+            cb.on_validation_epoch_end(_make_trainer(), module)
+
+        print_metrics_tables.assert_called_once()
+        _trainer_arg, title_arg, overall_arg, per_class_arg = print_metrics_tables.call_args.args
+        assert title_arg == "val (ema)"
+        assert overall_arg["mAP 50:95"] == pytest.approx(0.4)
+        assert {row["name"] for row in per_class_arg} == {"cat", "dog"}
+
+        logged_keys = {c.args[0] for c in module.log.call_args_list}
+        assert "val/ema_AP/cat" in logged_keys
+        assert "val/ema_AP/dog" in logged_keys
+        assert "val/AP/cat" not in logged_keys
+        assert "val/AP/dog" not in logged_keys
+
     def test_eval_interval_skips_non_matching_epochs(self) -> None:
         """Validation metric computation is skipped on non-interval epochs."""
         cb = COCOEvalCallback(eval_interval=3)
@@ -1391,6 +1490,46 @@ class TestValidationBatchEndEvalEmaOnly:
         cb.map_metric.update.assert_not_called()
         called_targets = cb.map_metric_ema.update.call_args[0][1]
         assert called_targets[0]["masks"].shape[-2:] == (4, 4)
+
+
+class TestEvalEmaOnlyBatchToEpochEndToEnd:
+    """Full batch -> epoch pipeline for eval_ema_only, with real (non-mocked) accumulators (#1285).
+
+    TestValidationBatchEndEvalEmaOnly and TestOnValidationEpochEnd each replace map_metric /
+    map_metric_ema with MagicMock and drive a single hook in isolation. Neither would catch a
+    wiring bug between the two (e.g. `_ema_has_updates` set by batch-time routing never reaching
+    epoch-end, or `_prepare_ema_metric` creating a `map_metric_ema` that batch-time routing never
+    populates). This test keeps the real MeanAveragePrecision instances created by setup() /
+    on_validation_epoch_start() and drives on_validation_batch_end then on_validation_epoch_end
+    in sequence on the same callback instance.
+    """
+
+    def test_eval_ema_only_real_batch_then_epoch_end_logs_ema_metrics(self) -> None:
+        ema_underlying = MagicMock(name="ema_underlying_model", return_value={"ema": True})
+        ema_cb = MagicMock(name="ema_callback")
+        ema_cb.get_ema_model_state_dict = MagicMock(name="get_ema_model_state_dict")
+        ema_cb._average_model = SimpleNamespace(module=SimpleNamespace(model=ema_underlying))
+        cb = COCOEvalCallback(max_dets=500, eval_ema_only=True)
+        trainer = _make_trainer(callbacks=[ema_cb])
+        module = _cpu_module()
+        cb.setup(trainer, module, stage="fit")
+        cb.on_validation_epoch_start(trainer, module)  # real map_metric_ema creation (_prepare_ema_metric)
+
+        outputs = {"results": _detection_preds(0), "targets": _detection_targets()}
+        batch = (torch.zeros(1), None)
+        cb.on_validation_batch_end(trainer, module, outputs, batch, 0)
+
+        ema_underlying.assert_not_called()  # eval_ema_only routes validation_step's own forward, no duplicate
+        assert cb._ema_has_updates is True
+        assert cb.map_metric._update_count == 0  # regular track never accumulated this epoch
+
+        cb.on_validation_epoch_end(trainer, module)
+
+        logged_keys = {c.args[0] for c in module.log.call_args_list}
+        assert "val/ema_mAP_50_95" in logged_keys
+        assert "val/ema_mAP_50" in logged_keys
+        assert "val/ema_mAR" in logged_keys
+        assert not any(k in {"val/mAP_50_95", "val/mAP_50", "val/mAP_75", "val/mAR"} for k in logged_keys)
 
 
 class TestConvertPreds:

--- a/tests/training/callbacks/test_coco_eval_callback.py
+++ b/tests/training/callbacks/test_coco_eval_callback.py
@@ -7,7 +7,7 @@
 
 import sys
 from types import ModuleType, SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import numpy as np
 import pytest
@@ -1048,6 +1048,57 @@ class TestOnValidationEpochEnd:
         assert "val/ema_AP/dog" in logged_keys
         assert "val/AP/cat" not in logged_keys
         assert "val/AP/dog" not in logged_keys
+
+    def test_eval_ema_only_resets_val_ema_keypoints_when_ema_not_yet_warmed_up(self) -> None:
+        """Regression for #1289 review: under eval_ema_only, when the base metric is empty AND the EMA metric has not
+        accumulated any updates this epoch (e.g. EMA not yet warmed up), _should_compute_ema returns False and the
+        early-return branch must fall back to resetting the val_ema keypoint split instead of computing it."""
+        cb = COCOEvalCallback(max_dets=500, eval_ema_only=True)
+        cb.setup(_make_trainer(), _make_pl_module(), stage="fit")
+        cb.map_metric = MagicMock(name="map_metric")
+        cb.map_metric._update_count = 0  # genuinely empty: eval_ema_only never routes here
+        cb.map_metric_ema = MagicMock(name="map_metric_ema")
+        cb._ema_has_updates = False  # EMA metric also has no updates this epoch
+        module = _make_pl_module()
+
+        with (
+            patch.object(cb, "_compute_and_log_keypoint_map") as compute_keypoint_map,
+            patch.object(cb, "_reset_keypoint_split") as reset_keypoint_split,
+        ):
+            cb.on_validation_epoch_end(_make_trainer(), module)
+
+        compute_keypoint_map.assert_not_called()
+        assert call("val_ema") in reset_keypoint_split.call_args_list
+        cb.map_metric_ema.compute.assert_not_called()
+
+    def test_eval_ema_only_summary_table_includes_segm_metrics(self) -> None:
+        """Regression for #1289 review: _print_ema_only_summary must include segm mAP entries in the overall table when
+        segmentation metrics are enabled, mirroring the base-metric path's segm handling."""
+        cb = COCOEvalCallback(max_dets=500, segmentation=True, eval_ema_only=True)
+        cb.setup(_make_trainer(), _make_pl_module(), stage="fit")
+        cb._class_names = ["cat"]
+        cb._cat_id_to_name = {0: "cat"}
+        cb.map_metric = MagicMock(name="map_metric")
+        cb.map_metric._update_count = 0  # genuinely empty: eval_ema_only never routes here
+        cb.map_metric_ema = MagicMock(name="map_metric_ema")
+        ema_metrics = _minimal_metrics(pfx="bbox_")
+        ema_metrics["map_per_class"] = torch.tensor([0.5])
+        ema_metrics["mar_500_per_class"] = torch.tensor([0.6])
+        ema_metrics["classes"] = torch.tensor([0])
+        ema_metrics["segm_map"] = torch.tensor(0.2)
+        ema_metrics["segm_map_50"] = torch.tensor(0.35)
+        cb.map_metric_ema.compute.return_value = ema_metrics
+        cb._ema_has_updates = True
+        module = _make_pl_module()
+
+        with patch.object(cb, "_print_metrics_tables") as print_metrics_tables:
+            cb.on_validation_epoch_end(_make_trainer(), module)
+
+        print_metrics_tables.assert_called_once()
+        _trainer_arg, title_arg, overall_arg, _per_class_arg = print_metrics_tables.call_args.args
+        assert title_arg == "val (ema)"
+        assert overall_arg["segm mAP 50:95"] == pytest.approx(0.2)
+        assert overall_arg["segm mAP 50"] == pytest.approx(0.35)
 
     def test_eval_interval_skips_non_matching_epochs(self) -> None:
         """Validation metric computation is skipped on non-interval epochs."""

--- a/tests/training/callbacks/test_coco_eval_callback.py
+++ b/tests/training/callbacks/test_coco_eval_callback.py
@@ -2120,3 +2120,25 @@ class TestComputeAndLogEmaResetPath:
             cb._compute_and_log(trainer, module, "val")
 
         mock_ema.reset.assert_called_once()
+
+    def test_clears_ema_has_updates_after_gate_true_compute(self) -> None:
+        """Regression for #1289 review: after a gate-True EMA compute, `_ema_has_updates` must be cleared to False.
+
+        Before this fix, `_compute_and_log_ema_metrics` reset `map_metric_ema` in both branches but never cleared
+        `_ema_has_updates`, so a stale `True` left over from a validation epoch could reach a later
+        `_compute_and_log(..., "train", ...)` call (when `compute_train_metrics=True`) and drive a spurious `compute()`
+        on the freshly emptied EMA metric.
+        """
+        cb = COCOEvalCallback(max_dets=500)
+        cb.setup(_make_trainer(), _make_pl_module(), stage="fit")
+        cb.map_metric_ema = MagicMock(name="map_metric_ema")
+        cb.map_metric_ema.compute.return_value = _minimal_metrics()
+        cb._ema_has_updates = True
+
+        with patch.object(cb, "_merge_metric_state_across_ranks"):
+            should_compute_ema, _ema_metrics = cb._compute_and_log_ema_metrics(
+                _make_trainer(), _make_pl_module(), "val", "", "mar_500"
+            )
+
+        assert should_compute_ema is True
+        assert cb._ema_has_updates is False


### PR DESCRIPTION
Fixes #1285.

You are correct that `eval_ema_only=True` produces no validation output at all, and it is a logic flaw, not a misconfiguration.

`on_validation_batch_end` routes every prediction to `map_metric_ema` when `eval_ema_only` is active (it never touches `map_metric`, by design, to avoid the duplicate forward pass). `_compute_and_log` then defaults to `map_metric` and returns early once it sees that metric has zero updates .. before it ever reaches the block that computes and logs `map_metric_ema`. So the epoch ends with nothing logged under `val/mAP_50_95` OR `val/ema_mAP_50_95`.

While testing that fix I found the same root cause breaks two more things, so this PR ended up a bit bigger than planned:

- `val/F1` was silently dropped too. `on_validation_batch_end` merges each batch's matching data into `f1_local` unconditionally, so under `eval_ema_only` there is real matching data all epoch, but the early-return branch reset it without ever running the F1 sweep.
- `BestModelCallback` never wrote `checkpoint_best_ema.pth` in this mode either. `on_validation_end` guards its whole body behind `if self.monitor not in trainer.callback_metrics: return`, and `monitor_regular` is never populated under `eval_ema_only` by design, so that guard was also skipping the EMA checkpoint block below it, even though `monitor_ema` has a real score every epoch.

Same shape of bug in three places: something used "the regular metric is empty" to mean "nothing happened this epoch," when the EMA-side accumulators had real data the whole time.

While closing those three, I noticed the fix for the F1/mAP scalars still left one thing broken: the per-epoch Rich table printed to the console (and to notebook output) is built entirely from the *base* metric's `compute()` output, so under `eval_ema_only` it never printed at all, for the whole run. That's still "no validation output," just moved from the logged scalars to the human-facing table.

`map_metric_ema` is built with the same `class_metrics` setting as the base metric, so the same per-class data is available there too. I wired that into the same early-return branch and gave it its own `ema_` key namespace (`val/ema_AP/<class>` instead of `val/AP/<class>`), so it can't collide with the base keys — same idea as how `val/ema_mAP_50_95` already stays separate from `val/mAP_50_95`.

I also checked for a fourth instance of the same bug shape: `RFDETREarlyStopping.on_validation_end` (`src/rfdetr/training/callbacks/best_model.py:695`) reads both `monitor_regular` and `monitor_ema` from `trainer.callback_metrics` too. Turns out it already falls back to the EMA value correctly when the regular key is `None` — it just had no test for that exact input shape (there was a test for "only regular available" but not the opposite case, "only EMA available", which is what `eval_ema_only` actually produces). Added that test as a regression guard rather than a fix, the code was already right.

**Changes**
- `src/rfdetr/training/callbacks/coco_eval.py`: extracted the EMA mAP block and the F1 sweep into their own methods (`_compute_and_log_ema_metrics`, `_compute_and_log_f1_metrics`) and call both from the empty-metric early-return branch, scoped to `split == "val"` (train/test never route into `map_metric_ema` this way, so it's a no-op there). Also added `_print_ema_only_summary`, which builds the same per-class table from `ema_metrics` (via `_build_per_class_rows`'s new `metric_prefix` arg) that the base-metric path already builds from `metrics`, so `eval_ema_only` runs get a printed table too, titled `val (ema)`.
- `src/rfdetr/training/callbacks/best_model.py`: narrowed the `self.monitor not in trainer.callback_metrics` guard to the regular-checkpoint block only, so the EMA checkpoint block runs on its own.
- `src/rfdetr/config.py` and `docs/learn/train/training-parameters.md`: the `eval_ema_only` description still said `val/mAP_*` gets remapped to EMA quality, which was never actually true and would be wrong anyway (`BestModelCallback` would then checkpoint unevaluated base weights under an EMA-derived score). Corrected to say what's actually true now: `val/mAP_*` stays unpopulated that epoch, the real score is under `val/ema_mAP_*`.
- Tests: one regression per bug (EMA mAP, F1 with a real matched pred/target pair, the EMA checkpoint write, and the printed per-class table), plus a batch-then-epoch-end test that drives both hooks on the same callback instance with real `MeanAveragePrecision` accumulators instead of mocks, since the other tests mock the accumulators and wouldn't catch a wiring bug between the two hooks. Also added `test_only_ema_available` for `RFDETREarlyStopping`, covering the input shape it was already correct on but untested for.

**Validation** `pytest tests/training/callbacks/test_coco_eval_callback.py tests/training/callbacks/test_best_model_callback.py -q` (247 passed), and the full `pytest tests/training/ -q -m "not gpu"` (919 passed, 0 failed, a few unrelated skips from optional deps I don't have installed). Checked each new regression test against the old code too by reverting just its file with `git stash` — all four fail without the fix and pass with it.
