### PR TITLE
Restore train/lr in the training progress bar

### DIFF
--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -584,14 +584,14 @@ class RFDETRModelModule(LightningModule):
         if isinstance(optimizer, list):
             optimizer = optimizer[0]
         # Optimizer may have multiple param groups with different LRs (e.g., backbone/decoder).
-        # Preserve the first group's LR for backward compatibility, but also log the
-        # min/max across all groups so the progress bar reflects the full schedule.
+        # Preserve the first group's LR for backward compatibility and progress-bar visibility.
+        # Keep min/max in the logs without taking extra progress-bar metric slots.
         group_lrs = [pg["lr"] for pg in optimizer.param_groups if "lr" in pg]
         if group_lrs:
             base_lr = group_lrs[0]
             min_lr = min(group_lrs)
             max_lr = max(group_lrs)
-            self.log("train/lr", base_lr, prog_bar=False, on_step=True, on_epoch=False)
+            self.log("train/lr", base_lr, prog_bar=True, on_step=True, on_epoch=False)
             self.log("train/lr_min", min_lr, prog_bar=False, on_step=True, on_epoch=False)
             self.log("train/lr_max", max_lr, prog_bar=False, on_step=True, on_epoch=False)
         if self._use_manual_optimization:

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -1018,15 +1018,15 @@ class TestTrainingStep:
         live_loss_calls = [c for c in module.log.call_args_list if c[0][0] == "loss"]
         assert len(live_loss_calls) == expected_live_loss_calls
 
-    def test_logs_learning_rate_without_progress_bar(self, tmp_path):
-        """Current learning rate should be logged without occupying progress-bar metric slots."""
+    def test_logs_learning_rate_to_progress_bar(self, tmp_path):
+        """Current learning rate must be logged every step as a progress-bar metric."""
         module, samples, targets, _, _ = self._run_step(tmp_path)
 
         module.training_step((samples, targets), batch_idx=0)
 
         lr_calls = [c for c in module.log.call_args_list if c[0][0] == "train/lr"]
         assert len(lr_calls) == 1
-        assert lr_calls[0].kwargs.get("prog_bar") is False
+        assert lr_calls[0].kwargs.get("prog_bar") is True
         assert lr_calls[0].kwargs.get("on_step") is True
         assert lr_calls[0].kwargs.get("on_epoch") is False
 

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -1030,6 +1030,36 @@ class TestTrainingStep:
         assert lr_calls[0].kwargs.get("on_step") is True
         assert lr_calls[0].kwargs.get("on_epoch") is False
 
+    def test_logs_learning_rate_range_for_multiple_param_groups(self, tmp_path):
+        """Multiple optimizer groups log first, minimum, and maximum rates with distinct visibility flags."""
+        module, samples, targets, _, _ = self._run_step(tmp_path)
+        first_param = nn.Parameter(torch.randn(4))
+        second_param = nn.Parameter(torch.randn(4))
+        third_param = nn.Parameter(torch.randn(4))
+        module.optimizers.return_value = torch.optim.SGD(
+            [
+                {"params": [first_param], "lr": 0.1},
+                {"params": [second_param], "lr": 0.05},
+                {"params": [third_param], "lr": 0.2},
+            ],
+            lr=0.1,
+        )
+
+        module.training_step((samples, targets), batch_idx=0)
+
+        expected_metrics = {
+            "train/lr": (0.1, True),
+            "train/lr_min": (0.05, False),
+            "train/lr_max": (0.2, False),
+        }
+        for metric_name, (expected_value, expected_prog_bar) in expected_metrics.items():
+            metric_calls = [call for call in module.log.call_args_list if call.args[0] == metric_name]
+            assert len(metric_calls) == 1
+            assert metric_calls[0].args[1] == pytest.approx(expected_value)
+            assert metric_calls[0].kwargs.get("prog_bar") is expected_prog_bar
+            assert metric_calls[0].kwargs.get("on_step") is True
+            assert metric_calls[0].kwargs.get("on_epoch") is False
+
     def test_logs_convergence_components_to_progress_bar(self, tmp_path):
         """Selected detection and keypoint losses should appear as compact progress-only metrics."""
         loss_dict = {


### PR DESCRIPTION
## Why

`train/lr` is still logged on every training step, but it no longer appears in the Rich progress bar. Restoring that metric makes the current learning rate visible during training while keeping the min/max summaries out of the limited progress-bar metric slots.

Fixes #1298

## What changed

- restore progress-bar visibility for the existing `train/lr` metric
- keep `train/lr_min` and `train/lr_max` as log-only metrics
- update the regression test to require step-level progress-bar visibility

## Verification

- rebased onto the current `develop`; `git range-diff` confirms the patch is unchanged
- `.venv/bin/python -m pytest src/ tests/ -n 2 -m "not gpu and not coco17 and not e2e_coreml and not e2e_executorch and not xla and not tpu" --ignore=tests/run_smoke_all_models.py --ignore=tests/legacy/test_checkpoint_compat.py --cov=rfdetr --cov-report=xml --timeout=420 --durations=50`
  - 3691 passed, 55 skipped
- `.venv/bin/python -m pytest tests/training/test_module_model.py -n 1`
  - 166 passed, 1 skipped
- `.venv/bin/python -m pytest tests/training/callbacks/test_gpu_memory_progress_bar_callback.py -n 1`
  - 25 passed, 1 skipped
- Rich progress-bar smoke test
  - `train/lr` rendered during training
  - no duplicate-metric warnings
- `.venv/bin/mypy src/rfdetr/ --no-error-summary`
  - the nullable classifier-label errors from the previous CI run are resolved by the updated base
  - the local run reports two existing `no-any-return` errors in `src/rfdetr/evaluation/coco_eval.py` (lines 178 and 190); both reproduce on a clean checkout of the current `develop`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/pre-commit run --all-files`
  - 18 of 19 hooks pass
  - the mypy hook reports only the same two upstream `coco_eval.py` errors above
- `git diff --check upstream/develop...HEAD`

## Not verified

- GPU/CUDA test suite was not rerun on this macOS machine

## Risks / rollback

The behavioral change is limited to one existing Lightning logging flag. Reverting the commit restores the previous progress-bar behavior.

## Migrations / external effects

None.

## Screenshots / preview

Not applicable; this changes terminal training progress output.