### PR TITLE
fix(inference): normalise the index-less cuda device before the deferred-move guard compares it

### DIFF
--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -205,6 +205,12 @@ def _move_model_context_to_device(model_ctx: Any) -> None:
         return
     if isinstance(target, str):
         target = torch.device(target)
+    if target.type == "cuda" and target.index is None:
+        # An index-less ``torch.device("cuda")`` never compares equal to the indexed device (e.g. ``cuda:0``) a
+        # real parameter reports once placed, even when they name the same physical GPU — resolve it to the index
+        # ``.to("cuda")`` would actually place on, so the guard below can detect "already on the right device" and
+        # skip re-moving every parameter on every call.
+        target = torch.device(target.type, torch.cuda.current_device())
     first_param = next(inner.parameters(), None)
     if first_param is not None and first_param.device != target:
         # ``predict()`` stacks ``@torch.inference_mode()`` on top of ``@_ensure_model_on_device``, so the deferred

--- a/tests/inference/test_model_device_move.py
+++ b/tests/inference/test_model_device_move.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import Any
+from unittest import mock
 
 import torch
 from torch import nn
@@ -66,3 +67,75 @@ class TestMoveModelContextUnderInferenceMode:
             _move_model_context_to_device(ctx)
 
         assert module.inference_mode_at_move is False
+
+
+class _FakeParam:
+    """Duck-typed stand-in for a parameter: only ``.device`` is read by the guard."""
+
+    def __init__(self, device: torch.device) -> None:
+        self.device = device
+
+
+class _CountingDeviceModule:
+    """Duck-typed module stand-in that counts real ``.to()`` calls without touching any accelerator.
+
+    ``_move_model_context_to_device`` only calls ``next(inner.parameters(), None)`` and ``inner.to(target)`` on the
+    model context's inner module, so a minimal stand-in exercises the guard logic without requiring a CUDA device to be
+    present (this repo's CPU-only CI has none).
+    """
+
+    def __init__(self, initial_device: torch.device) -> None:
+        self._device = initial_device
+        self.to_call_count = 0
+
+    def parameters(self) -> Any:
+        """Yield the single fake parameter tracking the module's current device.
+
+        Examples:
+            >>> module = _CountingDeviceModule(torch.device("cpu"))
+            >>> next(module.parameters()).device
+            device(type='cpu')
+        """
+        yield _FakeParam(self._device)
+
+    def to(self, device: torch.device) -> "_CountingDeviceModule":
+        """Record the call and move the fake parameter to *device*."""
+        self.to_call_count += 1
+        self._device = device
+        return self
+
+
+class TestMoveModelContextIndexNormalization:
+    """``torch.device('cuda')`` (no index) must compare equal to the indexed device it resolves to.
+
+    ``model_ctx.device`` is built from a plain ``"cuda"`` string (see ``_build_model_context``), which
+    ``torch.device()`` converts to an index-less device. A real parameter's ``.device`` always carries an explicit index
+    once placed. Comparing the two with ``!=`` is ``True`` even when they name the same physical GPU, so without index
+    normalization the guard below would move the whole model on every single call instead of only the first one that
+    actually changes device.
+    """
+
+    def test_second_call_skips_redundant_move_when_target_has_no_index(self) -> None:
+        """A second call with an index-less target must not re-trigger ``.to()`` once already placed."""
+        module = _CountingDeviceModule(initial_device=torch.device("cpu"))
+        ctx = SimpleNamespace(device=torch.device("cuda"), model=module)
+
+        with mock.patch("torch.cuda.current_device", return_value=0):
+            _move_model_context_to_device(ctx)
+            assert module.to_call_count == 1
+            assert next(module.parameters()).device == torch.device("cuda", 0)
+
+            _move_model_context_to_device(ctx)
+
+        assert module.to_call_count == 1
+
+    def test_explicit_index_mismatch_still_triggers_move(self) -> None:
+        """An explicit different cuda index (multi-GPU) must still trigger a real move."""
+        module = _CountingDeviceModule(initial_device=torch.device("cuda", 0))
+        ctx = SimpleNamespace(device=torch.device("cuda", 1), model=module)
+
+        with mock.patch("torch.cuda.current_device", return_value=0):
+            _move_model_context_to_device(ctx)
+
+        assert module.to_call_count == 1
+        assert next(module.parameters()).device == torch.device("cuda", 1)


### PR DESCRIPTION
`_move_model_context_to_device` (`detr.py:192-216`) has a guard meant to move the model to the target device only once, on the first call:

```python
first_param = next(inner.parameters(), None)
if first_param is not None and first_param.device != target:
    ...
    model_ctx.model = inner.to(target)
```

`target` comes from `torch.device(args.device)`, and `args.device` is usually the plain string `"cuda"` — no index. Once the model is actually moved, `first_param.device` always reports an index (`cuda:0`). `torch.device('cuda') != torch.device('cuda:0')` is `True` in PyTorch even though they name the same physical GPU:

```python
>>> torch.device('cuda') != torch.zeros(1).cuda().device
True
```

So the guard never skips. Every call to `predict()` or `inference()` re-runs `inner.to(target)`, which walks and copies every parameter tensor in the model, not just the first one.

I confirmed the mechanism directly with a monkeypatch on `_move_model_context_to_device`, counting how many times the guard's internal condition evaluates `True` across 5 consecutive `predict()` calls on the same already-on-GPU model: 5 out of 5, never skips.

For the wall-time impact I ran the same model with the buggy guard and with the fix, alternating in the same process to rule out warmup or ordering effects, real COCO images, 15 reps per round. On an A100 (`RFDETRSegSmall`, 16 images): 117.07ms → 112.47ms, a 3.9% reduction (a second buggy round gives 118.71ms, so it is not an ordering artefact). `RFDETRSegMedium` gives 4.0% (136.27ms → 130.77ms). The absolute cost is roughly constant regardless of batch size — it scales with the number of parameters, not with how many images you pass. So the percentage gets bigger the smaller the batch: 13.8% with 1 image, 9.9% with 4, 3.1% with 16. And one image at a time is probably the most common `predict()` pattern in production, a camera feed with one frame per call.

I also ran it on a much slower GPU I have locally (RTX 4060 laptop) and the result is different: same mechanism (confirmed with the same monkeypatch test), but the wall-time gain drops into the noise floor, 0.1-1.3% across 3 rounds with overlapping ranges. A slower GPU means a longer total forward pass, so the same ~5ms fixed overhead ends up being a smaller part of the total. I'm not claiming one number here .. the bug itself (the guard never skips) is hardware-independent, but how much it costs in wall-time depends a lot on the GPU and the batch size.

Predictions are bit-identical with and without the fix on both GPUs (`torch.equal()` on `xyxy`, `confidence` and `class_id` for every image) — this only avoids redundant work, it doesn't change any value.

**Changes**
- `src/rfdetr/detr.py`: normalise `target` to an explicit-index device with `torch.cuda.current_device()` before the guard compares it, only when `target.type == "cuda"` and `target.index is None`.
- `tests/inference/test_model_device_move.py`: added `TestMoveModelContextIndexNormalization` with two cases. First, a second call with an index-less target must skip the move (this is the actual bug — it fails against the pre-fix code and passes with the fix). Second, an explicit different index (`cuda:1` vs `cuda:0`, a real multi-GPU setup) must still trigger a move, so the fix doesn't get so broad that it starts ignoring a real index mismatch. Both use a duck-typed stand-in module so the test doesn't need real CUDA hardware and runs on the CPU CI job.

**Validation**
- Full suite (`pytest src/ tests/`, `train,augment,cli,visual` extras): 3628 passed, 68 skipped.
- `mypy src/rfdetr/` — no new errors (the 2 pre-existing ones in `coco_eval.py` are unrelated and present on `develop` without this change too).
- `pre-commit run --all-files` clean.
- Patch applies cleanly on `develop` at `c107a748`.

This is low risk: the guard already runs under an explicit `torch.inference_mode(False)`, it only moves parameters, and the fix only changes how the comparison resolves the device — not when the move happens or where it moves to. It affects `predict()` (the hot path, called in a loop in production) and `inference()` (called once to compile/optimise, so the impact there is marginal).

Happy to adjust the fix or the test if you'd rather guard against this some other way.
