### PR TITLE
fix(models): apply `spatial_features_proj` in `SegmentationHead`'s `skip_blocks` path

### DIFF
--- a/src/rfdetr/models/heads/segmentation.py
+++ b/src/rfdetr/models/heads/segmentation.py
@@ -264,8 +264,9 @@ class SegmentationHead(nn.Module):
                 mask_logits.append(torch.einsum("bchw,bnc->bnhw", spatial_features_proj, qf) + self.bias)
         else:
             assert len(query_features) == 1, "skip_blocks is only supported for length 1 query features"
+            spatial_features_proj = self.spatial_features_proj(spatial_features)
             qf = self.query_features_proj(self.query_features_block(query_features[0]))
-            mask_logits.append(torch.einsum("bchw,bnc->bnhw", spatial_features, qf) + self.bias)
+            mask_logits.append(torch.einsum("bchw,bnc->bnhw", spatial_features_proj, qf) + self.bias)
 
         return mask_logits
 
@@ -302,11 +303,12 @@ class SegmentationHead(nn.Module):
         else:
             assert len(query_features) == 1, "skip_blocks is only supported for length 1 query features"
 
+            spatial_features_proj = self.spatial_features_proj(spatial_features)
             qf = self.query_features_proj(self.query_features_block(query_features[0]))
 
             output_dicts.append(
                 {
-                    "spatial_features": spatial_features,
+                    "spatial_features": spatial_features_proj,
                     "query_features": qf,
                     "bias": self.bias,
                 }

--- a/tests/models/heads/test_segmentation_head.py
+++ b/tests/models/heads/test_segmentation_head.py
@@ -3,14 +3,15 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-"""Tests for DepthwiseConvBlock and _DepthwiseConvWithoutCuDNN (segmentation head)."""
+"""Tests for DepthwiseConvBlock, _DepthwiseConvWithoutCuDNN, and SegmentationHead."""
 
 from contextlib import contextmanager
 
 import pytest
 import torch
+import torch.nn.functional as F  # noqa: N812
 
-from rfdetr.models.heads.segmentation import DepthwiseConvBlock
+from rfdetr.models.heads.segmentation import DepthwiseConvBlock, SegmentationHead
 
 
 @pytest.fixture(autouse=True)
@@ -261,3 +262,89 @@ def test_depthwise_conv_block_layer_scale(layer_scale_init_value: float) -> None
     if layer_scale_init_value > 0:
         assert block.gamma is not None
         assert block.gamma.grad is not None
+
+
+class TestSegmentationHeadSkipBlocksAppliesProjection:
+    """``skip_blocks=True`` must run ``spatial_features_proj`` on the spatial features, exactly like the
+    ``skip_blocks=False`` branch and ``forward_export()`` both already do — the two-stage encoder-only mask path
+    (``skip_blocks=True``) is not a distinct architecture, just a shorter path through the same head, so it must not
+    skip a learned layer the other paths apply."""
+
+    @staticmethod
+    def _build_head() -> SegmentationHead:
+        """Build a tiny head whose spatial_features_proj is a real, non-identity layer.
+
+        bottleneck_ratio=1 (the default used by every released segmentation model) makes
+        spatial_features_proj a real, randomly-initialized Conv2d(4, 4, kernel_size=1) — not
+        nn.Identity() — so skipping it is numerically observable.
+
+        Examples:
+            >>> head = TestSegmentationHeadSkipBlocksAppliesProjection._build_head()
+            >>> isinstance(head.spatial_features_proj, torch.nn.Conv2d)
+            True
+        """
+        return SegmentationHead(in_dim=4, num_blocks=1, bottleneck_ratio=1, downsample_ratio=1)
+
+    def test_forward_skip_blocks_applies_spatial_features_proj(self) -> None:
+        """forward(skip_blocks=True) must project spatial_features before the mask einsum."""
+        head = self._build_head()
+        spatial_features = torch.randn(1, 4, 4, 4)
+        query_features = torch.randn(1, 2, 4)
+        image_size = (4, 4)
+
+        with torch.no_grad():
+            resized = F.interpolate(spatial_features, size=image_size, mode="bilinear", align_corners=False)
+            expected_proj = head.spatial_features_proj(resized)
+            expected_qf = head.query_features_proj(head.query_features_block(query_features))
+            expected = torch.einsum("bchw,bnc->bnhw", expected_proj, expected_qf) + head.bias
+
+            actual = head.forward(spatial_features, [query_features], image_size, skip_blocks=True)[0]
+
+        torch.testing.assert_close(actual, expected)
+
+    def test_sparse_forward_skip_blocks_applies_spatial_features_proj(self) -> None:
+        """sparse_forward(skip_blocks=True) must return the already-projected spatial_features in its dict output."""
+        head = self._build_head()
+        spatial_features = torch.randn(1, 4, 4, 4)
+        query_features = torch.randn(1, 2, 4)
+        image_size = (4, 4)
+
+        with torch.no_grad():
+            resized = F.interpolate(spatial_features, size=image_size, mode="bilinear", align_corners=False)
+            expected_proj = head.spatial_features_proj(resized)
+
+            actual = head.sparse_forward(spatial_features, [query_features], image_size, skip_blocks=True)[0]
+
+        torch.testing.assert_close(actual["spatial_features"], expected_proj)
+
+
+class TestSegmentationHeadSkipBlocksFalseUnaffected:
+    """Regression guard for the ``skip_blocks=False`` branch, untouched by this fix.
+
+    ``SegmentationHead`` had no test coverage at all before this PR (neither branch), so this class
+    covers the branch this fix does not modify, alongside ``TestSegmentationHeadSkipBlocksAppliesProjection``
+    for the branch it does.
+    """
+
+    def test_forward_skip_blocks_false_applies_spatial_features_proj(self) -> None:
+        """forward(skip_blocks=False) already projects spatial_features per decoder layer."""
+        head = SegmentationHead(in_dim=4, num_blocks=2, bottleneck_ratio=1, downsample_ratio=1)
+        spatial_features = torch.randn(1, 4, 4, 4)
+        query_features = [torch.randn(1, 2, 4), torch.randn(1, 2, 4)]
+        image_size = (4, 4)
+
+        with torch.no_grad():
+            resized = F.interpolate(spatial_features, size=image_size, mode="bilinear", align_corners=False)
+            expected_logits = []
+            block_input = resized
+            for block, qf in zip(head.blocks, query_features):
+                block_input = block(block_input)
+                sf_proj = head.spatial_features_proj(block_input)
+                qf_proj = head.query_features_proj(head.query_features_block(qf))
+                expected_logits.append(torch.einsum("bchw,bnc->bnhw", sf_proj, qf_proj) + head.bias)
+
+            actual_logits = head.forward(spatial_features, query_features, image_size, skip_blocks=False)
+
+        assert len(actual_logits) == len(expected_logits)
+        for actual, expected in zip(actual_logits, expected_logits):
+            torch.testing.assert_close(actual, expected)

--- a/tests/models/heads/test_segmentation_head.py
+++ b/tests/models/heads/test_segmentation_head.py
@@ -271,19 +271,19 @@ class TestSegmentationHeadSkipBlocksAppliesProjection:
     skip a learned layer the other paths apply."""
 
     @staticmethod
-    def _build_head() -> SegmentationHead:
+    def _build_head(bottleneck_ratio: int = 1) -> SegmentationHead:
         """Build a tiny head whose spatial_features_proj is a real, non-identity layer.
 
-        bottleneck_ratio=1 (the default used by every released segmentation model) makes
-        spatial_features_proj a real, randomly-initialized Conv2d(4, 4, kernel_size=1) — not
-        nn.Identity() — so skipping it is numerically observable.
+        A non-``None`` bottleneck ratio makes ``spatial_features_proj`` a real, randomly initialized convolution rather
+        than ``nn.Identity()``, so skipping it is numerically observable. Ratios greater than one also verify the
+        channel-reducing contract shared by the spatial and query projections.
 
         Examples:
             >>> head = TestSegmentationHeadSkipBlocksAppliesProjection._build_head()
             >>> isinstance(head.spatial_features_proj, torch.nn.Conv2d)
             True
         """
-        return SegmentationHead(in_dim=4, num_blocks=1, bottleneck_ratio=1, downsample_ratio=1)
+        return SegmentationHead(in_dim=4, num_blocks=1, bottleneck_ratio=bottleneck_ratio, downsample_ratio=1)
 
     def test_forward_skip_blocks_applies_spatial_features_proj(self) -> None:
         """forward(skip_blocks=True) must project spatial_features before the mask einsum."""
@@ -316,6 +316,25 @@ class TestSegmentationHeadSkipBlocksAppliesProjection:
             actual = head.sparse_forward(spatial_features, [query_features], image_size, skip_blocks=True)[0]
 
         torch.testing.assert_close(actual["spatial_features"], expected_proj)
+
+    @pytest.mark.parametrize(
+        "bottleneck_ratio",
+        [pytest.param(1, id="same_channels"), pytest.param(2, id="projected_channels")],
+    )
+    def test_forward_export_skip_blocks_matches_training_path(self, bottleneck_ratio: int) -> None:
+        """Exported encoder-only masks must apply the same spatial projection as the training path."""
+        head = self._build_head(bottleneck_ratio)
+        spatial_features = torch.randn(1, 4, 4, 4)
+        query_features = [torch.randn(1, 2, 4)]
+        image_size = (4, 4)
+
+        with torch.no_grad():
+            expected = head.forward(spatial_features, query_features, image_size, skip_blocks=True)[0]
+            head.export()
+            actual = head.forward(spatial_features, query_features, image_size, skip_blocks=True)[0]
+
+        assert actual.shape == (1, 2, 4, 4)
+        torch.testing.assert_close(actual, expected)
 
 
 class TestSegmentationHeadSkipBlocksFalseUnaffected:

--- a/tests/models/test_criterion.py
+++ b/tests/models/test_criterion.py
@@ -5,10 +5,17 @@
 # ------------------------------------------------------------------------
 """Unit tests for SetCriterion edge paths: _output_device and num_boxes_for_targets."""
 
+from unittest.mock import MagicMock
+
 import pytest
 import torch
+from torch import Tensor
 
 from rfdetr.models.criterion import SetCriterion
+from rfdetr.models.heads.segmentation import SegmentationHead
+from rfdetr.models.lwdetr import LWDETR
+from rfdetr.models.matcher import HungarianMatcher
+from rfdetr.utilities.tensors import NestedTensor
 
 
 class _MatcherStub:
@@ -137,3 +144,136 @@ class TestLossMasksEmptyMatch:
         assert spatial_features.grad is not None
         assert query_features.grad is not None
         assert bias.grad is not None
+
+
+class TestLossMasksNonEmptyMatchUsesRealSegmentationHeadOutput:
+    """The non-empty-match branch of the dict path (``criterion.py``'s einsum over
+    ``outputs["pred_masks"]["spatial_features"]``) reads that key straight off the dict with no projection of its own —
+    it trusts whatever produced it.
+
+    ``SegmentationHead``-only tests can't catch a regression here, since they never call ``loss_masks``. This builds the
+    dict with a real ``SegmentationHead`` (``sparse_forward(skip_blocks=True)``, non-identity ``spatial_features_proj``)
+    instead of hand-built tensors, and checks the loss is sensitive to whether the projection was applied and that
+    gradient reaches ``spatial_features_proj.weight``.
+    """
+
+    def test_loss_backprops_to_projection_weight_and_is_sensitive_to_it(self) -> None:
+        torch.manual_seed(0)
+        hidden, mask_size = 4, 8
+        head = SegmentationHead(in_dim=hidden, num_blocks=1, bottleneck_ratio=1, downsample_ratio=1)
+        spatial_features = torch.randn(1, hidden, mask_size, mask_size)
+        query_features = torch.randn(1, 2, hidden)
+        targets = [{"masks": torch.rand(2, mask_size, mask_size)}]
+        indices = [(torch.tensor([0, 1]), torch.tensor([0, 1]))]
+        criterion = _bare_criterion()
+        criterion.mask_point_sample_ratio = 16
+
+        # Real head output: spatial_features is already projected by sparse_forward.
+        real_dict = head.sparse_forward(spatial_features, [query_features], (mask_size, mask_size), skip_blocks=True)[0]
+        torch.manual_seed(1)  # get_uncertain_point_coords_with_randomness draws torch.rand internally.
+        real_losses = criterion.loss_masks({"pred_masks": real_dict}, targets, indices, num_boxes=torch.tensor(2.0))
+        (real_losses["loss_mask_ce"] + real_losses["loss_mask_dice"]).backward()
+        assert head.spatial_features_proj.weight.grad is not None
+        assert torch.isfinite(head.spatial_features_proj.weight.grad).all()
+
+        # Corrupted dict: same query_features/bias, but spatial_features is the RAW, unprojected
+        # tensor — exactly what the pre-fix skip_blocks=True branch used to hand loss_masks.
+        with torch.no_grad():
+            raw_resized = torch.nn.functional.interpolate(
+                spatial_features, size=(mask_size, mask_size), mode="bilinear", align_corners=False
+            )
+        corrupted_dict = {
+            "spatial_features": raw_resized,
+            "query_features": real_dict["query_features"].detach(),
+            "bias": real_dict["bias"].detach(),
+        }
+        torch.manual_seed(1)  # same point-sampling draw as the real-dict call above, for a fair comparison.
+        corrupted_losses = criterion.loss_masks(
+            {"pred_masks": corrupted_dict}, targets, indices, num_boxes=torch.tensor(2.0)
+        )
+
+        assert not torch.allclose(real_losses["loss_mask_ce"], corrupted_losses["loss_mask_ce"])
+        assert not torch.allclose(real_losses["loss_mask_dice"], corrupted_losses["loss_mask_dice"])
+
+
+def _build_encoder_only_features(batch_size: int, hidden_dim: int, size: int) -> list[NestedTensor]:
+    """Build the single-level backbone feature map an ``LWDETR`` forward pass consumes.
+
+    Examples:
+        >>> len(_build_encoder_only_features(batch_size=1, hidden_dim=4, size=4))
+        1
+    """
+    return [
+        NestedTensor(
+            torch.randn(batch_size, hidden_dim, size, size),
+            torch.zeros(batch_size, size, size, dtype=torch.bool),
+        )
+    ]
+
+
+class TestEncOutputsMaskLossThroughRealForwardPath:
+    """No prior test drove a real ``SegmentationHead`` through the actual production path: ``LWDETR.forward()`` building
+    ``enc_outputs["pred_masks"]`` with ``skip_blocks=True``, then ``SetCriterion.forward()``'s ``"enc_outputs"`` branch
+    (``lwdetr.py``'s two-stage block, ``criterion.py``'s ``_enc``-suffixed losses).
+
+    The other tests in this module and in ``test_matcher.py`` call ``SegmentationHead.sparse_forward()``,
+    ``loss_masks()``, and ``HungarianMatcher.__call__()`` directly instead — real coverage of each unit, but none of
+    them exercise the forward/criterion wiring that actually reaches ``enc_outputs`` in training, where ``two_stage``
+    and ``aux_loss`` both default to ``True`` for every released ``RFDETRSeg*`` model.
+    """
+
+    def test_loss_mask_ce_enc_backprops_to_projection_weight(self) -> None:
+        torch.manual_seed(0)
+        batch_size, hidden_dim, num_queries, num_queries_enc, num_classes, mask_size = 1, 4, 2, 3, 3, 8
+
+        backbone = MagicMock()
+        backbone.return_value = (_build_encoder_only_features(batch_size, hidden_dim, size=4), [torch.zeros(1)], None)
+
+        transformer = MagicMock()
+        transformer.d_model = hidden_dim
+        transformer.return_value = (
+            torch.randn(1, batch_size, num_queries, hidden_dim),  # hs (1 decoder layer)
+            torch.rand(1, batch_size, num_queries, 4) * 0.4 + 0.3,  # ref_unsigmoid
+            torch.randn(batch_size, num_queries_enc, hidden_dim),  # hs_enc
+            torch.rand(batch_size, num_queries_enc, 4) * 0.4 + 0.3,  # ref_enc
+        )
+
+        model = LWDETR(
+            backbone=backbone,
+            transformer=transformer,
+            segmentation_head=SegmentationHead(in_dim=hidden_dim, num_blocks=1, bottleneck_ratio=1, downsample_ratio=1),
+            num_classes=num_classes,
+            num_queries=num_queries,
+            aux_loss=False,
+            group_detr=1,
+            two_stage=True,
+            bbox_reparam=False,
+        )
+
+        outputs = model(torch.randn(batch_size, 3, mask_size, mask_size))
+        assert isinstance(outputs["enc_outputs"]["pred_masks"], dict)
+
+        criterion = SetCriterion(
+            num_classes=num_classes,
+            matcher=HungarianMatcher(),
+            weight_dict={},
+            focal_alpha=0.25,
+            losses=["masks"],
+            group_detr=1,
+            mask_point_sample_ratio=16,
+        )
+        targets: list[dict[str, Tensor]] = [
+            {
+                "labels": torch.tensor([0]),
+                "boxes": torch.rand(1, 4) * 0.4 + 0.3,
+                "masks": torch.rand(1, mask_size, mask_size),
+            }
+        ]
+
+        losses = criterion(outputs, targets)
+
+        assert "loss_mask_ce_enc" in losses
+        (losses["loss_mask_ce_enc"] + losses["loss_mask_dice_enc"]).backward()
+        proj_grad = model.segmentation_head.spatial_features_proj.weight.grad
+        assert proj_grad is not None
+        assert torch.isfinite(proj_grad).all()

--- a/tests/models/test_matcher.py
+++ b/tests/models/test_matcher.py
@@ -11,6 +11,7 @@ import pytest
 import torch
 
 from rfdetr.models import matcher as matcher_module
+from rfdetr.models.heads.segmentation import SegmentationHead
 from rfdetr.models.matcher import HungarianMatcher
 
 
@@ -1745,3 +1746,75 @@ class TestCompactPathCriterionEquivalence:
         for layer, (compact_grad_logits, compact_grad_boxes) in zip(all_layer_outputs, compact_grads):
             assert torch.equal(compact_grad_logits, layer["pred_logits"].grad)
             assert torch.equal(compact_grad_boxes, layer["pred_boxes"].grad)
+
+
+def _spy_on_assign(monkeypatch: pytest.MonkeyPatch) -> list[torch.Tensor]:
+    """Wrap the static ``_assign_compact_cost_matrix`` to record each cost matrix it receives, without changing its
+    behavior — lets a test compare the matrix's numeric content between two ``forward()`` calls.
+
+    Examples:
+        >>> _spy_on_assign(pytest.MonkeyPatch())  # doctest: +SKIP
+
+        # Needs a live pytest.MonkeyPatch fixture torn down by a running test, not standalone.
+    """
+    captured: list[torch.Tensor] = []
+    original = HungarianMatcher._assign_compact_cost_matrix
+
+    def spy(cost_matrix: torch.Tensor, sizes: list[int], group_detr: int) -> list[tuple[torch.Tensor, torch.Tensor]]:
+        captured.append(cost_matrix.clone())
+        return original(cost_matrix, sizes, group_detr)
+
+    monkeypatch.setattr(HungarianMatcher, "_assign_compact_cost_matrix", staticmethod(spy))
+    return captured
+
+
+class TestMatcherDictMaskCostUsesProjectedFeatures:
+    """The dict form of ``pred_masks`` (the ``else`` branch around matcher.py:409) point-samples
+    ``outputs["pred_masks"]["spatial_features"]`` straight off the dict for the mask cost — it applies no projection of
+    its own, trusting whatever produced the dict.
+
+    Only ``SegmentationHead``-level tests existed before this; none ran a real head's dict output through the matcher.
+    This builds the dict with a real ``SegmentationHead`` (``sparse_forward(skip_blocks=True)``, non-identity
+    ``spatial_features_proj``) and checks the resulting cost matrix is sensitive to whether that projection was applied.
+    """
+
+    def test_cost_matrix_differs_between_projected_and_raw_spatial_features(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        torch.manual_seed(10)
+        hidden, mask_size, num_queries = 4, 8, 4
+        head = SegmentationHead(in_dim=hidden, num_blocks=1, bottleneck_ratio=1, downsample_ratio=1)
+        sizes = [1, 2]
+        outputs, targets = _random_detection_batch(seed=11, sizes=sizes, num_queries=num_queries)
+        bs = len(targets)
+        spatial_features = torch.randn(bs, hidden, mask_size, mask_size)
+        query_features = torch.randn(bs, num_queries, hidden)
+        for target, size in zip(targets, sizes):
+            target["masks"] = torch.rand(size, mask_size, mask_size)
+
+        real_dict = head.sparse_forward(spatial_features, [query_features], (mask_size, mask_size), skip_blocks=True)[0]
+        matcher = HungarianMatcher()
+        captured = _spy_on_assign(monkeypatch)
+
+        outputs["pred_masks"] = real_dict
+        torch.manual_seed(20)  # controls the mask point_coords draw, shared across both calls below
+        matcher(outputs, targets)
+        real_cost = captured[-1]
+
+        with torch.no_grad():
+            # Raw, unprojected spatial_features at the same resolution sparse_forward interpolates to —
+            # exactly what the pre-fix skip_blocks=True branch used to hand the matcher.
+            raw_resized = torch.nn.functional.interpolate(
+                spatial_features, size=(mask_size, mask_size), mode="bilinear", align_corners=False
+            )
+        corrupted_dict = {
+            "spatial_features": raw_resized,
+            "query_features": real_dict["query_features"].detach(),
+            "bias": real_dict["bias"].detach(),
+        }
+        outputs["pred_masks"] = corrupted_dict
+        torch.manual_seed(20)  # same point_coords draw as the real-dict call above, for a fair comparison
+        matcher(outputs, targets)
+        corrupted_cost = captured[-1]
+
+        assert not torch.allclose(real_cost, corrupted_cost)


### PR DESCRIPTION
`SegmentationHead` builds each instance mask by combining `spatial_features` `(B, C, H, W)` with that instance's `query_features` `(B, N, C)` through an einsum. Before that combination, `spatial_features` is meant to go through `self.spatial_features_proj`, a real trained `Conv2d` (not identity, with the default `bottleneck_ratio=1`).

`forward()` and `sparse_forward()` both have a `skip_blocks=False` and a `skip_blocks=True` branch. The `False` branch applies the projection. The `True` branch, used for the two-stage encoder-only mask output (`enc_outputs["pred_masks"]`), was using raw `spatial_features` instead — no projection at all. `forward_export()` (the export path) already got this right, so only training/eval through native `forward()`/`sparse_forward()` had the bug.

This matters because `two_stage=True` is `ModelConfig`'s default and no `RFDETRSeg*` variant changes it, so every released segmentation model hits this branch. The auxiliary loss (`loss_mask_ce_enc`/`loss_mask_dice_enc`) only gets built when both `args.aux_loss` and `args.two_stage` are set (`lwdetr.py:864-869`). But `aux_loss=True` is also the default and no `RFDETRSeg*` overrides it either, so in practice every released seg model trains it, with the exact same weight as the main mask loss. So the gradient really trains against a prediction computed from un-projected features.

I checked this against `RFDETRSegNano` with its real pretrained weights, not synthetic ones: comparing the buggy output against the correct one (applying the projection by hand) on the same test input gives a mean difference of 53.5, max 330.6, on an output range with std≈27 (correct) vs std≈71 (buggy). After the fix, it matches the correct reference exactly (diff=0.0).

`SegmentationHead` had zero tests before this PR — `grep -rln "SegmentationHead" tests/` returns nothing, so nothing could have caught this. And the two other places that read this same dict (`HungarianMatcher`'s mask cost, `SetCriterion.loss_masks`) had no test that ran a real head's output through them either — I closed that gap too, see the third commit below.

**Changes**

- `segmentation.py`: adds `spatial_features_proj = self.spatial_features_proj(spatial_features)` before the mask einsum in both `skip_blocks=True` branches (`forward()` and `sparse_forward()`).
- `test_segmentation_head.py`: `TestSegmentationHeadSkipBlocksAppliesProjection`, one test per method, each builds the correct reference by hand (interpolate → project → einsum) and compares it against the real output. I confirmed both fail against the code without the fix (100% mismatched elements) before turning green with it.
- Second commit: since the file had no coverage at all, I also added `TestSegmentationHeadSkipBlocksFalseUnaffected` as a regression guard for the branch this fix does not touch, and a doctest on the `_build_head` test helper (`AGENTS.md` requires one on any non-`test_*` helper other tests call).
- Third commit: `SegmentationHead`-only tests can't catch a regression in how the matcher or criterion consume the dict — neither ever called them. Added `test_criterion.py::TestLossMasksNonEmptyMatchUsesRealSegmentationHeadOutput`, which runs a real `SegmentationHead.sparse_forward(skip_blocks=True)` output through `loss_masks` and checks gradient reaches `spatial_features_proj.weight`. And `test_matcher.py::TestMatcherDictMaskCostUsesProjectedFeatures`, which does the same through `HungarianMatcher` and checks the cost matrix is sensitive to whether the projection was applied. Both fail against the pre-fix branch for the expected reason (no gradient / identical cost between "real" and "corrupted" dicts, since pre-fix the real dict already was the corrupted one).
- Fourth commit: the three tests above call `sparse_forward`/`loss_masks`/`HungarianMatcher` directly, not the actual production wiring. Added `test_criterion.py::TestEncOutputsMaskLossThroughRealForwardPath`, which builds a real `LWDETR` (`two_stage=True`, mocked backbone/transformer) and runs its actual `forward()` to `enc_outputs["pred_masks"]`, then `SetCriterion.forward()`'s real `_enc`-suffixed branch — checks gradient reaches `spatial_features_proj.weight` through that full path. Fails against the pre-fix branch for the same reason.

**Validation**

- `test_segmentation_head.py` + `test_criterion.py` + `test_matcher.py` together: 127 passed, 3 skipped (GPU-only).
- Suites that consume the head's output (`test_criterion_keypoints.py`, `test_builders.py`, `test_builder_characterization.py`): 72 passed.
- `test_evaluate.py`, minus the one test that trains a real model end-to-end (already environment-heavy on this shared machine in earlier sessions, unrelated to this diff): 26 passed.
- `pre-commit run --all-files`: all 19 hooks clean, `mypy --strict` included.
- Patch applies cleanly on `develop`.

But we need to be honest about one thing instead of hiding it: this changes real training behaviour, not just a number in a log. Any `RFDETRSeg*` retrained from scratch with this fix will converge somewhat differently, since the encoder's auxiliary mask loss now trains against the correct feature space instead of a broken one. Doesn't affect already-exported models or the main decoder-based mask head, which never had the bug .. the scope is specifically the two-stage `enc_outputs["pred_masks"]` signal.
