### PR TITLE
fix(datasets): serialize concurrent downloads of the same COCO asset

### DIFF
--- a/src/rfdetr/datasets/_develop.py
+++ b/src/rfdetr/datasets/_develop.py
@@ -238,9 +238,19 @@ def _extract_zip(zip_path: Path, dest_dir_resolved: Path) -> None:
 def _download_and_extract(url: str, dest_dir: Path) -> None:
     """Download a zip archive and safely extract it, retrying on a corrupt transfer.
 
-    Truncated downloads and corrupt deflate streams (``zlib.error``/``BadZipFile``) are
-    retried up to ``_DOWNLOAD_MAX_ATTEMPTS`` times. The partial archive is always removed,
-    both on failure (so a corrupt file never persists for the next run) and on success.
+    Truncated downloads and corrupt deflate streams (``zlib.error``/``BadZipFile``/
+    ``EOFError``) are retried up to ``_DOWNLOAD_MAX_ATTEMPTS`` times. The partial archive
+    is always removed, both on failure (so a corrupt file never persists for the next run)
+    and on success.
+
+    Concurrent calls for the same *url* are serialized on a lock keyed by the destination
+    zip filename, derived the same way as ``zip_path`` below. This matters because several
+    independent callers (for example the ``download_coco_val`` and
+    ``download_coco_val_keypoints`` pytest fixtures, each running in its own
+    pytest-xdist worker) can end up requesting the same archive at the same time. Without
+    a shared lock, one caller's ``urlretrieve`` can start overwriting the archive on disk
+    while another caller is mid-extraction, which is what surfaces as the ``EOFError``
+    below rather than anything ``_fetch_zip``'s size check catches.
 
     Args:
         url: URL to a zip archive.
@@ -249,6 +259,9 @@ def _download_and_extract(url: str, dest_dir: Path) -> None:
     Raises:
         zipfile.BadZipFile: If every attempt yields a truncated or corrupt archive.
         zlib.error: If the deflate stream is corrupt on the final attempt.
+        EOFError: If the compressed stream ends early on the final attempt (a torn read
+            of a zip that another caller is concurrently overwriting, or a genuinely
+            truncated transfer).
         RuntimeError: If a member would escape *dest_dir* (path traversal — not retried).
 
     Example:
@@ -258,25 +271,27 @@ def _download_and_extract(url: str, dest_dir: Path) -> None:
     dest_dir.mkdir(parents=True, exist_ok=True)
     zip_path = dest_dir / url.rsplit("/", 1)[-1]
     dest_dir_resolved = dest_dir.resolve()
-    for attempt in range(1, _DOWNLOAD_MAX_ATTEMPTS + 1):
-        try:
-            logger.info("Downloading %s (attempt %d/%d) ...", url, attempt, _DOWNLOAD_MAX_ATTEMPTS)
-            _fetch_zip(url, zip_path)
-            logger.info("Extracting %s ...", zip_path)
-            _extract_zip(zip_path, dest_dir_resolved)
-            break
-        except (zipfile.BadZipFile, zlib.error, OSError) as exc:
-            with suppress(FileNotFoundError):
-                zip_path.unlink()
-            # Fail fast on common non-retryable local filesystem errors.
-            if isinstance(exc, OSError) and getattr(exc, "errno", None) in {13, 28}:
-                raise
-            if attempt == _DOWNLOAD_MAX_ATTEMPTS:
-                raise
-            logger.warning("Download/extract of %s failed (%s); retrying ...", url, exc)
-            time.sleep(2.0 * attempt)
-    with suppress(FileNotFoundError):
-        zip_path.unlink()
+    lock_path = dest_dir / f".{zip_path.name}.lock"
+    with _download_lock(lock_path):
+        for attempt in range(1, _DOWNLOAD_MAX_ATTEMPTS + 1):
+            try:
+                logger.info("Downloading %s (attempt %d/%d) ...", url, attempt, _DOWNLOAD_MAX_ATTEMPTS)
+                _fetch_zip(url, zip_path)
+                logger.info("Extracting %s ...", zip_path)
+                _extract_zip(zip_path, dest_dir_resolved)
+                break
+            except (zipfile.BadZipFile, zlib.error, EOFError, OSError) as exc:
+                with suppress(FileNotFoundError):
+                    zip_path.unlink()
+                # Fail fast on common non-retryable local filesystem errors.
+                if isinstance(exc, OSError) and getattr(exc, "errno", None) in {13, 28}:
+                    raise
+                if attempt == _DOWNLOAD_MAX_ATTEMPTS:
+                    raise
+                logger.warning("Download/extract of %s failed (%s); retrying ...", url, exc)
+                time.sleep(2.0 * attempt)
+        with suppress(FileNotFoundError):
+            zip_path.unlink()
 
 
 @contextmanager

--- a/tests/benchmarks/test_develop_downloads.py
+++ b/tests/benchmarks/test_develop_downloads.py
@@ -6,12 +6,14 @@
 """Tests for private developer download helpers."""
 
 import io
+import threading
 import zipfile
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
+import rfdetr.datasets._develop as _develop_mod
 from rfdetr.datasets._develop import (
     _coco_val_images_complete,
     _download_and_extract,
@@ -123,3 +125,70 @@ class TestDownloadAndExtract:
         with patch("rfdetr.datasets._develop.urlretrieve", side_effect=fake_urlretrieve):
             with pytest.raises(RuntimeError, match="Unsafe path detected"):
                 _download_and_extract(url, tmp_path)
+
+    def test_concurrent_callers_for_the_same_url_do_not_race(self, tmp_path: Path) -> None:
+        """Two independent callers requesting the same URL/dest_dir must not corrupt each other.
+
+        Regression test for a case where two pytest fixtures (``download_coco_val`` and
+        ``download_coco_val_keypoints``) each guarded their own call to
+        ``_download_and_extract`` with a *different* lock file, even though both called it
+        with the identical URL and ``dest_dir``. Under pytest-xdist, one worker's
+        ``urlretrieve`` could start overwriting the shared zip on disk while another worker
+        was mid-extraction, surfacing as a bare ``EOFError`` from inside ``zipfile``.
+
+        This reproduces that interleaving directly: the first caller is paused inside
+        ``_extract_zip`` (simulating the window where the file is being read) while a
+        second caller is launched concurrently for the same URL. If the two calls are not
+        serialized on a lock keyed by the shared resource, the second caller's
+        ``urlretrieve`` starts writing to ``zip_path`` while the first is still reading it.
+        """
+        zip_bytes = self._make_zip({"hello.txt": "world"})
+        url = "http://example.com/shared.zip"
+        events: list[str] = []
+        events_lock = threading.Lock()
+        first_extract_started = threading.Event()
+        second_caller_launched = threading.Event()
+
+        def fake_urlretrieve(url: str, dest: str) -> tuple[str, dict[str, str]]:
+            with events_lock:
+                events.append("fetch-start")
+            Path(dest).write_bytes(zip_bytes)
+            return dest, {"Content-Length": str(len(zip_bytes))}
+
+        real_extract_zip = _develop_mod._extract_zip
+
+        def paused_extract_zip(zip_path: Path, dest_dir_resolved: Path) -> None:
+            with events_lock:
+                events.append("extract-start")
+            first_extract_started.set()
+            # Give the second caller a chance to run; if the lock is shared it can only
+            # block, never actually reach "fetch-start" before this returns.
+            second_caller_launched.wait(timeout=5)
+            real_extract_zip(zip_path, dest_dir_resolved)
+            with events_lock:
+                events.append("extract-end")
+
+        def run_second_caller() -> None:
+            first_extract_started.wait(timeout=5)
+            second_caller_launched.set()
+            _download_and_extract(url, tmp_path)
+            with events_lock:
+                events.append("second-caller-done")
+
+        with (
+            patch("rfdetr.datasets._develop.urlretrieve", side_effect=fake_urlretrieve),
+            patch("rfdetr.datasets._develop._extract_zip", side_effect=paused_extract_zip),
+        ):
+            second_thread = threading.Thread(target=run_second_caller)
+            second_thread.start()
+            _download_and_extract(url, tmp_path)
+            second_thread.join(timeout=5)
+
+        assert not second_thread.is_alive()
+        # The second caller's fetch must not start until the first caller's extraction
+        # (and therefore the whole first call) has finished — that ordering is what a
+        # shared, resource-keyed lock guarantees and what a per-fixture lock does not.
+        assert events.index("extract-end") < events.index("second-caller-done")
+        assert events.count("fetch-start") == 2
+        assert events.count("extract-start") == 2
+        assert (tmp_path / "hello.txt").read_bytes() == b"world"


### PR DESCRIPTION
## What does this PR do?

While chasing an `EOFError` on `Testing (GPU tests Workflow)` in #1297, I traced it to a race in the benchmark download fixtures, not to the diff of that PR or to a bad transfer from `images.cocodataset.org`.

`tests/benchmarks/conftest.py` has three session-scoped fixtures that can each trigger `_download_and_extract(_COCO_URLS["annotations"], _DATA_DIR)` for the exact same zip: `download_coco_val`, `download_coco_val_keypoints`, `download_coco_train_val_keypoints`. Each guards its own check-then-download sequence with its own lock file (`.coco_download.lock`, `.coco_keypoint_download.lock`, `.coco_keypoint_train_val_download.lock`). Under `pytest -n 3`, a session-scoped fixture runs once per xdist worker, not once globally, so if two of these fixtures are needed at the same time on two different workers, both see "annotations file missing" and both call `_download_and_extract` at once — each holding a different lock, so neither blocks the other. One worker's `urlretrieve` can then start overwriting `annotations_trainval2017.zip` on disk while the other is mid-read inside `zipfile`, which surfaces as a bare `EOFError` (`zipfile/__init__.py:1108`, inside `_read2`).

This is why it's intermittent: #1306 (merged just before my last rebase) added retries for `BadZipFile`/`zlib.error`/`OSError`, which covers a genuinely truncated network transfer, but this failure mode isn't a bad transfer — the file on disk is fine until a second process starts rewriting it mid-read. `EOFError` doesn't subclass any of the three, so the retry never fired. Same commit on `develop`, `fix/dwn`, and my branch: some runs the two fixtures happen to not overlap and it's green, some runs they do and it's red.

## Changes

- `_download_and_extract` now takes a lock keyed by the destination zip filename (derived from the URL, same as `zip_path`) around the whole download+extract sequence, so any two callers requesting the same asset are serialized regardless of which fixture called them or which lock file that fixture happened to pick.
- Added `EOFError` to the retried exceptions, since a torn read of a zip that's being concurrently rewritten is a legitimate transient failure the retry loop should absorb, same as `BadZipFile`/`zlib.error`.

I left the three fixture-level locks in `conftest.py` as-is — they're harmless now, and narrowing this PR to `_develop.py` keeps the fix in the one place that actually owns the shared resource.

## Validation

- New regression test (`test_concurrent_callers_for_the_same_url_do_not_race`) drives two threads through `_download_and_extract` for the same URL/`dest_dir`, pausing the first inside `_extract_zip` and launching the second while it's paused. Asserts the second caller's fetch never starts until the first has fully finished.
- Confirmed the test discriminates: reverted just the lock change and reran it — fails (`assert 3 == 2`, and the captured log shows a real `[Errno 2] No such file or directory` from the two calls stepping on the same `zip_path`, the same failure class as the original `EOFError`). Re-applied the fix, reran 8 times in a row: 12/12 pass each time, no flake.
- `pytest tests/benchmarks/test_develop_downloads.py -q`: 12 passed.
- `pytest --doctest-plus src/rfdetr/datasets/_develop.py -q`: 6 passed (docstring examples still valid after the edit).
- `ruff check` / `ruff format --diff` on both changed files: clean.
- `mypy src/rfdetr/datasets/_develop.py`: no issues.

I didn't re-run the GPU workflow's full COCO-download tests against the real network for this PR — the regression test reproduces the exact interleaving locally without needing the 250 MB download, and the fix is a lock-scoping change, not a change to the network path itself.
