### PR TITLE
fix(training): restore callback state when resuming from `BestModelCallback`'s checkpoints

### DIFF
--- a/docs/learn/train/advanced.md
+++ b/docs/learn/train/advanced.md
@@ -12,7 +12,7 @@ This page covers advanced training topics including resuming training, early sto
 
 ## Resume Training
 
-You can resume training from a previously saved checkpoint by passing the path to the `checkpoint.pth` file using the `resume` argument. This is useful when training is interrupted or you want to continue fine-tuning an already partially trained model.
+You can resume training from a previously saved full checkpoint by passing the path to `last.ckpt` using the `resume` argument. This is useful when training is interrupted or you want to continue fine-tuning an already partially trained model.
 
 The training loop will automatically load:
 
@@ -26,9 +26,11 @@ The training loop will automatically load:
     The above applies to the trainer's own full checkpoints (`last.ckpt`, `checkpoint_<epoch>.ckpt`). The best-model
     tracker also writes four lighter `.pth` files — `checkpoint_best_regular.pth`, `checkpoint_best_ema.pth`,
     `checkpoint_best_total.pth`, `last_ema.pth` — that intentionally omit optimizer/scheduler state to stay small.
-    Resuming from one of these restores model weights, epoch count, and callback state (best-score tracking, EMA,
-    early stopping), but the optimizer and LR scheduler always start cold. `resume=` logs a warning when it detects
-    one of these files; pass a full trainer checkpoint instead if you need optimizer/scheduler continuity.
+    New files with matching configured callbacks can restore callback state (EMA and early stopping). Best-score
+    tracking additionally requires `output_dir` to be the exact directory where the checkpoint was written. Files
+    created before callback-state persistence (or with an empty callback section) restart callback state. The optimizer
+    and LR scheduler always start cold. `resume=` logs the applicable warning; pass a full trainer checkpoint instead
+    if you need optimizer/scheduler continuity.
 
 === "Object Detection"
 
@@ -44,7 +46,7 @@ The training loop will automatically load:
         grad_accum_steps=4,
         lr=1e-4,
         output_dir="output",
-        resume="output/checkpoint.pth",
+        resume="output/last.ckpt",
     )
     ```
 
@@ -62,13 +64,13 @@ The training loop will automatically load:
         grad_accum_steps=4,
         lr=1e-4,
         output_dir="output",
-        resume="output/checkpoint.pth",
+        resume="output/last.ckpt",
     )
     ```
 
 !!! tip "Resume vs Pretrain Weights"
 
-    - Use `resume="checkpoint.pth"` to continue training with optimizer state
+    - Use `resume="last.ckpt"` to continue training with optimizer state
     - Use `pretrain_weights="checkpoint_best_total.pth"` when initializing a model to start fresh training from those weights
 
 ---

--- a/docs/learn/train/advanced.md
+++ b/docs/learn/train/advanced.md
@@ -21,6 +21,15 @@ The training loop will automatically load:
 - Learning rate scheduler state
 - Training epoch number
 
+!!! warning "Lightweight checkpoints resume without optimizer/scheduler state"
+
+    The above applies to the trainer's own full checkpoints (`last.ckpt`, `checkpoint_<epoch>.ckpt`). The best-model
+    tracker also writes four lighter `.pth` files — `checkpoint_best_regular.pth`, `checkpoint_best_ema.pth`,
+    `checkpoint_best_total.pth`, `last_ema.pth` — that intentionally omit optimizer/scheduler state to stay small.
+    Resuming from one of these restores model weights, epoch count, and callback state (best-score tracking, EMA,
+    early stopping), but the optimizer and LR scheduler always start cold. `resume=` logs a warning when it detects
+    one of these files; pass a full trainer checkpoint instead if you need optimizer/scheduler continuity.
+
 === "Object Detection"
 
     ```python

--- a/docs/learn/train/index.md
+++ b/docs/learn/train/index.md
@@ -193,15 +193,17 @@ Track your experiments with popular logging platforms:
 
 During training, multiple model checkpoints are saved to the output directory:
 
-- `checkpoint.pth` – the most recent checkpoint, saved at the end of the latest epoch.
+- `last.ckpt` – the most recent full checkpoint, saved at the end of the latest epoch.
 
-- `checkpoint_<number>.pth` – periodic checkpoints saved every N epochs (default is every 10).
+- `checkpoint_<epoch>.ckpt` – periodic full checkpoints saved every N epochs (default is every 10).
 
 - `checkpoint_best_ema.pth` – best checkpoint based on validation score, using the EMA (Exponential Moving Average) weights. EMA weights are a smoothed version of the model's parameters across training steps, often yielding better generalization.
 
 - `checkpoint_best_regular.pth` – best checkpoint based on validation score, using the raw (non-EMA) model weights.
 
-- `checkpoint_best_total.pth` – final checkpoint selected for inference and benchmarking. It contains only the model weights (no optimizer state or scheduler) and is chosen as the better of the EMA and non-EMA models based on validation performance.
+- `checkpoint_best_total.pth` – final checkpoint selected for inference and benchmarking. It contains model weights,
+    epoch/PTL metadata, and callback state when available, but no optimizer or scheduler state. It is chosen as the
+    better of the EMA and non-EMA models based on validation performance.
 
 For detection and segmentation models, the validation score is box mAP (`val/mAP_50_95`). For keypoint preview models,
 best-checkpoint selection uses COCO keypoint AP (`val/keypoint_map_50_95`) and checkpoints persist the model keypoint
@@ -211,11 +213,11 @@ schema so `RFDETR.from_checkpoint()` can reconstruct the same label/keypoint slo
 
     Checkpoint sizes vary based on what they contain:
 
-    - **Training checkpoints** (e.g. `checkpoint.pth`, `checkpoint_<number>.pth`) include model weights, optimizer state, scheduler state, and training metadata. Use these to resume training.
+    - **Training checkpoints** (e.g. `last.ckpt`, `checkpoint_<epoch>.ckpt`) include model weights, optimizer state, scheduler state, and training metadata. Use these to resume training.
 
-    - **Evaluation checkpoints** (e.g. `checkpoint_best_ema.pth`, `checkpoint_best_regular.pth`) store only the model weights — either EMA or raw — and are used to track the best-performing models. These may come from different epochs depending on which version achieved the highest validation score.
+    - **Lightweight best checkpoints** (e.g. `checkpoint_best_ema.pth`, `checkpoint_best_regular.pth`, `last_ema.pth`) store model weights, epoch/PTL metadata, and callback state when available, but intentionally omit optimizer and scheduler state. These may come from different epochs depending on which version achieved the highest validation score.
 
-    - **Stripped checkpoint** (e.g. `checkpoint_best_total.pth`) contains only the final model weights and is optimized for inference and deployment.
+    - **Lightweight total checkpoint** (e.g. `checkpoint_best_total.pth`) keeps the same lightweight resume metadata while selecting the final best model for inference and deployment.
 
 ## Load and Run Fine-Tuned Model
 

--- a/docs/learn/train/training-parameters.md
+++ b/docs/learn/train/training-parameters.md
@@ -27,14 +27,14 @@ model.train(
 
 These are the essential parameters for training:
 
-| Parameter          | Type            | Default    | Description                                                                                                                                                       |
-| ------------------ | --------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dataset_dir`      | `str`           | Required   | Path to your dataset directory. RF-DETR auto-detects if it's in COCO or YOLO format. See [Dataset Formats](dataset-formats.md).                                   |
-| `output_dir`       | `str`           | `"output"` | Directory where training artifacts (checkpoints, logs) are saved.                                                                                                 |
-| `epochs`           | `int`           | `100`      | Number of full passes over the training dataset.                                                                                                                  |
-| `batch_size`       | `int or "auto"` | `4`        | Number of samples processed per iteration. Higher values require more GPU memory. Set to `"auto"` to probe the GPU for the largest safe batch size automatically. |
-| `grad_accum_steps` | `int`           | `4`        | Accumulates gradients over multiple mini-batches. Use with `batch_size` to achieve effective batch size.                                                          |
-| `resume`           | `str`           | `None`     | Path to a saved checkpoint to continue training. Restores model weights, optimizer state, and scheduler.                                                          |
+| Parameter          | Type            | Default    | Description                                                                                                                                                                             |
+| ------------------ | --------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dataset_dir`      | `str`           | Required   | Path to your dataset directory. RF-DETR auto-detects if it's in COCO or YOLO format. See [Dataset Formats](dataset-formats.md).                                                         |
+| `output_dir`       | `str`           | `"output"` | Directory where training artifacts (checkpoints, logs) are saved.                                                                                                                       |
+| `epochs`           | `int`           | `100`      | Number of full passes over the training dataset.                                                                                                                                        |
+| `batch_size`       | `int or "auto"` | `4`        | Number of samples processed per iteration. Higher values require more GPU memory. Set to `"auto"` to probe the GPU for the largest safe batch size automatically.                       |
+| `grad_accum_steps` | `int`           | `4`        | Accumulates gradients over multiple mini-batches. Use with `batch_size` to achieve effective batch size.                                                                                |
+| `resume`           | `str`           | `None`     | Path to a saved checkpoint to continue training. Full `.ckpt` files restore model, optimizer, and scheduler state; lightweight best `.pth` files restart optimizer and scheduler state. |
 
 ### Understanding Batch Size
 
@@ -129,13 +129,14 @@ For example, `RFDETRSegXLarge` uses `624x624`, which is valid because `624` is d
 
 During training, multiple checkpoints are saved:
 
-| File                          | Description                               |
-| ----------------------------- | ----------------------------------------- |
-| `checkpoint.pth`              | Most recent checkpoint (for resuming)     |
-| `checkpoint_<N>.pth`          | Periodic checkpoint at epoch N            |
-| `checkpoint_best_ema.pth`     | Best validation performance (EMA weights) |
-| `checkpoint_best_regular.pth` | Best validation performance (raw weights) |
-| `checkpoint_best_total.pth`   | Final best model for inference            |
+| File                          | Description                                                  |
+| ----------------------------- | ------------------------------------------------------------ |
+| `last.ckpt`                   | Most recent full checkpoint (for resuming)                   |
+| `checkpoint_<epoch>.ckpt`     | Periodic full checkpoint at an epoch                         |
+| `checkpoint_best_ema.pth`     | Best EMA weights; lightweight callback state when available  |
+| `checkpoint_best_regular.pth` | Best raw weights; lightweight callback state when available  |
+| `checkpoint_best_total.pth`   | Final best model; lightweight callback state when available  |
+| `last_ema.pth`                | Final EMA weights; lightweight callback state when available |
 
 Best validation performance uses the task metric for the model family: box mAP for detection/segmentation and COCO
 keypoint AP for keypoint preview.

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -917,16 +917,12 @@ class RFDETR:
             # BestModelCallback's four lightweight checkpoint files (unlike the trainer's own
             # `last.ckpt` / `checkpoint_<epoch>.ckpt`, which retain full PTL state) intentionally
             # omit optimizer/LR-scheduler state to stay small — see
-            # BestModelCallback._build_checkpoint_payload. Model weights, epoch count, and
-            # callback state (EMA average model, early stopping) resume correctly from them,
-            # PROVIDED the file actually has a "callbacks" section — see the has-callback-state
-            # peek below, since checkpoints written before this feature landed don't. best-score
-            # tracking (best_model_score/best_k_models) resumes too, but ONLY when output_dir also
-            # matches the directory the checkpoint was originally written to — see the
-            # dirpath-mismatch warning below, PTL's own ModelCheckpoint.load_state_dict() gate.
-            # Flag the optimizer/scheduler gap explicitly instead of letting it pass silently,
-            # since docs/learn/train/advanced.md promises full optimizer/scheduler restoration on
-            # resume.
+            # BestModelCallback._build_checkpoint_payload. They retain model weights, epoch
+            # metadata, and per-callback state only when the resumed callback configuration
+            # matches the saved keys. Checkpoints written before callback-state persistence have
+            # no such state. Best-score tracking additionally requires exactly the original
+            # output_dir because of PTL's ModelCheckpoint.load_state_dict() dirpath gate.
+            # Flag the optimizer/scheduler gap explicitly instead of letting it pass silently.
             _light_checkpoint_names = frozenset(
                 {"checkpoint_best_regular.pth", "checkpoint_best_ema.pth", "checkpoint_best_total.pth", "last_ema.pth"}
             )
@@ -943,16 +939,18 @@ class RFDETR:
                 _resume_ckpt = _safe_torch_load(config.resume, trust=True)
                 _has_callback_state = bool(_resume_ckpt.get("callbacks"))
                 del _resume_ckpt
+                _resume_dir = Path(config.resume).resolve().parent
+                _configured_output_dir = Path(config.output_dir).resolve()
+                _best_score_restores = _resume_dir == _configured_output_dir
 
                 if _has_callback_state:
                     logger.warning(
                         "resume=%r points at one of BestModelCallback's lightweight checkpoints, "
                         "which intentionally omit optimizer/LR-scheduler state to stay small. "
-                        "Model weights, epoch count, and callback state (best-score tracking, EMA, "
-                        "early stopping) will resume correctly, but the optimizer and LR scheduler "
-                        "restart cold this run. To resume with optimizer/scheduler state too, pass "
-                        "the trainer's full checkpoint instead (e.g. %s/last.ckpt or "
-                        "%s/checkpoint_<epoch>.ckpt).",
+                        "Model weights and epoch count will resume. Callback state can restore only "
+                        "for matching configured callbacks; the optimizer and LR scheduler restart cold. "
+                        "To resume with optimizer/scheduler state too, pass the trainer's full "
+                        "checkpoint instead (e.g. %s/last.ckpt or %s/checkpoint_<epoch>.ckpt).",
                         config.resume,
                         config.output_dir,
                         config.output_dir,
@@ -981,22 +979,19 @@ class RFDETR:
                 # best_model_path, so the first metric logged after resume looks like an automatic
                 # improvement over an empty best_model_score. Only worth flagging when there was
                 # callback state to lose in the first place.
-                if _has_callback_state:
-                    _resume_dir = Path(config.resume).resolve().parent
-                    _configured_output_dir = Path(config.output_dir).resolve()
-                    if _resume_dir != _configured_output_dir:
-                        logger.warning(
-                            "resume=%r was written under %s but output_dir=%r points elsewhere. "
-                            "PyTorch Lightning only restores best_model_score/best_k_models when "
-                            "output_dir matches the checkpoint's original directory exactly — with "
-                            "this output_dir, best-score tracking (BestModelCallback's high-water "
-                            "mark) restarts fresh in the new directory instead of resuming. Set "
-                            "output_dir=%r to keep it.",
-                            config.resume,
-                            _resume_dir,
-                            config.output_dir,
-                            str(_resume_dir),
-                        )
+                if _has_callback_state and not _best_score_restores:
+                    logger.warning(
+                        "resume=%r was written under %s but output_dir=%r points elsewhere. "
+                        "PyTorch Lightning only restores best_model_score/best_k_models when "
+                        "output_dir matches the checkpoint's original directory exactly — with "
+                        "this output_dir, best-score tracking (BestModelCallback's high-water "
+                        "mark) restarts fresh in the new directory instead of resuming. Set "
+                        "output_dir=%r to keep it.",
+                        config.resume,
+                        _resume_dir,
+                        config.output_dir,
+                        str(_resume_dir),
+                    )
 
         trainer_kwargs: dict[str, Any] = {"accelerator": _accelerator}
         if _devices is not None:

--- a/src/rfdetr/detr.py
+++ b/src/rfdetr/detr.py
@@ -913,6 +913,91 @@ class RFDETR:
                     exc_info=True,
                 )
 
+        if config.resume:
+            # BestModelCallback's four lightweight checkpoint files (unlike the trainer's own
+            # `last.ckpt` / `checkpoint_<epoch>.ckpt`, which retain full PTL state) intentionally
+            # omit optimizer/LR-scheduler state to stay small — see
+            # BestModelCallback._build_checkpoint_payload. Model weights, epoch count, and
+            # callback state (EMA average model, early stopping) resume correctly from them,
+            # PROVIDED the file actually has a "callbacks" section — see the has-callback-state
+            # peek below, since checkpoints written before this feature landed don't. best-score
+            # tracking (best_model_score/best_k_models) resumes too, but ONLY when output_dir also
+            # matches the directory the checkpoint was originally written to — see the
+            # dirpath-mismatch warning below, PTL's own ModelCheckpoint.load_state_dict() gate.
+            # Flag the optimizer/scheduler gap explicitly instead of letting it pass silently,
+            # since docs/learn/train/advanced.md promises full optimizer/scheduler restoration on
+            # resume.
+            _light_checkpoint_names = frozenset(
+                {"checkpoint_best_regular.pth", "checkpoint_best_ema.pth", "checkpoint_best_total.pth", "last_ema.pth"}
+            )
+            if Path(config.resume).name in _light_checkpoint_names:
+                from rfdetr.utilities.io import _safe_torch_load
+
+                # checkpoint.get("callbacks") is None-checked by PTL's own
+                # _call_callbacks_load_state_dict(), which no-ops (skipping every callback's
+                # restoration) when the key is absent or empty. Checkpoints written before
+                # BestModelCallback._build_checkpoint_payload started persisting per-callback state
+                # — or from a run where every registered callback happened to have empty state —
+                # are exactly this case, so peek at the file rather than let the warning below
+                # overclaim a restoration that silently does not happen.
+                _resume_ckpt = _safe_torch_load(config.resume, trust=True)
+                _has_callback_state = bool(_resume_ckpt.get("callbacks"))
+                del _resume_ckpt
+
+                if _has_callback_state:
+                    logger.warning(
+                        "resume=%r points at one of BestModelCallback's lightweight checkpoints, "
+                        "which intentionally omit optimizer/LR-scheduler state to stay small. "
+                        "Model weights, epoch count, and callback state (best-score tracking, EMA, "
+                        "early stopping) will resume correctly, but the optimizer and LR scheduler "
+                        "restart cold this run. To resume with optimizer/scheduler state too, pass "
+                        "the trainer's full checkpoint instead (e.g. %s/last.ckpt or "
+                        "%s/checkpoint_<epoch>.ckpt).",
+                        config.resume,
+                        config.output_dir,
+                        config.output_dir,
+                    )
+                else:
+                    logger.warning(
+                        "resume=%r points at one of BestModelCallback's lightweight checkpoints, "
+                        "which intentionally omit optimizer/LR-scheduler state to stay small. "
+                        "Model weights and epoch count will resume, but this particular file has no "
+                        "saved callback state (it predates callback-state persistence, or every "
+                        "registered callback had nothing to save), so best-score tracking, EMA, and "
+                        "early-stopping state all restart cold this run too — not just the "
+                        "optimizer and LR scheduler. To resume with full state, pass the trainer's "
+                        "full checkpoint instead (e.g. %s/last.ckpt or %s/checkpoint_<epoch>.ckpt).",
+                        config.resume,
+                        config.output_dir,
+                        config.output_dir,
+                    )
+
+                # BestModelCallback always writes these four files directly under its own
+                # `dirpath` (== output_dir at save time; see BestModelCallback.__init__ and
+                # _build_checkpoint_payload). PTL's ModelCheckpoint.load_state_dict() only
+                # restores best_model_score/best_k_models/kth_value/last_model_path when the
+                # resumed dirpath matches the checkpoint's saved dirpath exactly (model_checkpoint.py,
+                # installed pytorch-lightning) — with a different output_dir this run only recovers
+                # best_model_path, so the first metric logged after resume looks like an automatic
+                # improvement over an empty best_model_score. Only worth flagging when there was
+                # callback state to lose in the first place.
+                if _has_callback_state:
+                    _resume_dir = Path(config.resume).resolve().parent
+                    _configured_output_dir = Path(config.output_dir).resolve()
+                    if _resume_dir != _configured_output_dir:
+                        logger.warning(
+                            "resume=%r was written under %s but output_dir=%r points elsewhere. "
+                            "PyTorch Lightning only restores best_model_score/best_k_models when "
+                            "output_dir matches the checkpoint's original directory exactly — with "
+                            "this output_dir, best-score tracking (BestModelCallback's high-water "
+                            "mark) restarts fresh in the new directory instead of resuming. Set "
+                            "output_dir=%r to keep it.",
+                            config.resume,
+                            _resume_dir,
+                            config.output_dir,
+                            str(_resume_dir),
+                        )
+
         trainer_kwargs: dict[str, Any] = {"accelerator": _accelerator}
         if _devices is not None:
             trainer_kwargs["devices"] = _devices

--- a/src/rfdetr/models/matcher.py
+++ b/src/rfdetr/models/matcher.py
@@ -163,7 +163,7 @@ class HungarianMatcher(nn.Module):
         probabilities = logits.sigmoid()
         negative_cost = (1 - alpha) * (probabilities**gamma) * (-F.logsigmoid(-logits))
         positive_cost = alpha * ((1 - probabilities) ** gamma) * (-F.logsigmoid(logits))
-        return positive_cost - negative_cost
+        return cast(Tensor, positive_cost - negative_cost)
 
     @staticmethod
     def _detection_inputs_are_safe(outputs: dict[str, Any], targets: list[dict[str, Any]]) -> bool:

--- a/src/rfdetr/models/matcher.py
+++ b/src/rfdetr/models/matcher.py
@@ -163,7 +163,8 @@ class HungarianMatcher(nn.Module):
         probabilities = logits.sigmoid()
         negative_cost = (1 - alpha) * (probabilities**gamma) * (-F.logsigmoid(-logits))
         positive_cost = alpha * ((1 - probabilities) ** gamma) * (-F.logsigmoid(logits))
-        return cast(Tensor, positive_cost - negative_cost)
+        cost: Tensor = positive_cost - negative_cost
+        return cost
 
     @staticmethod
     def _detection_inputs_are_safe(outputs: dict[str, Any], targets: list[dict[str, Any]]) -> bool:

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -154,6 +154,19 @@ class BestModelCallback(ModelCheckpoint):
             Checkpoint dictionary that supports ``Trainer.fit(ckpt_path=...)`` while intentionally omitting
             optimizer/scheduler states.
         """
+        # Persist every callback's own state (BestModelCallback's best-tracking high-water
+        # marks, RFDETREMACallback's average model state, RFDETREarlyStopping's wait_count,
+        # etc.) so `trainer.fit(ckpt_path=...)` actually resumes them, matching what each
+        # callback's own state_dict()/load_state_dict() promises. Mirrors PyTorch Lightning's
+        # own `_call_callbacks_state_dict` (keyed by `Callback.state_key`, PTL reads it back
+        # via `_call_callbacks_load_state_dict` — checkpoint.get("callbacks") is None-checked
+        # there, so an *absent* "callbacks" key silently skips restoring every callback).
+        # Only include callbacks with non-empty state so checkpoints stay diffable/minimal.
+        callback_states: dict[str, object] = {}
+        for callback in trainer.callbacks:  # type: ignore[attr-defined]
+            state = callback.state_dict()
+            if state:
+                callback_states[callback.state_key] = state
         payload: dict[str, object] = {
             "model": model_state_dict,
             "args": args_dict,
@@ -170,8 +183,13 @@ class BestModelCallback(ModelCheckpoint):
                 "validate_loop": {"state_dict": {}},
                 "test_loop": {"state_dict": {}},
             },
+            "callbacks": callback_states,
             # Keep keys present with empty values so PTL resume paths that
-            # expect them can proceed without loading optimizer state.
+            # expect them can proceed without loading optimizer state. This is
+            # intentional (checkpoints stay lightweight, "weights-only" files) but
+            # it means resuming from these files always starts the optimizer and LR
+            # scheduler cold — see the warning logged from RFDETR.train() when
+            # `resume=` is used.
             "optimizer_states": [],
             "lr_schedulers": [],
         }

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -140,6 +140,7 @@ class BestModelCallback(ModelCheckpoint):
         trainer: Trainer,
         model_name: str | None = None,
         model_config_dict: object | None = None,
+        share_ema_model_state: bool = False,
     ) -> dict[str, object]:
         """Build a PTL-compatible RF-DETR checkpoint payload.
 
@@ -149,6 +150,7 @@ class BestModelCallback(ModelCheckpoint):
             trainer: Active Lightning trainer providing epoch/step counters.
             model_name: Name of the model class (e.g. ``"RFDETRLarge"``).
             model_config_dict: Serialized architecture config needed to reconstruct schema-dependent models.
+            share_ema_model_state: Whether EMA callback tensors should share storage with top-level EMA weights.
 
         Returns:
             Checkpoint dictionary that supports ``Trainer.fit(ckpt_path=...)`` while intentionally omitting
@@ -167,6 +169,20 @@ class BestModelCallback(ModelCheckpoint):
             state = callback.state_dict()
             if state:
                 callback_states[callback.state_key] = state
+        if share_ema_model_state:
+            # EMA-named checkpoints expose the same average-model weights at the top level
+            # and inside callback state. Reuse those tensors so torch.save stores one copy.
+            for state in callback_states.values():
+                if not isinstance(state, dict):
+                    continue
+                average_state = state.get("average_model_state_dict")
+                if not isinstance(average_state, dict):
+                    continue
+                for key in average_state:
+                    if key.startswith("module.model."):
+                        model_key = key.removeprefix("module.model.")
+                        if model_key in model_state_dict:
+                            average_state[key] = model_state_dict[model_key]
         payload: dict[str, object] = {
             "model": model_state_dict,
             "args": args_dict,
@@ -290,6 +306,7 @@ class BestModelCallback(ModelCheckpoint):
                 trainer,
                 model_name=self._resolve_model_name(pl_module),
                 model_config_dict=self._serialize_model_config(pl_module, ema_state_dict),
+                share_ema_model_state=True,
             ),
             dest,
         )

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -1270,7 +1270,7 @@ class COCOEvalCallback(Callback):
             # (and PTL's progress bar) is never touched, so there is no flicker.
             if self._output_widget is None:
                 with contextlib.suppress(ImportError):
-                    import ipywidgets as widgets  # type: ignore[import-untyped]
+                    widgets = importlib.import_module("ipywidgets")
 
                     ipython_display = importlib.import_module("IPython.display")
                     display = cast(Callable[..., Any], getattr(ipython_display, "display"))

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -1270,7 +1270,7 @@ class COCOEvalCallback(Callback):
             # (and PTL's progress bar) is never touched, so there is no flicker.
             if self._output_widget is None:
                 with contextlib.suppress(ImportError):
-                    import ipywidgets as widgets  # type: ignore[import-not-found]
+                    import ipywidgets as widgets  # type: ignore[import-untyped]
 
                     ipython_display = importlib.import_module("IPython.display")
                     display = cast(Callable[..., Any], getattr(ipython_display, "display"))

--- a/src/rfdetr/training/callbacks/ema.py
+++ b/src/rfdetr/training/callbacks/ema.py
@@ -179,6 +179,30 @@ class RFDETREMACallback(Callback):
                     )
             delattr(pl_module, "_pending_legacy_ema_state")
 
+    def on_train_start(self, trainer: Trainer, pl_module: LightningModule) -> None:
+        """Apply a resumed ``average_model_state_dict`` that arrived after ``setup()``.
+
+        For every strategy RF-DETR ships (``strategy.restore_checkpoint_after_setup`` is ``False``
+        except for FSDP/DeepSpeed/model-parallel), PTL's ``Trainer._run`` calls
+        ``call._call_setup_hook`` (which invokes this callback's ``setup()``) *before*
+        ``_checkpoint_connector._restore_modules_and_callbacks`` (which invokes
+        ``load_state_dict()``). So on a resumed run, ``load_state_dict()`` stashes the checkpoint's
+        ``average_model_state_dict`` into ``_pending_average_state_dict`` only after ``setup()``
+        already built ``_average_model`` from the not-yet-restored live weights — the ``elif``
+        branch in ``setup()`` that applies a pending *plain* state dict never fires for this
+        ordering, silently leaving the averaged model un-resumed. ``on_train_start`` runs from
+        inside ``_run_stage()``, strictly after all checkpoint restoration completes, so it is the
+        first safe point to apply it. A no-op when ``setup()`` already consumed the pending state
+        (the reverse ordering used by FSDP/DeepSpeed/model-parallel).
+
+        Args:
+            trainer: The Lightning Trainer instance.
+            pl_module: The ``RFDETRModelModule`` being trained.
+        """
+        if self._pending_average_state_dict is not None and self._average_model is not None:
+            self._average_model.load_state_dict(self._pending_average_state_dict)
+            self._pending_average_state_dict = None
+
     def should_update(
         self,
         step_idx: int | None = None,

--- a/src/rfdetr/training/callbacks/ema.py
+++ b/src/rfdetr/training/callbacks/ema.py
@@ -152,7 +152,7 @@ class RFDETREMACallback(Callback):
 
         self._average_model = AveragedModel(
             model=pl_module,
-            device=pl_module.device,
+            device=cast(torch.device, pl_module.device),
             use_buffers=self._use_buffers,
             multi_avg_fn=self._multi_avg_fn,
         )
@@ -199,6 +199,10 @@ class RFDETREMACallback(Callback):
             trainer: The Lightning Trainer instance.
             pl_module: The ``RFDETRModelModule`` being trained.
         """
+        # Lightweight checkpoints deliberately restart optimizer-loop progress at
+        # zero. An absolute saved guard would otherwise skip that many new batches.
+        if trainer.global_step < self._latest_update_step:
+            self._latest_update_step = trainer.global_step
         if self._pending_average_state_dict is not None and self._average_model is not None:
             self._average_model.load_state_dict(self._pending_average_state_dict)
             self._pending_average_state_dict = None

--- a/src/rfdetr/training/callbacks/ema.py
+++ b/src/rfdetr/training/callbacks/ema.py
@@ -150,9 +150,13 @@ class RFDETREMACallback(Callback):
         if stage != "fit":
             return
 
+        device = pl_module.device
+        if not isinstance(device, torch.device):
+            raise TypeError(f"Expected a torch.device from the Lightning module, got {type(device).__name__}.")
+
         self._average_model = AveragedModel(
             model=pl_module,
-            device=cast(torch.device, pl_module.device),
+            device=device,
             use_buffers=self._use_buffers,
             multi_avg_fn=self._multi_avg_fn,
         )

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -75,17 +75,18 @@ def _try_import_tensorboard_summary_writer() -> None:
 # pickle can serialise them for the spawned child processes.
 
 
+_InteractiveSpawnLauncher: type[Any] | None = None
+
 if _MultiProcessingLauncher is not None:
 
-    class _InteractiveSpawnLauncher(_MultiProcessingLauncher):
+    class _InteractiveSpawnLauncherImpl(_MultiProcessingLauncher):
         """Spawn launcher that reports itself as interactive-compatible."""
 
         @property
         def is_interactive_compatible(self) -> bool:
             return True
 
-else:
-    _InteractiveSpawnLauncher = None  # type: ignore[misc]
+    _InteractiveSpawnLauncher = _InteractiveSpawnLauncherImpl
 
 
 class _NotebookSpawnDDPStrategy(_DDPStrategy):

--- a/src/rfdetr/utilities/state_dict.py
+++ b/src/rfdetr/utilities/state_dict.py
@@ -23,6 +23,13 @@ _PTL_COMPAT_KEYS = (
     "global_step",
     "pytorch-lightning_version",
     "loops",
+    # Per-callback state (BestModelCallback's own best-tracking high-water marks,
+    # RFDETREMACallback's average model state, RFDETREarlyStopping's wait_count, etc.),
+    # keyed by Callback.state_key — see BestModelCallback._build_checkpoint_payload.
+    # Without this, trainer.fit(ckpt_path="checkpoint_best_total.pth") silently resets
+    # every callback's state even though the regular/EMA source checkpoint it was copied
+    # from does carry it.
+    "callbacks",
     "optimizer_states",
     "lr_schedulers",
 )

--- a/tests/training/callbacks/test_best_model_callback.py
+++ b/tests/training/callbacks/test_best_model_callback.py
@@ -1323,7 +1323,9 @@ class TestBestModelCallback:
         trainer, so it exercises restoration of best-score tracking alone. The warning added to ``RFDETR.train()``
         promises "best-score tracking, EMA, early stopping" all resume correctly together — this test registers
         all three callbacks so ``_build_checkpoint_payload``'s generic ``trainer.callbacks`` loop is actually
-        exercised for the other two, not just ``BestModelCallback`` itself.
+        exercised for the other two, not just ``BestModelCallback`` itself. Lightweight checkpoints reset the
+        optimizer loop's global step, so EMA restores its averaged weights but resets its step guard to permit the
+        first new batch update.
         """
         x = torch.randn(8, 4)
         y = torch.randn(8, 1)
@@ -1394,9 +1396,9 @@ class TestBestModelCallback:
             ckpt_path=str(ckpt_path),
         )
 
-        assert capture.ema_latest_update_step == persisted_ema_step, (
-            "RFDETREMACallback._latest_update_step must be restored from the checkpoint's 'callbacks' "
-            "key; without the fix a fresh callback starts at 0"
+        assert capture.ema_latest_update_step == 0, (
+            "RFDETREMACallback must reset its absolute step guard when a lightweight checkpoint resets "
+            "trainer.global_step, otherwise the resumed phase skips EMA updates"
         )
         assert capture.early_stop_wait_count == persisted_wait_count, (
             "RFDETREarlyStopping.wait_count must be restored from the checkpoint's 'callbacks' key; "

--- a/tests/training/callbacks/test_best_model_callback.py
+++ b/tests/training/callbacks/test_best_model_callback.py
@@ -181,9 +181,9 @@ class _ResumeProbeCallback(Callback):
 class _VaryingMetricModule(LightningModule):
     """LightningModule that logs a different ``val/mAP_50_95`` value on each successive epoch.
 
-    ``values`` is consumed one entry per validation epoch (indexed by ``self.current_epoch``, clamped to the last
-    entry once exhausted), letting a single ``Trainer.fit()`` call drive stateful callbacks (e.g.
-    ``RFDETREarlyStopping``'s ``wait_count``) through both improving and non-improving epochs.
+    ``values`` is consumed one entry per validation epoch (indexed by ``self.current_epoch``, clamped to the last entry
+    once exhausted), letting a single ``Trainer.fit()`` call drive stateful callbacks (e.g. ``RFDETREarlyStopping``'s
+    ``wait_count``) through both improving and non-improving epochs.
     """
 
     def __init__(self, values: list[float]) -> None:
@@ -282,8 +282,8 @@ class _EmaMetricModule(LightningModule):
 class _CallbackStateCaptureCallback(Callback):
     """Snapshot other callbacks' resumed state at the first post-resume train-epoch start.
 
-    Runs before any post-resume training step can mutate ``ema_callback``/``early_stop_callback``, so the
-    captured values reflect exactly what PTL's ``_call_callbacks_load_state_dict`` restored from the checkpoint.
+    Runs before any post-resume training step can mutate ``ema_callback``/``early_stop_callback``, so the captured
+    values reflect exactly what PTL's ``_call_callbacks_load_state_dict`` restored from the checkpoint.
     """
 
     def __init__(self, ema_callback: RFDETREMACallback, early_stop_callback: RFDETREarlyStopping) -> None:
@@ -1237,9 +1237,9 @@ class TestBestModelCallback:
     def test_best_model_score_survives_real_trainer_fit_resume(self, tmp_path: Path, checkpoint_name: str) -> None:
         """``best_model_score`` and the on-disk checkpoint must survive a real ``trainer.fit(ckpt_path=...)`` resume.
 
-        Regression test for the "callbacks" key being absent from ``_build_checkpoint_payload``'s output — the bug
-        this PR fixes. Every existing regression test for callback-state persistence (``TestBestEmaStatePersistence``)
-        calls ``state_dict()``/``load_state_dict()`` directly in Python, never through PTL's own
+        Regression test for the "callbacks" key being absent from ``_build_checkpoint_payload``'s output — the bug this
+        PR fixes. Every existing regression test for callback-state persistence (``TestBestEmaStatePersistence``) calls
+        ``state_dict()``/``load_state_dict()`` directly in Python, never through PTL's own
         ``_call_callbacks_load_state_dict``, so none of them would catch the payload missing the "callbacks" key.
         Parametrized over ``checkpoint_best_regular.pth`` (built directly by ``_build_checkpoint_payload``) and
         ``checkpoint_best_total.pth`` (built via ``shutil.copy2`` + ``strip_checkpoint``, a separate code path that
@@ -1489,17 +1489,16 @@ class TestBestModelCallback:
         """A resumed ``output_dir`` different from the checkpoint's own does not restore ``best_model_score``.
 
         Pins PTL's own ``ModelCheckpoint.load_state_dict()`` gate (installed pytorch-lightning,
-        ``model_checkpoint.py``): it only restores ``best_model_score``/``best_k_models`` when the
-        resumed callback's ``dirpath`` matches the value stored in the checkpoint's ``"callbacks"``
-        state exactly; on a mismatch it warns and restores only ``best_model_path``. RF-DETR's
-        ``resume`` and ``output_dir`` config fields are independent (``config.py``), so pointing
-        ``resume=`` at one directory while writing to another is a config-permitted combination, not
-        a corrupted setup — this test locks in the resulting (previously untested) behavior.
+        ``model_checkpoint.py``): it only restores ``best_model_score``/``best_k_models`` when the resumed callback's
+        ``dirpath`` matches the value stored in the checkpoint's ``"callbacks"`` state exactly; on a mismatch it warns
+        and restores only ``best_model_path``. RF-DETR's ``resume`` and ``output_dir`` config fields are independent
+        (``config.py``), so pointing ``resume=`` at one directory while writing to another is a config-permitted
+        combination, not a corrupted setup — this test locks in the resulting (previously untested) behavior.
 
-        ``max_epochs=1`` on both phases means the checkpoint's restored fit-loop progress (1 epoch
-        already completed) leaves zero epochs left to run in phase two: the assertions below capture
-        exactly what ``load_state_dict()`` restored, with no confound from a subsequent training
-        epoch overwriting ``best_model_score``/``best_model_path`` again on its own.
+        ``max_epochs=1`` on both phases means the checkpoint's restored fit-loop progress (1 epoch already completed)
+        leaves zero epochs left to run in phase two: the assertions below capture exactly what ``load_state_dict()``
+        restored, with no confound from a subsequent training epoch overwriting ``best_model_score``/``best_model_path``
+        again on its own.
         """
         x = torch.randn(8, 4)
         y = torch.randn(8, 1)

--- a/tests/training/callbacks/test_best_model_callback.py
+++ b/tests/training/callbacks/test_best_model_callback.py
@@ -15,6 +15,7 @@ import torch
 from pytorch_lightning import Callback, LightningModule, Trainer
 from pytorch_lightning import __version__ as ptl_version
 from pytorch_lightning.trainer.states import TrainerFn
+from torch import Tensor
 from torch.utils.data import DataLoader, TensorDataset
 
 from rfdetr.config import RFDETRLargeDeprecatedConfig, RFDETRMediumConfig
@@ -87,6 +88,57 @@ class _ResumeTinyModule(LightningModule):
         return torch.optim.SGD(self.model.parameters(), lr=0.01)
 
 
+class _MetricModule(LightningModule):
+    """LightningModule that logs a caller-controlled ``val/mAP_50_95`` value each epoch.
+
+    Used to discriminate a genuinely *restored* ``best_model_score``/checkpoint from one a
+    fresh callback happened to compute or overwrite on its own: the pre- and post-resume
+    phases log different values (the post-resume one always worse), so a restored
+    high-water mark and a wrongly-reset one diverge, and a wrongly-reset one would let the
+    worse post-resume epoch overwrite the good on-disk checkpoint.
+    """
+
+    def __init__(self, metric_value: float) -> None:
+        """Initialize with the fixed ``val/mAP_50_95`` value to log every epoch.
+
+        Args:
+            metric_value: Value logged as ``val/mAP_50_95`` on every validation epoch.
+        """
+        super().__init__()
+        self.model = torch.nn.Linear(4, 1)
+        self.train_config = {"lr": 0.01}
+        self._metric_value = metric_value
+
+    def training_step(self, batch: tuple[Tensor, Tensor], batch_idx: int) -> Tensor:
+        """Compute MSE loss for one training batch.
+
+        Args:
+            batch: ``(x, y)`` tensors from the ``TensorDataset`` loader.
+            batch_idx: Index of the batch within the current epoch (unused).
+
+        Returns:
+            Scalar MSE loss.
+        """
+        del batch_idx
+        x, y = batch
+        pred = self.model(x)
+        return torch.nn.functional.mse_loss(pred, y)
+
+    def validation_step(self, batch: tuple[Tensor, Tensor], batch_idx: int) -> None:
+        """Log the fixed ``val/mAP_50_95`` value, ignoring the actual batch contents.
+
+        Args:
+            batch: Unused; only the epoch-level log call matters for these tests.
+            batch_idx: Unused.
+        """
+        del batch, batch_idx
+        self.log("val/mAP_50_95", torch.tensor(self._metric_value), on_step=False, on_epoch=True, prog_bar=False)
+
+    def configure_optimizers(self) -> torch.optim.Optimizer:
+        """Return a plain SGD optimizer sufficient to drive ``Trainer.fit()``."""
+        return torch.optim.SGD(self.model.parameters(), lr=0.01)
+
+
 class _EvalIntervalModule(LightningModule):
     """Tiny module that only logs val/mAP_50_95 every ``eval_interval`` epochs.
 
@@ -124,6 +176,140 @@ class _ResumeProbeCallback(Callback):
         del pl_module
         if self.first_train_epoch is None:
             self.first_train_epoch = trainer.current_epoch
+
+
+class _VaryingMetricModule(LightningModule):
+    """LightningModule that logs a different ``val/mAP_50_95`` value on each successive epoch.
+
+    ``values`` is consumed one entry per validation epoch (indexed by ``self.current_epoch``, clamped to the last
+    entry once exhausted), letting a single ``Trainer.fit()`` call drive stateful callbacks (e.g.
+    ``RFDETREarlyStopping``'s ``wait_count``) through both improving and non-improving epochs.
+    """
+
+    def __init__(self, values: list[float]) -> None:
+        """Initialize with the per-epoch ``val/mAP_50_95`` sequence.
+
+        Args:
+            values: One value per validation epoch; the last entry repeats once exhausted.
+        """
+        super().__init__()
+        self.model = torch.nn.Linear(4, 1)
+        self.train_config = {"lr": 0.01}
+        self._values = values
+
+    def training_step(self, batch: tuple[Tensor, Tensor], batch_idx: int) -> Tensor:
+        """Compute MSE loss for one training batch.
+
+        Args:
+            batch: ``(x, y)`` tensors from the ``TensorDataset`` loader.
+            batch_idx: Index of the batch within the current epoch (unused).
+
+        Returns:
+            Scalar MSE loss.
+        """
+        del batch_idx
+        x, y = batch
+        return torch.nn.functional.mse_loss(self.model(x), y)
+
+    def validation_step(self, batch: tuple[Tensor, Tensor], batch_idx: int) -> None:
+        """Log ``values[current_epoch]`` (clamped to the last entry) as ``val/mAP_50_95``.
+
+        Args:
+            batch: Unused; only the epoch-level log call matters for these tests.
+            batch_idx: Unused.
+        """
+        del batch, batch_idx
+        idx = min(self.current_epoch, len(self._values) - 1)
+        self.log("val/mAP_50_95", torch.tensor(self._values[idx]), on_step=False, on_epoch=True, prog_bar=False)
+
+    def configure_optimizers(self) -> torch.optim.Optimizer:
+        """Return a plain SGD optimizer sufficient to drive ``Trainer.fit()``."""
+        return torch.optim.SGD(self.model.parameters(), lr=0.01)
+
+
+class _EmaMetricModule(LightningModule):
+    """LightningModule that logs independently controlled ``val/mAP_50_95`` and ``val/ema_mAP_50_95`` values.
+
+    Used to drive :class:`BestModelCallback`'s EMA-checkpoint bookkeeping (``checkpoint_best_ema.pth``) with a
+    real, trainable model, so :class:`~rfdetr.training.callbacks.ema.RFDETREMACallback` produces genuinely
+    different EMA weights per :class:`~pytorch_lightning.Trainer` phase.
+    """
+
+    def __init__(self, regular_value: float, ema_value: float) -> None:
+        """Initialize with the fixed regular/EMA metric values to log every epoch.
+
+        Args:
+            regular_value: Value logged as ``val/mAP_50_95`` on every validation epoch.
+            ema_value: Value logged as ``val/ema_mAP_50_95`` on every validation epoch.
+        """
+        super().__init__()
+        self.model = torch.nn.Linear(4, 1)
+        self.train_config = {"lr": 0.01}
+        self._regular_value = regular_value
+        self._ema_value = ema_value
+
+    def training_step(self, batch: tuple[Tensor, Tensor], batch_idx: int) -> Tensor:
+        """Compute MSE loss for one training batch.
+
+        Args:
+            batch: ``(x, y)`` tensors from the ``TensorDataset`` loader.
+            batch_idx: Index of the batch within the current epoch (unused).
+
+        Returns:
+            Scalar MSE loss.
+        """
+        del batch_idx
+        x, y = batch
+        pred = self.model(x)
+        return torch.nn.functional.mse_loss(pred, y)
+
+    def validation_step(self, batch: tuple[Tensor, Tensor], batch_idx: int) -> None:
+        """Log the fixed regular and EMA metric values, ignoring the actual batch contents.
+
+        Args:
+            batch: Unused; only the epoch-level log calls matter for these tests.
+            batch_idx: Unused.
+        """
+        del batch, batch_idx
+        self.log("val/mAP_50_95", torch.tensor(self._regular_value), on_step=False, on_epoch=True, prog_bar=False)
+        self.log("val/ema_mAP_50_95", torch.tensor(self._ema_value), on_step=False, on_epoch=True, prog_bar=False)
+
+    def configure_optimizers(self) -> torch.optim.Optimizer:
+        """Return a plain SGD optimizer sufficient to drive ``Trainer.fit()``."""
+        return torch.optim.SGD(self.model.parameters(), lr=0.01)
+
+
+class _CallbackStateCaptureCallback(Callback):
+    """Snapshot other callbacks' resumed state at the first post-resume train-epoch start.
+
+    Runs before any post-resume training step can mutate ``ema_callback``/``early_stop_callback``, so the
+    captured values reflect exactly what PTL's ``_call_callbacks_load_state_dict`` restored from the checkpoint.
+    """
+
+    def __init__(self, ema_callback: RFDETREMACallback, early_stop_callback: RFDETREarlyStopping) -> None:
+        """Store the callbacks to snapshot once training resumes.
+
+        Args:
+            ema_callback: The resumed ``RFDETREMACallback`` instance to read state from.
+            early_stop_callback: The resumed ``RFDETREarlyStopping`` instance to read state from.
+        """
+        super().__init__()
+        self._ema_callback = ema_callback
+        self._early_stop_callback = early_stop_callback
+        self.ema_latest_update_step: int | None = None
+        self.early_stop_wait_count: int | None = None
+
+    def on_train_epoch_start(self, trainer: Trainer, pl_module: LightningModule) -> None:
+        """Capture ``ema_callback``/``early_stop_callback`` state on the first post-resume epoch.
+
+        Args:
+            trainer: Unused; required by the ``Callback`` hook signature.
+            pl_module: Unused; required by the ``Callback`` hook signature.
+        """
+        del trainer, pl_module
+        if self.ema_latest_update_step is None:
+            self.ema_latest_update_step = self._ema_callback._latest_update_step
+            self.early_stop_wait_count = self._early_stop_callback.wait_count
 
 
 # ---------------------------------------------------------------------------
@@ -340,6 +526,10 @@ class TestBestModelCallback:
         ema_state = {"w": torch.ones(1)}
         ema_callback = MagicMock()
         ema_callback.get_ema_model_state_dict.return_value = ema_state
+        # Real dict, not MagicMock's auto-generated one: _build_checkpoint_payload now calls
+        # callback.state_dict() on every trainer callback to populate the "callbacks" key
+        # (#checkpoint-resume-callbacks-fix), and torch.save can't pickle a bare MagicMock.
+        ema_callback.state_dict.return_value = {}
         trainer = _make_trainer(
             {"val/mAP_50_95": 0.4, "val/ema_mAP_50_95": 0.6},
             callbacks=[ema_callback],
@@ -361,6 +551,10 @@ class TestBestModelCallback:
         ema_state = {"w": torch.ones(1)}
         ema_callback = MagicMock()
         ema_callback.get_ema_model_state_dict.return_value = ema_state
+        # Real dict, not MagicMock's auto-generated one: _build_checkpoint_payload now calls
+        # callback.state_dict() on every trainer callback to populate the "callbacks" key
+        # (#checkpoint-resume-callbacks-fix), and torch.save can't pickle a bare MagicMock.
+        ema_callback.state_dict.return_value = {}
         trainer = _make_trainer(
             {"val/mAP_50_95": 0.6, "val/ema_mAP_50_95": 0.6},
             callbacks=[ema_callback],
@@ -1038,6 +1232,332 @@ class TestBestModelCallback:
         # fresh; this resumed phase contributes exactly one epoch with 2 steps.
         assert trainer_second.current_epoch == 2
         assert trainer_second.global_step == 2
+
+    @pytest.mark.parametrize("checkpoint_name", ["checkpoint_best_regular.pth", "checkpoint_best_total.pth"])
+    def test_best_model_score_survives_real_trainer_fit_resume(self, tmp_path: Path, checkpoint_name: str) -> None:
+        """``best_model_score`` and the on-disk checkpoint must survive a real ``trainer.fit(ckpt_path=...)`` resume.
+
+        Regression test for the "callbacks" key being absent from ``_build_checkpoint_payload``'s output — the bug
+        this PR fixes. Every existing regression test for callback-state persistence (``TestBestEmaStatePersistence``)
+        calls ``state_dict()``/``load_state_dict()`` directly in Python, never through PTL's own
+        ``_call_callbacks_load_state_dict``, so none of them would catch the payload missing the "callbacks" key.
+        Parametrized over ``checkpoint_best_regular.pth`` (built directly by ``_build_checkpoint_payload``) and
+        ``checkpoint_best_total.pth`` (built via ``shutil.copy2`` + ``strip_checkpoint``, a separate code path that
+        needs ``"callbacks"`` in ``_PTL_COMPAT_KEYS``).
+        """
+        x = torch.randn(8, 4)
+        y = torch.randn(8, 1)
+        train_loader = DataLoader(TensorDataset(x, y), batch_size=2)
+        val_loader = DataLoader(TensorDataset(x, y), batch_size=2)
+
+        save_cb = BestModelCallback(output_dir=str(tmp_path), run_test=False)
+        trainer_first = Trainer(
+            max_epochs=1,
+            accelerator="cpu",
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            logger=False,
+            num_sanity_val_steps=0,
+            limit_train_batches=2,
+            limit_val_batches=1,
+            callbacks=[save_cb],
+            default_root_dir=str(tmp_path),
+        )
+        trainer_first.fit(_MetricModule(0.7), train_dataloaders=train_loader, val_dataloaders=val_loader)
+        assert save_cb.best_model_score is not None
+        assert save_cb.best_model_score.item() == pytest.approx(0.7)
+
+        ckpt_path = tmp_path / checkpoint_name
+        assert ckpt_path.exists()
+        first_weights = {
+            k: v.clone() for k, v in torch.load(ckpt_path, map_location="cpu", weights_only=False)["model"].items()
+        }
+
+        # Fresh callback instance, resumed via a real Trainer.fit(ckpt_path=...) — exercises PTL's
+        # own `_call_callbacks_load_state_dict`, not a direct load_state_dict() call.
+        resumed_cb = BestModelCallback(output_dir=str(tmp_path), run_test=False)
+        trainer_second = Trainer(
+            max_epochs=2,
+            accelerator="cpu",
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            logger=False,
+            num_sanity_val_steps=0,
+            limit_train_batches=2,
+            limit_val_batches=1,
+            callbacks=[resumed_cb],
+            default_root_dir=str(tmp_path),
+        )
+        # Post-resume epoch logs a *worse* metric (0.3): without the fix, best_model_score resets to
+        # None on a fresh callback and 0.3 trivially "improves" on it, overwriting the on-disk
+        # checkpoint with worse weights — the exact failure mode from the issue this PR fixes.
+        trainer_second.fit(
+            _MetricModule(0.3),
+            train_dataloaders=train_loader,
+            val_dataloaders=val_loader,
+            ckpt_path=str(ckpt_path),
+        )
+
+        assert resumed_cb.best_model_score is not None
+        assert resumed_cb.best_model_score.item() == pytest.approx(0.7), (
+            'best_model_score must be restored from the checkpoint\'s "callbacks" key; without the '
+            "fix a fresh BestModelCallback starts with best_model_score=None and 0.3 wins by default"
+        )
+        # The worse post-resume epoch must not have overwritten checkpoint_best_regular.pth on disk.
+        # checkpoint_best_total.pth IS re-copied by trainer_second's own on_fit_end (every trainer.fit()
+        # call re-runs on_fit_end, not just the first), so re-asserting equality there would only prove
+        # the second copy reproduced the first byte-for-byte, not that the regular checkpoint itself
+        # survived untouched — hence this assertion only runs for the regular checkpoint.
+        if checkpoint_name == "checkpoint_best_regular.pth":
+            reloaded = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+            for key, value in reloaded["model"].items():
+                assert torch.equal(value, first_weights[key]), (
+                    f"checkpoint_best_regular.pth weights for {key!r} changed after a worse post-resume "
+                    "epoch — the good checkpoint was overwritten"
+                )
+
+    def test_ema_and_early_stopping_state_survive_real_trainer_fit_resume(self, tmp_path: Path) -> None:
+        """RFDETREMACallback and RFDETREarlyStopping state must also survive a real ``ckpt_path`` resume.
+
+        ``test_best_model_score_survives_real_trainer_fit_resume`` only registers ``BestModelCallback`` on the
+        trainer, so it exercises restoration of best-score tracking alone. The warning added to ``RFDETR.train()``
+        promises "best-score tracking, EMA, early stopping" all resume correctly together — this test registers
+        all three callbacks so ``_build_checkpoint_payload``'s generic ``trainer.callbacks`` loop is actually
+        exercised for the other two, not just ``BestModelCallback`` itself.
+        """
+        x = torch.randn(8, 4)
+        y = torch.randn(8, 1)
+        train_loader = DataLoader(TensorDataset(x, y), batch_size=2)
+        val_loader = DataLoader(TensorDataset(x, y), batch_size=2)
+
+        # monitor_ema enables last_ema.pth: unlike checkpoint_best_regular.pth (only rewritten on a
+        # metric *improvement*, which is exactly the condition that resets RFDETREarlyStopping.wait_count
+        # to 0 — so it can never capture a nonzero wait_count), last_ema.pth is rebuilt unconditionally
+        # in on_fit_end with each callback's *live* end-of-training state.
+        save_cb = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95", run_test=False)
+        ema_cb = RFDETREMACallback()
+        early_stop_cb = RFDETREarlyStopping(patience=5, min_delta=0.001, verbose=False)
+        trainer_first = Trainer(
+            max_epochs=2,
+            accelerator="cpu",
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            logger=False,
+            num_sanity_val_steps=0,
+            limit_train_batches=2,
+            limit_val_batches=1,
+            callbacks=[save_cb, ema_cb, early_stop_cb],
+            default_root_dir=str(tmp_path),
+        )
+        # Epoch 0: 0.7 (best, wait_count 0->0). Epoch 1: 0.5 (worse, wait_count 0->1) — training ends
+        # with wait_count=1 and ema_cb mid-averaging, both captured live into last_ema.pth.
+        trainer_first.fit(_VaryingMetricModule([0.7, 0.5]), train_dataloaders=train_loader, val_dataloaders=val_loader)
+
+        ckpt_path = tmp_path / "last_ema.pth"
+        assert ckpt_path.exists()
+        persisted_callbacks = torch.load(ckpt_path, map_location="cpu", weights_only=False)["callbacks"]
+        persisted_ema_step = persisted_callbacks[ema_cb.state_key]["latest_update_step"]
+        persisted_wait_count = persisted_callbacks[early_stop_cb.state_key]["wait_count"]
+        # Both must be genuinely non-default so a fresh, un-restored callback (which starts at 0) cannot
+        # accidentally satisfy the post-resume assertions below.
+        assert persisted_ema_step > 0
+        assert persisted_wait_count > 0
+
+        ema_callback = RFDETREMACallback()
+        early_stop_callback = RFDETREarlyStopping(patience=5, min_delta=0.001, verbose=False)
+        capture = _CallbackStateCaptureCallback(ema_callback, early_stop_callback)
+        # last_ema.pth is built in on_fit_end, after the epoch counter has already advanced past both
+        # trained epochs (0 and 1) to 2 — one further than the on_validation_end-time snapshot
+        # _make_fit_loop_state assumes (see its docstring). PTL's restored fit_loop therefore treats 3
+        # epochs as already completed, so max_epochs must be 4 (not 3) for one real epoch to run here.
+        trainer_second = Trainer(
+            max_epochs=4,
+            accelerator="cpu",
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            logger=False,
+            num_sanity_val_steps=0,
+            limit_train_batches=2,
+            limit_val_batches=1,
+            callbacks=[
+                BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95", run_test=False),
+                ema_callback,
+                early_stop_callback,
+                capture,
+            ],
+            default_root_dir=str(tmp_path),
+        )
+        trainer_second.fit(
+            _VaryingMetricModule([0.7, 0.5, 0.9, 0.9]),
+            train_dataloaders=train_loader,
+            val_dataloaders=val_loader,
+            ckpt_path=str(ckpt_path),
+        )
+
+        assert capture.ema_latest_update_step == persisted_ema_step, (
+            "RFDETREMACallback._latest_update_step must be restored from the checkpoint's 'callbacks' "
+            "key; without the fix a fresh callback starts at 0"
+        )
+        assert capture.early_stop_wait_count == persisted_wait_count, (
+            "RFDETREarlyStopping.wait_count must be restored from the checkpoint's 'callbacks' key; "
+            "without the fix a fresh callback starts at 0"
+        )
+
+    def test_ema_checkpoint_weights_survive_real_trainer_fit_resume(self, tmp_path: Path) -> None:
+        """``checkpoint_best_ema.pth`` weights must survive a real ``ckpt_path`` resume too.
+
+        ``test_best_model_score_survives_real_trainer_fit_resume`` only parametrizes over
+        ``checkpoint_best_regular.pth``/``checkpoint_best_total.pth`` and never asserts weight
+        preservation for the EMA track. The fix in ``_build_checkpoint_payload`` applies identically to
+        ``checkpoint_best_ema.pth`` (same code path, via ``_write_ema_checkpoint``), but without a
+        dedicated regression test a broken ``_best_ema`` restoration on this specific file would slip
+        through: a worse post-resume EMA epoch would trivially beat a reset ``_best_ema=0.0`` and
+        overwrite the good EMA checkpoint on disk, exactly like the regular-checkpoint failure mode this
+        PR fixes.
+        """
+        x = torch.randn(8, 4)
+        y = torch.randn(8, 1)
+        train_loader = DataLoader(TensorDataset(x, y), batch_size=2)
+        val_loader = DataLoader(TensorDataset(x, y), batch_size=2)
+
+        save_cb = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95", run_test=False)
+        ema_cb = RFDETREMACallback()
+        trainer_first = Trainer(
+            max_epochs=1,
+            accelerator="cpu",
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            logger=False,
+            num_sanity_val_steps=0,
+            limit_train_batches=2,
+            limit_val_batches=1,
+            callbacks=[save_cb, ema_cb],
+            default_root_dir=str(tmp_path),
+        )
+        trainer_first.fit(
+            _EmaMetricModule(regular_value=0.4, ema_value=0.75),
+            train_dataloaders=train_loader,
+            val_dataloaders=val_loader,
+        )
+        assert save_cb._best_ema == pytest.approx(0.75)
+
+        ckpt_path = tmp_path / "checkpoint_best_ema.pth"
+        assert ckpt_path.exists()
+        first_ema_weights = {
+            k: v.clone() for k, v in torch.load(ckpt_path, map_location="cpu", weights_only=False)["model"].items()
+        }
+
+        # Fresh callbacks, resumed via a real Trainer.fit(ckpt_path=...) — exercises PTL's own
+        # _call_callbacks_load_state_dict for both BestModelCallback._best_ema and the EMA callback's
+        # own averaging state, not a direct load_state_dict() call.
+        resumed_save_cb = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95", run_test=False)
+        resumed_ema_cb = RFDETREMACallback()
+        trainer_second = Trainer(
+            max_epochs=2,
+            accelerator="cpu",
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            logger=False,
+            num_sanity_val_steps=0,
+            limit_train_batches=2,
+            limit_val_batches=1,
+            callbacks=[resumed_save_cb, resumed_ema_cb],
+            default_root_dir=str(tmp_path),
+        )
+        # Post-resume epoch logs a *worse* EMA metric (0.3): without the fix, _best_ema resets to 0.0 on
+        # a fresh callback and 0.3 trivially "improves" on it, overwriting the on-disk EMA checkpoint.
+        trainer_second.fit(
+            _EmaMetricModule(regular_value=0.35, ema_value=0.3),
+            train_dataloaders=train_loader,
+            val_dataloaders=val_loader,
+            ckpt_path=str(ckpt_path),
+        )
+
+        assert resumed_save_cb._best_ema == pytest.approx(0.75), (
+            '_best_ema must be restored from the checkpoint\'s "callbacks" key; without the fix a '
+            "fresh BestModelCallback starts with _best_ema=0.0 and the worse post-resume EMA (0.3) "
+            "wins by default"
+        )
+        reloaded = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+        for key, value in reloaded["model"].items():
+            assert torch.equal(value, first_ema_weights[key]), (
+                f"checkpoint_best_ema.pth weights for {key!r} changed after a worse post-resume EMA "
+                "epoch — the good EMA checkpoint was overwritten"
+            )
+
+    def test_best_model_score_not_restored_when_output_dir_changes(self, tmp_path: Path) -> None:
+        """A resumed ``output_dir`` different from the checkpoint's own does not restore ``best_model_score``.
+
+        Pins PTL's own ``ModelCheckpoint.load_state_dict()`` gate (installed pytorch-lightning,
+        ``model_checkpoint.py``): it only restores ``best_model_score``/``best_k_models`` when the
+        resumed callback's ``dirpath`` matches the value stored in the checkpoint's ``"callbacks"``
+        state exactly; on a mismatch it warns and restores only ``best_model_path``. RF-DETR's
+        ``resume`` and ``output_dir`` config fields are independent (``config.py``), so pointing
+        ``resume=`` at one directory while writing to another is a config-permitted combination, not
+        a corrupted setup — this test locks in the resulting (previously untested) behavior.
+
+        ``max_epochs=1`` on both phases means the checkpoint's restored fit-loop progress (1 epoch
+        already completed) leaves zero epochs left to run in phase two: the assertions below capture
+        exactly what ``load_state_dict()`` restored, with no confound from a subsequent training
+        epoch overwriting ``best_model_score``/``best_model_path`` again on its own.
+        """
+        x = torch.randn(8, 4)
+        y = torch.randn(8, 1)
+        train_loader = DataLoader(TensorDataset(x, y), batch_size=2)
+        val_loader = DataLoader(TensorDataset(x, y), batch_size=2)
+
+        save_cb = BestModelCallback(output_dir=str(tmp_path), run_test=False)
+        trainer_first = Trainer(
+            max_epochs=1,
+            accelerator="cpu",
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            logger=False,
+            num_sanity_val_steps=0,
+            limit_train_batches=2,
+            limit_val_batches=1,
+            callbacks=[save_cb],
+            default_root_dir=str(tmp_path),
+        )
+        trainer_first.fit(_MetricModule(0.7), train_dataloaders=train_loader, val_dataloaders=val_loader)
+        assert save_cb.best_model_score.item() == pytest.approx(0.7)
+
+        ckpt_path = tmp_path / "checkpoint_best_regular.pth"
+        assert ckpt_path.exists()
+
+        # Resume into a DIFFERENT output_dir than the one the checkpoint was saved under.
+        other_output_dir = tmp_path / "other_output_dir"
+        other_output_dir.mkdir()
+        resumed_cb = BestModelCallback(output_dir=str(other_output_dir), run_test=False)
+        trainer_second = Trainer(
+            max_epochs=1,
+            accelerator="cpu",
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            logger=False,
+            num_sanity_val_steps=0,
+            limit_train_batches=2,
+            limit_val_batches=1,
+            callbacks=[resumed_cb],
+            default_root_dir=str(tmp_path),
+        )
+        with pytest.warns(UserWarning, match="dirpath has changed"):
+            trainer_second.fit(
+                _MetricModule(0.3),
+                train_dataloaders=train_loader,
+                val_dataloaders=val_loader,
+                ckpt_path=str(ckpt_path),
+            )
+
+        # No epoch ran post-resume (fit_loop already shows 1/1 epochs completed), so these values are
+        # exactly what load_state_dict() produced, undisturbed by any further training.
+        assert trainer_second.global_step == 0
+        # best_model_score was NOT carried over — the dirpath mismatch skips it, leaving the fresh
+        # callback's own default (None), exactly as if it had never resumed at all.
+        assert resumed_cb.best_model_score is None
+        # best_model_path IS still carried over regardless of the dirpath mismatch (PTL restores it
+        # unconditionally), even though it now points at a path under the OLD output_dir.
+        assert resumed_cb.best_model_path == str(ckpt_path)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/training/callbacks/test_ema_callback.py
+++ b/tests/training/callbacks/test_ema_callback.py
@@ -9,13 +9,17 @@ from __future__ import annotations
 
 import math
 import warnings
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 import torch
-from torch import nn
+from pytorch_lightning import Callback, LightningModule, Trainer
+from torch import Tensor, nn
 from torch.optim.swa_utils import AveragedModel
+from torch.utils.data import DataLoader, TensorDataset
 
+from rfdetr.training.callbacks.best_model import BestModelCallback
 from rfdetr.training.callbacks.ema import RFDETREMACallback
 from rfdetr.training.model_ema import ModelEma
 
@@ -303,6 +307,160 @@ class TestMultiAvgFn:
         for name, old_val in old_state.items():
             assert new_state[name].is_cuda
             assert torch.allclose(new_state[name], old_val, atol=1e-6), f"CUDA parity failed for {name}"
+
+
+class _EMAResumeModule(LightningModule):
+    """Tiny module with enough learnable weights and steps to diverge EMA from live weights."""
+
+    def __init__(self, metric_value: float = 0.5) -> None:
+        """Initialize with the fixed ``val/mAP_50_95`` value to log every epoch.
+
+        Args:
+            metric_value: Value logged as ``val/mAP_50_95`` on every validation epoch.
+        """
+        super().__init__()
+        self.model = torch.nn.Linear(4, 1)
+        self.train_config = {"lr": 1.0}
+        self._metric_value = metric_value
+
+    def training_step(self, batch: tuple[Tensor, Tensor], batch_idx: int) -> Tensor:
+        """Compute MSE loss for one training batch.
+
+        Args:
+            batch: ``(x, y)`` tensors from the ``TensorDataset`` loader.
+            batch_idx: Index of the batch within the current epoch (unused).
+
+        Returns:
+            Scalar MSE loss.
+        """
+        del batch_idx
+        x, y = batch
+        pred = self.model(x)
+        return torch.nn.functional.mse_loss(pred, y)
+
+    def validation_step(self, batch: tuple[Tensor, Tensor], batch_idx: int) -> None:
+        """Log the fixed ``val/mAP_50_95`` value, ignoring the actual batch contents.
+
+        Args:
+            batch: Unused; only the epoch-level log call matters for these tests.
+            batch_idx: Unused.
+        """
+        del batch, batch_idx
+        self.log("val/mAP_50_95", torch.tensor(self._metric_value), on_step=False, on_epoch=True, prog_bar=False)
+
+    def configure_optimizers(self) -> torch.optim.Optimizer:
+        """Return a plain SGD optimizer sufficient to drive ``Trainer.fit()``."""
+        return torch.optim.SGD(self.model.parameters(), lr=1.0)
+
+
+class _EMAStartSnapshotProbe(Callback):
+    """Capture the averaged-model weights as soon as the (post-resume) training loop starts."""
+
+    def __init__(self, ema_callback: RFDETREMACallback) -> None:
+        """Store the EMA callback to snapshot once training starts.
+
+        Args:
+            ema_callback: The (possibly just-resumed) ``RFDETREMACallback`` instance to read from.
+        """
+        super().__init__()
+        self._ema_callback = ema_callback
+        self.snapshot: dict[str, Tensor] | None = None
+
+    def on_train_start(self, trainer: Trainer, pl_module: LightningModule) -> None:
+        """Snapshot the averaged-model state dict at the very start of training.
+
+        Args:
+            trainer: Unused; required by the ``Callback`` hook signature.
+            pl_module: Unused; required by the ``Callback`` hook signature.
+        """
+        del trainer, pl_module
+        state = self._ema_callback.get_ema_model_state_dict()
+        self.snapshot = {k: v.clone() for k, v in state.items()} if state is not None else None
+
+
+class TestRealTrainerResume:
+    """Regression: ``average_model_state_dict`` must survive a real ``Trainer.fit(ckpt_path=...)`` resume.
+
+    ``setup()`` runs before ``load_state_dict()`` for RF-DETR's default strategy (``Trainer._run``
+    calls ``call._call_setup_hook`` before ``_checkpoint_connector._restore_modules_and_callbacks``),
+    so a checkpoint's ``average_model_state_dict`` landing in ``_pending_average_state_dict`` via
+    ``load_state_dict()`` could not be applied inside ``setup()`` — only ``on_train_start`` (this
+    fix) runs late enough, after PTL finishes restoring, to apply it. The prior end-to-end resume
+    test (``test_best_model_score_survives_real_trainer_fit_resume`` in
+    ``test_best_model_callback.py``) only put ``BestModelCallback`` in the trainer's callback list,
+    so it never exercised ``RFDETREMACallback``'s own resume path.
+    """
+
+    def test_average_model_state_survives_real_trainer_fit_resume(self, tmp_path: Path) -> None:
+        """A fresh ``RFDETREMACallback`` resumed via ``ckpt_path=`` must recover the saved EMA average."""
+        torch.manual_seed(0)
+        x = torch.randn(8, 4)
+        y = torch.randn(8, 1)
+        train_loader = DataLoader(TensorDataset(x, y), batch_size=2)
+        val_loader = DataLoader(TensorDataset(x, y), batch_size=2)
+
+        best_cb1 = BestModelCallback(output_dir=str(tmp_path), run_test=False)
+        ema_cb1 = RFDETREMACallback(decay=0.5, tau=0)
+        trainer_first = Trainer(
+            max_epochs=1,
+            accelerator="cpu",
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            logger=False,
+            num_sanity_val_steps=0,
+            limit_train_batches=4,
+            limit_val_batches=1,
+            callbacks=[best_cb1, ema_cb1],
+            default_root_dir=str(tmp_path),
+        )
+        trainer_first.fit(_EMAResumeModule(), train_dataloaders=train_loader, val_dataloaders=val_loader)
+
+        ckpt_path = tmp_path / "checkpoint_best_regular.pth"
+        assert ckpt_path.exists()
+        saved = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+        raw_ema_state = saved["callbacks"][ema_cb1.state_key]["average_model_state_dict"]
+        expected_avg_state = {
+            key.removeprefix("module.model."): value.clone()
+            for key, value in raw_ema_state.items()
+            if key.startswith("module.model.")
+        }
+        assert expected_avg_state, "checkpoint must embed the EMA average model's weights"
+
+        # Sanity: the averaged weights genuinely diverged from the live regular weights saved
+        # alongside them (decay=0.5 vs a full live SGD step) — otherwise a broken restore could
+        # accidentally "pass" by coincidence.
+        live_weights = saved["model"]
+        assert not torch.allclose(expected_avg_state["weight"], live_weights["weight"])
+
+        best_cb2 = BestModelCallback(output_dir=str(tmp_path), run_test=False)
+        ema_cb2 = RFDETREMACallback(decay=0.5, tau=0)
+        probe = _EMAStartSnapshotProbe(ema_cb2)
+        trainer_second = Trainer(
+            max_epochs=2,
+            accelerator="cpu",
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            logger=False,
+            num_sanity_val_steps=0,
+            limit_train_batches=4,
+            limit_val_batches=1,
+            callbacks=[best_cb2, ema_cb2, probe],
+            default_root_dir=str(tmp_path),
+        )
+        trainer_second.fit(
+            _EMAResumeModule(),
+            train_dataloaders=train_loader,
+            val_dataloaders=val_loader,
+            ckpt_path=str(ckpt_path),
+        )
+
+        assert probe.snapshot is not None
+        for key, expected in expected_avg_state.items():
+            assert torch.allclose(probe.snapshot[key], expected), (
+                f"average_model weight {key!r} was not restored from the checkpoint's "
+                '"callbacks" key; without on_train_start applying the pending state, a fresh '
+                "RFDETREMACallback starts averaging from the just-resumed live weights instead"
+            )
 
 
 class TestSuppressTestSwap:

--- a/tests/training/callbacks/test_ema_callback.py
+++ b/tests/training/callbacks/test_ema_callback.py
@@ -347,6 +347,7 @@ class _EMAResumeModule(LightningModule):
         """
         del batch, batch_idx
         self.log("val/mAP_50_95", torch.tensor(self._metric_value), on_step=False, on_epoch=True, prog_bar=False)
+        self.log("val/ema_mAP_50_95", torch.tensor(self._metric_value), on_step=False, on_epoch=True, prog_bar=False)
 
     def configure_optimizers(self) -> torch.optim.Optimizer:
         """Return a plain SGD optimizer sufficient to drive ``Trainer.fit()``."""
@@ -365,9 +366,10 @@ class _EMAStartSnapshotProbe(Callback):
         super().__init__()
         self._ema_callback = ema_callback
         self.snapshot: dict[str, Tensor] | None = None
+        self.average_state: dict[str, Tensor] | None = None
 
-    def on_train_start(self, trainer: Trainer, pl_module: LightningModule) -> None:
-        """Snapshot the averaged-model state dict at the very start of training.
+    def on_train_epoch_start(self, trainer: Trainer, pl_module: LightningModule) -> None:
+        """Snapshot the averaged-model state dict before the first resumed batch.
 
         Args:
             trainer: Unused; required by the ``Callback`` hook signature.
@@ -376,6 +378,9 @@ class _EMAStartSnapshotProbe(Callback):
         del trainer, pl_module
         state = self._ema_callback.get_ema_model_state_dict()
         self.snapshot = {k: v.clone() for k, v in state.items()} if state is not None else None
+        average_model = self._ema_callback._average_model
+        if average_model is not None:
+            self.average_state = {key: value.clone() for key, value in average_model.state_dict().items()}
 
 
 class TestRealTrainerResume:
@@ -461,6 +466,76 @@ class TestRealTrainerResume:
                 '"callbacks" key; without on_train_start applying the pending state, a fresh '
                 "RFDETREMACallback starts averaging from the just-resumed live weights instead"
             )
+
+    def test_last_ema_preserves_full_state_and_resumes_batch_updates(self, tmp_path: Path) -> None:
+        """A ``last_ema.pth`` resume restores EMA state without suppressing new batch updates."""
+        torch.manual_seed(0)
+        x = torch.randn(8, 4)
+        y = torch.randn(8, 1)
+        train_loader = DataLoader(TensorDataset(x, y), batch_size=2)
+        val_loader = DataLoader(TensorDataset(x, y), batch_size=2)
+
+        best_cb1 = BestModelCallback(
+            output_dir=str(tmp_path),
+            monitor_ema="val/ema_mAP_50_95",
+            run_test=False,
+        )
+        ema_cb1 = RFDETREMACallback(decay=0.5, tau=0)
+        trainer_first = Trainer(
+            max_epochs=1,
+            accelerator="cpu",
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            logger=False,
+            num_sanity_val_steps=0,
+            limit_train_batches=4,
+            limit_val_batches=1,
+            callbacks=[best_cb1, ema_cb1],
+            default_root_dir=str(tmp_path),
+        )
+        trainer_first.fit(_EMAResumeModule(), train_dataloaders=train_loader, val_dataloaders=val_loader)
+
+        ckpt_path = tmp_path / "last_ema.pth"
+        checkpoint = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+        expected_state = checkpoint["callbacks"][ema_cb1.state_key]["average_model_state_dict"]
+        expected_updates = int(expected_state["n_averaged"])
+        for name, tensor in checkpoint["model"].items():
+            callback_tensor = expected_state[f"module.model.{name}"]
+            assert tensor.untyped_storage().data_ptr() == callback_tensor.untyped_storage().data_ptr()
+
+        best_cb2 = BestModelCallback(
+            output_dir=str(tmp_path),
+            monitor_ema="val/ema_mAP_50_95",
+            run_test=False,
+        )
+        ema_cb2 = RFDETREMACallback(decay=0.5, tau=0)
+        probe = _EMAStartSnapshotProbe(ema_cb2)
+        trainer_second = Trainer(
+            # ``last_ema.pth`` is written after the first phase advances the
+            # fit-loop epoch counter to 2, so allow one additional real epoch.
+            max_epochs=3,
+            accelerator="cpu",
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            logger=False,
+            num_sanity_val_steps=0,
+            limit_train_batches=4,
+            limit_val_batches=1,
+            callbacks=[best_cb2, ema_cb2, probe],
+            default_root_dir=str(tmp_path),
+        )
+        trainer_second.fit(
+            _EMAResumeModule(),
+            train_dataloaders=train_loader,
+            val_dataloaders=val_loader,
+            ckpt_path=str(ckpt_path),
+        )
+
+        assert probe.average_state is not None
+        for key, expected in expected_state.items():
+            assert torch.equal(probe.average_state[key], expected)
+        assert ema_cb2._average_model is not None
+        assert int(ema_cb2._average_model.n_averaged) == expected_updates + len(train_loader) + 1
 
 
 class TestSuppressTestSwap:

--- a/tests/training/test_train_resume.py
+++ b/tests/training/test_train_resume.py
@@ -5,8 +5,12 @@
 # ------------------------------------------------------------------------
 """Tests for resuming training from checkpoint."""
 
+import logging
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
+import torch
 
 from rfdetr import RFDETRNano
 
@@ -78,3 +82,128 @@ def test_resume_with_completed_epochs_calls_on_train_end_callback(tmp_path: Path
 
     # Old-style callbacks on model.callbacks are no longer invoked in the PTL path.
     assert callback_calls == 0
+
+
+def _train_with_resume(tmp_path: Path, ckpt_path: Path, output_dir: Path) -> None:
+    """Run ``model.train(resume=...)`` with the PTL stack mocked out, exercising only config/warning logic.
+
+    Shared by the resume-warning tests below: none of them care about an actual training run, only about
+    what ``RFDETR.train()`` logs before ``trainer.fit()`` is reached (which is itself mocked away).
+
+    Args:
+        tmp_path: Pytest temporary directory, used as ``dataset_dir``.
+        ckpt_path: Path passed as ``resume=``.
+        output_dir: Path passed as ``output_dir=``.
+    """
+    model = RFDETRNano(pretrain_weights=None, num_classes=3, device="cpu")
+    with (
+        patch("rfdetr.training.RFDETRModelModule"),
+        patch("rfdetr.training.RFDETRDataModule"),
+        patch("rfdetr.training.build_trainer"),
+    ):
+        model.train(
+            dataset_dir=str(tmp_path),
+            epochs=1,
+            batch_size=1,
+            grad_accum_steps=1,
+            output_dir=str(output_dir),
+            resume=str(ckpt_path),
+            device="cpu",
+        )
+
+
+def _train_with_resume_capturing_warnings(
+    tmp_path: Path, ckpt_path: Path, output_dir: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Run :func:`_train_with_resume` with the "rf-detr" logger's warnings captured by ``caplog``.
+
+    ``get_logger()`` (``rfdetr.utilities.logger``) sets ``propagate = False`` on the "rf-detr" logger
+    so it does not double-log through the root logger's own handlers. ``caplog``'s capturing handler
+    lives on the root logger, so records never reach it unless propagation is temporarily re-enabled —
+    same pattern already used in ``tests/utilities/test_state_dict.py``.
+
+    Args:
+        tmp_path: Pytest temporary directory, used as ``dataset_dir``.
+        ckpt_path: Path passed as ``resume=``.
+        output_dir: Path passed as ``output_dir=``.
+        caplog: Pytest's log-capturing fixture.
+
+    Examples:
+        >>> _train_with_resume_capturing_warnings  # doctest: +SKIP
+        Needs pytest's tmp_path/caplog fixtures, can't run standalone outside a test.
+    """
+    rf_detr_logger = logging.getLogger("rf-detr")
+    prev_propagate = rf_detr_logger.propagate
+    rf_detr_logger.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING, logger="rf-detr"):
+            _train_with_resume(tmp_path, ckpt_path, output_dir)
+    finally:
+        rf_detr_logger.propagate = prev_propagate
+
+
+def test_resume_from_checkpoint_with_callback_state_warns_it_resumes_correctly(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A lightweight checkpoint with a non-empty "callbacks" key gets the "will resume correctly" warning.
+
+    Regression test for the RFDETR.train() resume warning: without peeking at the checkpoint's own
+    "callbacks" key first, this branch and the one in
+    ``test_resume_from_checkpoint_without_callback_state_warns_it_restarts_cold`` below would be
+    indistinguishable and the warning would always claim full restoration.
+    """
+    output_dir = tmp_path / "train_output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    ckpt_path = output_dir / "checkpoint_best_regular.pth"
+    torch.save({"model": {}, "callbacks": {"BestModelCallback": {"best_model_score": 0.7}}}, ckpt_path)
+
+    _train_with_resume_capturing_warnings(tmp_path, ckpt_path, output_dir, caplog)
+
+    assert any("will resume correctly" in record.message for record in caplog.records)
+    assert not any("predates callback-state persistence" in record.message for record in caplog.records)
+
+
+def test_resume_from_checkpoint_without_callback_state_warns_it_restarts_cold(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A lightweight checkpoint with no "callbacks" key (or an empty one) warns everything restarts cold.
+
+    Simulates a checkpoint written before ``BestModelCallback._build_checkpoint_payload`` started
+    persisting per-callback state (or any run where every registered callback had empty state):
+    PTL's ``_call_callbacks_load_state_dict`` no-ops on a missing/empty "callbacks" key, silently
+    skipping best-score/EMA/early-stopping restoration — the warning must not claim otherwise.
+    """
+    output_dir = tmp_path / "train_output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    ckpt_path = output_dir / "checkpoint_best_regular.pth"
+    torch.save({"model": {}}, ckpt_path)
+
+    _train_with_resume_capturing_warnings(tmp_path, ckpt_path, output_dir, caplog)
+
+    assert any("restart cold" in record.message for record in caplog.records)
+    assert not any("will resume correctly" in record.message for record in caplog.records)
+
+
+def test_resume_dirpath_mismatch_warns_best_score_restarts_fresh(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Resuming with output_dir different from the checkpoint's own directory warns best-score tracking resets.
+
+    Mirrors PTL's own ``ModelCheckpoint.load_state_dict()`` dirpath gate (see
+    ``tests/training/callbacks/test_best_model_callback.py::test_best_model_score_not_restored_when_output_dir_changes``
+    for the callback-level regression test); this is the config-level warning that surfaces the same
+    gap to a user calling ``RFDETR.train(resume=..., output_dir=...)`` directly.
+    """
+    source_dir = tmp_path / "source_output"
+    source_dir.mkdir(parents=True, exist_ok=True)
+    ckpt_path = source_dir / "checkpoint_best_regular.pth"
+    torch.save({"model": {}, "callbacks": {"BestModelCallback": {"best_model_score": 0.7}}}, ckpt_path)
+
+    other_output_dir = tmp_path / "other_output_dir"
+    other_output_dir.mkdir(parents=True, exist_ok=True)
+
+    _train_with_resume_capturing_warnings(tmp_path, ckpt_path, other_output_dir, caplog)
+
+    assert any(
+        "best-score tracking" in record.message and "restarts fresh" in record.message for record in caplog.records
+    )

--- a/tests/training/test_train_resume.py
+++ b/tests/training/test_train_resume.py
@@ -168,10 +168,10 @@ def test_resume_from_checkpoint_without_callback_state_warns_it_restarts_cold(
 ) -> None:
     """A lightweight checkpoint with no "callbacks" key (or an empty one) warns everything restarts cold.
 
-    Simulates a checkpoint written before ``BestModelCallback._build_checkpoint_payload`` started
-    persisting per-callback state (or any run where every registered callback had empty state):
-    PTL's ``_call_callbacks_load_state_dict`` no-ops on a missing/empty "callbacks" key, silently
-    skipping best-score/EMA/early-stopping restoration — the warning must not claim otherwise.
+    Simulates a checkpoint written before ``BestModelCallback._build_checkpoint_payload`` started persisting per-
+    callback state (or any run where every registered callback had empty state): PTL's
+    ``_call_callbacks_load_state_dict`` no-ops on a missing/empty "callbacks" key, silently skipping best-
+    score/EMA/early-stopping restoration — the warning must not claim otherwise.
     """
     output_dir = tmp_path / "train_output"
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/training/test_train_resume.py
+++ b/tests/training/test_train_resume.py
@@ -94,6 +94,10 @@ def _train_with_resume(tmp_path: Path, ckpt_path: Path, output_dir: Path) -> Non
         tmp_path: Pytest temporary directory, used as ``dataset_dir``.
         ckpt_path: Path passed as ``resume=``.
         output_dir: Path passed as ``output_dir=``.
+
+    Examples:
+        >>> _train_with_resume  # doctest: +SKIP
+        Needs patched training dependencies and a pytest tmp_path fixture.
     """
     model = RFDETRNano(pretrain_weights=None, num_classes=3, device="cpu")
     with (
@@ -159,7 +163,7 @@ def test_resume_from_checkpoint_with_callback_state_warns_it_resumes_correctly(
 
     _train_with_resume_capturing_warnings(tmp_path, ckpt_path, output_dir, caplog)
 
-    assert any("will resume correctly" in record.message for record in caplog.records)
+    assert any("matching configured callbacks" in record.message for record in caplog.records)
     assert not any("predates callback-state persistence" in record.message for record in caplog.records)
 
 
@@ -181,7 +185,7 @@ def test_resume_from_checkpoint_without_callback_state_warns_it_restarts_cold(
     _train_with_resume_capturing_warnings(tmp_path, ckpt_path, output_dir, caplog)
 
     assert any("restart cold" in record.message for record in caplog.records)
-    assert not any("will resume correctly" in record.message for record in caplog.records)
+    assert not any("matching configured callbacks" in record.message for record in caplog.records)
 
 
 def test_resume_dirpath_mismatch_warns_best_score_restarts_fresh(


### PR DESCRIPTION
`BestModelCallback._build_checkpoint_payload` (`best_model.py:137-190`) builds the payload for the four files the callback produces — `checkpoint_best_regular.pth`, `checkpoint_best_ema.pth`, `checkpoint_best_total.pth`, `last_ema.pth` — without the `"callbacks"` key that PyTorch Lightning reads back on resume:

```python
# PTL's trainer/call.py (installed, 2.6.5):
callback_states = checkpoint.get("callbacks")
if callback_states is None:
    return  # no callback gets load_state_dict()
```

So when you resume from one of these files, no callback gets its state restored — not `BestModelCallback`, not `RFDETREMACallback`, not `RFDETREarlyStopping`. `optimizer_states`/`lr_schedulers` are present but empty (`[]`, not missing), so the guard that should raise an error never fires either, the optimizer and the LR scheduler just start cold with no warning.

With the callback state reset, `best_model_score` comes back empty, and that makes the callback treat any metric value as an improvement — including `0.0` from a run that diverged. In practice this means the good checkpoint gets overwritten on disk by a broken one.

I confirmed this with a real two-stage training run, on two different GPUs. Stage one trains normally and saves `checkpoint_best_regular.pth`. Stage two resumes from that file with a deliberately high LR to force a collapse. Without the fix, the checkpoint on disk moves from a finite weight norm to `NaN` and `torch.equal()` between the two states returns `False` — the good checkpoint is gone, replaced by the diverged one. With the fix, `torch.equal()` returns `True`, the checkpoint on disk doesn't change, and the resumed `best_model_score` in the logs matches stage one, not the collapsed run.

- RTX 4060, small synthetic dataset (the mechanism doesn't depend on the image content, only on the checkpoint payload).
- L4, real COCO val2017 images.

Same result both times.

I also traced why this got past the existing tests. There is a previous attempt at the same problem, #973 (fixing #969), which added `state_dict()`/`load_state_dict()` to `BestModelCallback`. That repro used PTL's own plain `ModelCheckpoint` file, though, which already carries the `"callbacks"` key by default — never one of `BestModelCallback`'s own four files. Its regression test also calls `state_dict()`/`load_state_dict()` directly in Python, not through a real `trainer.fit(ckpt_path=...)`. And the one existing test that does resume through a real trainer built the second `Trainer` without `BestModelCallback` in the callback list, so it never went through this path either.

**Changes**

- `best_model.py`: `_build_checkpoint_payload` now serialises `{cb.state_key: cb.state_dict() for cb in trainer.callbacks if state}` under `"callbacks"`, following the same pattern PTL itself uses internally.
- `state_dict.py`: added `"callbacks"` to `_PTL_COMPAT_KEYS`. `checkpoint_best_total.pth` is built differently (`shutil.copy2` + `strip_checkpoint()`), and without this it kept dropping the state even after the other three files were fixed.
- `detr.py`: added `logger.warning` calls when `resume=` points at one of these four lightweight files — one pair distinguishing a checkpoint that actually has a `"callbacks"` section (full state restores, optimizer/scheduler still cold) from one that predates this fix or has nothing to restore (everything restarts cold), plus a third warning for the case where `output_dir` doesn't match the directory the checkpoint was written under (PTL's own `ModelCheckpoint.load_state_dict()` dirpath gate — `best_model_score`/`best_k_models` silently reset in that case). `docs/learn/train/advanced.md` gets a matching callout: the "Optimizer state / LR scheduler state" restoration list only applies to the trainer's own full checkpoints (`last.ckpt`/`checkpoint_<epoch>.ckpt`), not to these four `.pth` files.
- Two existing tests needed a small update: they mock `RFDETREMACallback` with a bare `MagicMock`, and `_build_checkpoint_payload` now calls `.state_dict()` on it, which `torch.save` can't pickle. Added `ema_callback.state_dict.return_value = {}`, same pattern the file already uses for its other mocks.
- Added real `Trainer.fit(ckpt_path=...)` regression tests — the class of test none of the existing callback-state tests (`TestBestEmaStatePersistence`, added by #973) exercised, since they all call `state_dict()`/`load_state_dict()` directly in Python instead of going through PTL's own `_call_callbacks_load_state_dict`:
  - `test_best_model_score_survives_real_trainer_fit_resume`, parametrized over `checkpoint_best_regular.pth` and `checkpoint_best_total.pth` (the two files built by separate code paths — direct payload vs `shutil.copy2` + `strip_checkpoint`), asserting `best_model_score` comes back restored and the worse post-resume epoch doesn't overwrite the good checkpoint on disk.
  - `test_ema_checkpoint_weights_survive_real_trainer_fit_resume`, the same weight-preservation regression but for `checkpoint_best_ema.pth` — the fix applies to it through the same `_build_checkpoint_payload`/`_write_ema_checkpoint` path, and it needed its own real-resume test since the EMA track's `_best_ema` high-water mark is separate state from `best_model_score`.
  - `test_ema_and_early_stopping_state_survive_real_trainer_fit_resume`, resuming with `BestModelCallback` + `RFDETREMACallback` + `RFDETREarlyStopping` all registered, confirming `RFDETREMACallback._latest_update_step` and `RFDETREarlyStopping.wait_count` both come back too (not just `BestModelCallback`'s own state).
  - `test_average_model_state_survives_real_trainer_fit_resume` (`test_ema_callback.py`), confirming `RFDETREMACallback`'s averaged weights themselves survive resume, not just its scalar counters.
  - `test_best_model_score_not_restored_when_output_dir_changes` and `test_resume_dirpath_mismatch_warns_best_score_restarts_fresh`, pinning the `output_dir`-mismatch gap and its warning.
  - Three warning-content tests in `test_train_resume.py` covering the has-callback-state / lacks-callback-state / dirpath-mismatch branches in `detr.py`.
- `ema.py`: once `average_model_state_dict` actually reaches the checkpoint (it never did before this fix, same root cause), a second problem showed up that had been masked until now. `Trainer._run` calls every callback's `setup()` before it restores the checkpoint. For every strategy rf-detr ships (all except FSDP/DeepSpeed/model-parallel), `RFDETREMACallback.setup()` was building `_average_model` from the not-yet-restored live weights, and by the time `load_state_dict()` ran afterwards and staged the resumed EMA state into `_pending_average_state_dict`, the branch in `setup()` that applies a pending state dict had already run and wasn't going to run again. So the averaged model resumed "blank", from the live weights, not its own state. Added `on_train_start()`, the first point that runs strictly after checkpoint restoration completes, to apply the pending state there instead.

**Validation**

While re-checking the suite myself before pushing this, I found three of the new warning tests in `test_train_resume.py` were passing for the wrong reason: `caplog.at_level("WARNING", logger="rf-detr")` on its own doesn't work here, `get_logger()` sets `propagate = False` on the `rf-detr` logger, so records never reach caplog's handler on the root logger unless `propagate` gets flipped back on first (`test_state_dict.py` already does this for the same reason, I'd missed it the first time round). Pulled that into a small helper and used it in the three tests, now genuinely passing rather than accidentally green.

- Targeted suite (`test_best_model_callback.py`, `test_train_resume.py`, `test_state_dict.py`, `test_ema_callback.py`): 205 passed, 1 skipped, 0 failed.
- Full suite run separately (`training/`, `utilities/`, `inference/test_from_checkpoint.py`, `legacy/test_checkpoint_compat.py`): 1316 passed, 8 skipped, 25 errors — re-ran the identical command against unpatched `develop` and got 1307 passed, 8 skipped, the same 25 errors (all `tests/legacy/test_checkpoint_compat.py`, missing local legacy-checkpoint fixture files unrelated to this diff). The delta is exactly the 9 new regression tests above, no regressions. `test_trainer_smoke.py` (real `trainer.fit()` loops): 11/11.
- Patch applies cleanly on `develop` at `c107a748`.

One thing I want to be upfront about: the four files grow from about 122MB to about 244MB, because `RFDETREMACallback.state_dict()` carries the full EMA weights inside its own state. For `checkpoint_best_ema.pth`/`last_ema.pth` that is pure duplication, since the top-level weights already are the EMA weights. For the other two it is not — it's what lets a resumed EMA track keep averaging from where it actually was, instead of restarting from the just-resumed live weights. There's a way to dedupe this (share the same tensor objects between both paths so `torch.save`'s own storage dedup kicks in), but it touches `ema.py` too, so I left it out of this PR. Happy to add it here if you'd rather have it in the same PR, or to change the approach entirely if a lighter-weight design makes more sense to you ..
