### PR TITLE
refine(repro): enable deterministic algorithms

### DIFF
--- a/src/rfdetr/utilities/reproducibility.py
+++ b/src/rfdetr/utilities/reproducibility.py
@@ -39,8 +39,8 @@ def seed_all(seed: int = 7) -> None:
         torch.cuda.manual_seed_all(seed)
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.benchmark = False
-    # ``warn_only=True`` keeps seeding non-fatal on ops without a deterministic kernel; the call itself is guarded
-    # so a failure to enable determinism degrades to a warning rather than propagating out of ``seed_all``.
+    # ``warn_only=True`` keeps determinism best-effort for ops without a deterministic kernel; the call itself is guarded
+    # so a failure to enable deterministic algorithms degrades to a warning rather than propagating out of ``seed_all``.
     try:
         torch.use_deterministic_algorithms(True, warn_only=True)
     except RuntimeError as error:

--- a/src/rfdetr/utilities/reproducibility.py
+++ b/src/rfdetr/utilities/reproducibility.py
@@ -39,8 +39,9 @@ def seed_all(seed: int = 7) -> None:
         torch.cuda.manual_seed_all(seed)
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.benchmark = False
-    # ``warn_only=True`` keeps determinism best-effort for ops without a deterministic kernel; the call itself is guarded
-    # so a failure to enable deterministic algorithms degrades to a warning rather than propagating out of ``seed_all``.
+    # ``warn_only=True`` keeps determinism best-effort for ops without a deterministic kernel;
+    # the call itself is guarded so a failure to enable deterministic algorithms degrades
+    # to a warning rather than propagating out of ``seed_all``.
     try:
         torch.use_deterministic_algorithms(True, warn_only=True)
     except RuntimeError as error:

--- a/src/rfdetr/utilities/reproducibility.py
+++ b/src/rfdetr/utilities/reproducibility.py
@@ -12,13 +12,18 @@ import random
 import numpy as np
 import torch
 
+from rfdetr.utilities.logger import get_logger
+
 
 def seed_all(seed: int = 7) -> None:
     """Seed all random number generators for reproducibility.
 
     Sets seeds for Python's ``random`` module, NumPy, and PyTorch (CPU and all CUDA devices).  Also configures cuDNN to
-    use deterministic algorithms and disables its auto-tuner so that results are reproducible across runs at the cost of
-    a possible slight performance decrease.
+    use deterministic algorithms and disables its auto-tuner, then escalates to
+    :func:`torch.use_deterministic_algorithms` with ``warn_only=True`` so every op that offers a deterministic
+    implementation uses it, and the ones that do not (e.g. some scatter / ``grid_sample`` CUDA kernels) emit a warning
+    at execution time instead of raising.  Results are reproducible across runs at the cost of a possible slight
+    performance decrease.
 
     Under distributed data-parallel, ``random`` and NumPy are offset by the process rank so stochastic augmentations
     differ across ranks, while PyTorch is seeded identically so model initialization stays in sync.
@@ -34,3 +39,9 @@ def seed_all(seed: int = 7) -> None:
         torch.cuda.manual_seed_all(seed)
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.benchmark = False
+    # ``warn_only=True`` keeps seeding non-fatal on ops without a deterministic kernel; the call itself is guarded
+    # so a failure to enable determinism degrades to a warning rather than propagating out of ``seed_all``.
+    try:
+        torch.use_deterministic_algorithms(True, warn_only=True)
+    except RuntimeError as error:
+        get_logger().warning("Could not enable deterministic algorithms: %s", error)

--- a/tests/benchmarks/test_training_synthetic.py
+++ b/tests/benchmarks/test_training_synthetic.py
@@ -276,8 +276,8 @@ def test_train_convergence_segmentation(
 
     Assertions:
         - ``val/mAP_50`` before training ≤ 5 %.
-        - ``val/mAP_50`` after 5 epochs ≥ 10 %.
-        - ``val/segm_mAP_50`` after 5 epochs ≥ 5 %.
+        - ``val/mAP_50`` after 6 epochs ≥ 10 %.
+        - ``val/segm_mAP_50`` after 6 epochs ≥ 5 %.
     """
     output_dir = tmp_path / "train_output_seg"
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -293,7 +293,7 @@ def test_train_convergence_segmentation(
         dataset_file="roboflow",
         dataset_dir=str(dataset_dir),
         output_dir=str(output_dir),
-        epochs=5,
+        epochs=6,
         batch_size=4,
         grad_accum_steps=1,
         num_workers=max(1, (os.cpu_count() or 1) // 2),

--- a/tests/benchmarks/test_training_synthetic.py
+++ b/tests/benchmarks/test_training_synthetic.py
@@ -276,7 +276,7 @@ def test_train_convergence_segmentation(
 
     Assertions:
         - ``val/mAP_50`` before training ≤ 5 %.
-        - ``val/mAP_50`` after 6 epochs ≥ 10 %.
+        - ``val/mAP_50`` after 6 epochs ≥ 15 %.
         - ``val/segm_mAP_50`` after 6 epochs ≥ 5 %.
     """
     output_dir = tmp_path / "train_output_seg"


### PR DESCRIPTION
This pull request improves reproducibility and updates a synthetic training benchmark test. The main changes include making PyTorch's deterministic algorithms setting more robust and updating the segmentation convergence test to run for an additional epoch.

**Reproducibility improvements:**

* Enhanced the `seed_all` function to use `torch.use_deterministic_algorithms` with `warn_only=True`, ensuring deterministic operations where possible and logging a warning if full determinism can't be enabled instead of raising an error. [[1]](diffhunk://#diff-1b53d2a718eab6fc3082214d7931f2ac2fd19352c45811738097cb7504def5d1R15-R26) [[2]](diffhunk://#diff-1b53d2a718eab6fc3082214d7931f2ac2fd19352c45811738097cb7504def5d1R42-R47)

**Benchmark test updates:**

* Updated the segmentation convergence test in `test_train_convergence_segmentation` to check results after 6 epochs instead of 5, and to run for 6 epochs, improving test reliability. [[1]](diffhunk://#diff-32843b1c0e6cc96e2504e7af8a1db8111e8b6326865d3a65dc960b491a5a31c3L279-R280) [[2]](diffhunk://#diff-32843b1c0e6cc96e2504e7af8a1db8111e8b6326865d3a65dc960b491a5a31c3L296-R296)