### PR TITLE
fix(training): evaluate the real test split for YOLO datasets

### DIFF
--- a/src/rfdetr/datasets/yolo.py
+++ b/src/rfdetr/datasets/yolo.py
@@ -44,6 +44,10 @@ REQUIRED_DATA_SUBDIRS = ["images", "labels"]
 YOLO_IMAGE_EXTENSIONS = {".bmp", ".dng", ".jpg", ".jpeg", ".mpo", ".png", ".tif", ".tiff", ".webp"}
 
 
+class YoloSplitUnavailableError(FileNotFoundError):
+    """Signal that a requested YOLO split has no image directory to evaluate."""
+
+
 def _parse_yolo_box(values: list[str]) -> NDArray[np.float32]:
     """Parse a YOLO center-width-height box into relative XYXY coordinates."""
     x_center, y_center, width, height = values
@@ -754,6 +758,17 @@ def _resolve_yolo_split_dirs(root: Path, data_file: Path, split: str) -> tuple[P
     Returns:
         ``(images_dir, labels_dir)`` as resolved :class:`~pathlib.Path` objects.
     """
+    if split == "test" and data_file.exists():
+        try:
+            declared_test_path = _load_yaml_mapping(data_file).get("test")
+        except (OSError, ValueError, TypeError, yaml.YAMLError):
+            declared_test_path = None
+        if declared_test_path is not None:
+            result = _resolve_split_from_yaml(root, data_file, split)
+            if result is None:
+                raise ValueError(f"YOLO test split declared in {data_file} could not be resolved")
+            return result
+
     result = _resolve_split_from_yaml(root, data_file, split)
     if result is not None:
         return result
@@ -771,6 +786,36 @@ def _resolve_yolo_split_dirs(root: Path, data_file: Path, split: str) -> tuple[P
                 return candidate, candidate_labels
 
     return img_dir, lb_dir
+
+
+def _validate_yolo_test_split(images_dir: Path, labels_dir: Path) -> None:
+    """Validate the filesystem contract for a YOLO test split.
+
+    A missing image directory means that the split is unavailable and may be
+    replaced with validation data.  Once the image directory exists, an empty
+    image directory or missing labels directory is invalid test data and must
+    propagate as an error instead of being relabeled as validation data.  An
+    existing labels directory may contain omitted or empty label files for
+    legitimate background images.
+
+    Args:
+        images_dir: Resolved directory containing test images.
+        labels_dir: Resolved directory containing test labels.
+
+    Raises:
+        YoloSplitUnavailableError: If the test image directory is absent.
+        ValueError: If the test images or labels directory is unusable.
+    """
+    if not images_dir.is_dir():
+        if images_dir.is_symlink():
+            raise ValueError(f"YOLO test images directory is an invalid symlink: {images_dir}")
+        raise YoloSplitUnavailableError(f"YOLO test images directory not found: {images_dir}")
+    if not labels_dir.is_dir():
+        raise ValueError(f"YOLO test labels directory not found: {labels_dir}")
+
+    image_paths = _list_yolo_image_paths(str(images_dir))
+    if not image_paths:
+        raise ValueError(f"YOLO test images directory contains no supported images: {images_dir}")
 
 
 class ConvertYolo:
@@ -1004,6 +1049,8 @@ def build_roboflow_from_yolo(image_set: str, args: Any, resolution: int) -> Yolo
     data_file = next((root / f for f in REQUIRED_YOLO_YAML_FILES if (root / f).exists()), root / "data.yaml")
     split_key = image_set.split("_")[0]
     img_folder, lb_folder = _resolve_yolo_split_dirs(root, data_file, split_key)
+    if split_key == "test":
+        _validate_yolo_test_split(img_folder, lb_folder)
     square_resize_div_64 = getattr(args, "square_resize_div_64", False)
     include_masks = getattr(args, "segmentation_head", False)
     multi_scale = getattr(args, "multi_scale", False)

--- a/src/rfdetr/training/module_data.py
+++ b/src/rfdetr/training/module_data.py
@@ -269,11 +269,40 @@ class RFDETRDataModule(LightningDataModule):
                 self._dataset_val = build_dataset("val", ns, resolution)
         elif stage == "test":
             if self._dataset_test is None:
-                split = "test" if self.train_config.dataset_file == "roboflow" else "val"
-                self._dataset_test = build_dataset(split, ns, resolution)
+                self._dataset_test = self._build_test_dataset(ns, resolution)
         elif stage == "predict":
             if self._dataset_val is None:
                 self._dataset_val = build_dataset("val", ns, resolution)
+
+    def _build_test_dataset(self, ns: Any, resolution: int) -> torch.utils.data.Dataset[Any]:
+        """Build the dataset backing ``setup("test")``, preferring a real test split.
+
+        ``roboflow`` and ``yolo`` datasets carry a labelled ``test`` split, so it is used directly.  A YOLO dataset is
+        not required to declare one; when the split cannot be resolved the ``val`` split is used instead and the
+        substitution is logged, because falling back silently reports validation numbers under the name "test".
+
+        ``coco`` and ``o365`` always fall back to ``val``: their ``test`` split is COCO test-dev, which ships without
+        annotations and therefore cannot be scored locally.
+
+        Args:
+            ns: Merged model/train config namespace forwarded to :func:`build_dataset`.
+            resolution: Target square resolution in pixels.
+
+        Returns:
+            The dataset to evaluate during the ``test`` stage.
+        """
+        dataset_file = self.train_config.dataset_file
+        if dataset_file == "roboflow":
+            return build_dataset("test", ns, resolution)
+        if dataset_file == "yolo":
+            try:
+                return build_dataset("test", ns, resolution)
+            except FileNotFoundError as exc:
+                logger.warning(
+                    "No resolvable 'test' split for this YOLO dataset (%s); evaluating the 'val' split instead.",
+                    exc,
+                )
+        return build_dataset("val", ns, resolution)
 
     def _resolve_batch_size(self) -> int:
         """Return the concrete training batch size.

--- a/src/rfdetr/training/module_data.py
+++ b/src/rfdetr/training/module_data.py
@@ -19,6 +19,7 @@ from rfdetr._namespace import _namespace_from_configs
 from rfdetr.config import AugmentationBackend, ModelConfig, TrainConfig
 from rfdetr.datasets import build_dataset
 from rfdetr.datasets.aug_configs import AUG_CONFIG
+from rfdetr.datasets.yolo import YoloSplitUnavailableError
 from rfdetr.utilities.box_ops import box_xyxy_to_cxcywh
 from rfdetr.utilities.logger import get_logger
 from rfdetr.utilities.tensors import make_collate_fn
@@ -297,10 +298,10 @@ class RFDETRDataModule(LightningDataModule):
         if dataset_file == "yolo":
             try:
                 return build_dataset("test", ns, resolution)
-            except FileNotFoundError as exc:
+            except YoloSplitUnavailableError as exc:
                 logger.warning(
                     "No resolvable 'test' split for this YOLO dataset (%s); evaluating the 'val' split instead.",
-                    exc,
+                    str(exc),
                 )
         return build_dataset("val", ns, resolution)
 

--- a/src/rfdetr/training/module_data.py
+++ b/src/rfdetr/training/module_data.py
@@ -281,8 +281,8 @@ class RFDETRDataModule(LightningDataModule):
         not required to declare one; when the split cannot be resolved the ``val`` split is used instead and the
         substitution is logged, because falling back silently reports validation numbers under the name "test".
 
-        ``coco`` and ``o365`` always fall back to ``val``: their ``test`` split is COCO test-dev, which ships without
-        annotations and therefore cannot be scored locally.
+        ``coco`` falls back to ``val`` because its ``test`` split is unlabelled COCO test-dev and cannot be scored
+        locally.  ``o365`` also falls back because its dataset builder exposes only ``train`` and ``val`` splits.
 
         Args:
             ns: Merged model/train config namespace forwarded to :func:`build_dataset`.

--- a/tests/datasets/test_yolo.py
+++ b/tests/datasets/test_yolo.py
@@ -16,6 +16,7 @@ from pycocotools.coco import COCO
 
 from rfdetr.datasets.yolo import (
     YoloDetection,
+    YoloSplitUnavailableError,
     _extract_yolo_class_names,
     _LazyYoloDetectionDataset,
     _resolve_yolo_split_dirs,
@@ -1136,6 +1137,127 @@ class TestBuildRoboflowFromYoloUltralytics:
 
         _, kwargs = mock_dataset.call_args
         assert "valid" in kwargs["img_folder"]
+
+    def test_missing_test_images_signal_unavailable_split(self, tmp_path: Path) -> None:
+        """A missing test image directory is the explicit val-fallback signal."""
+        (tmp_path / "data.yaml").write_text("names:\n  0: person\n", encoding="utf-8")
+        args = self._make_args(str(tmp_path))
+
+        from rfdetr.datasets.yolo import build_roboflow_from_yolo
+
+        with pytest.raises(YoloSplitUnavailableError, match="test images directory"):
+            build_roboflow_from_yolo("test", args, resolution=64)
+
+    def test_broken_test_images_symlink_is_not_treated_as_missing(self, tmp_path: Path) -> None:
+        """A broken test image symlink is invalid data, not an unavailable split."""
+        (tmp_path / "data.yaml").write_text("names:\n  0: person\n", encoding="utf-8")
+        images_dir = tmp_path / "test" / "images"
+        images_dir.parent.mkdir(parents=True)
+        images_dir.symlink_to(tmp_path / "deleted-images", target_is_directory=True)
+
+        args = self._make_args(str(tmp_path))
+        from rfdetr.datasets.yolo import build_roboflow_from_yolo
+
+        with pytest.raises(ValueError, match="invalid symlink"):
+            build_roboflow_from_yolo("test", args, resolution=64)
+
+    @pytest.mark.parametrize(
+        "setup_case, expected_message",
+        [
+            pytest.param("empty_images", "contains no supported images", id="empty-images"),
+            pytest.param("missing_labels", "labels directory not found", id="missing-labels"),
+        ],
+    )
+    def test_invalid_existing_test_split_propagates(
+        self, tmp_path: Path, setup_case: str, expected_message: str
+    ) -> None:
+        """Existing but unusable test data must not fall back to validation data."""
+        (tmp_path / "data.yaml").write_text("names:\n  0: person\n", encoding="utf-8")
+        images_dir = tmp_path / "test" / "images"
+        labels_dir = tmp_path / "test" / "labels"
+        images_dir.mkdir(parents=True)
+        if setup_case != "missing_labels":
+            labels_dir.mkdir()
+        if setup_case != "empty_images":
+            Image.new("RGB", (8, 6), color=(255, 255, 255)).save(images_dir / "sample.png")
+
+        args = self._make_args(str(tmp_path))
+        from rfdetr.datasets.yolo import build_roboflow_from_yolo
+
+        with pytest.raises(ValueError, match=expected_message):
+            build_roboflow_from_yolo("test", args, resolution=64)
+
+    def test_declared_broken_test_path_propagates(self, tmp_path: Path) -> None:
+        """A declared but unusable YAML test path must not become a val fallback."""
+        (tmp_path / "data.yaml").write_text(
+            "path: .\nval: val/images\ntest: missing-test/images\nnames:\n  0: person\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "val" / "images").mkdir(parents=True)
+        (tmp_path / "val" / "labels").mkdir()
+        args = self._make_args(str(tmp_path))
+
+        from rfdetr.datasets.yolo import build_roboflow_from_yolo
+
+        with pytest.raises(ValueError, match="test split declared"):
+            build_roboflow_from_yolo("test", args, resolution=64)
+
+    def test_declared_test_path_with_missing_labels_propagates(self, tmp_path: Path) -> None:
+        """A declared test image path with missing labels must not become a val fallback."""
+        (tmp_path / "data.yaml").write_text(
+            "path: .\nval: val/images\ntest: custom/images\nnames:\n  0: person\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "val" / "images").mkdir(parents=True)
+        (tmp_path / "val" / "labels").mkdir()
+        custom_images = tmp_path / "custom" / "images"
+        custom_images.mkdir(parents=True)
+        Image.new("RGB", (8, 6), color=(255, 255, 255)).save(custom_images / "sample.png")
+        args = self._make_args(str(tmp_path))
+
+        from rfdetr.datasets.yolo import build_roboflow_from_yolo
+
+        with pytest.raises(ValueError, match="test split declared"):
+            build_roboflow_from_yolo("test", args, resolution=64)
+
+    def test_valid_test_split_builds_real_dataset(self, tmp_path: Path) -> None:
+        """A non-empty labelled test split builds and preserves its sample."""
+        (tmp_path / "data.yaml").write_text("names:\n  0: person\n", encoding="utf-8")
+        images_dir = tmp_path / "test" / "images"
+        labels_dir = tmp_path / "test" / "labels"
+        images_dir.mkdir(parents=True)
+        labels_dir.mkdir()
+        Image.new("RGB", (8, 6), color=(255, 255, 255)).save(images_dir / "sample.png")
+        (labels_dir / "sample.txt").write_text("0 0.5 0.5 0.5 0.5\n", encoding="utf-8")
+        args = self._make_args(str(tmp_path))
+
+        from rfdetr.datasets.yolo import build_roboflow_from_yolo
+
+        with patch("rfdetr.datasets.yolo.make_coco_transforms", return_value=None):
+            dataset = build_roboflow_from_yolo("test", args, resolution=64)
+
+        assert len(dataset) == 1
+        _, target = dataset[0]
+        assert target["labels"].tolist() == [0]
+
+    def test_background_only_test_split_is_valid_with_labels_directory(self, tmp_path: Path) -> None:
+        """A true-negative test image remains valid when its labels directory exists."""
+        (tmp_path / "data.yaml").write_text("names:\n  0: person\n", encoding="utf-8")
+        images_dir = tmp_path / "test" / "images"
+        labels_dir = tmp_path / "test" / "labels"
+        images_dir.mkdir(parents=True)
+        labels_dir.mkdir()
+        Image.new("RGB", (8, 6), color=(255, 255, 255)).save(images_dir / "background.png")
+        args = self._make_args(str(tmp_path))
+
+        from rfdetr.datasets.yolo import build_roboflow_from_yolo
+
+        with patch("rfdetr.datasets.yolo.make_coco_transforms", return_value=None):
+            dataset = build_roboflow_from_yolo("test", args, resolution=64)
+
+        assert len(dataset) == 1
+        _, target = dataset[0]
+        assert target["labels"].numel() == 0
 
 
 class TestExtractYoloClassNames:

--- a/tests/datasets/test_yolo.py
+++ b/tests/datasets/test_yolo.py
@@ -106,6 +106,36 @@ kpt_names:
     return image_dir, label_dir, data_file
 
 
+def _write_yolo_test_split(
+    tmp_path: Path,
+    *,
+    images: bool = True,
+    labels: bool = True,
+    image_name: str = "sample.png",
+    label_content: str | None = None,
+) -> tuple[Path, Path]:
+    """Create the standard YOLO test split used by builder regression tests.
+
+    Examples:
+        >>> import tempfile
+        >>> root = Path(tempfile.mkdtemp())
+        >>> image_dir, label_dir = _write_yolo_test_split(root, images=False)
+        >>> image_dir.is_dir(), label_dir.is_dir()
+        (True, True)
+    """
+    (tmp_path / "data.yaml").write_text("names:\n  0: person\n", encoding="utf-8")
+    image_dir = tmp_path / "test" / "images"
+    label_dir = tmp_path / "test" / "labels"
+    image_dir.mkdir(parents=True)
+    if images:
+        Image.new("RGB", (8, 6), color=(255, 255, 255)).save(image_dir / image_name)
+    if labels:
+        label_dir.mkdir(parents=True)
+        if label_content is not None:
+            label_dir.joinpath(Path(image_name).with_suffix(".txt")).write_text(label_content, encoding="utf-8")
+    return image_dir, label_dir
+
+
 class TestBuildRoboflowFromYoloAugConfig:
     """Regression tests for #769: aug_config forwarded to transform builders."""
 
@@ -1162,24 +1192,17 @@ class TestBuildRoboflowFromYoloUltralytics:
             build_roboflow_from_yolo("test", args, resolution=64)
 
     @pytest.mark.parametrize(
-        "setup_case, expected_message",
+        "images, labels, expected_message",
         [
-            pytest.param("empty_images", "contains no supported images", id="empty-images"),
-            pytest.param("missing_labels", "labels directory not found", id="missing-labels"),
+            pytest.param(False, True, "contains no supported images", id="empty-images"),
+            pytest.param(True, False, "labels directory not found", id="missing-labels"),
         ],
     )
     def test_invalid_existing_test_split_propagates(
-        self, tmp_path: Path, setup_case: str, expected_message: str
+        self, tmp_path: Path, images: bool, labels: bool, expected_message: str
     ) -> None:
         """Existing but unusable test data must not fall back to validation data."""
-        (tmp_path / "data.yaml").write_text("names:\n  0: person\n", encoding="utf-8")
-        images_dir = tmp_path / "test" / "images"
-        labels_dir = tmp_path / "test" / "labels"
-        images_dir.mkdir(parents=True)
-        if setup_case != "missing_labels":
-            labels_dir.mkdir()
-        if setup_case != "empty_images":
-            Image.new("RGB", (8, 6), color=(255, 255, 255)).save(images_dir / "sample.png")
+        _write_yolo_test_split(tmp_path, images=images, labels=labels)
 
         args = self._make_args(str(tmp_path))
         from rfdetr.datasets.yolo import build_roboflow_from_yolo
@@ -1222,13 +1245,7 @@ class TestBuildRoboflowFromYoloUltralytics:
 
     def test_valid_test_split_builds_real_dataset(self, tmp_path: Path) -> None:
         """A non-empty labelled test split builds and preserves its sample."""
-        (tmp_path / "data.yaml").write_text("names:\n  0: person\n", encoding="utf-8")
-        images_dir = tmp_path / "test" / "images"
-        labels_dir = tmp_path / "test" / "labels"
-        images_dir.mkdir(parents=True)
-        labels_dir.mkdir()
-        Image.new("RGB", (8, 6), color=(255, 255, 255)).save(images_dir / "sample.png")
-        (labels_dir / "sample.txt").write_text("0 0.5 0.5 0.5 0.5\n", encoding="utf-8")
+        _write_yolo_test_split(tmp_path, label_content="0 0.5 0.5 0.5 0.5\n")
         args = self._make_args(str(tmp_path))
 
         from rfdetr.datasets.yolo import build_roboflow_from_yolo
@@ -1242,12 +1259,7 @@ class TestBuildRoboflowFromYoloUltralytics:
 
     def test_background_only_test_split_is_valid_with_labels_directory(self, tmp_path: Path) -> None:
         """A true-negative test image remains valid when its labels directory exists."""
-        (tmp_path / "data.yaml").write_text("names:\n  0: person\n", encoding="utf-8")
-        images_dir = tmp_path / "test" / "images"
-        labels_dir = tmp_path / "test" / "labels"
-        images_dir.mkdir(parents=True)
-        labels_dir.mkdir()
-        Image.new("RGB", (8, 6), color=(255, 255, 255)).save(images_dir / "background.png")
+        _write_yolo_test_split(tmp_path, image_name="background.png")
         args = self._make_args(str(tmp_path))
 
         from rfdetr.datasets.yolo import build_roboflow_from_yolo

--- a/tests/datasets/test_yolo.py
+++ b/tests/datasets/test_yolo.py
@@ -20,6 +20,7 @@ from rfdetr.datasets.yolo import (
     _extract_yolo_class_names,
     _LazyYoloDetectionDataset,
     _resolve_yolo_split_dirs,
+    build_roboflow_from_yolo,
     is_valid_yolo_dataset,
 )
 
@@ -106,36 +107,6 @@ kpt_names:
     return image_dir, label_dir, data_file
 
 
-def _write_yolo_test_split(
-    tmp_path: Path,
-    *,
-    images: bool = True,
-    labels: bool = True,
-    image_name: str = "sample.png",
-    label_content: str | None = None,
-) -> tuple[Path, Path]:
-    """Create the standard YOLO test split used by builder regression tests.
-
-    Examples:
-        >>> import tempfile
-        >>> root = Path(tempfile.mkdtemp())
-        >>> image_dir, label_dir = _write_yolo_test_split(root, images=False)
-        >>> image_dir.is_dir(), label_dir.is_dir()
-        (True, True)
-    """
-    (tmp_path / "data.yaml").write_text("names:\n  0: person\n", encoding="utf-8")
-    image_dir = tmp_path / "test" / "images"
-    label_dir = tmp_path / "test" / "labels"
-    image_dir.mkdir(parents=True)
-    if images:
-        Image.new("RGB", (8, 6), color=(255, 255, 255)).save(image_dir / image_name)
-    if labels:
-        label_dir.mkdir(parents=True)
-        if label_content is not None:
-            label_dir.joinpath(Path(image_name).with_suffix(".txt")).write_text(label_content, encoding="utf-8")
-    return image_dir, label_dir
-
-
 class TestBuildRoboflowFromYoloAugConfig:
     """Regression tests for #769: aug_config forwarded to transform builders."""
 
@@ -183,8 +154,6 @@ class TestBuildRoboflowFromYoloAugConfig:
             mock_transform.return_value = MagicMock()
             mock_dataset.return_value = MagicMock()
 
-            from rfdetr.datasets.yolo import build_roboflow_from_yolo
-
             build_roboflow_from_yolo("train", args, resolution=640)
 
         _, kwargs = mock_transform.call_args
@@ -204,8 +173,6 @@ class TestBuildRoboflowFromYoloAugConfig:
         ):
             mock_transform.return_value = MagicMock()
             mock_dataset.return_value = MagicMock()
-
-            from rfdetr.datasets.yolo import build_roboflow_from_yolo
 
             build_roboflow_from_yolo("train", args, resolution=640)
 
@@ -227,8 +194,6 @@ class TestBuildRoboflowFromYoloAugConfig:
             mock_path.return_value.exists.return_value = True
             mock_transform.return_value = MagicMock()
             mock_dataset.return_value = MagicMock()
-
-            from rfdetr.datasets.yolo import build_roboflow_from_yolo
 
             build_roboflow_from_yolo("train", args, resolution=640)
 
@@ -1113,6 +1078,45 @@ class TestIsValidYoloDatasetUltralytics:
 class TestBuildRoboflowFromYoloUltralytics:
     """build_roboflow_from_yolo must handle Ultralytics YOLO layout (#1177)."""
 
+    @staticmethod
+    def _write_yolo_dataset(
+        tmp_path: Path,
+        *,
+        images: bool = True,
+        labels: bool = True,
+        image_name: str = "sample.png",
+        label_content: str | None = None,
+        test_yaml_path: str | None = None,
+        create_test_images_dir: bool = True,
+    ) -> tuple[Path, Path]:
+        """Create the YOLO dataset layout used by builder regression tests.
+
+        Examples:
+            >>> import tempfile
+            >>> root = Path(tempfile.mkdtemp())
+            >>> image_dir, label_dir = TestBuildRoboflowFromYoloUltralytics._write_yolo_dataset(root, images=False)
+            >>> image_dir.is_dir(), label_dir.is_dir()
+            (True, True)
+        """
+        yaml_text = "names:\n  0: person\n"
+        if test_yaml_path is not None:
+            yaml_text = f"path: .\nval: val/images\ntest: {test_yaml_path}\nnames:\n  0: person\n"
+            (tmp_path / "val" / "images").mkdir(parents=True)
+            (tmp_path / "val" / "labels").mkdir()
+        (tmp_path / "data.yaml").write_text(yaml_text, encoding="utf-8")
+
+        image_dir = tmp_path / (test_yaml_path or "test/images")
+        label_dir = image_dir.parent / "labels"
+        if create_test_images_dir:
+            image_dir.mkdir(parents=True)
+        if images:
+            Image.new("RGB", (8, 6), color=(255, 255, 255)).save(image_dir / image_name)
+        if labels:
+            label_dir.mkdir(parents=True)
+            if label_content is not None:
+                label_dir.joinpath(Path(image_name).with_suffix(".txt")).write_text(label_content, encoding="utf-8")
+        return image_dir, label_dir
+
     def _make_args(self, dataset_dir: str) -> types.SimpleNamespace:
         return types.SimpleNamespace(
             dataset_dir=dataset_dir,
@@ -1142,8 +1146,6 @@ class TestBuildRoboflowFromYoloUltralytics:
             mock_transform.return_value = MagicMock()
             mock_dataset.return_value = MagicMock()
 
-            from rfdetr.datasets.yolo import build_roboflow_from_yolo
-
             build_roboflow_from_yolo("val", args, resolution=640)
 
         _, kwargs = mock_dataset.call_args
@@ -1161,8 +1163,6 @@ class TestBuildRoboflowFromYoloUltralytics:
             mock_transform.return_value = MagicMock()
             mock_dataset.return_value = MagicMock()
 
-            from rfdetr.datasets.yolo import build_roboflow_from_yolo
-
             build_roboflow_from_yolo("val", args, resolution=640)
 
         _, kwargs = mock_dataset.call_args
@@ -1172,8 +1172,6 @@ class TestBuildRoboflowFromYoloUltralytics:
         """A missing test image directory is the explicit val-fallback signal."""
         (tmp_path / "data.yaml").write_text("names:\n  0: person\n", encoding="utf-8")
         args = self._make_args(str(tmp_path))
-
-        from rfdetr.datasets.yolo import build_roboflow_from_yolo
 
         with pytest.raises(YoloSplitUnavailableError, match="test images directory"):
             build_roboflow_from_yolo("test", args, resolution=64)
@@ -1186,8 +1184,6 @@ class TestBuildRoboflowFromYoloUltralytics:
         images_dir.symlink_to(tmp_path / "deleted-images", target_is_directory=True)
 
         args = self._make_args(str(tmp_path))
-        from rfdetr.datasets.yolo import build_roboflow_from_yolo
-
         with pytest.raises(ValueError, match="invalid symlink"):
             build_roboflow_from_yolo("test", args, resolution=64)
 
@@ -1202,53 +1198,38 @@ class TestBuildRoboflowFromYoloUltralytics:
         self, tmp_path: Path, images: bool, labels: bool, expected_message: str
     ) -> None:
         """Existing but unusable test data must not fall back to validation data."""
-        _write_yolo_test_split(tmp_path, images=images, labels=labels)
+        self._write_yolo_dataset(tmp_path, images=images, labels=labels)
 
         args = self._make_args(str(tmp_path))
-        from rfdetr.datasets.yolo import build_roboflow_from_yolo
-
         with pytest.raises(ValueError, match=expected_message):
             build_roboflow_from_yolo("test", args, resolution=64)
 
     def test_declared_broken_test_path_propagates(self, tmp_path: Path) -> None:
         """A declared but unusable YAML test path must not become a val fallback."""
-        (tmp_path / "data.yaml").write_text(
-            "path: .\nval: val/images\ntest: missing-test/images\nnames:\n  0: person\n",
-            encoding="utf-8",
+        self._write_yolo_dataset(
+            tmp_path,
+            test_yaml_path="missing-test/images",
+            images=False,
+            labels=False,
+            create_test_images_dir=False,
         )
-        (tmp_path / "val" / "images").mkdir(parents=True)
-        (tmp_path / "val" / "labels").mkdir()
         args = self._make_args(str(tmp_path))
-
-        from rfdetr.datasets.yolo import build_roboflow_from_yolo
 
         with pytest.raises(ValueError, match="test split declared"):
             build_roboflow_from_yolo("test", args, resolution=64)
 
     def test_declared_test_path_with_missing_labels_propagates(self, tmp_path: Path) -> None:
         """A declared test image path with missing labels must not become a val fallback."""
-        (tmp_path / "data.yaml").write_text(
-            "path: .\nval: val/images\ntest: custom/images\nnames:\n  0: person\n",
-            encoding="utf-8",
-        )
-        (tmp_path / "val" / "images").mkdir(parents=True)
-        (tmp_path / "val" / "labels").mkdir()
-        custom_images = tmp_path / "custom" / "images"
-        custom_images.mkdir(parents=True)
-        Image.new("RGB", (8, 6), color=(255, 255, 255)).save(custom_images / "sample.png")
+        self._write_yolo_dataset(tmp_path, test_yaml_path="custom/images", labels=False)
         args = self._make_args(str(tmp_path))
-
-        from rfdetr.datasets.yolo import build_roboflow_from_yolo
 
         with pytest.raises(ValueError, match="test split declared"):
             build_roboflow_from_yolo("test", args, resolution=64)
 
     def test_valid_test_split_builds_real_dataset(self, tmp_path: Path) -> None:
         """A non-empty labelled test split builds and preserves its sample."""
-        _write_yolo_test_split(tmp_path, label_content="0 0.5 0.5 0.5 0.5\n")
+        self._write_yolo_dataset(tmp_path, label_content="0 0.5 0.5 0.5 0.5\n")
         args = self._make_args(str(tmp_path))
-
-        from rfdetr.datasets.yolo import build_roboflow_from_yolo
 
         with patch("rfdetr.datasets.yolo.make_coco_transforms", return_value=None):
             dataset = build_roboflow_from_yolo("test", args, resolution=64)
@@ -1259,10 +1240,8 @@ class TestBuildRoboflowFromYoloUltralytics:
 
     def test_background_only_test_split_is_valid_with_labels_directory(self, tmp_path: Path) -> None:
         """A true-negative test image remains valid when its labels directory exists."""
-        _write_yolo_test_split(tmp_path, image_name="background.png")
+        self._write_yolo_dataset(tmp_path, image_name="background.png")
         args = self._make_args(str(tmp_path))
-
-        from rfdetr.datasets.yolo import build_roboflow_from_yolo
 
         with patch("rfdetr.datasets.yolo.make_coco_transforms", return_value=None):
             dataset = build_roboflow_from_yolo("test", args, resolution=64)

--- a/tests/datasets/test_yolo.py
+++ b/tests/datasets/test_yolo.py
@@ -1088,6 +1088,7 @@ class TestBuildRoboflowFromYoloUltralytics:
         label_content: str | None = None,
         test_yaml_path: str | None = None,
         create_test_images_dir: bool = True,
+        image_symlink_target: Path | None = None,
     ) -> tuple[Path, Path]:
         """Create the YOLO dataset layout used by builder regression tests.
 
@@ -1107,7 +1108,10 @@ class TestBuildRoboflowFromYoloUltralytics:
 
         image_dir = tmp_path / (test_yaml_path or "test/images")
         label_dir = image_dir.parent / "labels"
-        if create_test_images_dir:
+        if image_symlink_target is not None:
+            image_dir.parent.mkdir(parents=True)
+            image_dir.symlink_to(image_symlink_target, target_is_directory=True)
+        elif create_test_images_dir:
             image_dir.mkdir(parents=True)
         if images:
             Image.new("RGB", (8, 6), color=(255, 255, 255)).save(image_dir / image_name)
@@ -1178,10 +1182,12 @@ class TestBuildRoboflowFromYoloUltralytics:
 
     def test_broken_test_images_symlink_is_not_treated_as_missing(self, tmp_path: Path) -> None:
         """A broken test image symlink is invalid data, not an unavailable split."""
-        (tmp_path / "data.yaml").write_text("names:\n  0: person\n", encoding="utf-8")
-        images_dir = tmp_path / "test" / "images"
-        images_dir.parent.mkdir(parents=True)
-        images_dir.symlink_to(tmp_path / "deleted-images", target_is_directory=True)
+        self._write_yolo_dataset(
+            tmp_path,
+            images=False,
+            labels=False,
+            image_symlink_target=tmp_path / "deleted-images",
+        )
 
         args = self._make_args(str(tmp_path))
         with pytest.raises(ValueError, match="invalid symlink"):

--- a/tests/training/test_module_data.py
+++ b/tests/training/test_module_data.py
@@ -461,8 +461,53 @@ class TestSetup:
         dm, _, _, fake_test = self._setup_with_mock(tmp_path, "test", dataset_file="roboflow")
         assert dm._dataset_test is fake_test
 
-    def test_test_stage_non_roboflow_uses_val_split(self, tmp_path):
-        """Setup('test') falls back to 'val' split for non-roboflow datasets."""
+    def test_test_stage_yolo_uses_test_split(self, tmp_path):
+        """Setup('test') requests 'test' split when dataset_file=='yolo'."""
+        dm, _, _, fake_test = self._setup_with_mock(tmp_path, "test", dataset_file="yolo")
+        assert dm._dataset_test is fake_test
+
+    def test_test_stage_yolo_falls_back_to_val_without_test_split(self, tmp_path):
+        """Setup('test') falls back to 'val' when a YOLO dataset declares no test split."""
+        mc = _base_model_config()
+        tc = _base_train_config(tmp_path, dataset_file="yolo")
+        from rfdetr.training.module_data import RFDETRDataModule
+
+        dm = RFDETRDataModule(mc, tc)
+        fake_val = _fake_dataset(20)
+
+        def _build(image_set, args, resolution):
+            if image_set == "test":
+                raise FileNotFoundError(str(tmp_path / "test" / "images"))
+            return fake_val
+
+        with patch("rfdetr.training.module_data.build_dataset", side_effect=_build):
+            dm.setup("test")
+
+        assert dm._dataset_test is fake_val
+
+    def test_test_stage_yolo_warns_when_falling_back_to_val(self, tmp_path):
+        """The YOLO test-to-val fallback is logged at WARNING rather than applied silently."""
+        mc = _base_model_config()
+        tc = _base_train_config(tmp_path, dataset_file="yolo")
+        from rfdetr.training.module_data import RFDETRDataModule
+
+        dm = RFDETRDataModule(mc, tc)
+
+        def _build(image_set, args, resolution):
+            if image_set == "test":
+                raise FileNotFoundError(str(tmp_path / "test" / "images"))
+            return _fake_dataset(20)
+
+        with (
+            patch("rfdetr.training.module_data.build_dataset", side_effect=_build),
+            patch("rfdetr.training.module_data.logger") as mock_logger,
+        ):
+            dm.setup("test")
+
+        mock_logger.warning.assert_called_once()
+
+    def test_test_stage_coco_uses_val_split(self, tmp_path):
+        """Setup('test') falls back to 'val' for COCO, whose test2017 split is unlabelled test-dev."""
         mc = _base_model_config()
         tc = _base_train_config(tmp_path, dataset_file="coco")
         from rfdetr.training.module_data import RFDETRDataModule

--- a/tests/training/test_module_data.py
+++ b/tests/training/test_module_data.py
@@ -470,6 +470,7 @@ class TestSetup:
         """Setup('test') falls back to 'val' when a YOLO dataset declares no test split."""
         mc = _base_model_config()
         tc = _base_train_config(tmp_path, dataset_file="yolo")
+        from rfdetr.datasets.yolo import YoloSplitUnavailableError
         from rfdetr.training.module_data import RFDETRDataModule
 
         dm = RFDETRDataModule(mc, tc)
@@ -477,7 +478,7 @@ class TestSetup:
 
         def _build(image_set, args, resolution):
             if image_set == "test":
-                raise FileNotFoundError(str(tmp_path / "test" / "images"))
+                raise YoloSplitUnavailableError(str(tmp_path / "test" / "images"))
             return fake_val
 
         with patch("rfdetr.training.module_data.build_dataset", side_effect=_build):
@@ -485,8 +486,8 @@ class TestSetup:
 
         assert dm._dataset_test is fake_val
 
-    def test_test_stage_yolo_warns_when_falling_back_to_val(self, tmp_path):
-        """The YOLO test-to-val fallback is logged at WARNING rather than applied silently."""
+    def test_test_stage_yolo_propagates_broken_test_split(self, tmp_path):
+        """Setup('test') propagates builder failures after a test split is resolved."""
         mc = _base_model_config()
         tc = _base_train_config(tmp_path, dataset_file="yolo")
         from rfdetr.training.module_data import RFDETRDataModule
@@ -495,7 +496,25 @@ class TestSetup:
 
         def _build(image_set, args, resolution):
             if image_set == "test":
-                raise FileNotFoundError(str(tmp_path / "test" / "images"))
+                raise FileNotFoundError("declared test label file is broken")
+            return _fake_dataset(20)
+
+        with patch("rfdetr.training.module_data.build_dataset", side_effect=_build):
+            with pytest.raises(FileNotFoundError, match="declared test label file is broken"):
+                dm.setup("test")
+
+    def test_test_stage_yolo_warns_when_falling_back_to_val(self, tmp_path):
+        """The YOLO test-to-val fallback is logged at WARNING rather than applied silently."""
+        mc = _base_model_config()
+        tc = _base_train_config(tmp_path, dataset_file="yolo")
+        from rfdetr.datasets.yolo import YoloSplitUnavailableError
+        from rfdetr.training.module_data import RFDETRDataModule
+
+        dm = RFDETRDataModule(mc, tc)
+
+        def _build(image_set, args, resolution):
+            if image_set == "test":
+                raise YoloSplitUnavailableError(str(tmp_path / "test" / "images"))
             return _fake_dataset(20)
 
         with (
@@ -504,7 +523,10 @@ class TestSetup:
         ):
             dm.setup("test")
 
-        mock_logger.warning.assert_called_once()
+        mock_logger.warning.assert_called_once_with(
+            "No resolvable 'test' split for this YOLO dataset (%s); evaluating the 'val' split instead.",
+            str(tmp_path / "test" / "images"),
+        )
 
     def test_test_stage_coco_uses_val_split(self, tmp_path):
         """Setup('test') falls back to 'val' for COCO, whose test2017 split is unlabelled test-dev."""

--- a/tests/training/test_module_data.py
+++ b/tests/training/test_module_data.py
@@ -16,6 +16,8 @@ import torch.utils.data
 from torch.utils.data import DataLoader
 
 from rfdetr.config import RFDETRBaseConfig, TrainConfig
+from rfdetr.datasets.yolo import YoloSplitUnavailableError
+from rfdetr.training.module_data import RFDETRDataModule
 from rfdetr.utilities.tensors import NestedTensor
 
 # ---------------------------------------------------------------------------
@@ -159,8 +161,6 @@ def _build_datamodule(model_config=None, train_config=None, tmp_path=None):
     """
     mc = model_config or _base_model_config()
     tc = train_config or _base_train_config(tmp_path)
-    from rfdetr.training.module_data import RFDETRDataModule
-
     return RFDETRDataModule(mc, tc)
 
 
@@ -170,12 +170,27 @@ def _build_datamodule(model_config=None, train_config=None, tmp_path=None):
 
 
 @pytest.fixture
-def build_datamodule(tmp_path):
-    """Factory fixture — returns a constructed RFDETRDataModule.
+def datamodule(tmp_path):
+    """Return a default RFDETRDataModule for tests that only need construction."""
+    return _build_datamodule(tmp_path=tmp_path)
 
-    build_dataset is mocked automatically. tmp_path is injected automatically so test methods do not need to declare it.
-    """
-    return lambda model_config=None, train_config=None: _build_datamodule(model_config, train_config, tmp_path)
+
+@pytest.fixture
+def yolo_datamodule(tmp_path):
+    """Return an RFDETRDataModule configured for a YOLO dataset."""
+    return _build_datamodule(
+        train_config=_base_train_config(tmp_path, dataset_file="yolo"),
+        tmp_path=tmp_path,
+    )
+
+
+@pytest.fixture
+def coco_datamodule(tmp_path):
+    """Return an RFDETRDataModule configured for a COCO dataset."""
+    return _build_datamodule(
+        train_config=_base_train_config(tmp_path, dataset_file="coco"),
+        tmp_path=tmp_path,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -186,74 +201,74 @@ def build_datamodule(tmp_path):
 class TestInit:
     """RFDETRDataModule.__init__ stores configs and initialises dataset slots."""
 
-    def test_stores_model_config(self, build_datamodule, base_model_config):
+    def test_stores_model_config(self, tmp_path, base_model_config):
         """model_config is accessible as an attribute after construction."""
         mc = base_model_config(num_classes=3)
-        dm = build_datamodule(model_config=mc)
+        dm = _build_datamodule(model_config=mc, tmp_path=tmp_path)
         assert dm.model_config is mc
 
-    def test_stores_train_config(self, build_datamodule, base_train_config):
+    def test_stores_train_config(self, tmp_path, base_train_config):
         """train_config is accessible as an attribute after construction."""
         tc = base_train_config(epochs=42)
-        dm = build_datamodule(train_config=tc)
+        dm = _build_datamodule(train_config=tc, tmp_path=tmp_path)
         assert dm.train_config is tc
 
-    def test_datasets_start_as_none(self, build_datamodule):
+    def test_datasets_start_as_none(self, datamodule):
         """All three dataset slots are None before setup() is called."""
-        dm = build_datamodule()
+        dm = datamodule
         assert dm._dataset_train is None
         assert dm._dataset_val is None
         assert dm._dataset_test is None
 
-    def test_prefetch_factor_defaults_to_two_when_workers_enabled(self, build_datamodule, base_train_config):
+    def test_prefetch_factor_defaults_to_two_when_workers_enabled(self, tmp_path, base_train_config):
         """prefetch_factor defaults to 2 for worker-based DataLoaders."""
         tc = base_train_config(num_workers=2, prefetch_factor=None)
-        dm = build_datamodule(train_config=tc)
+        dm = _build_datamodule(train_config=tc, tmp_path=tmp_path)
         assert dm._prefetch_factor == 2
 
-    def test_prefetch_factor_honors_train_config(self, build_datamodule, base_train_config):
+    def test_prefetch_factor_honors_train_config(self, tmp_path, base_train_config):
         """prefetch_factor from TrainConfig is forwarded when workers are enabled."""
         tc = base_train_config(num_workers=2, prefetch_factor=5)
-        dm = build_datamodule(train_config=tc)
+        dm = _build_datamodule(train_config=tc, tmp_path=tmp_path)
         assert dm._prefetch_factor == 5
 
-    def test_prefetch_factor_none_when_workers_disabled(self, build_datamodule, base_train_config):
+    def test_prefetch_factor_none_when_workers_disabled(self, tmp_path, base_train_config):
         """prefetch_factor is None when num_workers == 0."""
         tc = base_train_config(num_workers=0, prefetch_factor=5)
-        dm = build_datamodule(train_config=tc)
+        dm = _build_datamodule(train_config=tc, tmp_path=tmp_path)
         assert dm._prefetch_factor is None
 
-    def test_pin_memory_override_is_respected(self, build_datamodule, base_train_config):
+    def test_pin_memory_override_is_respected(self, tmp_path, base_train_config):
         """pin_memory can be explicitly overridden from TrainConfig."""
         tc = base_train_config(pin_memory=False)
-        dm = build_datamodule(train_config=tc)
+        dm = _build_datamodule(train_config=tc, tmp_path=tmp_path)
         assert dm._pin_memory is False
 
     @patch("rfdetr.config.DEVICE", "cuda")
-    def test_pin_memory_defaults_to_false_when_accelerator_is_cpu(self, build_datamodule, base_train_config):
+    def test_pin_memory_defaults_to_false_when_accelerator_is_cpu(self, tmp_path, base_train_config):
         """Default pin_memory stays off when training is explicitly CPU-only."""
         tc = base_train_config(pin_memory=None, accelerator="cpu")
-        dm = build_datamodule(train_config=tc)
+        dm = _build_datamodule(train_config=tc, tmp_path=tmp_path)
         assert dm._pin_memory is False
 
-    def test_persistent_workers_override_is_respected(self, build_datamodule, base_train_config):
+    def test_persistent_workers_override_is_respected(self, tmp_path, base_train_config):
         """persistent_workers can be explicitly overridden from TrainConfig."""
         tc = base_train_config(num_workers=2, persistent_workers=False)
-        dm = build_datamodule(train_config=tc)
+        dm = _build_datamodule(train_config=tc, tmp_path=tmp_path)
         assert dm._persistent_workers is False
 
-    def test_ddp_notebook_preserves_num_workers(self, build_datamodule, base_train_config):
+    def test_ddp_notebook_preserves_num_workers(self, tmp_path, base_train_config):
         """ddp_notebook keeps num_workers as configured (spawn-based DDP children initialise CUDA fresh; DataLoader fork
         workers are CPU-only and never touch CUDA, so nested forks are safe)."""
         tc = base_train_config(num_workers=4, strategy="ddp_notebook")
-        dm = build_datamodule(train_config=tc)
+        dm = _build_datamodule(train_config=tc, tmp_path=tmp_path)
         assert dm._num_workers == 4
         assert dm._prefetch_factor == 2
 
-    def test_other_strategy_preserves_num_workers(self, build_datamodule, base_train_config):
+    def test_other_strategy_preserves_num_workers(self, tmp_path, base_train_config):
         """Non-ddp_notebook strategies also keep num_workers as configured."""
         tc = base_train_config(num_workers=4, strategy="ddp")
-        dm = build_datamodule(train_config=tc)
+        dm = _build_datamodule(train_config=tc, tmp_path=tmp_path)
         assert dm._num_workers == 4
         assert dm._prefetch_factor == 2  # default prefetch_factor for num_workers>0
 
@@ -261,7 +276,7 @@ class TestInit:
 class TestPrivateShowSamples:
     """RFDETRDataModule._show_samples renders transformed input samples."""
 
-    def test_private_show_samples_returns_figure_for_keypoint_targets(self, build_datamodule, monkeypatch):
+    def test_private_show_samples_returns_figure_for_keypoint_targets(self, datamodule, monkeypatch):
         """_show_samples should render transformed boxes and keypoints without raw COCO parsing."""
         import matplotlib
 
@@ -269,7 +284,7 @@ class TestPrivateShowSamples:
         from matplotlib import pyplot as plt
         from matplotlib.figure import Figure
 
-        dm = build_datamodule()
+        dm = datamodule
         monkeypatch.setattr(dm, "_get_dataset_for_visualization", lambda split: _VisualDataset())
 
         figure = dm._show_samples(1, split="train", columns=1)
@@ -278,14 +293,14 @@ class TestPrivateShowSamples:
         assert len(figure.axes) == 1
         plt.close(figure)
 
-    def test_private_show_samples_accepts_figure_size_and_shortens_long_titles(self, build_datamodule, monkeypatch):
+    def test_private_show_samples_accepts_figure_size_and_shortens_long_titles(self, datamodule, monkeypatch):
         """_show_samples should keep long image names inside subplot titles."""
         import matplotlib
 
         matplotlib.use("Agg", force=True)
         from matplotlib import pyplot as plt
 
-        dm = build_datamodule()
+        dm = datamodule
         monkeypatch.setattr(dm, "_get_dataset_for_visualization", lambda split: _VisualDataset())
         monkeypatch.setattr(dm, "_source_image_path", lambda dataset, idx: Path(f"{'very_long_name_' * 8}.jpg"))
 
@@ -297,21 +312,21 @@ class TestPrivateShowSamples:
         assert len(title) <= 48
         plt.close(figure)
 
-    def test_private_show_samples_rejects_non_positive_count(self, build_datamodule):
+    def test_private_show_samples_rejects_non_positive_count(self, datamodule):
         """_show_samples should fail fast for invalid counts."""
-        dm = build_datamodule()
+        dm = datamodule
 
         with pytest.raises(ValueError, match=r"count must be positive"):
             dm._show_samples(0)
 
-    def test_private_show_samples_rejects_invalid_figure_size(self, build_datamodule):
+    def test_private_show_samples_rejects_invalid_figure_size(self, datamodule):
         """_show_samples should fail fast for invalid figure sizes."""
-        dm = build_datamodule()
+        dm = datamodule
 
         with pytest.raises(ValueError, match=r"figure_size values must be positive"):
             dm._show_samples(1, figure_size=(4.0, 0.0))
 
-    def test_private_show_samples_missing_visual_extra_has_install_hint(self, build_datamodule, monkeypatch):
+    def test_private_show_samples_missing_visual_extra_has_install_hint(self, datamodule, monkeypatch):
         """_show_samples should explain how to install optional visualization dependencies."""
         real_import = builtins.__import__
 
@@ -320,14 +335,14 @@ class TestPrivateShowSamples:
                 raise ImportError("matplotlib is intentionally unavailable")
             return real_import(name, *args, **kwargs)
 
-        dm = build_datamodule()
+        dm = datamodule
         monkeypatch.setattr(dm, "_get_dataset_for_visualization", lambda split: _VisualDataset())
         monkeypatch.setattr(builtins, "__import__", fake_import)
 
         with pytest.raises(ImportError, match=r"rfdetr\[visual\]"):
             dm._show_samples(1)
 
-    def test_private_show_samples_returns_figure_for_segmentation_targets(self, build_datamodule, monkeypatch):
+    def test_private_show_samples_returns_figure_for_segmentation_targets(self, datamodule, monkeypatch):
         """_show_samples renders mask overlays when dataset targets include instance masks."""
         import matplotlib
         import numpy as np
@@ -354,7 +369,7 @@ class TestPrivateShowSamples:
                     },
                 )
 
-        dm = build_datamodule()
+        dm = datamodule
         monkeypatch.setattr(dm, "_get_dataset_for_visualization", lambda split: _SegDataset())
 
         mock_instance = MagicMock()
@@ -368,7 +383,7 @@ class TestPrivateShowSamples:
         mock_instance.annotate.assert_called_once()
         plt.close(figure)
 
-    def test_private_show_samples_detection_only_does_not_call_mask_annotator(self, build_datamodule, monkeypatch):
+    def test_private_show_samples_detection_only_does_not_call_mask_annotator(self, datamodule, monkeypatch):
         """_show_samples skips MaskAnnotator when dataset targets have no masks key."""
         from unittest.mock import patch as _patch
 
@@ -377,7 +392,7 @@ class TestPrivateShowSamples:
 
         matplotlib.use("Agg", force=True)
 
-        dm = build_datamodule()
+        dm = datamodule
         monkeypatch.setattr(dm, "_get_dataset_for_visualization", lambda split: _VisualDataset())
 
         with _patch("supervision.MaskAnnotator") as mock_mask_ann:
@@ -386,7 +401,7 @@ class TestPrivateShowSamples:
         mock_mask_ann.assert_not_called()
         plt.close(figure)
 
-    def test_private_show_samples_empty_masks_skips_mask_annotator(self, build_datamodule, monkeypatch):
+    def test_private_show_samples_empty_masks_skips_mask_annotator(self, datamodule, monkeypatch):
         """_show_samples skips MaskAnnotator when masks tensor has zero instances (0, H, W)."""
         from unittest.mock import patch as _patch
 
@@ -410,7 +425,7 @@ class TestPrivateShowSamples:
                     },
                 )
 
-        dm = build_datamodule()
+        dm = datamodule
         monkeypatch.setattr(dm, "_get_dataset_for_visualization", lambda split: _EmptyMasksDataset())
 
         with _patch("supervision.MaskAnnotator") as mock_mask_ann:
@@ -427,8 +442,6 @@ class TestSetup:
         """Helper: construct DataModule and call setup(stage) with build_dataset mocked."""
         mc = _base_model_config()
         tc = _base_train_config(tmp_path, dataset_file=dataset_file, **train_overrides)
-        from rfdetr.training.module_data import RFDETRDataModule
-
         dm = RFDETRDataModule(mc, tc)
         fake_train = _fake_dataset(100)
         fake_val = _fake_dataset(20)
@@ -466,14 +479,9 @@ class TestSetup:
         dm, _, _, fake_test = self._setup_with_mock(tmp_path, "test", dataset_file="yolo")
         assert dm._dataset_test is fake_test
 
-    def test_test_stage_yolo_falls_back_to_val_without_test_split(self, tmp_path):
+    def test_test_stage_yolo_falls_back_to_val_without_test_split(self, tmp_path, yolo_datamodule):
         """Setup('test') falls back to 'val' when a YOLO dataset declares no test split."""
-        mc = _base_model_config()
-        tc = _base_train_config(tmp_path, dataset_file="yolo")
-        from rfdetr.datasets.yolo import YoloSplitUnavailableError
-        from rfdetr.training.module_data import RFDETRDataModule
-
-        dm = RFDETRDataModule(mc, tc)
+        dm = yolo_datamodule
         fake_val = _fake_dataset(20)
 
         def _build(image_set, args, resolution):
@@ -486,13 +494,9 @@ class TestSetup:
 
         assert dm._dataset_test is fake_val
 
-    def test_test_stage_yolo_propagates_broken_test_split(self, tmp_path):
+    def test_test_stage_yolo_propagates_broken_test_split(self, yolo_datamodule):
         """Setup('test') propagates builder failures after a test split is resolved."""
-        mc = _base_model_config()
-        tc = _base_train_config(tmp_path, dataset_file="yolo")
-        from rfdetr.training.module_data import RFDETRDataModule
-
-        dm = RFDETRDataModule(mc, tc)
+        dm = yolo_datamodule
 
         def _build(image_set, args, resolution):
             if image_set == "test":
@@ -503,14 +507,9 @@ class TestSetup:
             with pytest.raises(FileNotFoundError, match="declared test label file is broken"):
                 dm.setup("test")
 
-    def test_test_stage_yolo_warns_when_falling_back_to_val(self, tmp_path):
+    def test_test_stage_yolo_warns_when_falling_back_to_val(self, tmp_path, yolo_datamodule):
         """The YOLO test-to-val fallback is logged at WARNING rather than applied silently."""
-        mc = _base_model_config()
-        tc = _base_train_config(tmp_path, dataset_file="yolo")
-        from rfdetr.datasets.yolo import YoloSplitUnavailableError
-        from rfdetr.training.module_data import RFDETRDataModule
-
-        dm = RFDETRDataModule(mc, tc)
+        dm = yolo_datamodule
 
         def _build(image_set, args, resolution):
             if image_set == "test":
@@ -528,13 +527,9 @@ class TestSetup:
             str(tmp_path / "test" / "images"),
         )
 
-    def test_test_stage_coco_uses_val_split(self, tmp_path):
+    def test_test_stage_coco_uses_val_split(self, coco_datamodule):
         """Setup('test') falls back to 'val' for COCO, whose test2017 split is unlabelled test-dev."""
-        mc = _base_model_config()
-        tc = _base_train_config(tmp_path, dataset_file="coco")
-        from rfdetr.training.module_data import RFDETRDataModule
-
-        dm = RFDETRDataModule(mc, tc)
+        dm = coco_datamodule
         requested_splits = []
 
         def _build(image_set, args, resolution):
@@ -551,8 +546,6 @@ class TestSetup:
         """Setup('fit') skips building if datasets are already populated."""
         mc = _base_model_config()
         tc = _base_train_config(tmp_path)
-        from rfdetr.training.module_data import RFDETRDataModule
-
         dm = RFDETRDataModule(mc, tc)
         existing_train = _fake_dataset(50)
         existing_val = _fake_dataset(10)
@@ -577,8 +570,6 @@ class TestSetup:
         """Setup('predict') skips building when _dataset_val is already set."""
         mc = _base_model_config()
         tc = _base_train_config(tmp_path)
-        from rfdetr.training.module_data import RFDETRDataModule
-
         dm = RFDETRDataModule(mc, tc)
         existing_val = _fake_dataset(20)
         dm._dataset_val = existing_val
@@ -599,8 +590,6 @@ class TestKeypointAugmentationWarning:
             num_keypoints_per_class=[17] if use_grouppose_keypoints else [],
         )
         tc = _base_train_config(tmp_path, augmentation_backend=augmentation_backend)
-        from rfdetr.training.module_data import RFDETRDataModule
-
         return RFDETRDataModule(mc, tc)
 
     def test_keypoint_mode_cpu_augmentation_no_warning(self, tmp_path):
@@ -653,8 +642,6 @@ class TestTrainDataloader:
             grad_accum_steps=grad_accum_steps,
             num_workers=num_workers,
         )
-        from rfdetr.training.module_data import RFDETRDataModule
-
         dm = RFDETRDataModule(mc, tc)
         dm._dataset_train = _fake_dataset(dataset_length)
         return dm
@@ -864,8 +851,6 @@ class TestValDataloader:
     def _setup_dm_with_val(self, tmp_path, dataset_length=50, batch_size=2, num_workers=0):
         mc = _base_model_config()
         tc = _base_train_config(tmp_path, batch_size=batch_size, num_workers=num_workers)
-        from rfdetr.training.module_data import RFDETRDataModule
-
         dm = RFDETRDataModule(mc, tc)
         dm._dataset_val = _fake_dataset(dataset_length)
         return dm
@@ -907,8 +892,6 @@ class TestTestDataloader:
     def _setup_dm_with_test(self, tmp_path, dataset_length=30, batch_size=2, num_workers=0):
         mc = _base_model_config()
         tc = _base_train_config(tmp_path, batch_size=batch_size, num_workers=num_workers)
-        from rfdetr.training.module_data import RFDETRDataModule
-
         dm = RFDETRDataModule(mc, tc)
         dm._dataset_test = _fake_dataset(dataset_length)
         return dm
@@ -944,8 +927,6 @@ class TestPredictDataloader:
     def _setup_dm_with_val(self, tmp_path, dataset_length=50, batch_size=2, num_workers=0):
         mc = _base_model_config()
         tc = _base_train_config(tmp_path, batch_size=batch_size, num_workers=num_workers)
-        from rfdetr.training.module_data import RFDETRDataModule
-
         dm = RFDETRDataModule(mc, tc)
         dm._dataset_val = _fake_dataset(dataset_length)
         return dm
@@ -984,17 +965,15 @@ class TestPredictDataloader:
 class TestClassNames:
     """class_names property extracts names from COCO dataset annotations."""
 
-    def test_returns_none_before_setup(self, build_datamodule):
+    def test_returns_none_before_setup(self, datamodule):
         """class_names is None when no dataset has been set up."""
-        dm = build_datamodule()
+        dm = datamodule
         assert dm.class_names is None
 
     def test_returns_names_from_train_dataset(self, tmp_path):
         """class_names reads from _dataset_train.coco.cats when available."""
         mc = _base_model_config()
         tc = _base_train_config(tmp_path)
-        from rfdetr.training.module_data import RFDETRDataModule
-
         dm = RFDETRDataModule(mc, tc)
         dm._dataset_train = _fake_dataset(50, with_coco=True)
         assert dm.class_names == ["cat", "dog"]
@@ -1003,8 +982,6 @@ class TestClassNames:
         """class_names falls back to _dataset_val when _dataset_train has no COCO."""
         mc = _base_model_config()
         tc = _base_train_config(tmp_path)
-        from rfdetr.training.module_data import RFDETRDataModule
-
         dm = RFDETRDataModule(mc, tc)
         dm._dataset_train = _fake_dataset(50, with_coco=False)
         dm._dataset_val = _fake_dataset(20, with_coco=True)
@@ -1014,8 +991,6 @@ class TestClassNames:
         """class_names returns None when no dataset has a coco attribute."""
         mc = _base_model_config()
         tc = _base_train_config(tmp_path)
-        from rfdetr.training.module_data import RFDETRDataModule
-
         dm = RFDETRDataModule(mc, tc)
         dm._dataset_train = _fake_dataset(50, with_coco=False)
         dm._dataset_val = _fake_dataset(20, with_coco=False)
@@ -1025,8 +1000,6 @@ class TestClassNames:
         """class_names are sorted by COCO category ID."""
         mc = _base_model_config()
         tc = _base_train_config(tmp_path)
-        from rfdetr.training.module_data import RFDETRDataModule
-
         dm = RFDETRDataModule(mc, tc)
         dataset = _fake_dataset(50)
         coco = MagicMock()
@@ -1040,8 +1013,6 @@ class TestClassNames:
         """class_names should preserve empty label slots so prediction class IDs map to the right names."""
         mc = _base_model_config()
         tc = _base_train_config(tmp_path)
-        from rfdetr.training.module_data import RFDETRDataModule
-
         dm = RFDETRDataModule(mc, tc)
         dataset = _fake_dataset(50)
         coco = MagicMock()
@@ -1060,8 +1031,6 @@ class TestSegmentationSupport:
         """RFDETRDataModule can be constructed with a SegmentationTrainConfig."""
         mc = base_model_config(segmentation_head=True)
         tc = seg_train_config()
-        from rfdetr.training.module_data import RFDETRDataModule
-
         dm = RFDETRDataModule(mc, tc)
         assert dm.train_config is tc
         assert dm.model_config.segmentation_head is True
@@ -1070,8 +1039,6 @@ class TestSegmentationSupport:
         """Segmentation-specific loss coefficients are present on train_config."""
         mc = base_model_config(segmentation_head=True)
         tc = seg_train_config()
-        from rfdetr.training.module_data import RFDETRDataModule
-
         dm = RFDETRDataModule(mc, tc)
         assert dm.train_config.mask_ce_loss_coef == pytest.approx(5.0)
         assert dm.train_config.mask_dice_loss_coef == pytest.approx(5.0)
@@ -1084,9 +1051,9 @@ class TestTransferBatchToDevice:
     unwrapping the NestedTensor into plain tensors.
     """
 
-    def test_samples_transferred_to_target_device(self, build_datamodule):
+    def test_samples_transferred_to_target_device(self, datamodule):
         """Both tensors and mask in NestedTensor must land on the target device."""
-        dm = build_datamodule()
+        dm = datamodule
         samples, targets = _make_batch()
         device = torch.device("cpu")
 
@@ -1095,9 +1062,9 @@ class TestTransferBatchToDevice:
         assert result_samples.tensors.device == device
         assert result_samples.mask.device == device
 
-    def test_targets_transferred_to_target_device(self, build_datamodule):
+    def test_targets_transferred_to_target_device(self, datamodule):
         """All tensor values in every target dict must be moved to the target device."""
-        dm = build_datamodule()
+        dm = datamodule
         samples, targets = _make_batch()
         device = torch.device("cpu")
 
@@ -1107,17 +1074,17 @@ class TestTransferBatchToDevice:
             for v in t.values():
                 assert v.device == device
 
-    def test_returns_tuple_of_correct_length(self, build_datamodule):
+    def test_returns_tuple_of_correct_length(self, datamodule):
         """Return value must be a (samples, targets) tuple to match batch contract."""
-        dm = build_datamodule()
+        dm = datamodule
         result = dm.transfer_batch_to_device(_make_batch(), torch.device("cpu"), dataloader_idx=0)
 
         assert isinstance(result, tuple)
         assert len(result) == 2
 
-    def test_preserves_nested_tensor_type(self, build_datamodule):
+    def test_preserves_nested_tensor_type(self, datamodule):
         """Device transfer must not unwrap NestedTensor into plain tensors."""
-        dm = build_datamodule()
+        dm = datamodule
         samples, targets = _make_batch()
 
         result_samples, _ = dm.transfer_batch_to_device((samples, targets), torch.device("cpu"), dataloader_idx=0)
@@ -1140,8 +1107,6 @@ class TestBackendResolution:
         """Construct a DataModule with the given augmentation_backend."""
         mc = _base_model_config()
         tc = _base_train_config(tmp_path, augmentation_backend=augmentation_backend)
-        from rfdetr.training.module_data import RFDETRDataModule
-
         return RFDETRDataModule(mc, tc)
 
     def _setup_with_mock_build(self, dm):
@@ -1275,8 +1240,6 @@ class TestOnAfterBatchTransfer:
         """Construct a DataModule for on_after_batch_transfer tests."""
         mc = _base_model_config(segmentation_head=segmentation_head)
         tc = _base_train_config(tmp_path)
-        from rfdetr.training.module_data import RFDETRDataModule
-
         return RFDETRDataModule(mc, tc)
 
     def _attach_mock_trainer(self, dm, training=True):
@@ -1488,8 +1451,6 @@ class TestKorniaSetupDoneSentinel:
     def _build_dm(self, tmp_path, augmentation_backend="auto"):
         mc = _base_model_config()
         tc = _base_train_config(tmp_path, augmentation_backend=augmentation_backend)
-        from rfdetr.training.module_data import RFDETRDataModule
-
         return RFDETRDataModule(mc, tc)
 
     def _setup_fit_with_mocks(self, dm):
@@ -1577,11 +1538,11 @@ class TestWorkerInitFn:
             pytest.param("predict_dataloader", id="predict"),
         ],
     )
-    def test_eval_dataloaders_set_worker_init_fn(self, build_datamodule, loader_name):
+    def test_eval_dataloaders_set_worker_init_fn(self, datamodule, loader_name):
         """Validation/test/predict DataLoaders wire the module-level worker seeding hook."""
         from rfdetr.training.module_data import _worker_init_fn
 
-        dm = build_datamodule()
+        dm = datamodule
         dm._dataset_val = _fake_dataset()
         dm._dataset_test = _fake_dataset()
 
@@ -1589,11 +1550,11 @@ class TestWorkerInitFn:
 
         assert loader.worker_init_fn is _worker_init_fn
 
-    def test_train_dataloader_sets_worker_init_fn(self, build_datamodule):
+    def test_train_dataloader_sets_worker_init_fn(self, datamodule):
         """The training DataLoader wires the module-level worker seeding hook."""
         from rfdetr.training.module_data import _worker_init_fn
 
-        dm = build_datamodule()
+        dm = datamodule
         dm._dataset_train = _fake_dataset()
 
         loader = dm.train_dataloader()

--- a/tests/training/test_module_data.py
+++ b/tests/training/test_module_data.py
@@ -170,9 +170,12 @@ def _build_datamodule(model_config=None, train_config=None, tmp_path=None):
 
 
 @pytest.fixture
-def datamodule(tmp_path):
-    """Return a default RFDETRDataModule for tests that only need construction."""
-    return _build_datamodule(tmp_path=tmp_path)
+def fixture_training_setup():
+    """Return the default model config, train config, and DataModule together."""
+    model_config = _base_model_config()
+    train_config = _base_train_config()
+    datamodule = _build_datamodule(model_config, train_config)
+    return model_config, train_config, datamodule
 
 
 @pytest.fixture
@@ -213,9 +216,9 @@ class TestInit:
         dm = _build_datamodule(train_config=tc, tmp_path=tmp_path)
         assert dm.train_config is tc
 
-    def test_datasets_start_as_none(self, datamodule):
+    def test_datasets_start_as_none(self, fixture_training_setup):
         """All three dataset slots are None before setup() is called."""
-        dm = datamodule
+        _, _, dm = fixture_training_setup
         assert dm._dataset_train is None
         assert dm._dataset_val is None
         assert dm._dataset_test is None
@@ -276,15 +279,15 @@ class TestInit:
 class TestPrivateShowSamples:
     """RFDETRDataModule._show_samples renders transformed input samples."""
 
-    def test_private_show_samples_returns_figure_for_keypoint_targets(self, datamodule, monkeypatch):
+    def test_private_show_samples_returns_figure_for_keypoint_targets(self, fixture_training_setup, monkeypatch):
         """_show_samples should render transformed boxes and keypoints without raw COCO parsing."""
+        _, _, dm = fixture_training_setup
         import matplotlib
 
         matplotlib.use("Agg", force=True)
         from matplotlib import pyplot as plt
         from matplotlib.figure import Figure
 
-        dm = datamodule
         monkeypatch.setattr(dm, "_get_dataset_for_visualization", lambda split: _VisualDataset())
 
         figure = dm._show_samples(1, split="train", columns=1)
@@ -293,14 +296,16 @@ class TestPrivateShowSamples:
         assert len(figure.axes) == 1
         plt.close(figure)
 
-    def test_private_show_samples_accepts_figure_size_and_shortens_long_titles(self, datamodule, monkeypatch):
+    def test_private_show_samples_accepts_figure_size_and_shortens_long_titles(
+        self, fixture_training_setup, monkeypatch
+    ):
         """_show_samples should keep long image names inside subplot titles."""
+        _, _, dm = fixture_training_setup
         import matplotlib
 
         matplotlib.use("Agg", force=True)
         from matplotlib import pyplot as plt
 
-        dm = datamodule
         monkeypatch.setattr(dm, "_get_dataset_for_visualization", lambda split: _VisualDataset())
         monkeypatch.setattr(dm, "_source_image_path", lambda dataset, idx: Path(f"{'very_long_name_' * 8}.jpg"))
 
@@ -312,22 +317,21 @@ class TestPrivateShowSamples:
         assert len(title) <= 48
         plt.close(figure)
 
-    def test_private_show_samples_rejects_non_positive_count(self, datamodule):
+    def test_private_show_samples_rejects_non_positive_count(self, fixture_training_setup):
         """_show_samples should fail fast for invalid counts."""
-        dm = datamodule
-
+        _, _, dm = fixture_training_setup
         with pytest.raises(ValueError, match=r"count must be positive"):
             dm._show_samples(0)
 
-    def test_private_show_samples_rejects_invalid_figure_size(self, datamodule):
+    def test_private_show_samples_rejects_invalid_figure_size(self, fixture_training_setup):
         """_show_samples should fail fast for invalid figure sizes."""
-        dm = datamodule
-
+        _, _, dm = fixture_training_setup
         with pytest.raises(ValueError, match=r"figure_size values must be positive"):
             dm._show_samples(1, figure_size=(4.0, 0.0))
 
-    def test_private_show_samples_missing_visual_extra_has_install_hint(self, datamodule, monkeypatch):
+    def test_private_show_samples_missing_visual_extra_has_install_hint(self, fixture_training_setup, monkeypatch):
         """_show_samples should explain how to install optional visualization dependencies."""
+        _, _, dm = fixture_training_setup
         real_import = builtins.__import__
 
         def fake_import(name, *args, **kwargs):
@@ -335,15 +339,15 @@ class TestPrivateShowSamples:
                 raise ImportError("matplotlib is intentionally unavailable")
             return real_import(name, *args, **kwargs)
 
-        dm = datamodule
         monkeypatch.setattr(dm, "_get_dataset_for_visualization", lambda split: _VisualDataset())
         monkeypatch.setattr(builtins, "__import__", fake_import)
 
         with pytest.raises(ImportError, match=r"rfdetr\[visual\]"):
             dm._show_samples(1)
 
-    def test_private_show_samples_returns_figure_for_segmentation_targets(self, datamodule, monkeypatch):
+    def test_private_show_samples_returns_figure_for_segmentation_targets(self, fixture_training_setup, monkeypatch):
         """_show_samples renders mask overlays when dataset targets include instance masks."""
+        _, _, dm = fixture_training_setup
         import matplotlib
         import numpy as np
 
@@ -369,7 +373,6 @@ class TestPrivateShowSamples:
                     },
                 )
 
-        dm = datamodule
         monkeypatch.setattr(dm, "_get_dataset_for_visualization", lambda split: _SegDataset())
 
         mock_instance = MagicMock()
@@ -383,8 +386,11 @@ class TestPrivateShowSamples:
         mock_instance.annotate.assert_called_once()
         plt.close(figure)
 
-    def test_private_show_samples_detection_only_does_not_call_mask_annotator(self, datamodule, monkeypatch):
+    def test_private_show_samples_detection_only_does_not_call_mask_annotator(
+        self, fixture_training_setup, monkeypatch
+    ):
         """_show_samples skips MaskAnnotator when dataset targets have no masks key."""
+        _, _, dm = fixture_training_setup
         from unittest.mock import patch as _patch
 
         import matplotlib
@@ -392,7 +398,6 @@ class TestPrivateShowSamples:
 
         matplotlib.use("Agg", force=True)
 
-        dm = datamodule
         monkeypatch.setattr(dm, "_get_dataset_for_visualization", lambda split: _VisualDataset())
 
         with _patch("supervision.MaskAnnotator") as mock_mask_ann:
@@ -401,8 +406,9 @@ class TestPrivateShowSamples:
         mock_mask_ann.assert_not_called()
         plt.close(figure)
 
-    def test_private_show_samples_empty_masks_skips_mask_annotator(self, datamodule, monkeypatch):
+    def test_private_show_samples_empty_masks_skips_mask_annotator(self, fixture_training_setup, monkeypatch):
         """_show_samples skips MaskAnnotator when masks tensor has zero instances (0, H, W)."""
+        _, _, dm = fixture_training_setup
         from unittest.mock import patch as _patch
 
         import matplotlib
@@ -425,7 +431,6 @@ class TestPrivateShowSamples:
                     },
                 )
 
-        dm = datamodule
         monkeypatch.setattr(dm, "_get_dataset_for_visualization", lambda split: _EmptyMasksDataset())
 
         with _patch("supervision.MaskAnnotator") as mock_mask_ann:
@@ -481,7 +486,6 @@ class TestSetup:
 
     def test_test_stage_yolo_falls_back_to_val_without_test_split(self, tmp_path, yolo_datamodule):
         """Setup('test') falls back to 'val' when a YOLO dataset declares no test split."""
-        dm = yolo_datamodule
         fake_val = _fake_dataset(20)
 
         def _build(image_set, args, resolution):
@@ -490,13 +494,12 @@ class TestSetup:
             return fake_val
 
         with patch("rfdetr.training.module_data.build_dataset", side_effect=_build):
-            dm.setup("test")
+            yolo_datamodule.setup("test")
 
-        assert dm._dataset_test is fake_val
+        assert yolo_datamodule._dataset_test is fake_val
 
     def test_test_stage_yolo_propagates_broken_test_split(self, yolo_datamodule):
         """Setup('test') propagates builder failures after a test split is resolved."""
-        dm = yolo_datamodule
 
         def _build(image_set, args, resolution):
             if image_set == "test":
@@ -505,11 +508,10 @@ class TestSetup:
 
         with patch("rfdetr.training.module_data.build_dataset", side_effect=_build):
             with pytest.raises(FileNotFoundError, match="declared test label file is broken"):
-                dm.setup("test")
+                yolo_datamodule.setup("test")
 
     def test_test_stage_yolo_warns_when_falling_back_to_val(self, tmp_path, yolo_datamodule):
         """The YOLO test-to-val fallback is logged at WARNING rather than applied silently."""
-        dm = yolo_datamodule
 
         def _build(image_set, args, resolution):
             if image_set == "test":
@@ -520,7 +522,7 @@ class TestSetup:
             patch("rfdetr.training.module_data.build_dataset", side_effect=_build),
             patch("rfdetr.training.module_data.logger") as mock_logger,
         ):
-            dm.setup("test")
+            yolo_datamodule.setup("test")
 
         mock_logger.warning.assert_called_once_with(
             "No resolvable 'test' split for this YOLO dataset (%s); evaluating the 'val' split instead.",
@@ -529,7 +531,6 @@ class TestSetup:
 
     def test_test_stage_coco_uses_val_split(self, coco_datamodule):
         """Setup('test') falls back to 'val' for COCO, whose test2017 split is unlabelled test-dev."""
-        dm = coco_datamodule
         requested_splits = []
 
         def _build(image_set, args, resolution):
@@ -537,7 +538,7 @@ class TestSetup:
             return _fake_dataset(10)
 
         with patch("rfdetr.training.module_data.build_dataset", side_effect=_build):
-            dm.setup("test")
+            coco_datamodule.setup("test")
 
         assert "val" in requested_splits
         assert "test" not in requested_splits
@@ -965,9 +966,9 @@ class TestPredictDataloader:
 class TestClassNames:
     """class_names property extracts names from COCO dataset annotations."""
 
-    def test_returns_none_before_setup(self, datamodule):
+    def test_returns_none_before_setup(self, fixture_training_setup):
         """class_names is None when no dataset has been set up."""
-        dm = datamodule
+        _, _, dm = fixture_training_setup
         assert dm.class_names is None
 
     def test_returns_names_from_train_dataset(self, tmp_path):
@@ -1051,9 +1052,9 @@ class TestTransferBatchToDevice:
     unwrapping the NestedTensor into plain tensors.
     """
 
-    def test_samples_transferred_to_target_device(self, datamodule):
+    def test_samples_transferred_to_target_device(self, fixture_training_setup):
         """Both tensors and mask in NestedTensor must land on the target device."""
-        dm = datamodule
+        _, _, dm = fixture_training_setup
         samples, targets = _make_batch()
         device = torch.device("cpu")
 
@@ -1062,9 +1063,9 @@ class TestTransferBatchToDevice:
         assert result_samples.tensors.device == device
         assert result_samples.mask.device == device
 
-    def test_targets_transferred_to_target_device(self, datamodule):
+    def test_targets_transferred_to_target_device(self, fixture_training_setup):
         """All tensor values in every target dict must be moved to the target device."""
-        dm = datamodule
+        _, _, dm = fixture_training_setup
         samples, targets = _make_batch()
         device = torch.device("cpu")
 
@@ -1074,17 +1075,17 @@ class TestTransferBatchToDevice:
             for v in t.values():
                 assert v.device == device
 
-    def test_returns_tuple_of_correct_length(self, datamodule):
+    def test_returns_tuple_of_correct_length(self, fixture_training_setup):
         """Return value must be a (samples, targets) tuple to match batch contract."""
-        dm = datamodule
+        _, _, dm = fixture_training_setup
         result = dm.transfer_batch_to_device(_make_batch(), torch.device("cpu"), dataloader_idx=0)
 
         assert isinstance(result, tuple)
         assert len(result) == 2
 
-    def test_preserves_nested_tensor_type(self, datamodule):
+    def test_preserves_nested_tensor_type(self, fixture_training_setup):
         """Device transfer must not unwrap NestedTensor into plain tensors."""
-        dm = datamodule
+        _, _, dm = fixture_training_setup
         samples, targets = _make_batch()
 
         result_samples, _ = dm.transfer_batch_to_device((samples, targets), torch.device("cpu"), dataloader_idx=0)
@@ -1538,11 +1539,11 @@ class TestWorkerInitFn:
             pytest.param("predict_dataloader", id="predict"),
         ],
     )
-    def test_eval_dataloaders_set_worker_init_fn(self, datamodule, loader_name):
+    def test_eval_dataloaders_set_worker_init_fn(self, fixture_training_setup, loader_name):
         """Validation/test/predict DataLoaders wire the module-level worker seeding hook."""
         from rfdetr.training.module_data import _worker_init_fn
 
-        dm = datamodule
+        _, _, dm = fixture_training_setup
         dm._dataset_val = _fake_dataset()
         dm._dataset_test = _fake_dataset()
 
@@ -1550,11 +1551,11 @@ class TestWorkerInitFn:
 
         assert loader.worker_init_fn is _worker_init_fn
 
-    def test_train_dataloader_sets_worker_init_fn(self, datamodule):
+    def test_train_dataloader_sets_worker_init_fn(self, fixture_training_setup):
         """The training DataLoader wires the module-level worker seeding hook."""
         from rfdetr.training.module_data import _worker_init_fn
 
-        dm = datamodule
+        _, _, dm = fixture_training_setup
         dm._dataset_train = _fake_dataset()
 
         loader = dm.train_dataloader()


### PR DESCRIPTION
## What does this PR do?

`setup("test")` picks the split with:

```python
split = "test" if self.train_config.dataset_file == "roboflow" else "val"
```

So for `dataset_file="yolo"`, `evaluate(split="test")` silently returns **val** metrics. The held-out test split is unreachable and nothing warns.

YOLO already supports it: `build_roboflow_from_yolo` documents `image_set` as train/val/test, and `_resolve_yolo_split_dirs` resolves `test` from `data.yaml` or the `test/images` convention. COCO genuinely can't, because `build_coco` maps `test` to unlabelled test-dev, so `coco` and `o365` keep the fallback unchanged.

A YOLO dataset that declares no test split still falls back to val, now with a warning instead of silently.

**Related Issue(s):** None, no existing report found.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

Three new tests in `tests/training/test_module_data.py`, written first and confirmed failing against the unfixed code: `yolo` requests the `test` split, falls back to `val` when no test split is declared, and logs a warning when it does. The existing coco case is renamed from `test_test_stage_non_roboflow_uses_val_split` to `test_test_stage_coco_uses_val_split`, since "non-roboflow" no longer describes the behaviour.

Full CPU suite per `ci-tests-cpu.yml` (excluding `benchmarks/`): 3667 passed, 90 skipped, 0 failures.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

Not applicable for docs: the coco/yolo asymmetry is documented in the new `_build_test_dataset` docstring.

## Additional Context

Scoped to `dataset_file="yolo"`. `roboflow` behaviour is unchanged, including letting `FileNotFoundError` propagate.


