### PR TITLE
fix(export): mirror PostProcess's multi-label selection in the ONNX/TFLite reference decode

### DIFF
--- a/src/rfdetr/export/_onnx/inference.py
+++ b/src/rfdetr/export/_onnx/inference.py
@@ -143,6 +143,7 @@ def _run_inference(
     session: Any,
     image_path: str | Path,
     threshold: float = 0.3,
+    num_select: int | None = None,
 ) -> tuple[Detections, PILImage.Image]:
     """Preprocess one image, run ONNX Runtime inference, and decode detections.
 
@@ -172,6 +173,8 @@ def _run_inference(
         image_path: Path to the input image (any format supported by Pillow).
             RGB images are used as-is; RGBA / palette images are converted.
         threshold: Confidence threshold; detections below this are discarded.
+        num_select: Maximum query/class pairs selected before thresholding. ``None`` uses the exported model's query
+            count, matching shipped RF-DETR configurations; pass an explicit value for custom exports.
 
     Returns:
         A tuple of ``(detections, pil_img)`` where ``detections`` contains pixel-space ``xyxy`` boxes and ``pil_img`` is
@@ -241,27 +244,34 @@ def _run_inference(
     logits = raw_outputs[logits_idx][0, :, :-1]  # (Q, num_classes)
 
     # RF-DETR uses per-class sigmoid (not softmax) — mirrors PostProcess.forward in postprocess.py.
-    logger.debug(
-        "Logits stats: shape=%s min=%.3f max=%.3f mean=%.3f",
-        logits.shape,
-        float(logits.min()),
-        float(logits.max()),
-        float(logits.mean()),
-    )
+    if logits.size:
+        logger.debug(
+            "Logits stats: shape=%s min=%.3f max=%.3f mean=%.3f",
+            logits.shape,
+            float(logits.min()),
+            float(logits.max()),
+            float(logits.mean()),
+        )
+    else:
+        logger.debug("Logits stats: empty shape=%s", logits.shape)
     one = np.asarray(1, dtype=logits.dtype)
     scores_all = one / (one + np.exp(-logits.clip(-88, 88)))
     # Flatten (Q, C) to Q*C query/class pairs and take the top-scoring ones before thresholding —
     # mirrors PostProcess._select_topk. A per-query argmax (the previous approach) keeps at most
     # one class per query, silently dropping legitimate detections whenever a query scores above
     # threshold on more than one class; see _topk.py for why that happens routinely here.
-    scores, cls, query_idx = _select_topk_multiclass(scores_all, threshold)
-    logger.debug(
-        "Scores stats: min=%.3f max=%.3f — detections above threshold %.2f: %d",
-        float(scores_all.min()),
-        float(scores_all.max()),
-        threshold,
-        int(scores.shape[0]),
-    )
+    selection_cap = boxes_cwh.shape[0] if num_select is None else num_select
+    scores, cls, query_idx = _select_topk_multiclass(scores_all, threshold, num_select=selection_cap)
+    if scores_all.size:
+        logger.debug(
+            "Scores stats: min=%.3f max=%.3f — detections above threshold %.2f: %d",
+            float(scores_all.min()),
+            float(scores_all.max()),
+            threshold,
+            int(scores.shape[0]),
+        )
+    else:
+        logger.debug("Scores stats: empty — detections above threshold %.2f: %d", threshold, int(scores.shape[0]))
 
     cx, cy, bw, bh = boxes_cwh[query_idx].T
     ow, oh = pil_img.size

--- a/src/rfdetr/export/_onnx/inference.py
+++ b/src/rfdetr/export/_onnx/inference.py
@@ -21,6 +21,7 @@ from PIL import Image as PILImage
 from supervision import Detections
 
 from rfdetr.export._resize import _bilinear_resize_half_pixel
+from rfdetr.export._topk import _select_topk_multiclass
 from rfdetr.utilities.logger import get_logger
 
 logger = get_logger()
@@ -249,23 +250,25 @@ def _run_inference(
     )
     one = np.asarray(1, dtype=logits.dtype)
     scores_all = one / (one + np.exp(-logits.clip(-88, 88)))
-    scores = scores_all.max(axis=-1)
-    cls = scores_all.argmax(axis=-1)
+    # Flatten (Q, C) to Q*C query/class pairs and take the top-scoring ones before thresholding —
+    # mirrors PostProcess._select_topk. A per-query argmax (the previous approach) keeps at most
+    # one class per query, silently dropping legitimate detections whenever a query scores above
+    # threshold on more than one class; see _topk.py for why that happens routinely here.
+    scores, cls, query_idx = _select_topk_multiclass(scores_all, threshold)
     logger.debug(
         "Scores stats: min=%.3f max=%.3f — detections above threshold %.2f: %d",
-        float(scores.min()),
-        float(scores.max()),
+        float(scores_all.min()),
+        float(scores_all.max()),
         threshold,
-        int((scores > threshold).sum()),
+        int(scores.shape[0]),
     )
-    keep = scores > threshold
 
-    cx, cy, bw, bh = boxes_cwh[keep].T
+    cx, cy, bw, bh = boxes_cwh[query_idx].T
     ow, oh = pil_img.size
     xyxy = np.stack([cx - bw / 2, cy - bh / 2, cx + bw / 2, cy + bh / 2], axis=1)
     xyxy *= np.array([ow, oh, ow, oh], dtype=np.float32)
 
-    return Detections(xyxy=xyxy, confidence=scores[keep], class_id=cls[keep].astype(int)), pil_img
+    return Detections(xyxy=xyxy, confidence=scores, class_id=cls.astype(int)), pil_img
 
 
 # Benchmarking helper — not part of production inference API; subject to removal.

--- a/src/rfdetr/export/_tflite/inference.py
+++ b/src/rfdetr/export/_tflite/inference.py
@@ -23,6 +23,7 @@ from PIL import Image as PILImage
 from supervision import Detections
 
 from rfdetr.export._resize import _bilinear_resize_half_pixel
+from rfdetr.export._topk import _select_topk_multiclass
 from rfdetr.utilities.logger import get_logger
 
 logger = get_logger()
@@ -277,18 +278,20 @@ def _run_inference(
     )
     one = np.asarray(1, dtype=logits.dtype)
     scores_all = one / (one + np.exp(-logits.clip(-88, 88)))
-    scores = scores_all.max(axis=-1)
-    cls = scores_all.argmax(axis=-1)
+    # Flatten (Q, C) to Q*C query/class pairs and take the top-scoring ones before thresholding —
+    # mirrors PostProcess._select_topk. A per-query argmax (the previous approach) keeps at most
+    # one class per query, silently dropping legitimate detections whenever a query scores above
+    # threshold on more than one class; see _topk.py for why that happens routinely here.
+    scores, cls, query_idx = _select_topk_multiclass(scores_all, threshold)
     logger.debug(
         "Scores stats: min=%.3f max=%.3f — detections above threshold %.2f: %d",
-        float(scores.min()),
-        float(scores.max()),
+        float(scores_all.min()),
+        float(scores_all.max()),
         threshold,
-        int((scores > threshold).sum()),
+        int(scores.shape[0]),
     )
-    keep = scores > threshold
 
-    cx, cy, bw, bh = boxes_cwh[keep].T
+    cx, cy, bw, bh = boxes_cwh[query_idx].T
     ow, oh = pil_img.size
     xyxy = np.stack([cx - bw / 2, cy - bh / 2, cx + bw / 2, cy + bh / 2], axis=1)
     xyxy *= np.array([ow, oh, ow, oh], dtype=np.float32)
@@ -306,9 +309,12 @@ def _run_inference(
                 len(rank4_candidates),
             )
     masks = None
-    if mask_idx is not None and keep.any():
+    if mask_idx is not None and query_idx.shape[0] > 0:
         raw_masks = interp.get_tensor(out_det[mask_idx]["index"])[0]  # (Q, Hm, Wm)
-        masks = _decode_masks(raw_masks[keep], (ow, oh))
+        # Fancy-index by query_idx, NOT a boolean mask: a query can now contribute more than one
+        # detection (see _select_topk_multiclass), so its mask must be gathered once per detection,
+        # repeats included, rather than once per unique query.
+        masks = _decode_masks(raw_masks[query_idx], (ow, oh))
 
-    detections = Detections(xyxy=xyxy, confidence=scores[keep], class_id=cls[keep].astype(int), mask=masks)
+    detections = Detections(xyxy=xyxy, confidence=scores, class_id=cls.astype(int), mask=masks)
     return detections, pil_img

--- a/src/rfdetr/export/_tflite/inference.py
+++ b/src/rfdetr/export/_tflite/inference.py
@@ -177,6 +177,7 @@ def _run_inference(
     interp: Any,
     image_path: str | Path,
     threshold: float = 0.3,
+    num_select: int | None = None,
 ) -> tuple[Detections, PILImage.Image]:
     """Preprocess one image, run TFLite inference, and decode detections.
 
@@ -189,6 +190,8 @@ def _run_inference(
         interp: Allocated TFLite interpreter returned by ``_create_interpreter``.
         image_path: Path to the input image (any format supported by Pillow).
         threshold: Confidence threshold; detections below this are discarded.
+        num_select: Maximum query/class pairs selected before thresholding. ``None`` uses the exported model's query
+            count, matching shipped RF-DETR configurations; pass an explicit value for custom exports.
 
     Returns:
         A tuple of ``(detections, pil_img)`` where ``detections`` contains pixel-space ``xyxy`` boxes (and ``mask`` for
@@ -269,27 +272,34 @@ def _run_inference(
     logits = interp.get_tensor(out_det[logits_idx]["index"])[0, :, :-1]  # (Q, num_classes)
 
     # RF-DETR uses per-class sigmoid (not softmax) — mirrors PostProcess.forward in postprocess.py.
-    logger.debug(
-        "Logits stats: shape=%s min=%.3f max=%.3f mean=%.3f",
-        logits.shape,
-        float(logits.min()),
-        float(logits.max()),
-        float(logits.mean()),
-    )
+    if logits.size:
+        logger.debug(
+            "Logits stats: shape=%s min=%.3f max=%.3f mean=%.3f",
+            logits.shape,
+            float(logits.min()),
+            float(logits.max()),
+            float(logits.mean()),
+        )
+    else:
+        logger.debug("Logits stats: empty shape=%s", logits.shape)
     one = np.asarray(1, dtype=logits.dtype)
     scores_all = one / (one + np.exp(-logits.clip(-88, 88)))
     # Flatten (Q, C) to Q*C query/class pairs and take the top-scoring ones before thresholding —
     # mirrors PostProcess._select_topk. A per-query argmax (the previous approach) keeps at most
     # one class per query, silently dropping legitimate detections whenever a query scores above
     # threshold on more than one class; see _topk.py for why that happens routinely here.
-    scores, cls, query_idx = _select_topk_multiclass(scores_all, threshold)
-    logger.debug(
-        "Scores stats: min=%.3f max=%.3f — detections above threshold %.2f: %d",
-        float(scores_all.min()),
-        float(scores_all.max()),
-        threshold,
-        int(scores.shape[0]),
-    )
+    selection_cap = logits.shape[0] if num_select is None else num_select
+    scores, cls, query_idx = _select_topk_multiclass(scores_all, threshold, num_select=selection_cap)
+    if scores_all.size:
+        logger.debug(
+            "Scores stats: min=%.3f max=%.3f — detections above threshold %.2f: %d",
+            float(scores_all.min()),
+            float(scores_all.max()),
+            threshold,
+            int(scores.shape[0]),
+        )
+    else:
+        logger.debug("Scores stats: empty — detections above threshold %.2f: %d", threshold, int(scores.shape[0]))
 
     cx, cy, bw, bh = boxes_cwh[query_idx].T
     ow, oh = pil_img.size

--- a/src/rfdetr/export/_topk.py
+++ b/src/rfdetr/export/_topk.py
@@ -1,0 +1,80 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Torch-free multi-class top-k selection shared by the export inference helpers.
+
+RF-DETR uses independent per-class sigmoids, not a mutually exclusive softmax, so a single query
+can legitimately score above threshold on more than one class at once (e.g. "car" and "truck").
+``PostProcess._select_topk`` (``rfdetr/models/postprocess.py``) accounts for this: it flattens the
+``(Q, C)`` score grid to ``Q * C`` query/class pairs and takes the top ``num_select`` scoring pairs
+*before* any threshold is applied, so a query can contribute more than one detection. Selecting the
+single highest-scoring class per query (``argmax`` over the class axis) silently drops the rest.
+
+The export inference helpers must reproduce that exact selection so exported ONNX/TFLite models
+match ``RFDETR.predict()`` detection-for-detection, not just box-for-box.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+# Matches PostProcess.__init__'s own ``num_select`` default (postprocess.py) and is the largest
+# value used by any shipped RF-DETR variant — the detection sizes (Nano/Small/Medium/Large) all
+# inherit 300 from RFDETRBaseConfig unchanged, but the segmentation configs override it lower
+# (RFDETRSegNano/SegSmall use 100, RFDETRSegMedium/SegLarge use 200; see config.py).
+# Exported ONNX/TFLite artifacts carry no training-time config, so there is no way for this decode
+# to recover the exact value a given checkpoint was trained/exported with; 300 is used as a
+# permissive ceiling. In the extreme case where a checkpoint configured with a smaller num_select
+# produces more than that many query/class pairs above `threshold` in a single image, this can
+# return a few more detections than `predict()` would for that same checkpoint — same order of
+# rarity as the multi-label case this module exists to fix correctly, and never fewer detections.
+DEFAULT_NUM_SELECT = 300
+
+
+def _select_topk_multiclass(
+    scores_all: NDArray[np.floating], threshold: float, num_select: int = DEFAULT_NUM_SELECT
+) -> tuple[NDArray[np.floating], NDArray[np.int64], NDArray[np.int64]]:
+    """Select the top ``num_select`` query/class pairs, then threshold.
+
+    Mirrors ``PostProcess._select_topk`` (flatten ``(Q, C)`` to ``Q * C``, take the top
+    ``num_select`` scoring pairs by ``torch.topk``, in descending score order) followed by the
+    caller's own ``scores > threshold`` filter — ``PostProcess`` never bakes thresholding into
+    ``_select_topk`` itself, it is always applied by the caller afterwards.
+
+    Uses ``np.argpartition`` + a stable ``np.argsort`` rather than a full sort, for the same
+    result with lower complexity on a large flattened array. This has not been verified to break
+    ties in the exact same order as ``torch.topk`` when two query/class pairs share the identical
+    floating-point score — real network logits essentially never tie exactly, so this is not
+    expected to matter in practice, but it is untested at that edge.
+
+    Args:
+        scores_all: Per-query, per-class sigmoid probabilities, shape ``(Q, C)``.
+        threshold: Confidence threshold; pairs at or below this score are dropped.
+        num_select: Maximum number of query/class pairs to consider before thresholding.
+
+    Returns:
+        A ``(scores, labels, query_indices)`` tuple, each 1-D and sorted by descending score,
+        containing only pairs that cleared ``threshold``. ``query_indices`` selects rows from
+        box/mask outputs and, unlike a per-query argmax, can repeat when a query has more than one
+        detection.
+    """
+    num_queries, num_classes = scores_all.shape
+    flat_scores = scores_all.reshape(-1)
+    num_to_select = min(num_select, flat_scores.shape[0])
+    if num_to_select < flat_scores.shape[0]:
+        top_idx = np.argpartition(flat_scores, -num_to_select)[-num_to_select:]
+    else:
+        top_idx = np.arange(flat_scores.shape[0])
+    # argpartition doesn't sort its output; PostProcess._select_topk relies on torch.topk's
+    # descending order (consumers like early-exit display code assume the highest score is first).
+    top_idx = top_idx[np.argsort(-flat_scores[top_idx], kind="stable")]
+
+    topk_scores = flat_scores[top_idx]
+    topk_query = top_idx // num_classes
+    topk_labels = top_idx % num_classes
+
+    keep = topk_scores > threshold
+    return topk_scores[keep], topk_labels[keep], topk_query[keep]

--- a/src/rfdetr/export/_topk.py
+++ b/src/rfdetr/export/_topk.py
@@ -21,16 +21,9 @@ from __future__ import annotations
 import numpy as np
 from numpy.typing import NDArray
 
-# Matches PostProcess.__init__'s own ``num_select`` default (postprocess.py) and is the largest
-# value used by any shipped RF-DETR variant — the detection sizes (Nano/Small/Medium/Large) all
-# inherit 300 from RFDETRBaseConfig unchanged, but the segmentation configs override it lower
-# (RFDETRSegNano/SegSmall use 100, RFDETRSegMedium/SegLarge use 200; see config.py).
-# Exported ONNX/TFLite artifacts carry no training-time config, so there is no way for this decode
-# to recover the exact value a given checkpoint was trained/exported with; 300 is used as a
-# permissive ceiling. In the extreme case where a checkpoint configured with a smaller num_select
-# produces more than that many query/class pairs above `threshold` in a single image, this can
-# return a few more detections than `predict()` would for that same checkpoint — same order of
-# rarity as the multi-label case this module exists to fix correctly, and never fewer detections.
+# Matches ``PostProcess.__init__``'s default for callers that use the helper directly. Inference
+# decoders pass their exported model's query count (or an explicit configured cap) so segmentation
+# variants with smaller ``num_select`` values preserve the same selection contract.
 DEFAULT_NUM_SELECT = 300
 
 
@@ -40,15 +33,13 @@ def _select_topk_multiclass(
     """Select the top ``num_select`` query/class pairs, then threshold.
 
     Mirrors ``PostProcess._select_topk`` (flatten ``(Q, C)`` to ``Q * C``, take the top
-    ``num_select`` scoring pairs by ``torch.topk``, in descending score order) followed by the
+    ``num_select`` scoring pairs in deterministic descending-score order) followed by the
     caller's own ``scores > threshold`` filter — ``PostProcess`` never bakes thresholding into
     ``_select_topk`` itself, it is always applied by the caller afterwards.
 
-    Uses ``np.argpartition`` + a stable ``np.argsort`` rather than a full sort, for the same
-    result with lower complexity on a large flattened array. This has not been verified to break
-    ties in the exact same order as ``torch.topk`` when two query/class pairs share the identical
-    floating-point score — real network logits essentially never tie exactly, so this is not
-    expected to matter in practice, but it is untested at that edge.
+    Uses a deterministic lexicographic order: descending score, then ascending flattened
+    query/class index. ``PostProcess._select_topk`` uses the same stable tie rule so exported
+    inference remains reproducible when scores are equal.
 
     Args:
         scores_all: Per-query, per-class sigmoid probabilities, shape ``(Q, C)``.
@@ -61,16 +52,27 @@ def _select_topk_multiclass(
         box/mask outputs and, unlike a per-query argmax, can repeat when a query has more than one
         detection.
     """
+    if scores_all.ndim != 2:
+        raise ValueError(f"scores_all must have shape (Q, C); got {scores_all.shape}")
+    if num_select < 0:
+        raise ValueError(f"num_select must be non-negative; got {num_select}")
+
     num_queries, num_classes = scores_all.shape
     flat_scores = scores_all.reshape(-1)
+    if num_select == 0 or flat_scores.size == 0:
+        return (
+            flat_scores[:0],
+            np.empty(0, dtype=np.int64),
+            np.empty(0, dtype=np.int64),
+        )
+
     num_to_select = min(num_select, flat_scores.shape[0])
-    if num_to_select < flat_scores.shape[0]:
-        top_idx = np.argpartition(flat_scores, -num_to_select)[-num_to_select:]
-    else:
-        top_idx = np.arange(flat_scores.shape[0])
-    # argpartition doesn't sort its output; PostProcess._select_topk relies on torch.topk's
-    # descending order (consumers like early-exit display code assume the highest score is first).
-    top_idx = top_idx[np.argsort(-flat_scores[top_idx], kind="stable")]
+    flat_idx = np.arange(flat_scores.shape[0], dtype=np.int64)
+    # PyTorch ranks NaNs ahead of finite values for descending argsort; preserve that ordering
+    # so the subsequent ``> threshold`` filter drops the same malformed scores rather than
+    # allowing a lower finite score to occupy the cap.
+    sort_scores = np.where(np.isnan(flat_scores), np.inf, flat_scores)
+    top_idx = np.lexsort((flat_idx, -sort_scores))[:num_to_select]
 
     topk_scores = flat_scores[top_idx]
     topk_query = top_idx // num_classes

--- a/src/rfdetr/export/_topk.py
+++ b/src/rfdetr/export/_topk.py
@@ -5,15 +5,15 @@
 # ------------------------------------------------------------------------
 """Torch-free multi-class top-k selection shared by the export inference helpers.
 
-RF-DETR uses independent per-class sigmoids, not a mutually exclusive softmax, so a single query
-can legitimately score above threshold on more than one class at once (e.g. "car" and "truck").
-``PostProcess._select_topk`` (``rfdetr/models/postprocess.py``) accounts for this: it flattens the
-``(Q, C)`` score grid to ``Q * C`` query/class pairs and takes the top ``num_select`` scoring pairs
-*before* any threshold is applied, so a query can contribute more than one detection. Selecting the
-single highest-scoring class per query (``argmax`` over the class axis) silently drops the rest.
+RF-DETR uses independent per-class sigmoids, not a mutually exclusive softmax, so a single query can legitimately score
+above threshold on more than one class at once (e.g. "car" and "truck"). ``PostProcess._select_topk``
+(``rfdetr/models/postprocess.py``) accounts for this: it flattens the ``(Q, C)`` score grid to ``Q * C`` query/class
+pairs and takes the top ``num_select`` scoring pairs *before* any threshold is applied, so a query can contribute more
+than one detection. Selecting the single highest-scoring class per query (``argmax`` over the class axis) silently drops
+the rest.
 
-The export inference helpers must reproduce that exact selection so exported ONNX/TFLite models
-match ``RFDETR.predict()`` detection-for-detection, not just box-for-box.
+The export inference helpers must reproduce that exact selection so exported ONNX/TFLite models match
+``RFDETR.predict()`` detection-for-detection, not just box-for-box.
 """
 
 from __future__ import annotations

--- a/src/rfdetr/models/postprocess.py
+++ b/src/rfdetr/models/postprocess.py
@@ -36,6 +36,8 @@ class PostProcess(nn.Module):
         upsample_masks_to_image_size: bool = True,
     ) -> None:
         super().__init__()
+        if num_select < 0:
+            raise ValueError(f"num_select must be non-negative; got {num_select}")
         self.num_select = num_select
         self.num_keypoints_per_class = num_keypoints_per_class or []
         self.trace_alpha = trace_alpha
@@ -131,7 +133,11 @@ class PostProcess(nn.Module):
         prob = out_logits.sigmoid()
         logits_for_topk = prob.view(out_logits.shape[0], -1)
         num_to_select = min(self.num_select, logits_for_topk.shape[1])
-        topk_values, topk_indexes = torch.topk(logits_for_topk, num_to_select, dim=1)
+        # Use the same deterministic tie rule as the torch-free export decoders: descending
+        # score, then ascending flattened query/class index.
+        sorted_indexes = torch.argsort(logits_for_topk, dim=1, descending=True, stable=True)
+        topk_indexes = sorted_indexes[:, :num_to_select]
+        topk_values = logits_for_topk.gather(1, topk_indexes)
         scores = topk_values
         topk_boxes = topk_indexes // out_logits.shape[2]
         labels = topk_indexes % out_logits.shape[2]

--- a/tests/export/test_onnx_inference.py
+++ b/tests/export/test_onnx_inference.py
@@ -1,0 +1,103 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Tests for ONNX Runtime inference decoding (``_run_inference`` in ``rfdetr/export/_onnx/inference.py``).
+
+Before this file, ``_run_inference``'s detection decode had no dedicated unit test at all — only its
+preprocessing half was covered (``test_onnx_preprocess_parity.py``). This file covers the multi-label
+query/class selection, using the same ``types.SimpleNamespace`` fake-session pattern the rest of the
+export test suite uses for mocking backend objects (see ``test_export.py``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from PIL import Image as PILImage
+
+from rfdetr.export._onnx.inference import _run_inference
+
+_INPUT_SHAPE = [1, 3, 224, 224]
+
+
+def _make_boxes() -> np.ndarray:
+    """Return (1, 10, 4) array of normalised cxcywh boxes, all centred at 0.5."""
+    return np.array([[[0.5, 0.5, 0.1, 0.1]] * 10], dtype=np.float32)
+
+
+def _make_logits(high_conf_idx: int | None = 0) -> np.ndarray:
+    """Return (1, 10, 82) logits with one high-confidence entry when requested (mirrors the TFLite
+    test helper of the same name in test_tflite_inference.py)."""
+    logits = np.full((1, 10, 82), -10.0, dtype=np.float32)
+    if high_conf_idx is not None:
+        logits[0, high_conf_idx, 0] = 10.0
+    return logits
+
+
+class _FakeSession:
+    """Minimal ``onnxruntime.InferenceSession`` stand-in for ``_run_inference``."""
+
+    def __init__(self, boxes: np.ndarray, logits: np.ndarray, input_shape: list[int] | None = None) -> None:
+        self._boxes = boxes
+        self._logits = logits
+        self._input_shape = input_shape if input_shape is not None else _INPUT_SHAPE
+
+    def get_inputs(self) -> list[SimpleNamespace]:
+        return [SimpleNamespace(name="input", shape=self._input_shape)]
+
+    def get_outputs(self) -> list[SimpleNamespace]:
+        return [SimpleNamespace(name="dets"), SimpleNamespace(name="labels")]
+
+    def run(self, output_names: list[str] | None, feeds: dict[str, np.ndarray]) -> list[np.ndarray]:
+        del output_names, feeds
+        return [self._boxes, self._logits]
+
+
+@pytest.fixture()
+def rgb_image(tmp_path: Path) -> Path:
+    """Write a small RGB JPEG to a temp file and return its path."""
+    p = tmp_path / "image.jpg"
+    PILImage.new("RGB", (64, 64), color=(100, 150, 200)).save(p)
+    return p
+
+
+class TestRunInferenceBasics:
+    def test_returns_detections_and_image(self, rgb_image: Path) -> None:
+        session = _FakeSession(_make_boxes(), _make_logits())
+        dets, img = _run_inference(session, rgb_image)
+        import supervision as sv
+
+        assert isinstance(dets, sv.Detections)
+        assert isinstance(img, PILImage.Image)
+
+    def test_detections_below_threshold_filtered(self, rgb_image: Path) -> None:
+        session = _FakeSession(_make_boxes(), _make_logits(high_conf_idx=None))
+        dets, _ = _run_inference(session, rgb_image, threshold=0.3)
+        assert len(dets) == 0
+
+
+class TestMulticlassSelection:
+    """``_run_inference`` must select query/class pairs the same way
+    ``PostProcess._select_topk`` does — flatten (Q, C) and rank all pairs together, not a
+    per-query argmax. See the analogous test in ``test_tflite_inference.py`` and the shared
+    selection helper in ``rfdetr/export/_topk.py``.
+    """
+
+    def test_multiclass_query_reports_every_class_above_threshold(self, rgb_image: Path) -> None:
+        logits = np.full((1, 10, 82), -100.0, dtype=np.float32)
+        logits[0, 0, 0] = 5.0  # sigmoid ~0.9933
+        logits[0, 0, 1] = 2.0  # sigmoid ~0.8808
+        logits[0, 0, 2] = 1.0  # sigmoid ~0.7311
+        session = _FakeSession(_make_boxes(), logits)
+
+        dets, _ = _run_inference(session, rgb_image, threshold=0.3)
+
+        assert len(dets) == 3, "query 0 clears threshold=0.3 on 3 classes; all 3 must be reported"
+        assert sorted(dets.class_id.tolist()) == [0, 1, 2]
+        assert list(dets.confidence) == sorted(dets.confidence, reverse=True)
+        assert dets.class_id[0] == 0  # highest logit (5.0) still ranks first

--- a/tests/export/test_onnx_inference.py
+++ b/tests/export/test_onnx_inference.py
@@ -26,13 +26,24 @@ _INPUT_SHAPE = [1, 3, 224, 224]
 
 
 def _make_boxes() -> np.ndarray:
-    """Return (1, 10, 4) array of normalised cxcywh boxes, all centred at 0.5."""
+    """Return normalised cxcywh boxes, all centred at 0.5.
+
+    Examples:
+        >>> _make_boxes().shape
+        (1, 10, 4)
+    """
     return np.array([[[0.5, 0.5, 0.1, 0.1]] * 10], dtype=np.float32)
 
 
 def _make_logits(high_conf_idx: int | None = 0) -> np.ndarray:
-    """Return (1, 10, 82) logits with one high-confidence entry when requested (mirrors the TFLite test helper of the
-    same name in test_tflite_inference.py)."""
+    """Return logits with one high-confidence entry when requested.
+
+    Examples:
+        >>> _make_logits().shape
+        (1, 10, 82)
+        >>> float(_make_logits()[0, 0, 0])
+        10.0
+    """
     logits = np.full((1, 10, 82), -10.0, dtype=np.float32)
     if high_conf_idx is not None:
         logits[0, high_conf_idx, 0] = 10.0
@@ -80,6 +91,14 @@ class TestRunInferenceBasics:
         dets, _ = _run_inference(session, rgb_image, threshold=0.3)
         assert len(dets) == 0
 
+    def test_empty_class_dimension_returns_no_detections(self, rgb_image: Path) -> None:
+        """A backend output with only the no-object logit decodes to an empty result."""
+        session = _FakeSession(_make_boxes(), np.empty((1, 10, 1), dtype=np.float32))
+
+        dets, _ = _run_inference(session, rgb_image)
+
+        assert len(dets) == 0
+
 
 class TestMulticlassSelection:
     """``_run_inference`` must select query/class pairs the same way ``PostProcess._select_topk`` does — flatten (Q, C)
@@ -102,3 +121,13 @@ class TestMulticlassSelection:
         assert sorted(dets.class_id.tolist()) == [0, 1, 2]
         assert list(dets.confidence) == sorted(dets.confidence, reverse=True)
         assert dets.class_id[0] == 0  # highest logit (5.0) still ranks first
+
+    def test_explicit_num_select_caps_export_decode(self, rgb_image: Path) -> None:
+        """An explicit exported-model cap limits query/class pairs before thresholding."""
+        logits = np.full((1, 10, 82), -100.0, dtype=np.float32)
+        logits[0, :, 0] = 10.0
+        session = _FakeSession(_make_boxes(), logits)
+
+        dets, _ = _run_inference(session, rgb_image, threshold=0.3, num_select=3)
+
+        assert len(dets) == 3

--- a/tests/export/test_onnx_inference.py
+++ b/tests/export/test_onnx_inference.py
@@ -5,10 +5,10 @@
 # ------------------------------------------------------------------------
 """Tests for ONNX Runtime inference decoding (``_run_inference`` in ``rfdetr/export/_onnx/inference.py``).
 
-Before this file, ``_run_inference``'s detection decode had no dedicated unit test at all — only its
-preprocessing half was covered (``test_onnx_preprocess_parity.py``). This file covers the multi-label
-query/class selection, using the same ``types.SimpleNamespace`` fake-session pattern the rest of the
-export test suite uses for mocking backend objects (see ``test_export.py``).
+Before this file, ``_run_inference``'s detection decode had no dedicated unit test at all — only its preprocessing half
+was covered (``test_onnx_preprocess_parity.py``). This file covers the multi-label query/class selection, using the same
+``types.SimpleNamespace`` fake-session pattern the rest of the export test suite uses for mocking backend objects (see
+``test_export.py``).
 """
 
 from __future__ import annotations
@@ -31,8 +31,8 @@ def _make_boxes() -> np.ndarray:
 
 
 def _make_logits(high_conf_idx: int | None = 0) -> np.ndarray:
-    """Return (1, 10, 82) logits with one high-confidence entry when requested (mirrors the TFLite
-    test helper of the same name in test_tflite_inference.py)."""
+    """Return (1, 10, 82) logits with one high-confidence entry when requested (mirrors the TFLite test helper of the
+    same name in test_tflite_inference.py)."""
     logits = np.full((1, 10, 82), -10.0, dtype=np.float32)
     if high_conf_idx is not None:
         logits[0, high_conf_idx, 0] = 10.0
@@ -82,10 +82,11 @@ class TestRunInferenceBasics:
 
 
 class TestMulticlassSelection:
-    """``_run_inference`` must select query/class pairs the same way
-    ``PostProcess._select_topk`` does — flatten (Q, C) and rank all pairs together, not a
-    per-query argmax. See the analogous test in ``test_tflite_inference.py`` and the shared
-    selection helper in ``rfdetr/export/_topk.py``.
+    """``_run_inference`` must select query/class pairs the same way ``PostProcess._select_topk`` does — flatten (Q, C)
+    and rank all pairs together, not a per-query argmax.
+
+    See the analogous test in ``test_tflite_inference.py`` and the shared selection helper in
+    ``rfdetr/export/_topk.py``.
     """
 
     def test_multiclass_query_reports_every_class_above_threshold(self, rgb_image: Path) -> None:

--- a/tests/export/test_tflite_inference.py
+++ b/tests/export/test_tflite_inference.py
@@ -468,8 +468,19 @@ class TestSigmoidScoring:
         dets, _ = _run_inference(interp, rgb_image, threshold=0.3)
         assert len(dets) == 0
 
-    def test_multiclass_class_id_is_argmax_of_logits(self, rgb_image: Path) -> None:
-        """Argmax of sigmoid equals argmax of logits; query with [5,2,1,...] gets class_id==0."""
+    def test_multiclass_query_reports_every_class_above_threshold(self, rgb_image: Path) -> None:
+        """A query scoring above threshold on more than one class must produce one detection per
+        class, not just the argmax class.
+
+        History: this test used to be ``test_multiclass_class_id_is_argmax_of_logits`` and asserted
+        the *opposite* — that only the single highest-scoring class (argmax) survived — codifying a
+        real bug as the expected contract. RF-DETR uses independent per-class sigmoids (not a
+        mutually exclusive softmax): a query with logits [5, 2, 1, ...] has three classes
+        (sigmoid ≈ 0.993, 0.881, 0.731) all above threshold=0.3, and `PostProcess._select_topk`
+        (postprocess.py) — the real predict() selection this decode must mirror — ranks Q*C
+        query/class pairs together, so all three are legitimate separate detections of the same
+        box. See rfdetr/export/_topk.py for the shared selection helper this now uses.
+        """
         # Shape (1, 10, 82): first query has logits [5, 2, 1, 0, ...], rest are -100
         logits = np.full((1, 10, 82), -100.0, dtype=np.float32)
         logits[0, 0, 0] = 5.0
@@ -477,8 +488,14 @@ class TestSigmoidScoring:
         logits[0, 0, 2] = 1.0
         interp = _make_interp(logits=logits)
         dets, _ = _run_inference(interp, rgb_image, threshold=0.3)
-        # argmax of sigmoid == argmax of logits because sigmoid is monotone increasing
-        assert dets.class_id[0] == 0
+
+        assert len(dets) == 3, "query 0 clears threshold=0.3 on 3 classes; all 3 must be reported"
+        assert sorted(dets.class_id.tolist()) == [0, 1, 2]
+        # All 3 detections share query 0's box (see _make_boxes: identical box per query).
+        np.testing.assert_allclose(dets.xyxy, np.tile(dets.xyxy[0], (3, 1)))
+        # Sorted by descending confidence, matching PostProcess._select_topk / torch.topk order.
+        assert list(dets.confidence) == sorted(dets.confidence, reverse=True)
+        assert dets.class_id[0] == 0  # highest logit (5.0) still ranks first
 
 
 # ---------------------------------------------------------------------------
@@ -649,6 +666,42 @@ class TestMaskDecoding:
         assert dets.mask.shape == (len(dets), img.height, img.width)
         assert dets.mask.dtype == bool
         assert dets.mask[0].all()  # query 0's all-positive logits decode to a full mask
+
+    def test_run_inference_multilabel_query_repeats_its_mask(self, rgb_image: Path) -> None:
+        """A query contributing more than one detection (multi-label) must gather its mask once per
+        detection, repeats included -- not a boolean mask over unique queries.
+
+        Before the fix, mask gathering was ``raw_masks[keep]`` with ``keep`` a boolean vector over
+        queries (at most one True per query, matching the old argmax-per-query decode). With the
+        fix, more than one detection can share a query index, so gathering must be by (possibly
+        repeating) integer index, not a boolean mask -- see _tflite/inference.py's comment on this.
+        """
+        boxes = _make_boxes()
+        logits = np.full((1, 10, 82), -100.0, dtype=np.float32)
+        logits[0, 0, 0] = 5.0  # sigmoid ~0.993, above threshold
+        logits[0, 0, 1] = 2.0  # sigmoid ~0.881, also above threshold -> query 0 yields 2 detections
+        masks = np.full((1, 10, 28, 28), -10.0, dtype=np.float32)
+        masks[0, 0] = 10.0  # query 0's mask: all-positive
+
+        def _get_tensor(index: int) -> np.ndarray:
+            return {1: boxes, 2: logits, 3: masks}[index]
+
+        interp = mock.MagicMock()
+        interp.get_input_details.return_value = [{"shape": _INPUT_SHAPE, "index": 0, "dtype": np.float32}]
+        interp.get_output_details.return_value = [
+            {"shape": [1, 10, 4], "name": "Identity_0", "index": 1},
+            {"shape": [1, 10, 82], "name": "Identity_1", "index": 2},
+            {"shape": [1, 10, 28, 28], "name": "Identity_2", "index": 3},
+        ]
+        interp.get_tensor.side_effect = _get_tensor
+
+        dets, _ = _run_inference(interp, rgb_image, threshold=0.3)
+        assert len(dets) == 2
+        assert sorted(dets.class_id.tolist()) == [0, 1]
+        # Both detections came from query 0, so both must carry query 0's (all-positive) mask.
+        assert dets.mask.shape[0] == 2
+        assert dets.mask[0].all()
+        assert dets.mask[1].all()
 
     def test_run_inference_no_mask_for_detection_model(self, rgb_image: Path) -> None:
         """A 2-output detection export leaves Detections.mask as None."""

--- a/tests/export/test_tflite_inference.py
+++ b/tests/export/test_tflite_inference.py
@@ -364,10 +364,30 @@ class TestRunInference:
         dets, _ = _run_inference(interp, rgb_image, threshold=0.3)
         assert len(dets) >= 1
 
+    def test_explicit_num_select_caps_export_decode(self, rgb_image: Path) -> None:
+        """An explicit exported-model cap limits query/class pairs before thresholding."""
+        logits = np.full((1, 10, 82), -100.0, dtype=np.float32)
+        logits[0, :, 0] = 10.0
+        interp = _make_interp(logits=logits)
+
+        dets, _ = _run_inference(interp, rgb_image, threshold=0.3, num_select=3)
+
+        assert len(dets) == 3
+
     def test_detections_below_threshold_filtered(self, rgb_image: Path) -> None:
         """No detections survive when all logits are zero (uniform probs < 0.3)."""
         interp = _make_interp(logits=_make_logits(high_conf_idx=None))
         dets, _ = _run_inference(interp, rgb_image, threshold=0.3)
+        assert len(dets) == 0
+
+    def test_empty_class_dimension_returns_no_detections(self, rgb_image: Path) -> None:
+        """A backend output with only the no-object logit decodes to an empty result."""
+        logits = np.empty((1, 10, 1), dtype=np.float32)
+        label_out = {"shape": [1, 10, 1], "name": "serving_default_labels:0", "index": 2}
+        interp = _make_interp(logits=logits, out_dets=[_DET_OUTPUT, label_out])
+
+        dets, _ = _run_inference(interp, rgb_image)
+
         assert len(dets) == 0
 
     def test_boxes_in_pixel_space(self, rgb_image: Path) -> None:
@@ -493,7 +513,7 @@ class TestSigmoidScoring:
         assert sorted(dets.class_id.tolist()) == [0, 1, 2]
         # All 3 detections share query 0's box (see _make_boxes: identical box per query).
         np.testing.assert_allclose(dets.xyxy, np.tile(dets.xyxy[0], (3, 1)))
-        # Sorted by descending confidence, matching PostProcess._select_topk / torch.topk order.
+        # Sorted by descending confidence, matching PostProcess._select_topk order.
         assert list(dets.confidence) == sorted(dets.confidence, reverse=True)
         assert dets.class_id[0] == 0  # highest logit (5.0) still ranks first
 

--- a/tests/export/test_tflite_inference.py
+++ b/tests/export/test_tflite_inference.py
@@ -469,8 +469,8 @@ class TestSigmoidScoring:
         assert len(dets) == 0
 
     def test_multiclass_query_reports_every_class_above_threshold(self, rgb_image: Path) -> None:
-        """A query scoring above threshold on more than one class must produce one detection per
-        class, not just the argmax class.
+        """A query scoring above threshold on more than one class must produce one detection per class, not just the
+        argmax class.
 
         History: this test used to be ``test_multiclass_class_id_is_argmax_of_logits`` and asserted
         the *opposite* — that only the single highest-scoring class (argmax) survived — codifying a
@@ -668,13 +668,13 @@ class TestMaskDecoding:
         assert dets.mask[0].all()  # query 0's all-positive logits decode to a full mask
 
     def test_run_inference_multilabel_query_repeats_its_mask(self, rgb_image: Path) -> None:
-        """A query contributing more than one detection (multi-label) must gather its mask once per
-        detection, repeats included -- not a boolean mask over unique queries.
+        """A query contributing more than one detection (multi-label) must gather its mask once per detection, repeats
+        included -- not a boolean mask over unique queries.
 
-        Before the fix, mask gathering was ``raw_masks[keep]`` with ``keep`` a boolean vector over
-        queries (at most one True per query, matching the old argmax-per-query decode). With the
-        fix, more than one detection can share a query index, so gathering must be by (possibly
-        repeating) integer index, not a boolean mask -- see _tflite/inference.py's comment on this.
+        Before the fix, mask gathering was ``raw_masks[keep]`` with ``keep`` a boolean vector over queries (at most one
+        True per query, matching the old argmax-per-query decode). With the fix, more than one detection can share a
+        query index, so gathering must be by (possibly repeating) integer index, not a boolean mask -- see
+        _tflite/inference.py's comment on this.
         """
         boxes = _make_boxes()
         logits = np.full((1, 10, 82), -100.0, dtype=np.float32)

--- a/tests/export/test_topk_selection_parity.py
+++ b/tests/export/test_topk_selection_parity.py
@@ -1,0 +1,119 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Decode-vs-``PostProcess`` selection parity: ``_select_topk_multiclass`` (``rfdetr/export/_topk.py``,
+shared by the ONNX and TFLite reference decoders) must select the exact same set of
+``(query, class, score)`` triples that ``PostProcess._select_topk`` (``rfdetr/models/postprocess.py``)
+selects for the same raw logits — at any query multiplicity, i.e. a query scoring above threshold on
+more than one class must produce more than one detection in both.
+
+History: before this fix, ``_run_inference`` in both ``_onnx/inference.py`` and
+``_tflite/inference.py`` selected a single class per query via ``scores_all.argmax(axis=-1)``.
+``PostProcess._select_topk`` instead flattens ``(Q, C)`` to ``Q * C`` query/class pairs and ranks all
+of them together, so a query can contribute more than one detection — exactly what happens when
+RF-DETR's independent per-class sigmoids put more than one class above threshold on the same query.
+No test exercised this divergence: ``test_onnx_preprocess_parity.py`` /
+``test_tflite_inference_parity.py`` only cover *preprocessing* (resize/normalise) parity, and the one
+existing decode test (``test_multiclass_class_id_is_argmax_of_logits`` in
+``test_tflite_inference.py``) asserted the old, wrong, single-detection-per-query behaviour as
+correct. This file locks the numeric selection itself, independent of either runtime backend.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from rfdetr.export._topk import _select_topk_multiclass
+from rfdetr.models.postprocess import PostProcess
+
+
+def _reference_select_topk(
+    logits_with_bg: torch.Tensor, num_select: int
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Call the real ``PostProcess._select_topk`` directly on one image's logits (batch size 1)."""
+    pp = PostProcess(num_select=num_select)
+    scores, labels, boxes = pp._select_topk(logits_with_bg.unsqueeze(0))
+    return scores[0], labels[0], boxes[0]
+
+
+class TestTopkSelectionParity:
+    @pytest.mark.parametrize("seed", [0, 1, 2, 7, 42])
+    def test_matches_postprocess_select_topk(self, seed: int) -> None:
+        """Random logits: the (query, class, score) set our NumPy helper keeps above threshold must
+        equal what PostProcess._select_topk + the same threshold keeps, for arbitrary multiplicity.
+        """
+        rng = np.random.default_rng(seed)
+        num_queries, num_fg_classes = 40, 12
+        threshold = 0.3
+
+        fg_logits = rng.normal(loc=-1.0, scale=3.0, size=(num_queries, num_fg_classes)).astype(np.float32)
+        # No-object slot: deeply suppressed, matching real training (class_embed never receives a
+        # positive target for it — see rfdetr/export/_topk.py) so it never wins topk in the
+        # reference either. This keeps the comparison apples-to-apples with what _run_inference
+        # actually computes: it drops this column before calling our helper (inference.py:238-240).
+        bg_logits = np.full((num_queries, 1), -100.0, dtype=np.float32)
+        logits_with_bg = torch.from_numpy(np.concatenate([fg_logits, bg_logits], axis=1))
+
+        ref_scores, ref_labels, ref_boxes = _reference_select_topk(logits_with_bg, num_select=300)
+        ref_keep = ref_scores > threshold
+        ref_by_pair = {
+            (int(q), int(c)): float(s)
+            for q, c, s in zip(
+                ref_boxes[ref_keep].tolist(), ref_labels[ref_keep].tolist(), ref_scores[ref_keep].tolist()
+            )
+        }
+
+        # float32 throughout, matching what _run_inference actually computes (inference.py:250:
+        # `one = np.asarray(1, dtype=logits.dtype)`).
+        one = np.asarray(1, dtype=np.float32)
+        scores_all = one / (one + np.exp(-fg_logits))
+        got_scores, got_labels, got_query = _select_topk_multiclass(scores_all, threshold, num_select=300)
+        got_by_pair = {(int(q), int(c)): float(s) for q, c, s in zip(got_query, got_labels, got_scores)}
+
+        # Compare which (query, class) pairs were selected exactly; compare their scores with a
+        # tight tolerance rather than exact equality — torch's fused sigmoid kernel and this
+        # module's `1/(1+exp(-x))` NumPy formula can differ in the last float32 ULP on the same
+        # input, which is expected numerical noise, not a selection-logic discrepancy.
+        assert set(got_by_pair) == set(ref_by_pair)
+        for pair, ref_s in ref_by_pair.items():
+            assert got_by_pair[pair] == pytest.approx(ref_s, abs=1e-4)
+
+    def test_multilabel_query_yields_multiple_detections(self) -> None:
+        """A single query with two classes above threshold must produce two detections — the exact
+        case the old per-query argmax silently collapsed to one."""
+        num_queries, num_fg_classes = 5, 4
+        threshold = 0.3
+        fg_logits = np.full((num_queries, num_fg_classes), -100.0, dtype=np.float32)
+        fg_logits[0, 0] = 5.0  # sigmoid ~0.9933
+        fg_logits[0, 1] = 2.0  # sigmoid ~0.8808
+        fg_logits[0, 2] = 1.0  # sigmoid ~0.7311
+        fg_logits[0, 3] = -1.0  # sigmoid ~0.2689, below threshold
+
+        one = np.asarray(1, dtype=np.float32)
+        scores_all = one / (one + np.exp(-fg_logits.clip(-88, 88)))
+        got_scores, got_labels, got_query = _select_topk_multiclass(scores_all, threshold, num_select=300)
+
+        assert got_query.tolist() == [0, 0, 0]
+        assert got_labels.tolist() == [0, 1, 2]
+        assert list(got_scores) == sorted(got_scores, reverse=True)
+
+    def test_num_select_caps_pairs_like_torch_topk(self) -> None:
+        """When more than num_select pairs exceed threshold, only the top num_select by score
+        survive — matching PostProcess._select_topk (topk happens before, not after, thresholding).
+        """
+        num_queries, num_fg_classes = 10, 10
+        threshold = 0.0
+        rng = np.random.default_rng(3)
+        # loc=3.0 keeps sigmoid well above threshold=0.0 for every pair, so all 100 pairs clear the
+        # threshold and only the num_select cap decides which survive.
+        fg_logits = rng.uniform(1.0, 5.0, size=(num_queries, num_fg_classes)).astype(np.float32)
+        scores_all = 1.0 / (1.0 + np.exp(-fg_logits))
+
+        num_select = 17
+        got_scores, _, _ = _select_topk_multiclass(scores_all, threshold, num_select=num_select)
+        assert got_scores.shape[0] == num_select
+        assert list(got_scores) == sorted(got_scores, reverse=True)

--- a/tests/export/test_topk_selection_parity.py
+++ b/tests/export/test_topk_selection_parity.py
@@ -3,22 +3,20 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-"""Decode-vs-``PostProcess`` selection parity: ``_select_topk_multiclass`` (``rfdetr/export/_topk.py``,
-shared by the ONNX and TFLite reference decoders) must select the exact same set of
-``(query, class, score)`` triples that ``PostProcess._select_topk`` (``rfdetr/models/postprocess.py``)
-selects for the same raw logits — at any query multiplicity, i.e. a query scoring above threshold on
-more than one class must produce more than one detection in both.
+"""Decode-vs-``PostProcess`` selection parity: ``_select_topk_multiclass`` (``rfdetr/export/_topk.py``, shared by the
+ONNX and TFLite reference decoders) must select the exact same set of ``(query, class, score)`` triples that
+``PostProcess._select_topk`` (``rfdetr/models/postprocess.py``) selects for the same raw logits — at any query
+multiplicity, i.e. a query scoring above threshold on more than one class must produce more than one detection in both.
 
-History: before this fix, ``_run_inference`` in both ``_onnx/inference.py`` and
-``_tflite/inference.py`` selected a single class per query via ``scores_all.argmax(axis=-1)``.
-``PostProcess._select_topk`` instead flattens ``(Q, C)`` to ``Q * C`` query/class pairs and ranks all
-of them together, so a query can contribute more than one detection — exactly what happens when
-RF-DETR's independent per-class sigmoids put more than one class above threshold on the same query.
-No test exercised this divergence: ``test_onnx_preprocess_parity.py`` /
-``test_tflite_inference_parity.py`` only cover *preprocessing* (resize/normalise) parity, and the one
-existing decode test (``test_multiclass_class_id_is_argmax_of_logits`` in
-``test_tflite_inference.py``) asserted the old, wrong, single-detection-per-query behaviour as
-correct. This file locks the numeric selection itself, independent of either runtime backend.
+History: before this fix, ``_run_inference`` in both ``_onnx/inference.py`` and ``_tflite/inference.py`` selected a
+single class per query via ``scores_all.argmax(axis=-1)``. ``PostProcess._select_topk`` instead flattens ``(Q, C)`` to
+``Q * C`` query/class pairs and ranks all of them together, so a query can contribute more than one detection — exactly
+what happens when RF-DETR's independent per-class sigmoids put more than one class above threshold on the same query. No
+test exercised this divergence: ``test_onnx_preprocess_parity.py`` / ``test_tflite_inference_parity.py`` only cover
+*preprocessing* (resize/normalise) parity, and the one existing decode test
+(``test_multiclass_class_id_is_argmax_of_logits`` in ``test_tflite_inference.py``) asserted the old, wrong, single-
+detection-per-query behaviour as correct. This file locks the numeric selection itself, independent of either runtime
+backend.
 """
 
 from __future__ import annotations
@@ -43,9 +41,8 @@ def _reference_select_topk(
 class TestTopkSelectionParity:
     @pytest.mark.parametrize("seed", [0, 1, 2, 7, 42])
     def test_matches_postprocess_select_topk(self, seed: int) -> None:
-        """Random logits: the (query, class, score) set our NumPy helper keeps above threshold must
-        equal what PostProcess._select_topk + the same threshold keeps, for arbitrary multiplicity.
-        """
+        """Random logits: the (query, class, score) set our NumPy helper keeps above threshold must equal what
+        PostProcess._select_topk + the same threshold keeps, for arbitrary multiplicity."""
         rng = np.random.default_rng(seed)
         num_queries, num_fg_classes = 40, 12
         threshold = 0.3
@@ -83,8 +80,8 @@ class TestTopkSelectionParity:
             assert got_by_pair[pair] == pytest.approx(ref_s, abs=1e-4)
 
     def test_multilabel_query_yields_multiple_detections(self) -> None:
-        """A single query with two classes above threshold must produce two detections — the exact
-        case the old per-query argmax silently collapsed to one."""
+        """A single query with two classes above threshold must produce two detections — the exact case the old per-
+        query argmax silently collapsed to one."""
         num_queries, num_fg_classes = 5, 4
         threshold = 0.3
         fg_logits = np.full((num_queries, num_fg_classes), -100.0, dtype=np.float32)
@@ -102,9 +99,8 @@ class TestTopkSelectionParity:
         assert list(got_scores) == sorted(got_scores, reverse=True)
 
     def test_num_select_caps_pairs_like_torch_topk(self) -> None:
-        """When more than num_select pairs exceed threshold, only the top num_select by score
-        survive — matching PostProcess._select_topk (topk happens before, not after, thresholding).
-        """
+        """When more than num_select pairs exceed threshold, only the top num_select by score survive — matching
+        PostProcess._select_topk (topk happens before, not after, thresholding)."""
         num_queries, num_fg_classes = 10, 10
         threshold = 0.0
         rng = np.random.default_rng(3)

--- a/tests/export/test_topk_selection_parity.py
+++ b/tests/export/test_topk_selection_parity.py
@@ -32,7 +32,13 @@ from rfdetr.models.postprocess import PostProcess
 def _reference_select_topk(
     logits_with_bg: torch.Tensor, num_select: int
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Call the real ``PostProcess._select_topk`` directly on one image's logits (batch size 1)."""
+    """Call ``PostProcess._select_topk`` directly on one image's logits (batch size 1).
+
+    Examples:
+        >>> logits = torch.zeros((2, 3))
+        >>> tuple(value.shape for value in _reference_select_topk(logits, num_select=2))
+        (torch.Size([2]), torch.Size([2]), torch.Size([2]))
+    """
     pp = PostProcess(num_select=num_select)
     scores, labels, boxes = pp._select_topk(logits_with_bg.unsqueeze(0))
     return scores[0], labels[0], boxes[0]
@@ -113,3 +119,60 @@ class TestTopkSelectionParity:
         got_scores, _, _ = _select_topk_multiclass(scores_all, threshold, num_select=num_select)
         assert got_scores.shape[0] == num_select
         assert list(got_scores) == sorted(got_scores, reverse=True)
+
+    @pytest.mark.parametrize("num_select", [100, 200], ids=["seg-nano-small", "seg-medium-large"])
+    def test_model_selection_caps_are_preserved(self, num_select: int) -> None:
+        """Export decoding retains the configured cap used by shipped segmentation variants."""
+        scores_all = np.full((250, 1), 0.9, dtype=np.float32)
+
+        got_scores, got_labels, got_query = _select_topk_multiclass(scores_all, threshold=0.0, num_select=num_select)
+
+        assert got_scores.shape == (num_select,)
+        assert got_labels.shape == (num_select,)
+        assert got_query.tolist() == list(range(num_select))
+
+    def test_zero_selection_returns_empty_arrays(self) -> None:
+        """Selecting zero pairs returns no detections, even when scores clear the threshold."""
+        scores, labels, queries = _select_topk_multiclass(np.array([[0.9, 0.8]], dtype=np.float32), 0.0, num_select=0)
+
+        assert scores.shape == (0,)
+        assert labels.shape == (0,)
+        assert queries.shape == (0,)
+
+    def test_tied_cutoff_uses_flattened_index_order(self) -> None:
+        """Equal scores use the same ascending flattened-index tie rule as ``PostProcess``."""
+        logits = torch.tensor([[0.0, 0.0], [0.0, -1.0]])
+        reference_scores, reference_labels, reference_queries = _reference_select_topk(logits, num_select=2)
+        scores_all = torch.sigmoid(logits).numpy()
+        scores, labels, queries = _select_topk_multiclass(scores_all, 0.0, num_select=2)
+
+        np.testing.assert_allclose(scores, reference_scores.numpy())
+        np.testing.assert_array_equal(labels, reference_labels.numpy())
+        np.testing.assert_array_equal(queries, reference_queries.numpy())
+
+    def test_negative_selection_is_rejected(self) -> None:
+        """Negative selection caps are invalid for both export and PyTorch postprocessing."""
+        with pytest.raises(ValueError, match="non-negative"):
+            _select_topk_multiclass(np.ones((1, 1), dtype=np.float32), 0.0, num_select=-1)
+        with pytest.raises(ValueError, match="non-negative"):
+            PostProcess(num_select=-1)
+
+    def test_nan_cutoff_matches_postprocess_filtering(self) -> None:
+        """NaN scores consume the same ranked slot and are then removed by the threshold filter."""
+        logits = torch.tensor([[float("nan"), 3.0], [2.0, -1.0]])
+        reference_scores, _, _ = _reference_select_topk(logits, num_select=1)
+        reference_kept = reference_scores[reference_scores > 0.3]
+        scores, labels, queries = _select_topk_multiclass(torch.sigmoid(logits).numpy(), 0.3, num_select=1)
+
+        assert reference_kept.shape == (0,)
+        assert scores.shape == (0,)
+        assert labels.shape == (0,)
+        assert queries.shape == (0,)
+
+    def test_empty_query_grid_returns_empty_arrays(self) -> None:
+        """An empty query grid is valid and produces typed empty outputs."""
+        scores, labels, queries = _select_topk_multiclass(np.empty((0, 3), dtype=np.float32), 0.0)
+
+        assert scores.shape == (0,)
+        assert labels.shape == (0,)
+        assert queries.shape == (0,)


### PR DESCRIPTION
`_run_inference` in `src/rfdetr/export/_onnx/inference.py:242-261` (and its near-literal copy in `_tflite/inference.py`) decodes predictions with `scores_all.argmax(axis=-1)` per query, at most one detection per query. But `predict()` (`PostProcess._select_topk`) flattens `(Q, C)` to `Q*C` and takes the top `num_select` scoring pairs before thresholding. So a single query can produce more than one detection. RF-DETR uses per-class sigmoid, not softmax, so two different classes can genuinely score above threshold on the same query. The code comment said this "mirrors PostProcess.forward" .. it doesn't, not in the multi-label case.

I checked this with real data: RTX 4060, 200 COCO val2017 images, the real `rf-detr-nano` checkpoint. I ran `predict()` itself and hooked `PostProcess._select_topk` to capture the exact `pred_logits` it receives. Then I compared three decodes on those same logits: the real reference, the fixed helper, and the old per-query argmax. The bug drops 30 detections across 26 of the 200 images (13%). The fixed decode matches the real reference exactly on all 200 images (log in the dossier's `repro/` folder). I'd also seen the same pattern earlier on an L4, a different batch of 200 images: 28 detections lost on 21/200 images at threshold 0.3, dropping to 1/200 at threshold 0.5 (the `predict()` default). I don't have the raw log for that L4 run in this repo, so treat it as a secondary data point, same order of magnitude, not primary evidence. The RTX 4060 run above is the one with the full audit trail.

I also traced why the existing tests never caught this. `test_onnx_preprocess_parity.py` only checks preprocessing (resize/normalise), never decode. The PR that added this decode (#1015) added `test_multiclass_class_id_is_argmax_of_logits`, which builds exactly this collision scenario and asserts as correct that only the argmax class survives. So this isn't just a coverage gap, the test expects the buggy behaviour and calls it correct.

This may be related to an open issue, `#901` ("ONNX results differ from pth"), still unresolved and without a concrete repro — one collaborator there guessed it was just hardware numeric noise. I can't say for sure this is what's behind that report, there's no repro to check against. But it's a real, deterministic bug in the reference decode itself, independent of hardware, the same kind of thing #1269 (antialias) fixed.

**Changes**

- Pulled the selection logic into a shared `src/rfdetr/export/_topk.py::_select_topk_multiclass`, the same pattern the existing shared `_resize.py` uses for bit-exact resizing. Before this the logic was duplicated in two files, which is how the bug ended up duplicated too. Both `_run_inference` functions call it now instead of the per-query argmax, mirroring `PostProcess._select_topk` exactly.
- The helper uses a fixed `num_select=300`, `PostProcess.__init__`'s own default. The detection sizes (nano/small/medium/large) all inherit 300 unchanged, the segmentation configs override it lower (100 for seg-nano/seg-small, 200 for seg-medium/seg-large). The exported ONNX/TFLite artefact carries no training config, so there's no way to recover the checkpoint's real `num_select` from it. 300 covers every detection variant exactly and is a safe ceiling for the segmentation ones too, documented as a known limitation in the helper's docstring. Only matters for a scene with more query/class pairs above threshold than that in a single image, which would be unusual.
- `_tflite/inference.py`'s mask decode indexed with `raw_masks[keep]`, a boolean per query, at most one mask per query. With the fix a query can produce more than one detection, so that's now `raw_masks[query_idx]`, an integer index that can repeat. Added a test confirming two detections from the same query correctly share the same mask.
- Rewrote the test that encoded the old behaviour: `test_multiclass_class_id_is_argmax_of_logits` is now `test_multiclass_query_reports_every_class_above_threshold`, asserting every class above threshold gets reported, ordered by descending score.
- Added `test_topk_selection_parity.py` (numeric parity against the real `PostProcess._select_topk`, imported directly, not reimplemented) and `test_onnx_inference.py` (new file, the ONNX decode had no dedicated test at all before this).

**Validation**

- Full `tests/export/` suite: 351 passed, 71 skipped, 0 failed. Same command against unpatched `develop`: 340 passed, 71 skipped, so the delta is exactly the 11 new tests, no regressions.
- `ruff format`/`ruff check` clean. `mypy src/rfdetr/ --no-error-summary` (the exact pre-commit invocation) clean on the new code, same 2 pre-existing errors in `coco_eval.py` on both sides, unrelated to this diff.
- Patch applies cleanly on `develop` at `c107a748`.

This is inference-only (numpy/onnxruntime/tflite-runtime), no gradients involved, low risk. The only observable behaviour change is the decode can now return more detections than before (the ones the bug was dropping), never fewer.
