### PR TITLE
refactor: enable mypy strict checking for rfdetr.datasets.save_grids

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -410,7 +410,6 @@ overrides = [
     "rfdetr.config",
     "rfdetr.datasets._develop",
     "rfdetr.datasets.coco",
-    "rfdetr.datasets.save_grids",
     "rfdetr.datasets.synthetic",
     "rfdetr.datasets.transforms",
     "rfdetr.datasets.yolo",

--- a/src/rfdetr/datasets/save_grids.py
+++ b/src/rfdetr/datasets/save_grids.py
@@ -35,7 +35,7 @@ class DatasetGridSaver:
     """
 
     def __init__(
-        self, data_loader: DataLoader, output_dir: Path, max_batches: int = 3, dataset_type: str = "train"
+        self, data_loader: DataLoader[Any], output_dir: Path, max_batches: int = 3, dataset_type: str = "train"
     ) -> None:
         self.data_loader = data_loader
         self.output_dir = output_dir
@@ -173,7 +173,7 @@ class DatasetGridSaver:
         single_target: dict[str, Any],
         image_shape: tuple[int, int],
         num_instances: int,
-    ) -> np.ndarray | None:
+    ) -> np.ndarray[Any, Any] | None:
         """Return target masks as ``(N, H, W)`` booleans aligned to the rendered image shape.
 
         Args:


### PR DESCRIPTION
## What does this PR do?

Enables strict `mypy` checking for `rfdetr.datasets.save_grids` and removes it from the `ignore_errors` override list in `pyproject.toml`.

Removing the override surfaced two `type-arg` errors, both fixed by supplying type parameters:

- `DatasetGridSaver.__init__`: `DataLoader` becomes `DataLoader[Any]`
- `DatasetGridSaver._extract_masks`: `np.ndarray` becomes `np.ndarray[Any, Any]`

Both follow conventions already present in the codebase. `DataLoader[Any]` matches `RFDETRDataModule.train_dataloader()` and `val_dataloader()` in `src/rfdetr/training/module_data.py`, which are the only call sites (via `src/rfdetr/detr.py`). `np.ndarray[Any, Any]` matches the annotation style used in `rfdetr.evaluation.coco_eval`, `rfdetr.export.main`, and `rfdetr.detr`.

There are no runtime behaviour changes: the module uses `from __future__ import annotations`, so neither annotation is evaluated at runtime.

**Related Issue(s):** Contributes to #564

## Type of Change

- Refactoring (no functional changes)

## Testing

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**

No new tests were added, as this is a type-annotation-only change with no runtime effect. Existing coverage was run unmodified:

- `mypy src/rfdetr/ --no-error-summary`: no errors reported for `save_grids`
- `pytest tests/datasets/test_save_grids.py tests/training/test_detr_shim.py`: 145 passed
- `pre-commit run --all-files`: passing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

Documentation was not updated as this change is internal typing only, with no public API surface affected.

One open question for maintainers: `_extract_masks` always returns a boolean array, so `np.ndarray[Any, np.dtype[np.bool_]]` would be more precise and also type-checks cleanly, matching the pattern used in `rfdetr.evaluation.matching`. I went with `np.ndarray[Any, Any]` since it is the more common convention across the codebase, but I am happy to tighten it if you would prefer the more specific annotation.