### PR TITLE
test(utilities): add docstrings and doctests to helper functions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -452,6 +452,9 @@ def sample_function(param1: int, param2: int = 10) -> bool:
 
 Following this pattern helps ensure consistency throughout the codebase.
 
+> [!IMPORTANT]
+> This applies to helper functions inside `tests/` too, not just `src/`. Any non-`test_*` function used as a test fixture/builder (e.g. `_make_checkpoint`, `_random_xyxy_boxes`) needs a docstring with an `Examples` doctest that exercises it directly — a small, fast check that the helper still does what its callers assume. `pyproject.toml`'s `--doctest-plus` runs doctests across `tests/` for exactly this reason (see the comment above `[tool.pytest.ini_options]`). Skip the live doctest (`# doctest: +SKIP` with a one-line reason) only when the helper cannot run standalone — e.g. it is a `@pytest.fixture` (pytest now hard-fails on direct fixture calls) or needs real GPU/XLA/network hardware.
+
 ## Reporting Bugs
 
 Bug reports are vital for continued improvement. When reporting an issue, please include a clear, minimal reproducible example that demonstrates the problem. Detailed bug reports assist us in swiftly diagnosing and addressing issues.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,6 +281,7 @@ result = subprocess.run(
 - MANDATORY Google-style docstrings for all functions and classes
 - **Do not duplicate types in docstrings** - types are in the function signature
 - Target Python version: 3.10+
+- **Helper functions in `tests/` need a doctest too**: any non-`test_*` function used by tests (fixture builders, assertion helpers, reference implementations) needs a docstring with an `Examples` doctest that exercises it directly — `pyproject.toml` runs `--doctest-plus` across `tests/` on purpose. Skip the live doctest (`# doctest: +SKIP` + one-line reason) only when the helper can't run standalone (e.g. a `@pytest.fixture`, or needs real GPU/XLA/network hardware).
 
 ## Common Workflows
 

--- a/tests/utilities/test_box_ops.py
+++ b/tests/utilities/test_box_ops.py
@@ -17,7 +17,15 @@ from rfdetr.utilities.box_ops import (
 
 
 def _random_xyxy_boxes(n: int, seed: int = 0) -> torch.Tensor:
-    """Generate ``n`` non-degenerate random boxes in xyxy format."""
+    """Generate ``n`` non-degenerate random boxes in xyxy format.
+
+    Examples:
+        >>> boxes = _random_xyxy_boxes(2, seed=0)
+        >>> boxes.shape
+        torch.Size([2, 4])
+        >>> bool((boxes[:, 2:] > boxes[:, :2]).all())
+        True
+    """
     gen = torch.Generator().manual_seed(seed)
     xy1 = torch.rand(n, 2, generator=gen)
     xy2 = xy1 + torch.rand(n, 2, generator=gen) * 0.5 + 0.01

--- a/tests/utilities/test_console.py
+++ b/tests/utilities/test_console.py
@@ -24,14 +24,31 @@ from rfdetr.utilities.console import (
 
 
 def _make_trainer(callbacks: list[object] | None = None) -> MagicMock:
-    """Return a minimal mock Trainer."""
+    """Return a minimal mock Trainer.
+
+    Examples:
+        >>> trainer = _make_trainer()
+        >>> trainer.callbacks
+        []
+        >>> trainer = _make_trainer(callbacks=["cb"])
+        >>> trainer.callbacks
+        ['cb']
+    """
     trainer = MagicMock(name="trainer")
     trainer.callbacks = callbacks or []
     return trainer
 
 
 def _minimal_overall(max_dets: int = 500) -> dict:
-    """Return an overall dict with the minimal keys _render_overall_merged expects."""
+    """Return an overall dict with the minimal keys _render_overall_merged expects.
+
+    Examples:
+        >>> overall = _minimal_overall()
+        >>> sorted(overall)
+        ['F1', 'Precision', 'Recall', 'mAP 50', 'mAP 50:95', 'mAP 75', 'mAR @500']
+        >>> overall["mAP 50"]
+        0.6
+    """
     return {
         "mAP 50:95": 0.4,
         "mAP 50": 0.6,

--- a/tests/utilities/test_distributed.py
+++ b/tests/utilities/test_distributed.py
@@ -14,7 +14,14 @@ from rfdetr.utilities.distributed import all_gather
 
 
 def _fake_all_gather(output_tensors, input_tensor) -> None:
-    """Stand-in for dist.all_gather: broadcast the local tensor to every output slot."""
+    """Stand-in for dist.all_gather: broadcast the local tensor to every output slot.
+
+    Examples:
+        >>> outs = [torch.zeros(2), torch.zeros(2)]
+        >>> _fake_all_gather(outs, torch.tensor([1.0, 2.0]))
+        >>> outs
+        [tensor([1., 2.]), tensor([1., 2.])]
+    """
     for out in output_tensors:
         out.copy_(input_tensor)
 
@@ -70,6 +77,14 @@ def _xla_all_gather_worker(_local_index: int) -> None:
 
     PJRT's multi-process spawn dispatches through ``concurrent.futures.ProcessPoolExecutor``, which pickles the target
     with stdlib ``pickle``; a nested function fails with ``AttributeError: Can't pickle local object``.
+
+    Examples:
+        Not directly callable in a doctest -- it dispatches ``dist.init_process_group("xla", ...)`` and requires
+        a real TPU/NEURON multi-process runtime supplied by ``torch_xla.launch``. See
+        ``test_all_gather_multiprocess_xla_collective_routing`` for the real invocation.
+
+        >>> callable(_xla_all_gather_worker)  # doctest: +SKIP
+        True
     """
     import torch.distributed as dist
     import torch_xla

--- a/tests/utilities/test_file_validation.py
+++ b/tests/utilities/test_file_validation.py
@@ -73,7 +73,13 @@ class _FakeResponse:
 
 
 def _assert_no_download_temp_files(tmp_path: Path, filename: str = "weights.bin") -> None:
-    """Assert that randomized temporary download files were cleaned up."""
+    """Assert that randomized temporary download files were cleaned up.
+
+    Examples:
+        >>> import tempfile
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     _assert_no_download_temp_files(Path(d))
+    """
     assert not list(tmp_path.glob(f"{filename}.*.tmp"))
 
 

--- a/tests/utilities/test_tensors.py
+++ b/tests/utilities/test_tensors.py
@@ -32,7 +32,14 @@ def _grid_sample_reference(
     padding_mode: str = "zeros",
     align_corners: bool = False,
 ) -> torch.Tensor:
-    """Ground-truth output from F.grid_sample for comparison."""
+    """Ground-truth output from F.grid_sample for comparison.
+
+    Examples:
+        >>> input = torch.arange(4, dtype=torch.float32).reshape(1, 1, 2, 2)
+        >>> grid = torch.zeros(1, 1, 1, 2)
+        >>> _grid_sample_reference(input, grid, align_corners=True)
+        tensor([[[[1.5000]]]])
+    """
     return F.grid_sample(
         input,
         grid,
@@ -54,6 +61,12 @@ def _call_manual_path(
     The function checks ``input.device.type not in ("mps", "xla")`` to decide which branch to take.  We patch
     ``torch.Tensor.device`` to return an object whose ``.type`` is *device_type* so the manual path runs on a normal CPU
     tensor without needing real MPS/XLA hardware.
+
+    Examples:
+        >>> input = torch.arange(4, dtype=torch.float32).reshape(1, 1, 2, 2)
+        >>> grid = torch.zeros(1, 1, 1, 2)
+        >>> _call_manual_path(input, grid, align_corners=True)
+        tensor([[[[1.5000]]]])
     """
 
     class _FakeDevice:
@@ -76,7 +89,15 @@ def _call_manual_path(
 
 @pytest.fixture
 def seed():
-    """Fix random seed for reproducible grid/input generation."""
+    """Fix random seed for reproducible grid/input generation.
+
+    Examples:
+        Injected by pytest as a fixture argument -- calling it directly (bypassing pytest's fixture machinery)
+        raises ``Failed: Fixture "seed" called directly``, so this is illustrative only, not run here. The
+        underlying effect is a plain ``torch.manual_seed(42)`` call:
+
+        >>> torch.manual_seed(42)  # doctest: +SKIP
+    """
     torch.manual_seed(42)
 
 
@@ -102,7 +123,19 @@ _LOW_PRECISION_GRAD_TOLERANCES = {
 
 
 def _require_grid_sample_dtype_support(dtype: torch.dtype) -> None:
-    """Skip test when current backend does not support grid_sample for dtype."""
+    """Skip test when current backend does not support grid_sample for dtype.
+
+    Examples:
+        Returns silently for a dtype the current backend supports:
+
+        >>> _require_grid_sample_dtype_support(torch.float32)
+
+        For a low-precision dtype the current backend may lack support for (e.g. float16/bfloat16 on some CPU
+        builds), this calls ``pytest.skip`` instead of raising -- not run here since the outcome is
+        backend-dependent.
+
+        >>> _require_grid_sample_dtype_support(torch.float16)  # doctest: +SKIP
+    """
     input = torch.randn(1, 1, 2, 2, dtype=dtype, requires_grad=True)
     grid = (torch.rand(1, 1, 1, 2, dtype=dtype) * 1.6 - 0.8).requires_grad_(True)
     try:


### PR DESCRIPTION
This pull request enforces and documents the requirement that all helper functions in `tests/` (not just in `src/`) must include a docstring with an `Examples` doctest. These doctests provide direct, fast checks that the helpers behave as expected, improving test reliability and code documentation. The PR updates both documentation and test helper functions to include these doctests, and clarifies when doctests should be skipped.

**Documentation updates:**

* `.github/CONTRIBUTING.md`, `AGENTS.md`: Added explicit guidance that all non-`test_*` helper functions in `tests/` require a docstring with an `Examples` doctest, and clarified when doctest skipping is appropriate (e.g., for fixtures or hardware-dependent helpers). [[1]](diffhunk://#diff-98e64bc1cd2db9333c6effe87bbe0d6dfe8714aba4c6bde45aa037fe0796e44cR455-R457) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R284)

**Test helper improvements:**

* `tests/utilities/test_box_ops.py`, `tests/utilities/test_console.py`, `tests/utilities/test_distributed.py`, `tests/utilities/test_file_validation.py`, `tests/utilities/test_tensors.py`: Added or expanded `Examples` doctests to all helper functions, including those used as fixtures, reference implementations, or assertion helpers. Where helpers cannot be run standalone (e.g., require hardware or are fixtures), doctests are marked with `# doctest: +SKIP` and a reason is provided. [[1]](diffhunk://#diff-cf0084c4cbc30207c47e8739804b690b49df06f2843162ef230ecbab9a391540L20-R28) [[2]](diffhunk://#diff-e34789d485ea341099a464afa1e83e2e1757f3057b8a46cac4176a52af9d8833L27-R51) [[3]](diffhunk://#diff-def9280050d1ce05bb5969cf917f8c8c3c8d3dc24d46092718630bacc5273d90L17-R24) [[4]](diffhunk://#diff-def9280050d1ce05bb5969cf917f8c8c3c8d3dc24d46092718630bacc5273d90R80-R87) [[5]](diffhunk://#diff-92b484c855d4fda2086a035479d6bbed977c5a0620dbfa70a8200b07b49094f0L76-R82) [[6]](diffhunk://#diff-6033a699e0a6b416a1ac6c31e531d733f2435074b25eb53efb88f5247dea8fb0L35-R42) [[7]](diffhunk://#diff-6033a699e0a6b416a1ac6c31e531d733f2435074b25eb53efb88f5247dea8fb0R64-R69) [[8]](diffhunk://#diff-6033a699e0a6b416a1ac6c31e531d733f2435074b25eb53efb88f5247dea8fb0L79-R100) [[9]](diffhunk://#diff-6033a699e0a6b416a1ac6c31e531d733f2435074b25eb53efb88f5247dea8fb0L105-R138)