### PR TITLE
refactor: enable mypy strict checking for rfdetr.detr

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -396,6 +396,7 @@ overrides = [
     "tensorflow", "tensorflow.*",
     "executorch", "executorch.*",
     "coremltools", "coremltools.*",
+    "roboflow", "roboflow.*",
     "rfdetr_plus", "rfdetr_plus.*",
   ], ignore_missing_imports = true },
   # Optional-import None assignments in console.py: type: ignore[assignment, misc] is needed when
@@ -412,6 +413,5 @@ overrides = [
     "rfdetr.datasets.save_grids",
     "rfdetr.datasets.synthetic",
     "rfdetr.datasets.transforms",
-    "rfdetr.detr",
   ], ignore_errors = true },
 ]

--- a/src/rfdetr/export/main.py
+++ b/src/rfdetr/export/main.py
@@ -24,7 +24,7 @@ from torch import Tensor, nn
 from torchvision.transforms.v2 import Compose, Resize, ToDtype, ToImage
 
 from rfdetr.datasets.transforms import Normalize
-from rfdetr.export._onnx.exporter import export_onnx
+from rfdetr.export._onnx.exporter import export_onnx as export_onnx  # re-exported for rfdetr.detr and the CLI
 from rfdetr.export._tensorrt import build_engine
 from rfdetr.models import BuilderArgs, build_model
 from rfdetr.models.backbone.backbone import Backbone


### PR DESCRIPTION
Part of #564. Enables `mypy --strict` for `rfdetr.detr`.

#1283 corrected the `ModelContext.model` declaration, which cleared three of this module's five errors. Two were left:

```
detr.py:1564: Module "rfdetr.export.main" does not explicitly export attribute "export_onnx"  [attr-defined]
detr.py:2550: Skipping analyzing "roboflow": module is installed, but missing library stubs  [import-untyped]
```

`export_onnx` is defined in `rfdetr.export._onnx.exporter` and re-imported by `rfdetr.export.main`, which `no_implicit_reexport` rejects. This makes the re-export explicit using the `import X as X` form already used in `rfdetr/datasets/__init__.py`. Worth noting: importing it straight from the defining module also satisfies mypy, but bypasses the tests that patch `rfdetr.export.main.export_onnx` and 25 of them fail.

`roboflow` joins the `ignore_missing_imports` block alongside the other packages that ship no stubs. One import site, `detr.py:2550`.

`detr.py` itself needed no changes.

## Testing

- `mypy src/rfdetr/ --no-error-summary` exits 0, also under `--platform linux` and on 3.10 through 3.13
- `pre-commit run --all-files`, all 19 hooks
- Full CPU suite: 3406 passed, 61 skipped
- gpu-marked export tests: 6 passed
- Confirmed `rfdetr.export.main.export_onnx` is still the same object, still patchable, and the public API surface is byte-identical to develop

Leaves 8 modules in the block.
