### PR TITLE
fix(weights): only warn about the legacy query fallback when it actually truncates

### DIFF
--- a/src/rfdetr/models/weights.py
+++ b/src/rfdetr/models/weights.py
@@ -449,8 +449,17 @@ def load_pretrain_weights(
                     _known,
                     _known_val,
                 )
-    # Warn once (not once per suffix key) when falling back to the legacy flat slice.
-    if mc.group_detr > 1 and (ckpt_num_queries is None or ckpt_group_detr is None):
+    target_query_rows = mc.num_queries * mc.group_detr
+    # Warn once (not once per suffix key) only when the fallback truncates a
+    # query tensor. Several published legacy checkpoints omit both args but
+    # already have exactly the configured number of rows, so their flat slice is
+    # an identity and cannot scramble any group.
+    legacy_fallback_truncates = any(
+        tensor.shape[0] > target_query_rows
+        for name, tensor in checkpoint["model"].items()
+        if any(name.endswith(suffix) for suffix in _QUERY_PARAM_SUFFIXES)
+    )
+    if mc.group_detr > 1 and (ckpt_num_queries is None or ckpt_group_detr is None) and legacy_fallback_truncates:
         logger.warning(
             "load_pretrain_weights: checkpoint lacks args.num_queries / "
             "args.group_detr; falling back to flat slice. With "
@@ -472,10 +481,9 @@ def load_pretrain_weights(
             else:
                 # Legacy checkpoint with no num_queries/group_detr in args:
                 # preserve the original flat slice for backward compatibility.
-                # NOTE: the flat slice is incorrect for group_detr > 1 — it scrambles
-                # groups 1+ when num_queries decreases. Legacy checkpoints predate
-                # multi-group training, so in practice they are all group_detr == 1.
-                checkpoint["model"][name] = tensor[: mc.num_queries * mc.group_detr]
+                # When this changes the row count and group_detr > 1, it may
+                # scramble groups 1+; the warning above covers that case.
+                checkpoint["model"][name] = tensor[:target_query_rows]
 
     checkpoint["model"] = remap_projector_to_cross_attn(checkpoint["model"], nn_model)
 

--- a/src/rfdetr/models/weights.py
+++ b/src/rfdetr/models/weights.py
@@ -41,6 +41,27 @@ _PE_KEY_SUFFIX = "embeddings.position_embeddings"
 _QUERY_PARAM_SUFFIXES: tuple[str, ...] = ("refpoint_embed.weight", "query_feat.weight")
 
 
+def _is_query_param(name: str) -> bool:
+    """Return whether *name* is a state-dict key for a packed query parameter.
+
+    Single source of truth for the ``_QUERY_PARAM_SUFFIXES`` suffix match, so every call site agrees on which keys are
+    reshaped per group.
+
+    Args:
+        name: A checkpoint / model ``state_dict`` key.
+
+    Returns:
+        ``True`` when the key ends with one of ``_QUERY_PARAM_SUFFIXES``.
+
+    Examples:
+        >>> _is_query_param("transformer.refpoint_embed.weight")
+        True
+        >>> _is_query_param("class_embed.weight")
+        False
+    """
+    return name.endswith(_QUERY_PARAM_SUFFIXES)
+
+
 def _slice_query_param_per_group(
     tensor: Tensor,
     ckpt_num_queries: int,
@@ -427,7 +448,7 @@ def load_pretrain_weights(
     # but TrainConfig does not include num_queries (it lives on ModelConfig).
     if (ckpt_num_queries is None) != (ckpt_group_detr is None):
         _first_query_key = next(
-            (k for k in checkpoint["model"] if any(k.endswith(s) for s in _QUERY_PARAM_SUFFIXES)),
+            (k for k in checkpoint["model"] if _is_query_param(k)),
             None,
         )
         if _first_query_key is not None:
@@ -451,15 +472,21 @@ def load_pretrain_weights(
                 )
     target_query_rows = mc.num_queries * mc.group_detr
     # Warn once (not once per suffix key) only when the fallback truncates a
-    # query tensor. Several published legacy checkpoints omit both args but
-    # already have exactly the configured number of rows, so their flat slice is
-    # an identity and cannot scramble any group.
-    legacy_fallback_truncates = any(
-        tensor.shape[0] > target_query_rows
-        for name, tensor in checkpoint["model"].items()
-        if any(name.endswith(suffix) for suffix in _QUERY_PARAM_SUFFIXES)
-    )
-    if mc.group_detr > 1 and (ckpt_num_queries is None or ckpt_group_detr is None) and legacy_fallback_truncates:
+    # query tensor. Checkpoints without args.num_queries/args.group_detr
+    # (published legacy files and BestModelCallback output, whose args value is a
+    # TrainConfig dump lacking both fields) already have exactly the configured
+    # number of rows, so their flat slice is a data identity: it cannot reorder
+    # or drop rows, but it does not guarantee that the checkpoint's (num_queries,
+    # group_detr) factorization matches the target.
+    # The truncation scan is the last conjunct so the cheap scalar guards short-circuit
+    # it away on every load that cannot warn.
+    if (
+        mc.group_detr > 1
+        and (ckpt_num_queries is None or ckpt_group_detr is None)
+        and any(
+            tensor.shape[0] > target_query_rows for name, tensor in checkpoint["model"].items() if _is_query_param(name)
+        )
+    ):
         logger.warning(
             "load_pretrain_weights: checkpoint lacks args.num_queries / "
             "args.group_detr; falling back to flat slice. With "
@@ -468,7 +495,7 @@ def load_pretrain_weights(
             mc.group_detr,
         )
     for name in list(checkpoint["model"].keys()):
-        if any(name.endswith(x) for x in _QUERY_PARAM_SUFFIXES):
+        if _is_query_param(name):
             tensor = checkpoint["model"][name]
             if ckpt_num_queries is not None and ckpt_group_detr is not None:
                 checkpoint["model"][name] = _slice_query_param_per_group(
@@ -479,10 +506,13 @@ def load_pretrain_weights(
                     target_group_detr=mc.group_detr,
                 )
             else:
-                # Legacy checkpoint with no num_queries/group_detr in args:
+                # Checkpoint without args.num_queries/args.group_detr (published legacy files
+                # and BestModelCallback output, whose args value is a TrainConfig dump lacking
+                # both fields):
                 # preserve the original flat slice for backward compatibility.
-                # When this changes the row count and group_detr > 1, it may
-                # scramble groups 1+; the warning above covers that case.
+                # This is only a data identity when the row total already matches;
+                # without metadata, a different (num_queries, group_detr) split
+                # is still reinterpreted under the target partition undetectably.
                 checkpoint["model"][name] = tensor[:target_query_rows]
 
     checkpoint["model"] = remap_projector_to_cross_attn(checkpoint["model"], nn_model)

--- a/tests/models/test_weights.py
+++ b/tests/models/test_weights.py
@@ -1003,6 +1003,45 @@ class TestLoadPretrainWeightsPerGroupQuerySlice:
             f"Expected scramble-risk warning for group_detr > 1; got: {captured}"
         )
 
+    def test_legacy_fallback_matching_rows_is_silent_identity(self, monkeypatch) -> None:
+        """Missing metadata needs no warning when the configured flat slice changes nothing."""
+        from rfdetr.models.weights import load_pretrain_weights
+
+        mc = RFDETRBaseConfig(
+            pretrain_weights="/fake/weights.pth",
+            device="cpu",
+            num_queries=4,
+            num_select=4,
+            group_detr=3,
+        )
+        labelled_refpoint = _labelled_query_tensor(num_queries=4, group_detr=3, dim=4)
+        labelled_query_feat = _labelled_query_tensor(num_queries=4, group_detr=3, dim=256)
+        checkpoint = {
+            "model": {
+                "class_embed.weight": torch.randn(91, 256),
+                "class_embed.bias": torch.randn(91),
+                "refpoint_embed.weight": labelled_refpoint,
+                "query_feat.weight": labelled_query_feat,
+            },
+            "args": {},
+        }
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
+
+        captured: list[str] = []
+
+        def _capture(msg: str, *args: object, **kwargs: object) -> None:
+            captured.append(msg % args if args else msg)
+
+        monkeypatch.setattr("rfdetr.models.weights.logger.warning", _capture)
+
+        nn_model = _fake_nn_model()
+        load_pretrain_weights(nn_model, mc)
+
+        passed_state = nn_model.load_state_dict.call_args[0][0]
+        assert torch.equal(passed_state["refpoint_embed.weight"], labelled_refpoint)
+        assert torch.equal(passed_state["query_feat.weight"], labelled_query_feat)
+        assert not any("scramble" in msg or "flat slice" in msg for msg in captured), captured
+
     def test_legacy_fallback_when_args_missing_num_queries_key(self, monkeypatch, tmp_path):
         """When checkpoint args dict lacks num_queries/group_detr keys, falls back to flat legacy slice."""
         from rfdetr.models.weights import load_pretrain_weights

--- a/tests/models/test_weights.py
+++ b/tests/models/test_weights.py
@@ -659,20 +659,24 @@ class TestApplyLora:
 # ---------------------------------------------------------------------------
 
 
-def _labelled_query_tensor(num_queries: int, group_detr: int, dim: int = 2) -> torch.Tensor:
-    """Build a query embedding tensor where row ``g * num_queries + q`` encodes ``[g * 100 + q, 0, ...]``.
+def _labelled_query_tensor(num_queries: int, group_detr: int, dim: int = 2, label_stride: int = 100) -> torch.Tensor:
+    """Build a query embedding tensor where row ``g * num_queries + q`` encodes ``[g * label_stride + q, 0, ...]``.
 
     This lets tests check the per-group ordering of the result without floating-point
-    fuzz: the first column carries the (group, query) identity directly.
+    fuzz: the first column carries the (group, query) identity directly. ``label_stride``
+    must exceed the largest ``q`` used by a caller, or labels from different groups collide
+    (e.g. the default stride of 100 collides once ``num_queries >= 100``).
 
     Examples:
         >>> _labelled_query_tensor(2, 2, dim=1).squeeze(-1).tolist()
         [0.0, 1.0, 100.0, 101.0]
+        >>> _labelled_query_tensor(150, 2, dim=1, label_stride=1000).squeeze(-1).tolist()[100]
+        100.0
     """
     rows = []
     for g in range(group_detr):
         for q in range(num_queries):
-            rows.append([float(g * 100 + q)] + [0.0] * (dim - 1))
+            rows.append([float(g * label_stride + q)] + [0.0] * (dim - 1))
     return torch.tensor(rows, dtype=torch.float32)
 
 
@@ -1003,19 +1007,161 @@ class TestLoadPretrainWeightsPerGroupQuerySlice:
             f"Expected scramble-risk warning for group_detr > 1; got: {captured}"
         )
 
-    def test_legacy_fallback_matching_rows_is_silent_identity(self, monkeypatch) -> None:
-        """Missing metadata needs no warning when the configured flat slice changes nothing."""
+    def test_legacy_fallback_mixed_truncating_and_non_truncating_tensors(self, monkeypatch) -> None:
+        """One query tensor truncates against target rows while its sibling does not — only the former is sliced.
+
+        ``legacy_fallback_truncates`` is computed via ``any(...)`` across every query-suffix tensor, so it stays
+        True even when only one of ``refpoint_embed.weight`` / ``query_feat.weight`` actually exceeds
+        ``target_query_rows``. The warning must still fire (``any`` sees the truncating tensor), but each tensor is
+        sliced independently in the per-tensor loop: the truncating one is shortened, the non-truncating one passes
+        through unchanged.
+        """
         from rfdetr.models.weights import load_pretrain_weights
 
         mc = RFDETRBaseConfig(
             pretrain_weights="/fake/weights.pth",
             device="cpu",
-            num_queries=4,
-            num_select=4,
+            num_queries=2,
+            num_select=2,
             group_detr=3,
         )
-        labelled_refpoint = _labelled_query_tensor(num_queries=4, group_detr=3, dim=4)
-        labelled_query_feat = _labelled_query_tensor(num_queries=4, group_detr=3, dim=256)
+        # target_query_rows = 2 * 3 = 6. refpoint has 8 rows (> 6, truncates); query_feat has 6 rows (== 6, no-op).
+        labelled_refpoint = _labelled_query_tensor(num_queries=8, group_detr=1, dim=4)
+        labelled_query_feat = _labelled_query_tensor(num_queries=6, group_detr=1, dim=256)
+        checkpoint = {
+            "model": {
+                "class_embed.weight": torch.randn(91, 256),
+                "class_embed.bias": torch.randn(91),
+                "refpoint_embed.weight": labelled_refpoint,
+                "query_feat.weight": labelled_query_feat,
+            },
+            "args": {},  # no num_queries / group_detr keys
+        }
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
+
+        captured: list[str] = []
+
+        def _capture(msg: str, *args: object, **kwargs: object) -> None:
+            try:
+                captured.append(msg % args if args else msg)
+            except TypeError:
+                captured.append(msg)
+
+        monkeypatch.setattr("rfdetr.models.weights.logger.warning", _capture)
+
+        nn_model = _fake_nn_model()
+        load_pretrain_weights(nn_model, mc)
+
+        assert any("group_detr" in msg and ("scramble" in msg or "flat slice" in msg) for msg in captured), (
+            f"Expected scramble-risk warning when at least one query tensor truncates; got: {captured}"
+        )
+        passed_state = nn_model.load_state_dict.call_args[0][0]
+        refpoint = passed_state["refpoint_embed.weight"]
+        query_feat = passed_state["query_feat.weight"]
+        assert refpoint.shape[0] == 6, (
+            f"Truncating tensor must be shortened to target_query_rows=6, got {refpoint.shape[0]}"
+        )
+        assert torch.equal(refpoint, labelled_refpoint[:6]), "Truncated tensor must keep the first 6 original rows."
+        assert torch.equal(query_feat, labelled_query_feat), (
+            "Non-truncating sibling tensor (already 6 rows) must pass through unchanged."
+        )
+
+    def test_legacy_fallback_matching_total_rows_can_still_scramble_groups(self, monkeypatch) -> None:
+        """Row-count match does not imply factorization match — the silent flat slice can still reinterpret groups.
+
+        Checkpoint trained with (num_queries=150, group_detr=2) has the same total row count (300) as a target
+        configured with (num_queries=100, group_detr=3). Because the totals match, ``legacy_fallback_truncates`` is
+        False and no warning fires — but the flat ``tensor[:300]`` slice is a no-op on row *values*, while the target
+        silently reinterprets those rows under its own (100, 3) partition. Row 100 is checkpoint group 0's query 100
+        under the checkpoint's own (150, 2) split, yet the target treats row 100 as group 1's query 0.
+        """
+        from rfdetr.models.weights import load_pretrain_weights
+
+        mc = RFDETRBaseConfig(
+            pretrain_weights="/fake/weights.pth",
+            device="cpu",
+            num_queries=100,
+            num_select=100,
+            group_detr=3,
+        )
+        # Non-colliding label scheme: default stride (100) collides once num_queries >= 100
+        # (checkpoint group0/query100 would equal group1/query0 = 100). Use stride=1000 so the
+        # checkpoint's own (group, query) identity survives intact through the flat slice.
+        labelled_refpoint = _labelled_query_tensor(num_queries=150, group_detr=2, dim=4, label_stride=1000)
+        labelled_query_feat = _labelled_query_tensor(num_queries=150, group_detr=2, dim=256, label_stride=1000)
+        checkpoint = {
+            "model": {
+                "class_embed.weight": torch.randn(91, 256),
+                "class_embed.bias": torch.randn(91),
+                "refpoint_embed.weight": labelled_refpoint,
+                "query_feat.weight": labelled_query_feat,
+            },
+            "args": {},  # no num_queries / group_detr keys
+        }
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
+
+        captured: list[str] = []
+
+        def _capture(msg: str, *args: object, **kwargs: object) -> None:
+            try:
+                captured.append(msg % args if args else msg)
+            except TypeError:
+                captured.append(msg)
+
+        monkeypatch.setattr("rfdetr.models.weights.logger.warning", _capture)
+
+        nn_model = _fake_nn_model()
+        load_pretrain_weights(nn_model, mc)
+
+        assert not any("scramble" in msg or "flat slice" in msg for msg in captured), (
+            f"Matching total row count (300 == 300) must not warn; got: {captured}"
+        )
+        passed_state = nn_model.load_state_dict.call_args[0][0]
+        # Checkpoint's own factorization (nq=150, g=2): row 100 is group 0, query 100 → label 0*1000+100 = 100.
+        # The target's factorization (nq=100, g=3) instead treats row 100 as group 1, query 0. The silent flat
+        # slice actually reinterprets the data under the target partition: pin that the CHECKPOINT's value
+        # (100), not a target-consistent group1/query0 value (which would be 1000), lands at row 100.
+        assert passed_state["refpoint_embed.weight"][100, 0].item() == 100.0, (
+            "Row 100 must still hold the checkpoint's group0/query100 value (100), proving the flat slice "
+            "silently reinterprets it as the target's group1/query0 without reordering anything."
+        )
+        assert passed_state["query_feat.weight"][100, 0].item() == 100.0
+
+    @pytest.mark.parametrize(
+        "mc_num_queries,mc_group_detr,ckpt_num_queries,ckpt_group_detr",
+        [
+            pytest.param(4, 3, 4, 3, id="matching_rows_group_detr_gt1"),
+            pytest.param(4, 1, 8, 1, id="truncating_rows_group_detr_eq1"),
+        ],
+    )
+    def test_legacy_fallback_is_silent_when_no_scramble_risk(
+        self,
+        monkeypatch,
+        mc_num_queries: int,
+        mc_group_detr: int,
+        ckpt_num_queries: int,
+        ckpt_group_detr: int,
+    ) -> None:
+        """Missing metadata needs no warning when either the flat slice is a no-op or ``group_detr == 1``.
+
+        Two distinct reasons both suppress the scramble-risk warning for the same missing-metadata flat-slice
+        fallback: (1) the configured flat slice changes nothing because row counts already match
+        (``group_detr > 1`` but nothing truncates), or (2) ``group_detr == 1`` has no groups to scramble even
+        though the flat slice does truncate rows. Both cases assert against the same
+        ``tensor[:target_query_rows]`` formula, which is a true no-op in case (1) and an actual truncation in
+        case (2) — this pins that the warning stays silent for both, for different reasons.
+        """
+        from rfdetr.models.weights import load_pretrain_weights
+
+        mc = RFDETRBaseConfig(
+            pretrain_weights="/fake/weights.pth",
+            device="cpu",
+            num_queries=mc_num_queries,
+            num_select=mc_num_queries,
+            group_detr=mc_group_detr,
+        )
+        labelled_refpoint = _labelled_query_tensor(num_queries=ckpt_num_queries, group_detr=ckpt_group_detr, dim=4)
+        labelled_query_feat = _labelled_query_tensor(num_queries=ckpt_num_queries, group_detr=ckpt_group_detr, dim=256)
         checkpoint = {
             "model": {
                 "class_embed.weight": torch.randn(91, 256),
@@ -1030,7 +1176,10 @@ class TestLoadPretrainWeightsPerGroupQuerySlice:
         captured: list[str] = []
 
         def _capture(msg: str, *args: object, **kwargs: object) -> None:
-            captured.append(msg % args if args else msg)
+            try:
+                captured.append(msg % args if args else msg)
+            except TypeError:
+                captured.append(msg)
 
         monkeypatch.setattr("rfdetr.models.weights.logger.warning", _capture)
 
@@ -1038,9 +1187,59 @@ class TestLoadPretrainWeightsPerGroupQuerySlice:
         load_pretrain_weights(nn_model, mc)
 
         passed_state = nn_model.load_state_dict.call_args[0][0]
+        target_query_rows = mc_num_queries * mc_group_detr
+        assert torch.equal(passed_state["refpoint_embed.weight"], labelled_refpoint[:target_query_rows])
+        assert torch.equal(passed_state["query_feat.weight"], labelled_query_feat[:target_query_rows])
+        assert not any("scramble" in msg or "flat slice" in msg for msg in captured), captured
+
+    def test_legacy_fallback_fewer_checkpoint_rows_than_target_is_silent_noop(self, monkeypatch) -> None:
+        """Growing num_queries (checkpoint has FEWER query rows than target) never warns — strict ``>`` excludes it.
+
+        ``legacy_fallback_truncates`` only trips on ``tensor.shape[0] > target_query_rows``. A checkpoint with 6 query
+        rows loaded into a target needing 12 (``num_queries=4, group_detr=3``) never satisfies that strict inequality,
+        so no warning fires — and ``tensor[:12]`` on a 6-row tensor is a no-op, so the tensor is untouched.
+        """
+        from rfdetr.models.weights import load_pretrain_weights
+
+        mc = RFDETRBaseConfig(
+            pretrain_weights="/fake/weights.pth",
+            device="cpu",
+            num_queries=4,
+            num_select=4,
+            group_detr=3,
+        )
+        labelled_refpoint = _labelled_query_tensor(num_queries=6, group_detr=1, dim=4)
+        labelled_query_feat = _labelled_query_tensor(num_queries=6, group_detr=1, dim=256)
+        checkpoint = {
+            "model": {
+                "class_embed.weight": torch.randn(91, 256),
+                "class_embed.bias": torch.randn(91),
+                "refpoint_embed.weight": labelled_refpoint,
+                "query_feat.weight": labelled_query_feat,
+            },
+            "args": {},  # no num_queries / group_detr keys
+        }
+        monkeypatch.setattr("rfdetr.models.weights.torch.load", lambda *a, **kw: checkpoint)
+
+        captured: list[str] = []
+
+        def _capture(msg: str, *args: object, **kwargs: object) -> None:
+            try:
+                captured.append(msg % args if args else msg)
+            except TypeError:
+                captured.append(msg)
+
+        monkeypatch.setattr("rfdetr.models.weights.logger.warning", _capture)
+
+        nn_model = _fake_nn_model()
+        load_pretrain_weights(nn_model, mc)
+
+        assert not any("scramble" in msg or "flat slice" in msg for msg in captured), (
+            f"Checkpoint with fewer rows (6) than target (12) must not warn; got: {captured}"
+        )
+        passed_state = nn_model.load_state_dict.call_args[0][0]
         assert torch.equal(passed_state["refpoint_embed.weight"], labelled_refpoint)
         assert torch.equal(passed_state["query_feat.weight"], labelled_query_feat)
-        assert not any("scramble" in msg or "flat slice" in msg for msg in captured), captured
 
     def test_legacy_fallback_when_args_missing_num_queries_key(self, monkeypatch, tmp_path):
         """When checkpoint args dict lacks num_queries/group_detr keys, falls back to flat legacy slice."""


### PR DESCRIPTION
## What does this PR do?

`load_pretrain_weights()` warns about a possible "query scramble" whenever a checkpoint is missing `args.num_queries`/`args.group_detr` and the model config has `group_detr > 1`. The fallback that follows the warning is `tensor[:mc.num_queries * mc.group_detr]`, a flat slice on the query tensors. That slice only scrambles anything when it actually **truncates** rows — if the checkpoint's query tensor already has exactly the configured number of rows, the slice is an identity view and nothing gets reordered or dropped.

That is exactly the case for the official `Large`, `SegSmall` and `KeypointPreview` checkpoints: none of them carries the metadata, but all three already have `num_queries * group_detr` rows (3900 = 300x13 for Large/SegSmall-shaped queries, 1300 = 100x13 for KeypointPreview). So loading any of them prints a warning claiming a possible accuracy hit from group scrambling, even though there is nothing to scramble.

The fix checks, before deciding to warn, whether any query tensor in the checkpoint actually has **more** rows than the target (`target_query_rows = mc.num_queries * mc.group_detr`). The fallback only truncates in that case, so the warning only fires when it's actually true. The slice itself is unchanged.

## Type of Change

- Bug fix (false-positive warning; no change to loaded weights or model behaviour)

## Why this was missed

The warning was added in #1019 ("fix query scramble", `4954c416`), which fixed a real bug: reducing `num_queries` on a multi-group checkpoint truncated it incorrectly. The regression test added there builds a checkpoint without metadata that *does* truncate, so it never covered a published checkpoint whose row count already matches the target. The warning did surface publicly once, in #1120, but buried in a thread about an unrelated NumPy crash, so it never got connected back to this pattern.

## Validation

Verified against the three official checkpoints that hit this path (Large, SegSmall, KeypointPreview XLarge): loaded the raw checkpoint, built the real model, and compared `refpoint_embed.weight` / `query_feat.weight` source vs. loaded tensor by SHA-256 in all three — identical, confirming the slice is a true identity in this case, not just a matching row count. Large and SegSmall's full loaded weight/config JSON is also byte-identical between the pre-fix and patched load (`cmp` exit 0).

New test `test_legacy_fallback_matching_rows_is_silent_identity` builds a checkpoint with 4 queries x 3 groups = 12 rows, matching the configured target exactly: 1 failed against the pre-fix code (captures the warning), passes with the fix. The existing truncation test (4 -> 2 queries x 3 groups, a real truncation) is untouched and still requires the warning — the dangerous case is not silenced.

`ruff check` / `ruff format --check` clean on both files. `mypy` reports the same two pre-existing issues on base and patched (`peft` import not available, one unused `type: ignore`); no new errors from this diff.

Let me know what you think ..
