### PR TITLE
fix(training): preserve metrics.csv history across resumed training

### DIFF
--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -216,9 +216,11 @@ def _preserve_csv_history_across_resume(csv_logger: CSVLogger, output_dir: str |
     the file before that deletion happens, restore it immediately after, and seed the writer's column
     cache to match so the next ``save()`` call appends rather than starting over.
 
-    Only call this for a resumed run (``tc.resume is not None``). Reusing ``output_dir`` for a fresh
-    run must still let ``CSVLogger`` reset ``metrics.csv`` — appending a fresh run's history onto an
-    unrelated prior run's would silently corrupt the log.
+    Only call this for a resumed run (a truthy tc.resume). This matches the
+    public Trainer.fit(..., ckpt_path=config.resume or None) normalization.
+    Reusing output_dir for a fresh run, including an empty resume value, must
+    still let CSVLogger reset metrics.csv — appending fresh-run history onto
+    unrelated prior-run history would silently corrupt the log.
 
     Args:
         csv_logger: The just-constructed ``CSVLogger`` for this run, not yet attached to a ``Trainer``.
@@ -360,7 +362,7 @@ def _append_training_callbacks(
     # CSVLogger is always enabled — no extra package required.
     # Produces metrics.csv in output_dir so there is always a log file.
     csv_logger = CSVLogger(save_dir=tc.output_dir, name="", version="")
-    if tc.resume is not None:
+    if tc.resume:
         _preserve_csv_history_across_resume(csv_logger, tc.output_dir)
     loggers.append(csv_logger)
 

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -216,6 +216,10 @@ def _preserve_csv_history_across_resume(csv_logger: CSVLogger, output_dir: str |
     the file before that deletion happens, restore it immediately after, and seed the writer's column
     cache to match so the next ``save()`` call appends rather than starting over.
 
+    Only call this for a resumed run (``tc.resume is not None``). Reusing ``output_dir`` for a fresh
+    run must still let ``CSVLogger`` reset ``metrics.csv`` — appending a fresh run's history onto an
+    unrelated prior run's would silently corrupt the log.
+
     Args:
         csv_logger: The just-constructed ``CSVLogger`` for this run, not yet attached to a ``Trainer``.
         output_dir: The training run's output directory; must match ``csv_logger``'s log location
@@ -356,7 +360,8 @@ def _append_training_callbacks(
     # CSVLogger is always enabled — no extra package required.
     # Produces metrics.csv in output_dir so there is always a log file.
     csv_logger = CSVLogger(save_dir=tc.output_dir, name="", version="")
-    _preserve_csv_history_across_resume(csv_logger, tc.output_dir)
+    if tc.resume is not None:
+        _preserve_csv_history_across_resume(csv_logger, tc.output_dir)
     loggers.append(csv_logger)
 
     if tc.tensorboard:

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -7,7 +7,9 @@
 
 from __future__ import annotations
 
+import csv
 import warnings
+from pathlib import Path
 from typing import Any, Literal
 
 import torch
@@ -203,6 +205,42 @@ def _requests_multiple_devices(devices: int | str, accelerator: str | None = Non
     return False
 
 
+def _preserve_csv_history_across_resume(csv_logger: CSVLogger, output_dir: str | Path) -> None:
+    """Stop CSVLogger from silently deleting metrics.csv history when a run resumes.
+
+    ``build_trainer`` constructs a brand-new ``CSVLogger(version="")`` every time training starts or
+    resumes, always pointed at the same ``output_dir``. The first access to ``CSVLogger.experiment``
+    triggers PTL's ``_ExperimentWriter._check_log_dir_exists``, which deletes any pre-existing
+    ``metrics.csv`` in that directory (see ``lightning.fabric.loggers.csv_logs``). On a fresh run there
+    is nothing to delete, but on a resumed run this wipes every row logged before the resume. Snapshot
+    the file before that deletion happens, restore it immediately after, and seed the writer's column
+    cache to match so the next ``save()`` call appends rather than starting over.
+
+    Args:
+        csv_logger: The just-constructed ``CSVLogger`` for this run, not yet attached to a ``Trainer``.
+        output_dir: The training run's output directory; must match ``csv_logger``'s log location
+            (``name=""``, ``version=""``).
+
+    Regression fix for :issue:`1321`.
+    """
+    metrics_path = Path(output_dir) / "metrics.csv"
+    if not metrics_path.is_file():
+        return
+    with metrics_path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        fieldnames = list(reader.fieldnames or [])
+        rows = list(reader)
+    if not rows:
+        return
+
+    experiment = csv_logger.experiment  # Triggers PTL's delete-on-init; restored right after.
+    with metrics_path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    experiment.metrics_keys = sorted(fieldnames)
+
+
 def _append_training_callbacks(
     callbacks: list[Callback],
     loggers: list[Any],
@@ -317,7 +355,9 @@ def _append_training_callbacks(
     # emits a UserWarning instead of crashing.
     # CSVLogger is always enabled — no extra package required.
     # Produces metrics.csv in output_dir so there is always a log file.
-    loggers.append(CSVLogger(save_dir=tc.output_dir, name="", version=""))
+    csv_logger = CSVLogger(save_dir=tc.output_dir, name="", version="")
+    _preserve_csv_history_across_resume(csv_logger, tc.output_dir)
+    loggers.append(csv_logger)
 
     if tc.tensorboard:
         try:

--- a/tests/training/test_metrics_csv.py
+++ b/tests/training/test_metrics_csv.py
@@ -188,7 +188,41 @@ class TestMetricsCSVResume:
     resumed epoch(s).
     """
 
-    def _fit_one_run(self, mc, tc, fake_criterion, max_epochs: int, ckpt_path: str | None):
+    def _fit_one_run(
+        self,
+        mc: RFDETRBaseConfig,
+        tc: TrainConfig,
+        fake_criterion: _FakeCriterion,
+        max_epochs: int,
+        ckpt_path: str | None,
+    ) -> None:
+        """Run one PTL ``fit()`` call against mocked model internals, writing into ``tc.output_dir``.
+
+        Args:
+            mc: Model config for the run.
+            tc: Train config for the run; ``tc.output_dir`` is where ``metrics.csv`` and checkpoints land.
+            fake_criterion: Shared criterion instance so loss values stay comparable across resumed runs.
+            max_epochs: Epoch count passed to ``build_trainer``.
+            ckpt_path: Checkpoint to resume PTL's trainer state from, or ``None`` for a fresh run.
+
+        Examples:
+            >>> import contextlib
+            >>> import io
+            >>> from tempfile import TemporaryDirectory
+            >>> with TemporaryDirectory() as d:
+            ...     mc = RFDETRBaseConfig(pretrain_weights=None, device='cpu', num_classes=3)
+            ...     tc = TrainConfig(
+            ...         dataset_dir=str(Path(d) / 'ds'),
+            ...         output_dir=str(Path(d) / 'out'),
+            ...         epochs=1,
+            ...         batch_size=2,
+            ...         tensorboard=False,
+            ...     )
+            ...     with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+            ...         TestMetricsCSVResume()._fit_one_run(mc, tc, _FakeCriterion(), max_epochs=1, ckpt_path=None)
+            ...     (Path(tc.output_dir) / 'metrics.csv').exists()
+            True
+        """
         with (
             patch("rfdetr.training.module_model.build_model_from_config", return_value=_TinyModel()),
             patch(
@@ -230,6 +264,7 @@ class TestMetricsCSVResume:
         last_ckpt = Path(tc.output_dir) / "last.ckpt"
         assert last_ckpt.exists(), "checkpoint_interval default (10) must still save a `last` checkpoint every epoch"
 
+        tc.resume = str(last_ckpt)
         self._fit_one_run(mc, tc, fake_criterion, max_epochs=2, ckpt_path=str(last_ckpt))
 
         rows_after_resume = pd.read_csv(csv_path)
@@ -240,4 +275,26 @@ class TestMetricsCSVResume:
             "Every row logged before the resume must still be present afterward — "
             'CSVLogger(version="") must not silently delete pre-existing metrics.csv history '
             "when re-instantiated against the same output_dir."
+        )
+
+    def test_reused_output_dir_without_resume_resets_history(self, base_model_config, base_train_config):
+        """A fresh run (``resume=None``) reusing a prior run's output_dir must reset metrics.csv, not append."""
+        mc = base_model_config()
+        tc = base_train_config(use_ema=False, run_test=False)
+        fake_criterion = _FakeCriterion()
+
+        self._fit_one_run(mc, tc, fake_criterion, max_epochs=1, ckpt_path=None)
+
+        csv_path = Path(tc.output_dir) / "metrics.csv"
+        rows_from_first_run = pd.read_csv(csv_path)
+        assert not rows_from_first_run.empty, "First run must have logged at least one row"
+
+        assert tc.resume is None, "This case only applies to a fresh run, not a resumed one"
+        self._fit_one_run(mc, tc, fake_criterion, max_epochs=1, ckpt_path=None)
+
+        rows_from_second_run = pd.read_csv(csv_path)
+        assert len(rows_from_second_run) == len(rows_from_first_run), (
+            f"Fresh run wrote {len(rows_from_second_run)} rows but the prior run wrote "
+            f"{len(rows_from_first_run)} — a fresh run (resume=None) reusing output_dir must let "
+            "CSVLogger reset metrics.csv, not silently append onto an unrelated prior run's history."
         )

--- a/tests/training/test_metrics_csv.py
+++ b/tests/training/test_metrics_csv.py
@@ -178,3 +178,66 @@ class TestDetectionMetricsCSV:
             f"({expected_if_divided:.4f}) than the raw criterion output "
             f"({expected_unscaled:.4f}). The division must have been removed."
         )
+
+
+class TestMetricsCSVResume:
+    """metrics.csv must retain history across a resumed run.
+
+    Regression test for #1321: resuming training builds a brand-new ``Trainer``/``CSVLogger`` pointed at the same
+    ``output_dir``. Every row written before the resume must still be present afterward, not just the rows from the
+    resumed epoch(s).
+    """
+
+    def _fit_one_run(self, mc, tc, fake_criterion, max_epochs: int, ckpt_path: str | None):
+        with (
+            patch("rfdetr.training.module_model.build_model_from_config", return_value=_TinyModel()),
+            patch(
+                "rfdetr.training.module_model.build_criterion_from_config",
+                return_value=(fake_criterion, MagicMock(side_effect=_fake_postprocess)),
+            ),
+            patch("rfdetr.training.module_data.build_dataset", return_value=_FakeDataset(length=20)),
+            patch(
+                "rfdetr.training.module_model.get_param_dict",
+                side_effect=lambda args, model: _make_param_dicts(model),
+            ),
+        ):
+            module = RFDETRModelModule(mc, tc)
+            datamodule = RFDETRDataModule(mc, tc)
+            trainer = build_trainer(
+                tc,
+                mc,
+                accelerator="cpu",
+                max_epochs=max_epochs,
+                limit_train_batches=2,
+                limit_val_batches=2,
+                log_every_n_steps=1,
+            )
+            trainer.fit(module, datamodule=datamodule, ckpt_path=ckpt_path)
+
+    def test_history_preserved_across_resume(self, base_model_config, base_train_config):
+        """A second build_trainer() call against the same output_dir must APPEND, not overwrite, metrics.csv."""
+        mc = base_model_config()
+        tc = base_train_config(use_ema=False, run_test=False)
+        fake_criterion = _FakeCriterion()
+
+        self._fit_one_run(mc, tc, fake_criterion, max_epochs=1, ckpt_path=None)
+
+        csv_path = Path(tc.output_dir) / "metrics.csv"
+        assert csv_path.exists(), "First run must have written metrics.csv"
+        rows_before_resume = pd.read_csv(csv_path)
+        assert not rows_before_resume.empty, "First run must have logged at least one row"
+
+        last_ckpt = Path(tc.output_dir) / "last.ckpt"
+        assert last_ckpt.exists(), "checkpoint_interval default (10) must still save a `last` checkpoint every epoch"
+
+        self._fit_one_run(mc, tc, fake_criterion, max_epochs=2, ckpt_path=str(last_ckpt))
+
+        rows_after_resume = pd.read_csv(csv_path)
+        assert len(rows_after_resume) > len(rows_before_resume), (
+            "metrics.csv must grow across a resume, not shrink or reset"
+        )
+        assert set(rows_before_resume["step"]).issubset(set(rows_after_resume["step"])), (
+            "Every row logged before the resume must still be present afterward — "
+            'CSVLogger(version="") must not silently delete pre-existing metrics.csv history '
+            "when re-instantiated against the same output_dir."
+        )

--- a/tests/training/test_metrics_csv.py
+++ b/tests/training/test_metrics_csv.py
@@ -271,10 +271,36 @@ class TestMetricsCSVResume:
         assert len(rows_after_resume) > len(rows_before_resume), (
             "metrics.csv must grow across a resume, not shrink or reset"
         )
-        assert set(rows_before_resume["step"]).issubset(set(rows_after_resume["step"])), (
-            "Every row logged before the resume must still be present afterward — "
-            'CSVLogger(version="") must not silently delete pre-existing metrics.csv history '
-            "when re-instantiated against the same output_dir."
+        assert set(rows_before_resume.columns).issubset(rows_after_resume.columns), (
+            "Every pre-resume metric column must remain available after the resume"
+        )
+        pd.testing.assert_frame_equal(
+            rows_before_resume.reset_index(drop=True),
+            rows_after_resume.loc[: len(rows_before_resume) - 1, rows_before_resume.columns].reset_index(drop=True),
+            check_dtype=False,
+        )
+
+    def test_reused_output_dir_with_empty_resume_resets_history(self, base_model_config, base_train_config):
+        """A fresh run with an empty resume value reusing output_dir must reset metrics.csv, like resume=None."""
+        mc = base_model_config()
+        tc = base_train_config(use_ema=False, run_test=False)
+        fake_criterion = _FakeCriterion()
+
+        self._fit_one_run(mc, tc, fake_criterion, max_epochs=1, ckpt_path=None)
+
+        csv_path = Path(tc.output_dir) / "metrics.csv"
+        rows_from_first_run = pd.read_csv(csv_path)
+        assert not rows_from_first_run.empty, "First run must have logged at least one row"
+
+        tc.resume = ""
+        assert tc.resume == "", "This case must exercise the public empty-string resume value"
+        self._fit_one_run(mc, tc, fake_criterion, max_epochs=1, ckpt_path=None)
+
+        rows_from_second_run = pd.read_csv(csv_path)
+        assert len(rows_from_second_run) == len(rows_from_first_run), (
+            f"Fresh run wrote {len(rows_from_second_run)} rows but the prior run wrote "
+            f"{len(rows_from_first_run)} — resume='' must let CSVLogger reset metrics.csv, "
+            "not silently append onto an unrelated prior run's history."
         )
 
     def test_reused_output_dir_without_resume_resets_history(self, base_model_config, base_train_config):


### PR DESCRIPTION
## Description

Fixes #1321. `metrics.csv`'s entire history from before a resume was silently overwritten, leaving only the rows logged after the resume.

`build_trainer()` constructs a brand-new `CSVLogger(save_dir=tc.output_dir, name="", version="")` every time training starts *or* resumes, always pointed at the same `output_dir`. The first access to `CSVLogger.experiment` (PyTorch Lightning) triggers `_ExperimentWriter._check_log_dir_exists`, which deletes any pre-existing `metrics.csv` found in that directory:

```
lightning_fabric/loggers/csv_logs.py:268: Experiment logs directory .../output/ exists and is not empty.
Previous log files in this directory will be deleted when the new ones are saved!
```

On a fresh run there's nothing there yet, so this is invisible. On a resumed run it wipes every epoch logged before the resume, which is what the issue reports (all data before epoch 35 disappearing after a stop/resume).

## Fix

`_preserve_csv_history_across_resume()` snapshots `metrics.csv`'s header and rows immediately before constructing `.experiment` (which is what triggers the delete), restores the file right after, and seeds the writer's internal `metrics_keys` cache to match the restored header. The next `save()` call then appends through PTL's normal `mode="a"` path instead of starting over. No-op on a fresh run (nothing to snapshot) and safe under DDP (non-zero ranks get PTL's `_DummyExperiment`, which silently no-ops the attribute set).

Out of scope: the issue also mentions 5 of 6 charts in `plot_metrics()` missing legends — that's a separate bug in `visualize/training.py`, unrelated to the CSVLogger issue, and not touched here.

## Testing

Added `TestMetricsCSVResume::test_history_preserved_across_resume` to `tests/training/test_metrics_csv.py`: fits 1 epoch, captures `metrics.csv`, then builds a fresh `Trainer`/`CSVLogger` against the same `output_dir` and resumes via `ckpt_path=last.ckpt` for one more epoch — mirroring exactly how `build_trainer()` gets called twice across a real stop/resume.

Confirmed red on the parent commit:
```
FAILED test_history_preserved_across_resume - AssertionError: metrics.csv must grow across a resume, not shrink or reset
assert 4 > 4
```
Green with the fix, full file passing:
```
$ pytest tests/training/test_metrics_csv.py -v
5 passed
```

`pre-commit run --files src/rfdetr/training/trainer.py tests/training/test_metrics_csv.py` is clean except two `mypy` `no-any-return` errors in `src/rfdetr/evaluation/coco_eval.py:178,190` — pre-existing on `develop` (reproduces identically via `git stash` + running mypy against the unmodified file), unrelated to this change, not touched by this PR.