### PR TITLE
lint(pre-commit): add no-wrap option to mdformat args

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -105,8 +105,7 @@ rf-detr/
 
 - **`mkdocs.yaml`** - Documentation site configuration
 
-> [!TIP]
-> When contributing, focus on the relevant directory for your change:
+> [!TIP] When contributing, focus on the relevant directory for your change:
 >
 > - Bug fixes/features → `src/rfdetr/` and `tests/`
 > - Documentation → `docs/`
@@ -274,8 +273,7 @@ Tests marked with `@pytest.mark.gpu` are excluded from CPU CI workflows and run 
 
 ### CI Testing
 
-> [!NOTE]
-> **CI Workflows (Source of Truth):** See `.github/workflows/ci-tests-cpu.yml` and `.github/workflows/ci-tests-gpu.yml` for exact commands.
+> [!NOTE] **CI Workflows (Source of Truth):** See `.github/workflows/ci-tests-cpu.yml` and `.github/workflows/ci-tests-gpu.yml` for exact commands.
 
 Our continuous integration tests run on:
 
@@ -316,8 +314,7 @@ uv run --no-sync pytest tests/models/test_model.py::test_model_loading
 
 All code must pass linting and formatting checks before being merged. We use **pre-commit hooks** to automate this process.
 
-> [!TIP]
-> Pre-commit hooks will auto-format many issues. If pre-commit fails, review the changes it made and re-stage the files.
+> [!TIP] Pre-commit hooks will auto-format many issues. If pre-commit fails, review the changes it made and re-stage the files.
 
 ### Setting Up Pre-commit
 
@@ -364,8 +361,7 @@ def old_fn(*args, **kwargs): ...
 
 RF-DETR's documentation is built with [MkDocs](https://www.mkdocs.org/) and the [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) theme. API reference pages are auto-generated from docstrings using [mkdocstrings](https://mkdocstrings.github.io/).
 
-> [!NOTE]
-> Building the full documentation locally requires the `plus` extra (`rfdetr[plus]`), which provides the XLarge and 2XLarge model pages. Without it, the build will fail on those reference pages.
+> [!NOTE] Building the full documentation locally requires the `plus` extra (`rfdetr[plus]`), which provides the XLarge and 2XLarge model pages. Without it, the build will fail on those reference pages.
 
 ### Install Documentation Dependencies
 
@@ -409,8 +405,7 @@ docs/
 mkdocs.yaml               # MkDocs configuration and navigation
 ```
 
-> [!TIP]
-> When adding a new documentation page, add it to the `nav` section in `mkdocs.yaml` so it appears in the site navigation. Pages that exist in `docs/` but are not listed in `nav` will not be included in the site.
+> [!TIP] When adding a new documentation page, add it to the `nav` section in `mkdocs.yaml` so it appears in the site navigation. Pages that exist in `docs/` but are not listed in `nav` will not be included in the site.
 
 ## CLA Signing
 
@@ -426,8 +421,7 @@ This step is essential before any merge can occur.
 
 For clarity and maintainability, any new functions or classes must include [Google-style docstrings](https://google.github.io/styleguide/pyguide.html) and use Python type hints. Type hints are mandatory in all function definitions, ensuring explicit parameter and return type declarations.
 
-> [!IMPORTANT]
-> Type hints are in the function signature. **Do not duplicate types in docstrings** - describe the parameter's purpose instead.
+> [!IMPORTANT] Type hints are in the function signature. **Do not duplicate types in docstrings** - describe the parameter's purpose instead.
 
 For example:
 
@@ -452,8 +446,7 @@ def sample_function(param1: int, param2: int = 10) -> bool:
 
 Following this pattern helps ensure consistency throughout the codebase.
 
-> [!IMPORTANT]
-> This applies to helper functions inside `tests/` too, not just `src/`. Any non-`test_*` function used as a test fixture/builder (e.g. `_make_checkpoint`, `_random_xyxy_boxes`) needs a docstring with an `Examples` doctest that exercises it directly — a small, fast check that the helper still does what its callers assume. `pyproject.toml`'s `--doctest-plus` runs doctests across `tests/` for exactly this reason (see the comment above `[tool.pytest.ini_options]`). Skip the live doctest (`# doctest: +SKIP` with a one-line reason) only when the helper cannot run standalone — e.g. it is a `@pytest.fixture` (pytest now hard-fails on direct fixture calls) or needs real GPU/XLA/network hardware.
+> [!IMPORTANT] This applies to helper functions inside `tests/` too, not just `src/`. Any non-`test_*` function used as a test fixture/builder (e.g. `_make_checkpoint`, `_random_xyxy_boxes`) needs a docstring with an `Examples` doctest that exercises it directly — a small, fast check that the helper still does what its callers assume. `pyproject.toml`'s `--doctest-plus` runs doctests across `tests/` for exactly this reason (see the comment above `[tool.pytest.ini_options]`). Skip the live doctest (`# doctest: +SKIP` with a one-line reason) only when the helper cannot run standalone — e.g. it is a `@pytest.fixture` (pytest now hard-fails on direct fixture calls) or needs real GPU/XLA/network hardware.
 
 ## Reporting Bugs
 
@@ -461,8 +454,7 @@ Bug reports are vital for continued improvement. When reporting an issue, please
 
 ## Adding a New Model
 
-> [!IMPORTANT]
-> Before implementing a new model, **discuss with maintainers first**. Project structure and patterns are subject to change.
+> [!IMPORTANT] Before implementing a new model, **discuss with maintainers first**. Project structure and patterns are subject to change.
 
 **General workflow:**
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -105,7 +105,9 @@ rf-detr/
 
 - **`mkdocs.yaml`** - Documentation site configuration
 
-> [!TIP] When contributing, focus on the relevant directory for your change:
+> [!TIP]
+>
+> When contributing, focus on the relevant directory for your change:
 >
 > - Bug fixes/features → `src/rfdetr/` and `tests/`
 > - Documentation → `docs/`
@@ -273,7 +275,9 @@ Tests marked with `@pytest.mark.gpu` are excluded from CPU CI workflows and run 
 
 ### CI Testing
 
-> [!NOTE] **CI Workflows (Source of Truth):** See `.github/workflows/ci-tests-cpu.yml` and `.github/workflows/ci-tests-gpu.yml` for exact commands.
+> [!NOTE]
+>
+> **CI Workflows (Source of Truth):** See `.github/workflows/ci-tests-cpu.yml` and `.github/workflows/ci-tests-gpu.yml` for exact commands.
 
 Our continuous integration tests run on:
 
@@ -314,7 +318,9 @@ uv run --no-sync pytest tests/models/test_model.py::test_model_loading
 
 All code must pass linting and formatting checks before being merged. We use **pre-commit hooks** to automate this process.
 
-> [!TIP] Pre-commit hooks will auto-format many issues. If pre-commit fails, review the changes it made and re-stage the files.
+> [!TIP]
+>
+> Pre-commit hooks will auto-format many issues. If pre-commit fails, review the changes it made and re-stage the files.
 
 ### Setting Up Pre-commit
 
@@ -361,7 +367,9 @@ def old_fn(*args, **kwargs): ...
 
 RF-DETR's documentation is built with [MkDocs](https://www.mkdocs.org/) and the [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) theme. API reference pages are auto-generated from docstrings using [mkdocstrings](https://mkdocstrings.github.io/).
 
-> [!NOTE] Building the full documentation locally requires the `plus` extra (`rfdetr[plus]`), which provides the XLarge and 2XLarge model pages. Without it, the build will fail on those reference pages.
+> [!NOTE]
+>
+> Building the full documentation locally requires the `plus` extra (`rfdetr[plus]`), which provides the XLarge and 2XLarge model pages. Without it, the build will fail on those reference pages.
 
 ### Install Documentation Dependencies
 
@@ -405,7 +413,9 @@ docs/
 mkdocs.yaml               # MkDocs configuration and navigation
 ```
 
-> [!TIP] When adding a new documentation page, add it to the `nav` section in `mkdocs.yaml` so it appears in the site navigation. Pages that exist in `docs/` but are not listed in `nav` will not be included in the site.
+> [!TIP]
+>
+> When adding a new documentation page, add it to the `nav` section in `mkdocs.yaml` so it appears in the site navigation. Pages that exist in `docs/` but are not listed in `nav` will not be included in the site.
 
 ## CLA Signing
 
@@ -421,7 +431,9 @@ This step is essential before any merge can occur.
 
 For clarity and maintainability, any new functions or classes must include [Google-style docstrings](https://google.github.io/styleguide/pyguide.html) and use Python type hints. Type hints are mandatory in all function definitions, ensuring explicit parameter and return type declarations.
 
-> [!IMPORTANT] Type hints are in the function signature. **Do not duplicate types in docstrings** - describe the parameter's purpose instead.
+> [!IMPORTANT]
+>
+> Type hints are in the function signature. **Do not duplicate types in docstrings** - describe the parameter's purpose instead.
 
 For example:
 
@@ -446,7 +458,9 @@ def sample_function(param1: int, param2: int = 10) -> bool:
 
 Following this pattern helps ensure consistency throughout the codebase.
 
-> [!IMPORTANT] This applies to helper functions inside `tests/` too, not just `src/`. Any non-`test_*` function used as a test fixture/builder (e.g. `_make_checkpoint`, `_random_xyxy_boxes`) needs a docstring with an `Examples` doctest that exercises it directly — a small, fast check that the helper still does what its callers assume. `pyproject.toml`'s `--doctest-plus` runs doctests across `tests/` for exactly this reason (see the comment above `[tool.pytest.ini_options]`). Skip the live doctest (`# doctest: +SKIP` with a one-line reason) only when the helper cannot run standalone — e.g. it is a `@pytest.fixture` (pytest now hard-fails on direct fixture calls) or needs real GPU/XLA/network hardware.
+> [!IMPORTANT]
+>
+> This applies to helper functions inside `tests/` too, not just `src/`. Any non-`test_*` function used as a test fixture/builder (e.g. `_make_checkpoint`, `_random_xyxy_boxes`) needs a docstring with an `Examples` doctest that exercises it directly — a small, fast check that the helper still does what its callers assume. `pyproject.toml`'s `--doctest-plus` runs doctests across `tests/` for exactly this reason (see the comment above `[tool.pytest.ini_options]`). Skip the live doctest (`# doctest: +SKIP` with a one-line reason) only when the helper cannot run standalone — e.g. it is a `@pytest.fixture` (pytest now hard-fails on direct fixture calls) or needs real GPU/XLA/network hardware.
 
 ## Reporting Bugs
 
@@ -454,7 +468,9 @@ Bug reports are vital for continued improvement. When reporting an issue, please
 
 ## Adding a New Model
 
-> [!IMPORTANT] Before implementing a new model, **discuss with maintainers first**. Project structure and patterns are subject to change.
+> [!IMPORTANT]
+>
+> Before implementing a new model, **discuss with maintainers first**. Project structure and patterns are subject to change.
 
 **General workflow:**
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,9 @@
 
 RF-DETR is a real-time transformer architecture for object detection and instance segmentation. Built on DINOv2 vision transformer backbone with PyTorch.
 
-**Project Type:** Python ML library (computer vision) **Python:** >=3.10 (3.10, 3.11, 3.12, 3.13) **License:** Apache 2.0 (Plus models under PML 1.0)
+- **Project Type:** Python ML library (computer vision)
+- **Python:** >=3.10 (3.10, 3.11, 3.12, 3.13)
+- **License:** Apache 2.0 (Plus models under PML 1.0)
 
 > [!TIP]
 >

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,15 +1,12 @@
 # RF-DETR Copilot Instructions
 
-> [!NOTE]
-> This document is GitHub Copilot-specific guidance. For canonical contribution guidelines (test-driven development, code quality, docstrings, etc.), see [CONTRIBUTING.md](CONTRIBUTING.md). For detailed agent-specific context, see [AGENTS.md](../AGENTS.md).
+> [!NOTE] This document is GitHub Copilot-specific guidance. For canonical contribution guidelines (test-driven development, code quality, docstrings, etc.), see [CONTRIBUTING.md](CONTRIBUTING.md). For detailed agent-specific context, see [AGENTS.md](../AGENTS.md).
 
 ## Repository Overview
 
 RF-DETR is a real-time transformer architecture for object detection and instance segmentation. Built on DINOv2 vision transformer backbone with PyTorch.
 
-**Project Type:** Python ML library (computer vision)
-**Python:** >=3.10 (3.10, 3.11, 3.12, 3.13)
-**License:** Apache 2.0 (Plus models under PML 1.0)
+**Project Type:** Python ML library (computer vision) **Python:** >=3.10 (3.10, 3.11, 3.12, 3.13) **License:** Apache 2.0 (Plus models under PML 1.0)
 
 > [!TIP]
 >
@@ -31,8 +28,7 @@ uv run --no-sync pytest src/ tests/ -n 2 -m "not gpu" --cov=rfdetr --cov-report=
 uv build
 ```
 
-> [!IMPORTANT]
-> Run `uv sync` after pulling changes to update dependencies.
+> [!IMPORTANT] Run `uv sync` after pulling changes to update dependencies.
 
 **Dependency extras:** `rfdetr[train]` is intentionally minimal and uses torchvision-native default augmentations. Custom Albumentations CPU configs and Kornia GPU augmentation both require `rfdetr[augment]`.
 
@@ -48,8 +44,7 @@ pre-commit run --all-files
 
 ## Key Conventions
 
-> [!NOTE]
-> Internal package organization (`src/rfdetr/`) is subject to change as this is an active research project. Explore the codebase to understand current module organization.
+> [!NOTE] Internal package organization (`src/rfdetr/`) is subject to change as this is an active research project. Explore the codebase to understand current module organization.
 
 **Imports:**
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,8 @@
 # RF-DETR Copilot Instructions
 
-> [!NOTE] This document is GitHub Copilot-specific guidance. For canonical contribution guidelines (test-driven development, code quality, docstrings, etc.), see [CONTRIBUTING.md](CONTRIBUTING.md). For detailed agent-specific context, see [AGENTS.md](../AGENTS.md).
+> [!NOTE]
+>
+> This document is GitHub Copilot-specific guidance. For canonical contribution guidelines (test-driven development, code quality, docstrings, etc.), see [CONTRIBUTING.md](CONTRIBUTING.md). For detailed agent-specific context, see [AGENTS.md](../AGENTS.md).
 
 ## Repository Overview
 
@@ -28,7 +30,9 @@ uv run --no-sync pytest src/ tests/ -n 2 -m "not gpu" --cov=rfdetr --cov-report=
 uv build
 ```
 
-> [!IMPORTANT] Run `uv sync` after pulling changes to update dependencies.
+> [!IMPORTANT]
+>
+> Run `uv sync` after pulling changes to update dependencies.
 
 **Dependency extras:** `rfdetr[train]` is intentionally minimal and uses torchvision-native default augmentations. Custom Albumentations CPU configs and Kornia GPU augmentation both require `rfdetr[augment]`.
 
@@ -44,7 +48,9 @@ pre-commit run --all-files
 
 ## Key Conventions
 
-> [!NOTE] Internal package organization (`src/rfdetr/`) is subject to change as this is an active research project. Explore the codebase to understand current module organization.
+> [!NOTE]
+>
+> Internal package organization (`src/rfdetr/`) is subject to change as this is an active research project. Explore the codebase to understand current module organization.
 
 **Imports:**
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,7 +68,7 @@ repos:
         additional_dependencies:
           - "mdformat-mkdocs[recommended]>=2.1.0"
           - "mdformat-ruff"
-        args: ["--number"]
+        args: ["--number", "--wrap=no"]
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,11 +44,15 @@ As an AI agent contributing to RF-DETR, you are responsible for:
     - Write secure code (prevent injection vulnerabilities)
     - Follow existing patterns in the codebase
 
-> [!NOTE] Keeping documentation current ensures consistency across agent contributions and reduces repeated feedback on the same issues.
+> [!NOTE]
+>
+> Keeping documentation current ensures consistency across agent contributions and reduces repeated feedback on the same issues.
 
 ## Build & Development Environment
 
-> [!NOTE] **Canonical Reference:** See [Development Environment Setup](.github/CONTRIBUTING.md#development-environment-setup) in CONTRIBUTING.md for complete setup instructions.
+> [!NOTE]
+>
+> **Canonical Reference:** See [Development Environment Setup](.github/CONTRIBUTING.md#development-environment-setup) in CONTRIBUTING.md for complete setup instructions.
 
 ### Setup
 
@@ -77,7 +81,9 @@ See `pyproject.toml` for complete dependency specifications:
 
 ## Testing
 
-> [!NOTE] **Canonical Reference:** See [Test-Driven Development](.github/CONTRIBUTING.md#test-driven-development) in CONTRIBUTING.md for complete guidelines.
+> [!NOTE]
+>
+> **Canonical Reference:** See [Test-Driven Development](.github/CONTRIBUTING.md#test-driven-development) in CONTRIBUTING.md for complete guidelines.
 >
 > **CI Workflows (Source of Truth):** See `.github/workflows/ci-tests-cpu.yml` and `.github/workflows/ci-tests-gpu.yml` for exact test commands used in CI.
 
@@ -96,7 +102,9 @@ pre-commit run --all-files
 
 ### Testing Principles
 
-> [!IMPORTANT] **Testing Requirements:**
+> [!IMPORTANT]
+>
+> **Testing Requirements:**
 >
 > - ⚠️ **During development:** Tests may fail as you work through TDD cycle
 > - ✅ **Before opening PR:** Final commit MUST have all tests passing
@@ -120,7 +128,9 @@ pre-commit run --all-files
 
 ## Code Quality & Linting
 
-> [!NOTE] **Canonical Reference:** See [Code Quality and Linting](.github/CONTRIBUTING.md#code-quality-and-linting) in CONTRIBUTING.md for setup and details.
+> [!NOTE]
+>
+> **Canonical Reference:** See [Code Quality and Linting](.github/CONTRIBUTING.md#code-quality-and-linting) in CONTRIBUTING.md for setup and details.
 
 ### Command
 
@@ -129,7 +139,9 @@ pre-commit run --all-files
 pre-commit run --all-files
 ```
 
-> [!TIP] Pre-commit hooks will auto-format many issues. Review changes and re-stage files.
+> [!TIP]
+>
+> Pre-commit hooks will auto-format many issues. Review changes and re-stage files.
 
 **Configuration Files:**
 
@@ -194,7 +206,9 @@ uv run twine check --strict dist/*
 
 ## Project Structure
 
-> [!NOTE] **Canonical Reference:** See [Project Structure](.github/CONTRIBUTING.md#project-structure) in CONTRIBUTING.md for complete project organization, directory descriptions, and configuration files.
+> [!NOTE]
+>
+> **Canonical Reference:** See [Project Structure](.github/CONTRIBUTING.md#project-structure) in CONTRIBUTING.md for complete project organization, directory descriptions, and configuration files.
 >
 > **Quick summary:** `src/rfdetr/` (source code), `tests/` (test suite), `docs/` (documentation), `.github/` (CI/CD), `pyproject.toml` (dependencies and config).
 >
@@ -273,15 +287,17 @@ result = subprocess.run(
 
 ### Type Hints & Docstrings
 
-> [!IMPORTANT] **Canonical Reference:** See [Google-Style Docstrings and Mandatory Type Hints](.github/CONTRIBUTING.md#google-style-docstrings-and-mandatory-type-hints) in CONTRIBUTING.md for complete requirements and examples.
-
-**Requirements:**
-
-- MANDATORY type hints for all function parameters and return types
-- MANDATORY Google-style docstrings for all functions and classes
-- **Do not duplicate types in docstrings** - types are in the function signature
-- Target Python version: 3.10+
-- **Helper functions in `tests/` need a doctest too**: any non-`test_*` function used by tests (fixture builders, assertion helpers, reference implementations) needs a docstring with an `Examples` doctest that exercises it directly — `pyproject.toml` runs `--doctest-plus` across `tests/` on purpose. Skip the live doctest (`# doctest: +SKIP` + one-line reason) only when the helper can't run standalone (e.g. a `@pytest.fixture`, or needs real GPU/XLA/network hardware).
+> [!IMPORTANT]
+>
+> **Canonical Reference:** See [Google-Style Docstrings and Mandatory Type Hints](.github/CONTRIBUTING.md#google-style-docstrings-and-mandatory-type-hints) in CONTRIBUTING.md for complete requirements and examples.
+>
+> **Requirements:**
+>
+> - MANDATORY type hints for all function parameters and return types
+> - MANDATORY Google-style docstrings for all functions and classes
+> - **Do not duplicate types in docstrings** - types are in the function signature
+> - Target Python version: 3.10+
+> - **Helper functions in `tests/` need a doctest too**: any non-`test_*` function used by tests (fixture builders, assertion helpers, reference implementations) needs a docstring with an `Examples` doctest that exercises it directly — `pyproject.toml` runs `--doctest-plus` across `tests/` on purpose. Skip the live doctest (`# doctest: +SKIP` + one-line reason) only when the helper can't run standalone (e.g. a `@pytest.fixture`, or needs real GPU/XLA/network hardware).
 
 ## Common Workflows
 
@@ -303,7 +319,9 @@ result = subprocess.run(
 
 ### Adding New Model Variants
 
-> [!IMPORTANT] **Canonical Reference:** See [Adding a New Model](.github/CONTRIBUTING.md#adding-a-new-model) in CONTRIBUTING.md for detailed guidance.
+> [!IMPORTANT]
+>
+> **Canonical Reference:** See [Adding a New Model](.github/CONTRIBUTING.md#adding-a-new-model) in CONTRIBUTING.md for detailed guidance.
 >
 > Always consult maintainers before implementing new models.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,13 +44,11 @@ As an AI agent contributing to RF-DETR, you are responsible for:
     - Write secure code (prevent injection vulnerabilities)
     - Follow existing patterns in the codebase
 
-> [!NOTE]
-> Keeping documentation current ensures consistency across agent contributions and reduces repeated feedback on the same issues.
+> [!NOTE] Keeping documentation current ensures consistency across agent contributions and reduces repeated feedback on the same issues.
 
 ## Build & Development Environment
 
-> [!NOTE]
-> **Canonical Reference:** See [Development Environment Setup](.github/CONTRIBUTING.md#development-environment-setup) in CONTRIBUTING.md for complete setup instructions.
+> [!NOTE] **Canonical Reference:** See [Development Environment Setup](.github/CONTRIBUTING.md#development-environment-setup) in CONTRIBUTING.md for complete setup instructions.
 
 ### Setup
 
@@ -79,8 +77,7 @@ See `pyproject.toml` for complete dependency specifications:
 
 ## Testing
 
-> [!NOTE]
-> **Canonical Reference:** See [Test-Driven Development](.github/CONTRIBUTING.md#test-driven-development) in CONTRIBUTING.md for complete guidelines.
+> [!NOTE] **Canonical Reference:** See [Test-Driven Development](.github/CONTRIBUTING.md#test-driven-development) in CONTRIBUTING.md for complete guidelines.
 >
 > **CI Workflows (Source of Truth):** See `.github/workflows/ci-tests-cpu.yml` and `.github/workflows/ci-tests-gpu.yml` for exact test commands used in CI.
 
@@ -99,8 +96,7 @@ pre-commit run --all-files
 
 ### Testing Principles
 
-> [!IMPORTANT]
-> **Testing Requirements:**
+> [!IMPORTANT] **Testing Requirements:**
 >
 > - ⚠️ **During development:** Tests may fail as you work through TDD cycle
 > - ✅ **Before opening PR:** Final commit MUST have all tests passing
@@ -117,18 +113,14 @@ pre-commit run --all-files
 - Use `@pytest.mark.parametrize` with `pytest.param(..., id="name")`
 - Mark GPU/heavy tests with `@pytest.mark.gpu`
 - Avoid multiple validation cases in a single test - see [CONTRIBUTING.md](.github/CONTRIBUTING.md#avoid-multiple-validation-cases-in-a-single-test) for details
-- Fixtures return ready-to-use concrete state or a cohesive tuple of related state. Do not return a callable factory
-    unless fixture-managed lifecycle is required; use an ordinary helper function for configurable construction.
-- Keep fixture dependencies minimal, unpack only the values a test needs, and avoid aliases or wrappers that merely
-    rename or forward an object without adding meaning.
+- Fixtures return ready-to-use concrete state or a cohesive tuple of related state. Do not return a callable factory unless fixture-managed lifecycle is required; use an ordinary helper function for configurable construction.
+- Keep fixture dependencies minimal, unpack only the values a test needs, and avoid aliases or wrappers that merely rename or forward an object without adding meaning.
 
-**CI Information:**
-See [CI Testing](.github/CONTRIBUTING.md#ci-testing) in CONTRIBUTING.md for details on OS/Python version matrix and workflow configurations.
+**CI Information:** See [CI Testing](.github/CONTRIBUTING.md#ci-testing) in CONTRIBUTING.md for details on OS/Python version matrix and workflow configurations.
 
 ## Code Quality & Linting
 
-> [!NOTE]
-> **Canonical Reference:** See [Code Quality and Linting](.github/CONTRIBUTING.md#code-quality-and-linting) in CONTRIBUTING.md for setup and details.
+> [!NOTE] **Canonical Reference:** See [Code Quality and Linting](.github/CONTRIBUTING.md#code-quality-and-linting) in CONTRIBUTING.md for setup and details.
 
 ### Command
 
@@ -137,8 +129,7 @@ See [CI Testing](.github/CONTRIBUTING.md#ci-testing) in CONTRIBUTING.md for deta
 pre-commit run --all-files
 ```
 
-> [!TIP]
-> Pre-commit hooks will auto-format many issues. Review changes and re-stage files.
+> [!TIP] Pre-commit hooks will auto-format many issues. Review changes and re-stage files.
 
 **Configuration Files:**
 
@@ -147,12 +138,8 @@ pre-commit run --all-files
 
 **Abstraction Discipline:**
 
-- Introduce an abstraction only when it reduces cognitive load and the number of concepts a reader must follow.
-    Extract stable repeated behavior or irrelevant construction mechanics while keeping behavior-defining inputs and
-    outcomes explicit at call sites.
-- Design an extracted helper for the complete related behavior already present, including relevant edge cases, and
-    place it in the narrowest scope shared by its consumers. Prefer small visible duplication over a helper, wrapper,
-    alias, or layer that adds indirection without semantic value.
+- Introduce an abstraction only when it reduces cognitive load and the number of concepts a reader must follow. Extract stable repeated behavior or irrelevant construction mechanics while keeping behavior-defining inputs and outcomes explicit at call sites.
+- Design an extracted helper for the complete related behavior already present, including relevant edge cases, and place it in the narrowest scope shared by its consumers. Prefer small visible duplication over a helper, wrapper, alias, or layer that adds indirection without semantic value.
 
 **License Header (required for all Python files):**
 
@@ -207,8 +194,7 @@ uv run twine check --strict dist/*
 
 ## Project Structure
 
-> [!NOTE]
-> **Canonical Reference:** See [Project Structure](.github/CONTRIBUTING.md#project-structure) in CONTRIBUTING.md for complete project organization, directory descriptions, and configuration files.
+> [!NOTE] **Canonical Reference:** See [Project Structure](.github/CONTRIBUTING.md#project-structure) in CONTRIBUTING.md for complete project organization, directory descriptions, and configuration files.
 >
 > **Quick summary:** `src/rfdetr/` (source code), `tests/` (test suite), `docs/` (documentation), `.github/` (CI/CD), `pyproject.toml` (dependencies and config).
 >
@@ -240,9 +226,7 @@ uv run twine check --strict dist/*
 
 **Imports:**
 
-- Keep imports at module scope by default. Use a local import only for a verified circular-import boundary, optional
-    dependency boundary, import-behavior test, or material startup/side-effect constraint; the reason must be evident
-    from the surrounding code or documented where it is not obvious.
+- Keep imports at module scope by default. Use a local import only for a verified circular-import boundary, optional dependency boundary, import-behavior test, or material startup/side-effect constraint; the reason must be evident from the surrounding code or documented where it is not obvious.
 
 ```python
 # Prefer direct project imports. Standard aliases such as `numpy as np`,
@@ -289,8 +273,7 @@ result = subprocess.run(
 
 ### Type Hints & Docstrings
 
-> [!IMPORTANT]
-> **Canonical Reference:** See [Google-Style Docstrings and Mandatory Type Hints](.github/CONTRIBUTING.md#google-style-docstrings-and-mandatory-type-hints) in CONTRIBUTING.md for complete requirements and examples.
+> [!IMPORTANT] **Canonical Reference:** See [Google-Style Docstrings and Mandatory Type Hints](.github/CONTRIBUTING.md#google-style-docstrings-and-mandatory-type-hints) in CONTRIBUTING.md for complete requirements and examples.
 
 **Requirements:**
 
@@ -320,8 +303,7 @@ result = subprocess.run(
 
 ### Adding New Model Variants
 
-> [!IMPORTANT]
-> **Canonical Reference:** See [Adding a New Model](.github/CONTRIBUTING.md#adding-a-new-model) in CONTRIBUTING.md for detailed guidance.
+> [!IMPORTANT] **Canonical Reference:** See [Adding a New Model](.github/CONTRIBUTING.md#adding-a-new-model) in CONTRIBUTING.md for detailed guidance.
 >
 > Always consult maintainers before implementing new models.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 All notable changes to RF-DETR are documented here.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
@@ -34,8 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- EMA training no longer performs an extra averaged-model update at epoch boundaries after the final optimizer step,
-    preventing one update per epoch from bypassing `ema_update_interval` and changing the EMA trajectory. ([#1319](https://github.com/roboflow/rf-detr/pull/1319))
+- EMA training no longer performs an extra averaged-model update at epoch boundaries after the final optimizer step, preventing one update per epoch from bypassing `ema_update_interval` and changing the EMA trajectory. ([#1319](https://github.com/roboflow/rf-detr/pull/1319))
 - Loading a detection checkpoint published before keypoint support no longer warns that `_kp_active_mask` is a "model parameter not in checkpoint (left at random init)". The key is a deterministic schema buffer the model always rebuilds from the configured keypoint schema — empty for detection-only variants — not a learned parameter, so its absence never affected the loaded weights. Affects `Nano`, `Small`, `Large` (2026) and `SegSmall`. The filter matches the exact terminal key, so a similarly-named real parameter still warns, and an *unexpected* `_kp_active_mask` in a checkpoint still warns; the filtered key is now recorded at debug level. ([#1302](https://github.com/roboflow/rf-detr/pull/1302))
 - Resuming training from one of `BestModelCallback`'s four lightweight checkpoints (`checkpoint_best_regular.pth`, `checkpoint_best_ema.pth`, `checkpoint_best_total.pth`, `last_ema.pth`) now restores per-callback state instead of silently restarting it cold. Those files intentionally omit optimizer/LR-scheduler state, and a warning now says so explicitly, distinguishing them from checkpoints that predate callback-state persistence entirely (where best-score tracking, EMA, and early-stopping all restart cold too). Best-score restore additionally requires the original `output_dir` to match. ([#1318](https://github.com/roboflow/rf-detr/pull/1318))
 - Training-time log calls no longer corrupt or duplicate the completed Rich epoch progress bar when `RichProgressBar(leave=True)` is active. A new stream handler tracks the log target by name and re-resolves `stdout`/`stderr` on every emit, following Rich's redirect proxies instead of capturing the pre-redirect stream once at import time. ([#1316](https://github.com/roboflow/rf-detr/pull/1316))

--- a/README.md
+++ b/README.md
@@ -2,17 +2,9 @@
 
 <div align="center">
 
-[![version](https://badge.fury.io/py/rfdetr.svg)](https://badge.fury.io/py/rfdetr)
-[![downloads](https://img.shields.io/pypi/dm/rfdetr)](https://pypistats.org/packages/rfdetr)
-[![codecov](https://codecov.io/gh/roboflow/rf-detr/graph/badge.svg?token=K8V4ARR3XV)](https://codecov.io/gh/roboflow/rf-detr)
-[![python-version](https://img.shields.io/pypi/pyversions/rfdetr)](https://badge.fury.io/py/rfdetr)
-[![license](https://img.shields.io/badge/license-Apache%202.0-blue)](https://github.com/roboflow/rf-detr/blob/main/LICENSE)
+[![version](https://badge.fury.io/py/rfdetr.svg)](https://badge.fury.io/py/rfdetr) [![downloads](https://img.shields.io/pypi/dm/rfdetr)](https://pypistats.org/packages/rfdetr) [![codecov](https://codecov.io/gh/roboflow/rf-detr/graph/badge.svg?token=K8V4ARR3XV)](https://codecov.io/gh/roboflow/rf-detr) [![python-version](https://img.shields.io/pypi/pyversions/rfdetr)](https://badge.fury.io/py/rfdetr) [![license](https://img.shields.io/badge/license-Apache%202.0-blue)](https://github.com/roboflow/rf-detr/blob/main/LICENSE)
 
-[![arXiv](https://img.shields.io/badge/arXiv-2511.09554-b31b1b.svg)](https://arxiv.org/abs/2511.09554)
-[![hf space](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/SkalskiP/RF-DETR)
-[![colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/roboflow-ai/notebooks/blob/main/notebooks/how-to-finetune-rf-detr-on-detection-dataset.ipynb)
-[![roboflow](https://raw.githubusercontent.com/roboflow-ai/notebooks/main/assets/badges/roboflow-blogpost.svg)](https://blog.roboflow.com/rf-detr)
-[![discord](https://img.shields.io/discord/1159501506232451173?logo=discord&label=discord&labelColor=fff&color=5865f2&link=https%3A%2F%2Fdiscord.gg%2FGbfgXGJ8Bk)](https://discord.gg/GbfgXGJ8Bk)
+[![arXiv](https://img.shields.io/badge/arXiv-2511.09554-b31b1b.svg)](https://arxiv.org/abs/2511.09554) [![hf space](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/SkalskiP/RF-DETR) [![colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/roboflow-ai/notebooks/blob/main/notebooks/how-to-finetune-rf-detr-on-detection-dataset.ipynb) [![roboflow](https://raw.githubusercontent.com/roboflow-ai/notebooks/main/assets/badges/roboflow-blogpost.svg)](https://blog.roboflow.com/rf-detr) [![discord](https://img.shields.io/discord/1159501506232451173?logo=discord&label=discord&labelColor=fff&color=5865f2&link=https%3A%2F%2Fdiscord.gg%2FGbfgXGJ8Bk)](https://discord.gg/GbfgXGJ8Bk)
 
 <a href="https://trendshift.io/repositories/14379?utm_source=repository-badge&amp;utm_medium=badge&amp;utm_campaign=badge-repository-14379" target="_blank" rel="noopener noreferrer">
 <img src="https://trendshift.io/api/badge/repositories/14379" alt="roboflow%2Frf-detr | Trendshift" width="250" height="55"/>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,8 +7,7 @@ hide:
 
 # Changelog
 
-RF-DETR release notes are maintained on [GitHub Releases](https://github.com/roboflow/rf-detr/releases).
-Use the release feed to review versioned package changes, migration notes, and model updates.
+RF-DETR release notes are maintained on [GitHub Releases](https://github.com/roboflow/rf-detr/releases). Use the release feed to review versioned package changes, migration notes, and model updates.
 
 - [Install the latest PyPI package](https://pypi.org/project/rfdetr/)
 - [Migration guide](getting-started/migration.md) — upgrade steps between major versions

--- a/docs/cookbooks/NOTES.md
+++ b/docs/cookbooks/NOTES.md
@@ -2,9 +2,7 @@
 
 Each `.ipynb` file here is rendered as a page under `/cookbooks/` in the docs site.
 
-Cards on the cookbooks landing page are driven by [`cards.yaml`](cards.yaml). The MkDocs hook
-`docs/hooks/cookbooks_cards.py` loads that file and exposes it to `docs/theme/notebooks.html`,
-which renders each entry as a card via a Jinja loop.
+Cards on the cookbooks landing page are driven by [`cards.yaml`](cards.yaml). The MkDocs hook `docs/hooks/cookbooks_cards.py` loads that file and exposes it to `docs/theme/notebooks.html`, which renders each entry as a card via a Jinja loop.
 
 ## Converting a jupytext `.py` to `.ipynb`
 
@@ -38,8 +36,7 @@ If jupytext is not installed: `pip install jupytext` (or `uv add jupytext --dev`
     description: One sentence describing what the notebook demonstrates.
 ```
 
-Available labels (reuse these to keep tags standardised): `TRAINING`, `AUGMENTATION`, `EXPORT`, `TFLITE`, `PYTORCH LIGHTNING`, `INFERENCE`, `SEGMENTATION`, `DEPLOY`.
-Current tag colours are assigned dynamically by the docs UI, so they may change if cards or labels are added or reordered.
+Available labels (reuse these to keep tags standardised): `TRAINING`, `AUGMENTATION`, `EXPORT`, `TFLITE`, `PYTORCH LIGHTNING`, `INFERENCE`, `SEGMENTATION`, `DEPLOY`. Current tag colours are assigned dynamically by the docs UI, so they may change if cards or labels are added or reordered.
 
 For newly added or updated notebooks, write markdown cells in plain, notebook-portable Markdown only — no MkDocs Material syntax (`!!! note`, `=== "Tab"`, admonition blocks). `mkdocs-jupyter` renders the site copy through the same plain renderer as a raw `.ipynb`, so MkDocs-only syntax shows up as literal text (e.g. `!!! warning "..."`) instead of a styled callout. Use a blockquote (`> **Note:** ...`) for callouts instead.
 

--- a/docs/getting-started/migration.md
+++ b/docs/getting-started/migration.md
@@ -4,17 +4,13 @@ description: Per-version migration guide for RF-DETR. Covers breaking changes an
 
 # Migration Guide
 
-Read each section between your current version and your target — every section covers
-only the delta between two adjacent releases.
+Read each section between your current version and your target — every section covers only the delta between two adjacent releases.
 
 ```
 1.4.x  →  1.5 →  1.6  →  1.7  →  1.8  →  1.9
 ```
 
-You can apply all changes in one go; working through sections one release at a time
-and verifying between each step is optional but makes failures easier to isolate.
-Deprecated APIs emit a `DeprecationWarning` until the version marked for removal.
-See the [Changelog](../changelog.md) for the full list of changes in each release.
+You can apply all changes in one go; working through sections one release at a time and verifying between each step is optional but makes failures easier to isolate. Deprecated APIs emit a `DeprecationWarning` until the version marked for removal. See the [Changelog](../changelog.md) for the full list of changes in each release.
 
 ---
 
@@ -24,9 +20,7 @@ See the [Changelog](../changelog.md) for the full list of changes in each releas
 
 !!! warning "Breaking: `albumentations` and `kornia` extras merged into `augment`"
 
-    **PyPI extras renamed.** Default training/validation/prediction/export augmentations now use
-    torchvision-native transforms, so `[train]` no longer installs Albumentations. Custom CPU
-    (Albumentations) and GPU (Kornia) augmentation both live behind a single new `augment` extra.
+    **PyPI extras renamed.** Default training/validation/prediction/export augmentations now use torchvision-native transforms, so `[train]` no longer installs Albumentations. Custom CPU (Albumentations) and GPU (Kornia) augmentation both live behind a single new `augment` extra.
 
     | Old extra                                | New extra               |
     | ---------------------------------------- | ----------------------- |
@@ -45,17 +39,11 @@ See the [Changelog](../changelog.md) for the full list of changes in each releas
 
 !!! note "`augmentation_backend` values renamed"
 
-    `augmentation_backend="tv"` and `"albu"` are renamed to `"torchvision"` and
-    `"albumentations"`. The old strings (and `"gpu"`) still work as aliases, so no code
-    changes are required — see [Augmentation Backend Values](../learn/train/augmentations.md#augmentation-backend-values)
-    for the full accepted set.
+    `augmentation_backend="tv"` and `"albu"` are renamed to `"torchvision"` and `"albumentations"`. The old strings (and `"gpu"`) still work as aliases, so no code changes are required — see [Augmentation Backend Values](../learn/train/augmentations.md#augmentation-backend-values) for the full accepted set.
 
 !!! warning "Breaking: default resize interpolation changed — pixel values and mAP may shift"
 
-    The default resize backend changed from Albumentations (cv2 `INTER_LINEAR`, no antialias) to
-    torchvision (`BILINEAR` + `antialias=True`). Resized pixel values differ slightly from previous
-    versions, and mAP may drift on existing benchmarks. **This affects training as well as
-    validation and test preprocessing** — not just the training split.
+    The default resize backend changed from Albumentations (cv2 `INTER_LINEAR`, no antialias) to torchvision (`BILINEAR` + `antialias=True`). Resized pixel values differ slightly from previous versions, and mAP may drift on existing benchmarks. **This affects training as well as validation and test preprocessing** — not just the training split.
 
     To restore the previous pixel-exact behaviour:
 
@@ -69,11 +57,7 @@ See the [Changelog](../changelog.md) for the full list of changes in each releas
     train_config = TrainConfig(aug_config=AUG_CONFIG, ...)
     ```
 
-    Installing `rfdetr[augment]` alone is **not** sufficient to pin this behaviour — with
-    Albumentations installed, `augmentation_backend="auto"`/`"cpu"` (the default) auto-selects
-    Albumentations for you, but identical code on a machine without `[augment]` installed silently
-    falls back to torchvision instead. The only setting that pins resize behaviour regardless of
-    what is installed is:
+    Installing `rfdetr[augment]` alone is **not** sufficient to pin this behaviour — with Albumentations installed, `augmentation_backend="auto"`/`"cpu"` (the default) auto-selects Albumentations for you, but identical code on a machine without `[augment]` installed silently falls back to torchvision instead. The only setting that pins resize behaviour regardless of what is installed is:
 
     ```python
     train_config = TrainConfig(augmentation_backend="torchvision", ...)
@@ -144,8 +128,7 @@ The following APIs were deprecated in earlier releases and are removed as of v1.
 
 !!! note "Deprecated: `RFDETR.optimize_for_inference()` renamed to `RFDETR.inference()`"
 
-    **`optimize_for_inference(compile=..., batch_size=..., dtype=..., inplace=...)`** — renamed to
-    `inference()` with the same signature.
+    **`optimize_for_inference(compile=..., batch_size=..., dtype=..., inplace=...)`** — renamed to `inference()` with the same signature.
 
     ```python
     # Before (deprecated)
@@ -157,9 +140,7 @@ The following APIs were deprecated in earlier releases and are removed as of v1.
 
 !!! note "Deprecated: `TrainConfig.lr_drop` and `TrainConfig.lr_min_factor`"
 
-    **`lr_drop` / `lr_min_factor`** — pass them through `lr_scheduler_kwargs` instead. For the managed
-    `"step"` / `"cosine"` presets the fields are still folded into `lr_scheduler_kwargs` (with a
-    `FutureWarning`); set with an explicit scheduler they are inert and warn.
+    **`lr_drop` / `lr_min_factor`** — pass them through `lr_scheduler_kwargs` instead. For the managed `"step"` / `"cosine"` presets the fields are still folded into `lr_scheduler_kwargs` (with a `FutureWarning`); set with an explicit scheduler they are inert and warn.
 
     ```python
     # Before (deprecated)
@@ -177,8 +158,7 @@ The following APIs were deprecated in earlier releases and are removed as of v1.
 
 !!! note "Breaking in v1.8.2: default keypoint schema changed to active-first `[17]`"
 
-    New checkpoints created from v1.8.2 onwards use `class_id=0` for person. Legacy `[0, 17]` checkpoints
-    are still supported — RF-DETR auto-detects the schema from the checkpoint at load time.
+    New checkpoints created from v1.8.2 onwards use `class_id=0` for person. Legacy `[0, 17]` checkpoints are still supported — RF-DETR auto-detects the schema from the checkpoint at load time.
 
     If your post-processing code offsets class IDs by 1 (common for background-first models), update it:
 
@@ -208,8 +188,7 @@ The following APIs were deprecated in earlier releases and are removed as of v1.
 
 !!! warning "Breaking: `supervision>=0.29.0` now required"
 
-    Required for `sv.KeyPoints` support. `pip install rfdetr==1.8.0` pulls this automatically.
-    If another dependency pins `supervision<0.29.0`, resolve the conflict manually.
+    Required for `sv.KeyPoints` support. `pip install rfdetr==1.8.0` pulls this automatically. If another dependency pins `supervision<0.29.0`, resolve the conflict manually.
 
 !!! warning "Breaking: `pyDeprecate` constraint narrowed to `>=0.9,<0.10`"
 
@@ -227,8 +206,7 @@ The following APIs were deprecated in earlier releases and are removed as of v1.
 
 !!! warning "Breaking: `peft` removed from the default install"
 
-    LoRA fine-tuning now requires the `lora` extra. If you use LoRA adapters during
-    training, update your install command.
+    LoRA fine-tuning now requires the `lora` extra. If you use LoRA adapters during training, update your install command.
 
     ```bash
     # Before
@@ -262,8 +240,7 @@ The following APIs were deprecated in earlier releases and are removed as of v1.
 
 !!! note "Deprecated: `build_namespace()` split into two functions"
 
-    **`build_namespace(model_config, train_config)`** — use `build_model_from_config` or
-    `build_criterion_from_config` instead.
+    **`build_namespace(model_config, train_config)`** — use `build_model_from_config` or `build_criterion_from_config` instead.
 
     ```python
     # Before (deprecated)
@@ -280,8 +257,7 @@ The following APIs were deprecated in earlier releases and are removed as of v1.
 
 !!! note "Deprecated: `load_pretrain_weights()` no longer takes `train_config`"
 
-    **`load_pretrain_weights(nn_model, model_config, train_config)`** — drop the
-    `train_config` positional argument.
+    **`load_pretrain_weights(nn_model, model_config, train_config)`** — drop the `train_config` positional argument.
 
     ```python
     # Before (deprecated)
@@ -320,9 +296,7 @@ The following APIs were deprecated in earlier releases and are removed as of v1.
 
 !!! note "Deprecated: `RFDETRBase` replaced by size-specific classes"
 
-    **`RFDETRBase`** defaulted to the small variant and is replaced by size-specific
-    classes. Choose the variant that matches your previous model size. If you used
-    `RFDETRBase()` without arguments, switch to `RFDETRSmall()`.
+    **`RFDETRBase`** defaulted to the small variant and is replaced by size-specific classes. Choose the variant that matches your previous model size. If you used `RFDETRBase()` without arguments, switch to `RFDETRSmall()`.
 
     ```python
     # Before (deprecated)
@@ -338,9 +312,7 @@ The following APIs were deprecated in earlier releases and are removed as of v1.
 
 !!! note "Deprecated: `RFDETRSegPreview` replaced by size-specific segmentation classes"
 
-    **`RFDETRSegPreview`** defaulted to the small variant and is replaced by size-specific
-    segmentation classes. If you used `RFDETRSegPreview()` without arguments, switch to
-    `RFDETRSegSmall()`.
+    **`RFDETRSegPreview`** defaulted to the small variant and is replaced by size-specific segmentation classes. If you used `RFDETRSegPreview()` without arguments, switch to `RFDETRSegSmall()`.
 
     ```python
     # Before (deprecated)
@@ -364,8 +336,7 @@ The following APIs were deprecated in earlier releases and are removed as of v1.
 
     **`transformers` minimum version raised to `>=5.1.0,<6.0.0`.**
 
-    Projects pinned to `transformers<5.0.0` must upgrade. If upgrading is not possible,
-    pin `rfdetr<1.6.0`.
+    Projects pinned to `transformers<5.0.0` must upgrade. If upgrading is not possible, pin `rfdetr<1.6.0`.
 
     ```bash
     pip install 'transformers>=5.1.0,<6.0.0'
@@ -410,8 +381,7 @@ The following APIs were deprecated in earlier releases and are removed as of v1.
 
 !!! note "Deprecated: `simplify` and `force` arguments in `RFDETR.export()`"
 
-    **`RFDETR.export(..., simplify=..., force=...)`** — both arguments are no-ops.
-    Remove them from your calls.
+    **`RFDETR.export(..., simplify=..., force=...)`** — both arguments are no-ops. Remove them from your calls.
 
     ```python
     # Before (deprecated)
@@ -425,8 +395,7 @@ The following APIs were deprecated in earlier releases and are removed as of v1.
 
 !!! note "Deprecated: `rfdetr.util.*` and `rfdetr.deploy.*` import paths"
 
-    Backward-compatibility shims are still active but emit `DeprecationWarning` on import.
-    Replace with the canonical paths listed in the table below.
+    Backward-compatibility shims are still active but emit `DeprecationWarning` on import. Replace with the canonical paths listed in the table below.
 
     | Deprecated module                 | Canonical replacement              |
     | --------------------------------- | ---------------------------------- |
@@ -478,8 +447,7 @@ The following APIs were deprecated in earlier releases and are removed as of v1.
 
     **`ModelConfig` now raises `ValidationError` on unknown keyword arguments.**
 
-    Previously, unrecognised fields were silently ignored. Remove or rename any
-    unrecognised keys you pass to `ModelConfig(...)`.
+    Previously, unrecognised fields were silently ignored. Remove or rename any unrecognised keys you pass to `ModelConfig(...)`.
 
     ```python
     # Before — silently accepted
@@ -493,9 +461,7 @@ The following APIs were deprecated in earlier releases and are removed as of v1.
 
 !!! note "Deprecated: `OPEN_SOURCE_MODELS` replaced by `ModelWeights` enum"
 
-    **`OPEN_SOURCE_MODELS` constant** — use the `ModelWeights` enum instead. A
-    `DeprecationWarning` is emitted on access. See the
-    [API reference](../reference/rfdetr.md) for available enum values.
+    **`OPEN_SOURCE_MODELS` constant** — use the `ModelWeights` enum instead. A `DeprecationWarning` is emitted on access. See the [API reference](../reference/rfdetr.md) for available enum values.
 
     ```python
     # Before (deprecated)

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,10 +28,7 @@ You can install and use `rfdetr` in a [**Python>=3.10**](https://www.python.org/
 
 !!! example "Installation"
 
-    <a href="https://badge.fury.io/py/rfdetr"><img alt="version" src="https://badge.fury.io/py/rfdetr.svg" width="125" height="20" /></a>
-    <a href="https://badge.fury.io/py/rfdetr"><img alt="python-version" src="https://img.shields.io/pypi/pyversions/rfdetr" width="198" height="20" /></a>
-    <a href="https://github.com/roboflow/rf-detr/blob/main/LICENSE"><img alt="license" src="https://img.shields.io/pypi/l/rfdetr" width="164" height="20" /></a>
-    <a href="https://pypistats.org/packages/rfdetr"><img alt="downloads" src="https://img.shields.io/pypi/dm/rfdetr" width="258" height="20" /></a>
+    <a href="https://badge.fury.io/py/rfdetr"><img alt="version" src="https://badge.fury.io/py/rfdetr.svg" width="125" height="20" /></a> <a href="https://badge.fury.io/py/rfdetr"><img alt="python-version" src="https://img.shields.io/pypi/pyversions/rfdetr" width="198" height="20" /></a> <a href="https://github.com/roboflow/rf-detr/blob/main/LICENSE"><img alt="license" src="https://img.shields.io/pypi/l/rfdetr" width="164" height="20" /></a> <a href="https://pypistats.org/packages/rfdetr"><img alt="downloads" src="https://img.shields.io/pypi/dm/rfdetr" width="258" height="20" /></a>
 
     === "pip"
 
@@ -155,42 +152,30 @@ RF-DETR achieves the best accuracy–latency trade-off among real-time object de
 | -------------------------- | ----------------------- | ------------ | ---------- | ---------- |
 | RF-DETR Keypoint (Preview) | 71.8                    | 9.7          | 40.7       | 576×576    |
 
-> Keypoint benchmarks report AP<sub>50:95</sub> (OKS-based); this is the standard COCO keypoint comparison metric.
-> For the full competitor comparison (YOLO11-pose, YOLO26-pose), see the [Benchmarks](learn/benchmarks.md#keypoints) page.
+> Keypoint benchmarks report AP<sub>50:95</sub> (OKS-based); this is the standard COCO keypoint comparison metric. For the full competitor comparison (YOLO11-pose, YOLO26-pose), see the [Benchmarks](learn/benchmarks.md#keypoints) page.
 
 ## Frequently Asked Questions
 
-**What is RF-DETR?**
-RF-DETR (Roboflow Detection Transformer) is a real-time object detection and instance segmentation model from Roboflow, accepted at ICLR 2026. It uses a DINOv2 vision transformer backbone and achieves state-of-the-art accuracy–latency trade-offs on COCO (60.1 AP50:95 for RF-DETR-2XL) and RF100-VL.
+**What is RF-DETR?** RF-DETR (Roboflow Detection Transformer) is a real-time object detection and instance segmentation model from Roboflow, accepted at ICLR 2026. It uses a DINOv2 vision transformer backbone and achieves state-of-the-art accuracy–latency trade-offs on COCO (60.1 AP50:95 for RF-DETR-2XL) and RF100-VL.
 
-**How does RF-DETR compare to YOLOv11?**
-RF-DETR-L achieves 56.5 AP50:95 on COCO at 6.8 ms latency on an NVIDIA T4, outperforming YOLOv11x (50.9 AP) at lower latency. The DINOv2 backbone gives RF-DETR stronger performance on domain-shift benchmarks such as RF100-VL.
+**How does RF-DETR compare to YOLOv11?** RF-DETR-L achieves 56.5 AP50:95 on COCO at 6.8 ms latency on an NVIDIA T4, outperforming YOLOv11x (50.9 AP) at lower latency. The DINOv2 backbone gives RF-DETR stronger performance on domain-shift benchmarks such as RF100-VL.
 
-**What GPU is required to train RF-DETR?**
-A CUDA-capable GPU with at least 8 GB VRAM (e.g., NVIDIA RTX 3060, T4, A10) is recommended for fine-tuning. Smaller models (RF-DETR-N and RF-DETR-S) can fit in 6 GB VRAM with reduced batch size. CPU inference is supported for evaluation.
+**What GPU is required to train RF-DETR?** A CUDA-capable GPU with at least 8 GB VRAM (e.g., NVIDIA RTX 3060, T4, A10) is recommended for fine-tuning. Smaller models (RF-DETR-N and RF-DETR-S) can fit in 6 GB VRAM with reduced batch size. CPU inference is supported for evaluation.
 
-**Which dataset formats does RF-DETR support?**
-RF-DETR supports COCO JSON and YOLO-format datasets (with `dataset_file: "yolo"`). Roboflow datasets export directly to both formats. Detection and segmentation datasets use the same format — the model variant determines the task.
+**Which dataset formats does RF-DETR support?** RF-DETR supports COCO JSON and YOLO-format datasets (with `dataset_file: "yolo"`). Roboflow datasets export directly to both formats. Detection and segmentation datasets use the same format — the model variant determines the task.
 
-**Can RF-DETR run in real time?**
-Yes. RF-DETR-N runs at 2.3 ms per frame on a T4 GPU (TensorRT FP16, batch 1), and RF-DETR-L at 6.8 ms — both well within real-time thresholds. ONNX and TFLite exports are available for edge deployment.
+**Can RF-DETR run in real time?** Yes. RF-DETR-N runs at 2.3 ms per frame on a T4 GPU (TensorRT FP16, batch 1), and RF-DETR-L at 6.8 ms — both well within real-time thresholds. ONNX and TFLite exports are available for edge deployment.
 
-**What is the difference between RF-DETR detection and segmentation models?**
-Detection models (e.g., `RFDETRLarge`) output bounding boxes. Segmentation models (e.g., `RFDETRSegLarge`) additionally output instance masks. Both share the same backbone and training API; segmentation adds a mask head and requires COCO-format segmentation annotations.
+**What is the difference between RF-DETR detection and segmentation models?** Detection models (e.g., `RFDETRLarge`) output bounding boxes. Segmentation models (e.g., `RFDETRSegLarge`) additionally output instance masks. Both share the same backbone and training API; segmentation adds a mask head and requires COCO-format segmentation annotations.
 
-**Does RF-DETR support keypoint detection?**
-RF-DETR Keypoint (Preview) detects 17 body keypoints per person on COCO, achieving 71.8 AP50:95 at 9.7 ms on NVIDIA T4. It is available in the `rfdetr` package as `RFDETRKeypointPreview`. See [Run Keypoint Models](learn/run/keypoints.md) for usage.
+**Does RF-DETR support keypoint detection?** RF-DETR Keypoint (Preview) detects 17 body keypoints per person on COCO, achieving 71.8 AP50:95 at 9.7 ms on NVIDIA T4. It is available in the `rfdetr` package as `RFDETRKeypointPreview`. See [Run Keypoint Models](learn/run/keypoints.md) for usage.
 
-**Is RF-DETR open source?**
-Yes. Core models (Nano through Large) and all training/inference code are released under the Apache 2.0 license. XLarge and 2XLarge models require the `rfdetr[plus]` package (PML 1.0 license).
+**Is RF-DETR open source?** Yes. Core models (Nano through Large) and all training/inference code are released under the Apache 2.0 license. XLarge and 2XLarge models require the `rfdetr[plus]` package (PML 1.0 license).
 
-**How do I fine-tune RF-DETR on a custom dataset?**
-Instantiate a model and call `model.train(...)` with your dataset directory in COCO JSON or YOLO format. Example: `model = RFDETRLarge(); model.train(dataset_dir='./dataset', epochs=50, batch_size=4)`. The model downloads pretrained weights automatically and saves best checkpoints automatically (use `resume=` to continue from one).
+**How do I fine-tune RF-DETR on a custom dataset?** Instantiate a model and call `model.train(...)` with your dataset directory in COCO JSON or YOLO format. Example: `model = RFDETRLarge(); model.train(dataset_dir='./dataset', epochs=50, batch_size=4)`. The model downloads pretrained weights automatically and saves best checkpoints automatically (use `resume=` to continue from one).
 
-**How do I export RF-DETR to ONNX or TensorRT?**
-Call `model.export(format="onnx")` after training or loading a checkpoint. ONNX export works on CPU and produces a single `.onnx` file compatible with ONNX Runtime and OpenCV DNN. For TensorRT deployment, use `model.export(format="tensorrt")`, which exports ONNX and then builds a `.trt` engine in-process via the TensorRT Python API; this requires `pip install rfdetr[tensorrt]` and a CUDA GPU.
+**How do I export RF-DETR to ONNX or TensorRT?** Call `model.export(format="onnx")` after training or loading a checkpoint. ONNX export works on CPU and produces a single `.onnx` file compatible with ONNX Runtime and OpenCV DNN. For TensorRT deployment, use `model.export(format="tensorrt")`, which exports ONNX and then builds a `.trt` engine in-process via the TensorRT Python API; this requires `pip install rfdetr[tensorrt]` and a CUDA GPU.
 
-**Which RF-DETR model size should I use?**
-RF-DETR-Nano (2.3 ms, 67.6 AP50 on COCO) is best for edge and real-time applications. RF-DETR-Large (6.8 ms, 56.5 AP50:95) offers the best accuracy–latency trade-off for server deployment. RF-DETR-2XLarge (17.2 ms, 60.1 AP50:95) maximizes accuracy when latency allows.
+**Which RF-DETR model size should I use?** RF-DETR-Nano (2.3 ms, 67.6 AP50 on COCO) is best for edge and real-time applications. RF-DETR-Large (6.8 ms, 56.5 AP50:95) offers the best accuracy–latency trade-off for server deployment. RF-DETR-2XLarge (17.2 ms, 60.1 AP50:95) maximizes accuracy when latency allows.
 
 > **Checkpoint note:** Current `RFDETRLarge` defaults to `rf-detr-large-2026.pth`. The older `rf-detr-large.pth` checkpoint is a legacy Large release kept for backward compatibility and has been superseded by the current release.

--- a/docs/learn/benchmarks.md
+++ b/docs/learn/benchmarks.md
@@ -25,11 +25,7 @@ Accuracy and latency are always measured using the same model artifact and the s
 
 !!! info "Metric definitions"
 
-    **AP50**: Detection accuracy at IoU threshold >= 0.50.
-    **AP50:95**: Mean accuracy averaged over IoU thresholds 0.50 to 0.95 (step 0.05) — the primary COCO metric.
-    **Params (M)**: Deployment (fused) `nn.Module` parameter count (`model.parameters()`) in millions, excluding training-only branches and folded normalization layers, and counting model parameters rather than the raw tensor count of the saved checkpoint. Rows marked † use the authors' reported counts rather than SAB-measured values.
-    Latency measured on NVIDIA T4, TensorRT 10.4, CUDA 12.4, FP16, batch size 1,
-    with 200 ms thermal buffer between passes to reduce GPU thermal variance.
+    **AP50**: Detection accuracy at IoU threshold >= 0.50. **AP50:95**: Mean accuracy averaged over IoU thresholds 0.50 to 0.95 (step 0.05) — the primary COCO metric. **Params (M)**: Deployment (fused) `nn.Module` parameter count (`model.parameters()`) in millions, excluding training-only branches and folded normalization layers, and counting model parameters rather than the raw tensor count of the saved checkpoint. Rows marked † use the authors' reported counts rather than SAB-measured values. Latency measured on NVIDIA T4, TensorRT 10.4, CUDA 12.4, FP16, batch size 1, with 200 ms thermal buffer between passes to reduce GPU thermal variance.
 
 ## Detection
 

--- a/docs/learn/export.md
+++ b/docs/learn/export.md
@@ -140,7 +140,9 @@ Pass `output_name="my-model"` to override the variant name and write `{output_na
 
 If you want lower latency on NVIDIA GPUs, you can convert the exported ONNX model to a TensorRT engine.
 
-> [!IMPORTANT] Run TensorRT conversion on the same machine and GPU family where you plan to deploy inference.
+> [!IMPORTANT]
+>
+> Run TensorRT conversion on the same machine and GPU family where you plan to deploy inference.
 
 ### Prerequisites
 

--- a/docs/learn/export.md
+++ b/docs/learn/export.md
@@ -12,8 +12,7 @@ description: Export RF-DETR models to ONNX, TensorRT, TFLite, ExecuTorch, and na
     - INT8 quantization requires calibration data from your dataset for accurate results
     - Custom input resolutions supported (must be divisible by `patch_size × num_windows`, which varies by model variant)
     - Export to ExecuTorch for on-device PyTorch inference (XNNPACK, CoreML, QNN)
-    - Export directly to native CoreML (`.mlpackage`) for Xcode / Apple-platform deployment — see
-        [Native CoreML Export](#native-coreml-export-mlpackage)
+    - Export directly to native CoreML (`.mlpackage`) for Xcode / Apple-platform deployment — see [Native CoreML Export](#native-coreml-export-mlpackage)
 
 RF-DETR supports exporting models to ONNX, TFLite, ExecuTorch, and native CoreML formats, enabling deployment across a wide range of inference frameworks, edge devices, and hardware accelerators.
 
@@ -125,10 +124,7 @@ model.export(backbone_only=True)
 
 ## Output Files
 
-Filenames are built from the model's variant name (e.g. `rfdetr-medium`, falling back to
-`inference_model` when no variant or `output_name` is set, or `backbone_model` when
-`backbone_only=True` in that same case) plus a detail suffix whenever a detail materially changes
-the artifact — even at its default value, since the file needs to say what it actually is:
+Filenames are built from the model's variant name (e.g. `rfdetr-medium`, falling back to `inference_model` when no variant or `output_name` is set, or `backbone_model` when `backbone_only=True` in that same case) plus a detail suffix whenever a detail materially changes the artifact — even at its default value, since the file needs to say what it actually is:
 
 | Format       | Filename pattern                                                                                                                                                                       | Detail encoded                                           |
 | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
@@ -138,17 +134,13 @@ the artifact — even at its default value, since the file needs to say what it 
 | `tensorrt`   | `{variant}_fp16.trt` / `{variant}_fp32.trt`                                                                                                                                            | `fp16`                                                   |
 | `tflite`     | `{variant}_fp32.tflite` + `{variant}_fp16.tflite` (+ `{variant}_dynamic_range_quant.tflite` for `quantization="int8"`)                                                                 | precision / quantization mode                            |
 
-Pass `output_name="my-model"` to override the variant name and write `{output_name}.{ext}`
-verbatim — this suppresses the detail suffix for every format **except** `tflite`, which always
-writes multiple files and so keeps its `_fp32`/`_fp16`/`_dynamic_range_quant` suffix even with a
-custom name (`{output_name}_fp32.tflite`, etc.).
+Pass `output_name="my-model"` to override the variant name and write `{output_name}.{ext}` verbatim — this suppresses the detail suffix for every format **except** `tflite`, which always writes multiple files and so keeps its `_fp32`/`_fp16`/`_dynamic_range_quant` suffix even with a custom name (`{output_name}_fp32.tflite`, etc.).
 
 ## Optional: Convert ONNX to TensorRT
 
 If you want lower latency on NVIDIA GPUs, you can convert the exported ONNX model to a TensorRT engine.
 
-> [!IMPORTANT]
-> Run TensorRT conversion on the same machine and GPU family where you plan to deploy inference.
+> [!IMPORTANT] Run TensorRT conversion on the same machine and GPU family where you plan to deploy inference.
 
 ### Prerequisites
 
@@ -168,21 +160,13 @@ model = RFDETRMedium(pretrain_weights="<path/to/checkpoint.pth>")
 model.export(format="tensorrt")
 ```
 
-This exports `output/inference_model.onnx` first and then produces `output/inference_model_fp16.trt`
-(the `_fp16`/`_fp32` suffix always reflects the precision actually built — see `fp16` in
-[Export Parameters](#export-parameters) — unless `output_name` is set).
+This exports `output/inference_model.onnx` first and then produces `output/inference_model_fp16.trt` (the `_fp16`/`_fp32` suffix always reflects the precision actually built — see `fp16` in [Export Parameters](#export-parameters) — unless `output_name` is set).
 
 !!! note "Who consumes the `.trt` engine?"
 
-    The `.trt` engine produced by `format="tensorrt"` is a standalone artifact for raw
-    TensorRT deployment. It is locked to the GPU architecture and
-    TensorRT version of the machine that built it, so it is not portable across
-    different GPUs or TensorRT releases.
+    The `.trt` engine produced by `format="tensorrt"` is a standalone artifact for raw TensorRT deployment. It is locked to the GPU architecture and TensorRT version of the machine that built it, so it is not portable across different GPUs or TensorRT releases.
 
-    If you plan to run inference with [`inference-models`](#run-inference-with-inference-models)
-    (the recommended path below), do **not** pass `format="tensorrt"` — `inference-models`
-    builds and manages its own TensorRT engine internally and does not consume this file.
-    Export a plain ONNX model instead and let `inference-models` handle the backend.
+    If you plan to run inference with [`inference-models`](#run-inference-with-inference-models) (the recommended path below), do **not** pass `format="tensorrt"` — `inference-models` builds and manages its own TensorRT engine internally and does not consume this file. Export a plain ONNX model instead and let `inference-models` handle the backend.
 
 ### Python API Conversion
 
@@ -197,9 +181,7 @@ engine_path = build_engine("output/inference_model.onnx", fp16=True)
 
 ## Run Inference with `inference-models`
 
-[`inference-models`](https://github.com/roboflow/inference/tree/main/inference_models) is the
-recommended library for running RF-DETR inference. It supports multiple backends — PyTorch,
-ONNX, and TensorRT — with automatic backend selection and a unified API.
+[`inference-models`](https://github.com/roboflow/inference/tree/main/inference_models) is the recommended library for running RF-DETR inference. It supports multiple backends — PyTorch, ONNX, and TensorRT — with automatic backend selection and a unified API.
 
 ### Installation
 
@@ -211,8 +193,7 @@ pip install inference-models
 pip install "inference-models[trt10]"  # TensorRT 10
 ```
 
-See the [inference-models installation guide](https://inference-models.roboflow.com/getting-started/installation/)
-for all installation options including Jetson and CUDA 11.x.
+See the [inference-models installation guide](https://inference-models.roboflow.com/getting-started/installation/) for all installation options including Jetson and CUDA 11.x.
 
 ### Load a Pre-trained RF-DETR Model
 
@@ -260,46 +241,29 @@ image = cv2.imread("image.jpg")
 predictions = model(image)
 ```
 
-`AutoModel.from_pretrained` accepts `backend="onnx"`, `backend="torch"`, or
-`backend="trt"` to override automatic backend selection.
+`AutoModel.from_pretrained` accepts `backend="onnx"`, `backend="torch"`, or `backend="trt"` to override automatic backend selection.
 
 ## TFLite Export
 
 !!! warning "Experimental — Use with Caution"
 
-    TFLite export is **experimental and work-in-progress**. The pipeline depends on
-    several upstream packages (`onnx2tf`, `ai_edge_litert`, `tflite-runtime`) that
-    have experienced breaking API changes and installation instabilities across
-    releases. You may encounter errors or unexpected results.
+    TFLite export is **experimental and work-in-progress**. The pipeline depends on several upstream packages (`onnx2tf`, `ai_edge_litert`, `tflite-runtime`) that have experienced breaking API changes and installation instabilities across releases. You may encounter errors or unexpected results.
 
     **Known instabilities:**
 
-    - `onnx2tf` output graph structure can change between minor versions, silently
-        altering output tensor layout and breaking downstream inference code.
-    - `ai_edge_litert` (Google's replacement for `tflite-runtime`) is still
-        stabilising its public API; version pinning is strongly recommended.
-    - INT8 quantization accuracy is sensitive to calibration data quality — poor
-        calibration causes silent precision loss with no error at export time.
-    - The ONNX → TF → TFLite conversion chain introduces numerical rounding that
-        may produce slightly different predictions from the original PyTorch model.
-    - Installation of the `[tflite]` extra may conflict with existing TensorFlow
-        or NumPy versions in your environment.
-    - `onnx` and TensorFlow both bundle Abseil and export its symbols weakly, so whichever
-        loads first supplies them to both. RF-DETR imports TensorFlow first on the TFLite route;
-        if your own code imports `onnx` before `tensorflow`, RF-DETR logs a warning and the
-        conversion may block forever while restoring the SavedModel (no error, 0% CPU). Importing
-        `onnx` *after* `tensorflow` is safe; otherwise, in a fresh process, preload/import
-        `tensorflow` before `onnx` and then run the export — freshness alone is not sufficient.
+    - `onnx2tf` output graph structure can change between minor versions, silently altering output tensor layout and breaking downstream inference code.
+    - `ai_edge_litert` (Google's replacement for `tflite-runtime`) is still stabilising its public API; version pinning is strongly recommended.
+    - INT8 quantization accuracy is sensitive to calibration data quality — poor calibration causes silent precision loss with no error at export time.
+    - The ONNX → TF → TFLite conversion chain introduces numerical rounding that may produce slightly different predictions from the original PyTorch model.
+    - Installation of the `[tflite]` extra may conflict with existing TensorFlow or NumPy versions in your environment.
+    - `onnx` and TensorFlow both bundle Abseil and export its symbols weakly, so whichever loads first supplies them to both. RF-DETR imports TensorFlow first on the TFLite route; if your own code imports `onnx` before `tensorflow`, RF-DETR logs a warning and the conversion may block forever while restoring the SavedModel (no error, 0% CPU). Importing `onnx` *after* `tensorflow` is safe; otherwise, in a fresh process, preload/import `tensorflow` before `onnx` and then run the export — freshness alone is not sufficient.
 
     **Recommendations:**
 
     - Pin your dependency versions (e.g. `onnx2tf==X.Y.Z`) and test before each upgrade.
     - Validate exported `.tflite` files against a held-out evaluation set before deploying.
-    - Prefer ONNX export when your target runtime supports it — it is more stable and
-        better tested.
-    - If export fails, check the [open issues](https://github.com/roboflow/rf-detr/issues)
-        for known workarounds or report a new one with your environment details
-        (`pip freeze`, Python version, OS).
+    - Prefer ONNX export when your target runtime supports it — it is more stable and better tested.
+    - If export fails, check the [open issues](https://github.com/roboflow/rf-detr/issues) for known workarounds or report a new one with your environment details (`pip freeze`, Python version, OS).
 
 Export your model to TFLite for deployment on mobile devices, microcontrollers, and edge hardware via TensorFlow Lite. The TFLite export pipeline converts ONNX → TensorFlow → TFLite using [onnx2tf](https://github.com/PINTO0309/onnx2tf).
 
@@ -490,22 +454,15 @@ labels = interpreter.get_tensor(labels_detail["index"])
 
 !!! warning "Experimental — Use with Caution"
 
-    ExecuTorch export is **experimental**. The `executorch` package is under active
-    development and its installation and API are subject to breaking changes between
-    releases.
+    ExecuTorch export is **experimental**. The `executorch` package is under active development and its installation and API are subject to breaking changes between releases.
 
     **Known limitations:**
 
-    - `dynamic_batch=True` is not supported: the runtime cannot resize RF-DETR's
-        windowed-attention reshapes, so export one `.pte` per batch size instead.
-    - The `"qnn"` backend requires a **source build** of ExecuTorch against the QAIRT
-        SDK and cannot be installed via `pip`.
-    - CoreML export runs in fp16; top-level detections are correct but raw tensor
-        values will differ from the PyTorch fp32 model as expected for fp16 computation.
+    - `dynamic_batch=True` is not supported: the runtime cannot resize RF-DETR's windowed-attention reshapes, so export one `.pte` per batch size instead.
+    - The `"qnn"` backend requires a **source build** of ExecuTorch against the QAIRT SDK and cannot be installed via `pip`.
+    - CoreML export runs in fp16; top-level detections are correct but raw tensor values will differ from the PyTorch fp32 model as expected for fp16 computation.
 
-ExecuTorch is PyTorch's on-device inference runtime. Unlike ONNX export, the model is exported
-directly via `torch.export` to a portable `.pte` binary — no intermediate ONNX conversion step
-is involved.
+ExecuTorch is PyTorch's on-device inference runtime. Unlike ONNX export, the model is exported directly via `torch.export` to a portable `.pte` binary — no intermediate ONNX conversion step is involved.
 
 ### Prerequisites
 
@@ -515,9 +472,7 @@ pip install "rfdetr[executorch]"
 
 ### XNNPACK Backend (Portable CPU, fp32)
 
-The `"xnnpack"` backend targets any CPU platform and runs in fp32. It is the recommended,
-portable backend and requires only the standard `rfdetr[executorch]` wheel. `backend` has no
-default — it must always be passed explicitly for `format="executorch"`.
+The `"xnnpack"` backend targets any CPU platform and runs in fp32. It is the recommended, portable backend and requires only the standard `rfdetr[executorch]` wheel. `backend` has no default — it must always be passed explicitly for `format="executorch"`.
 
 === "Object Detection"
 
@@ -539,23 +494,15 @@ default — it must always be passed explicitly for `format="executorch"`.
     model.export(format="executorch", backend="xnnpack")
     ```
 
-This produces `output/rfdetr-seg-medium_xnnpack.pte` — the file is named after the model variant
-plus the backend (`{variant}_{backend}.pte`, or `{variant}_qnn_{soc}.pte` for the SoC-locked `qnn`
-backend), not a generic `inference_model_{backend}.pte`. The backend is always encoded because it
-determines which hardware/runtime can load the file.
+This produces `output/rfdetr-seg-medium_xnnpack.pte` — the file is named after the model variant plus the backend (`{variant}_{backend}.pte`, or `{variant}_qnn_{soc}.pte` for the SoC-locked `qnn` backend), not a generic `inference_model_{backend}.pte`. The backend is always encoded because it determines which hardware/runtime can load the file.
 
 ### CoreML Backend (Apple Neural Engine, fp16)
 
 !!! note "Not the same as native CoreML export"
 
-    This is the ExecuTorch delegate — `format="executorch", backend="coreml"` — which produces a
-    `.pte` file for the ExecuTorch runtime. It is distinct from `format="coreml"`, which produces a
-    native `.mlpackage` directly (no ExecuTorch runtime involved); see
-    [Native CoreML Export](#native-coreml-export-mlpackage) below.
+    This is the ExecuTorch delegate — `format="executorch", backend="coreml"` — which produces a `.pte` file for the ExecuTorch runtime. It is distinct from `format="coreml"`, which produces a native `.mlpackage` directly (no ExecuTorch runtime involved); see [Native CoreML Export](#native-coreml-export-mlpackage) below.
 
-The `"coreml"` backend targets Apple devices (iPhone, iPad, Mac) and runs in fp16 on the
-Neural Engine. It requires `coremltools`, which is **not** included in the `rfdetr[executorch]`
-extra — install it separately:
+The `"coreml"` backend targets Apple devices (iPhone, iPad, Mac) and runs in fp16 on the Neural Engine. It requires `coremltools`, which is **not** included in the `rfdetr[executorch]` extra — install it separately:
 
 ```bash
 pip install coremltools
@@ -571,14 +518,11 @@ model.export(format="executorch", backend="coreml")
 
 !!! note
 
-    CoreML export uses fp16 arithmetic. Top-level detections (bounding boxes and class labels)
-    are correct, but raw tensor values will differ from the PyTorch fp32 baseline at the fp16
-    precision level — this is expected behavior.
+    CoreML export uses fp16 arithmetic. Top-level detections (bounding boxes and class labels) are correct, but raw tensor values will differ from the PyTorch fp32 baseline at the fp16 precision level — this is expected behavior.
 
 ### QNN Backend (Qualcomm Snapdragon HTP, fp16)
 
-The `"qnn"` backend targets the Qualcomm AI Engine (HTP) on Snapdragon SoCs and runs in fp16.
-It **requires a source build** of ExecuTorch against the QAIRT SDK and cannot be installed via `pip`.
+The `"qnn"` backend targets the Qualcomm AI Engine (HTP) on Snapdragon SoCs and runs in fp16. It **requires a source build** of ExecuTorch against the QAIRT SDK and cannot be installed via `pip`.
 
 ```python
 from rfdetr import RFDETRMedium
@@ -588,44 +532,26 @@ model = RFDETRMedium(pretrain_weights="<path/to/checkpoint.pth>")
 model.export(format="executorch", backend="qnn", soc="SM8650")
 ```
 
-The `soc` parameter is required for QNN and must be a `QcomChipset` name matching your target
-device. For example, `"SM8650"` targets the Snapdragon 8 Gen 3. This produces
-`output/rfdetr-medium_qnn_SM8650.pte` — the SoC is baked into the filename (not just the
-backend) since a QNN `.pte` is compiled ahead-of-time for one specific chip and will not run on
-another.
+The `soc` parameter is required for QNN and must be a `QcomChipset` name matching your target device. For example, `"SM8650"` targets the Snapdragon 8 Gen 3. This produces `output/rfdetr-medium_qnn_SM8650.pte` — the SoC is baked into the filename (not just the backend) since a QNN `.pte` is compiled ahead-of-time for one specific chip and will not run on another.
 
 !!! warning
 
-    QNN export is validated on-device but cannot be tested in CI (requires QAIRT SDK).
-    Validate detections on your target Snapdragon device before deploying to production.
+    QNN export is validated on-device but cannot be tested in CI (requires QAIRT SDK). Validate detections on your target Snapdragon device before deploying to production.
 
 ### ExecuTorch Limitations
 
-- **`dynamic_batch=True` is not supported.** The ExecuTorch runtime cannot resize RF-DETR's
-    windowed-attention reshapes for a variable batch size. Export one `.pte` file per batch size
-    instead (e.g. `batch_size=1` for single-image inference).
-- **QNN requires a source build.** The QNN backend is not available via the pip wheel; see the
-    ExecuTorch documentation for source-build instructions against the QAIRT SDK.
+- **`dynamic_batch=True` is not supported.** The ExecuTorch runtime cannot resize RF-DETR's windowed-attention reshapes for a variable batch size. Export one `.pte` file per batch size instead (e.g. `batch_size=1` for single-image inference).
+- **QNN requires a source build.** The QNN backend is not available via the pip wheel; see the ExecuTorch documentation for source-build instructions against the QAIRT SDK.
 
 ### ExecuTorch Inference Example
 
 !!! warning "torch/executorch ABI compatibility"
 
-    Loading a `.pte` via `executorch.runtime` (below) requires a `torch` version whose ABI
-    matches the `executorch` wheel you installed — `.pte` **export** itself does not need
-    `executorch.runtime` and is unaffected. For `executorch==1.3.1`, pin `torch<2.13`
-    (`pip install "torch<2.13"`); a newer `torch` release can silently break `executorch.runtime`
-    with an `undefined symbol` / `dlopen` error at import time, since ExecuTorch's prebuilt wheels
-    are compiled against whichever `torch` ABI existed at their release time.
+    Loading a `.pte` via `executorch.runtime` (below) requires a `torch` version whose ABI matches the `executorch` wheel you installed — `.pte` **export** itself does not need `executorch.runtime` and is unaffected. For `executorch==1.3.1`, pin `torch<2.13` (`pip install "torch<2.13"`); a newer `torch` release can silently break `executorch.runtime` with an `undefined symbol` / `dlopen` error at import time, since ExecuTorch's prebuilt wheels are compiled against whichever `torch` ABI existed at their release time.
 
 !!! warning "The input tensor must be contiguous"
 
-    The ExecuTorch runtime reads the input buffer as contiguous NCHW and ignores tensor strides.
-    Preprocessing steps that permute axes — `np.transpose`, `Tensor.permute`, torchvision's
-    `ToImage` — return a strided view rather than a copy, and such a view is misread as a
-    scrambled image. Nothing errors: the model runs without error and returns plausible-shaped
-    output, but every detection's score collapses below threshold. Finish preprocessing with
-    `np.ascontiguousarray(...)` (or `Tensor.contiguous()`) before calling `execute`.
+    The ExecuTorch runtime reads the input buffer as contiguous NCHW and ignores tensor strides. Preprocessing steps that permute axes — `np.transpose`, `Tensor.permute`, torchvision's `ToImage` — return a strided view rather than a copy, and such a view is misread as a scrambled image. Nothing errors: the model runs without error and returns plausible-shaped output, but every detection's score collapses below threshold. Finish preprocessing with `np.ascontiguousarray(...)` (or `Tensor.contiguous()`) before calling `execute`.
 
 ```python
 import torch
@@ -659,22 +585,13 @@ boxes, labels = outputs[0], outputs[1]
 
 !!! warning "Experimental — Use with Caution"
 
-    Native CoreML export is **experimental and work-in-progress**. `dynamic_batch=True` is not
-    supported — fixed shapes are required for reliable ANE / GPU scheduling. Export one
-    `.mlpackage` per batch size instead.
+    Native CoreML export is **experimental and work-in-progress**. `dynamic_batch=True` is not supported — fixed shapes are required for reliable ANE / GPU scheduling. Export one `.mlpackage` per batch size instead.
 
 !!! note "Not the same as the ExecuTorch CoreML backend"
 
-    `format="coreml"` exports directly via `torch.export` + `coremltools` to a native
-    `.mlpackage` (mlprogram, iOS 16+) — no ONNX and no ExecuTorch runtime involved. This is
-    distinct from [`format="executorch", backend="coreml"`](#coreml-backend-apple-neural-engine-fp16),
-    which produces a `.pte` file for the ExecuTorch runtime. Passing both `format="coreml"` and
-    `backend="coreml"` together does not fall through to the ExecuTorch delegate — `backend` is
-    ignored (with a warning) and the native `.mlpackage` path always runs.
+    `format="coreml"` exports directly via `torch.export` + `coremltools` to a native `.mlpackage` (mlprogram, iOS 16+) — no ONNX and no ExecuTorch runtime involved. This is distinct from [`format="executorch", backend="coreml"`](#coreml-backend-apple-neural-engine-fp16), which produces a `.pte` file for the ExecuTorch runtime. Passing both `format="coreml"` and `backend="coreml"` together does not fall through to the ExecuTorch delegate — `backend` is ignored (with a warning) and the native `.mlpackage` path always runs.
 
-RF-DETR's native CoreML export produces a `.mlpackage` you can drag directly into Xcode, with no
-ONNX intermediary and no ExecuTorch runtime dependency — the lowest-friction path for Apple-native
-(iOS / macOS) developers.
+RF-DETR's native CoreML export produces a `.mlpackage` you can drag directly into Xcode, with no ONNX intermediary and no ExecuTorch runtime dependency — the lowest-friction path for Apple-native (iOS / macOS) developers.
 
 ### Prerequisites
 
@@ -704,16 +621,11 @@ pip install "rfdetr[coreml]"
     model.export(format="coreml")
     ```
 
-This produces `output/rfdetr-medium_fp32.mlpackage` — the file is named after the model variant
-plus the resolved precision (`{variant}_fp32.mlpackage` / `{variant}_fp16.mlpackage`), not a
-generic `inference_model_fp32.mlpackage`. The precision is always encoded, even at its default
-value, since fp16 vs fp32 materially changes the bundle.
+This produces `output/rfdetr-medium_fp32.mlpackage` — the file is named after the model variant plus the resolved precision (`{variant}_fp32.mlpackage` / `{variant}_fp16.mlpackage`), not a generic `inference_model_fp32.mlpackage`. The precision is always encoded, even at its default value, since fp16 vs fp32 materially changes the bundle.
 
 ### Compute Precision
 
-CoreML export defaults to `FLOAT32` for tight CPU parity with eager PyTorch. Pass
-`coreml_precision="float16"` for a smaller, ANE-oriented bundle (expect larger numeric drift) —
-this also changes the output filename to `output/rfdetr-medium_fp16.mlpackage`:
+CoreML export defaults to `FLOAT32` for tight CPU parity with eager PyTorch. Pass `coreml_precision="float16"` for a smaller, ANE-oriented bundle (expect larger numeric drift) — this also changes the output filename to `output/rfdetr-medium_fp16.mlpackage`:
 
 ```python
 model.export(format="coreml", coreml_precision="float16")
@@ -721,9 +633,7 @@ model.export(format="coreml", coreml_precision="float16")
 
 !!! note
 
-    Output tensor names in the saved `.mlpackage` spec are coremltools-inferred, not renamed to
-    `dets`/`labels`/etc. — match outputs by **position**, in the same order as the ONNX
-    `output_names` contract (`dets, labels` for detection; `dets, labels, masks` for segmentation).
+    Output tensor names in the saved `.mlpackage` spec are coremltools-inferred, not renamed to `dets`/`labels`/etc. — match outputs by **position**, in the same order as the ONNX `output_names` contract (`dets, labels` for detection; `dets, labels, masks` for segmentation).
 
 ### CoreML Inference Example
 
@@ -757,19 +667,11 @@ Once exported, you can use the ONNX model with various inference frameworks:
 
 ### ONNX Runtime
 
-The exported graph returns **raw** tensors — `dets` (`pred_boxes`, normalized `cxcywh`) and
-`labels` (`pred_logits`, un-activated). Nothing is decoded inside the graph, so your inference
-code must apply sigmoid, drop the no-object background column, and convert box format
-yourself.
+The exported graph returns **raw** tensors — `dets` (`pred_boxes`, normalized `cxcywh`) and `labels` (`pred_logits`, un-activated). Nothing is decoded inside the graph, so your inference code must apply sigmoid, drop the no-object background column, and convert box format yourself.
 
 !!! warning "Match outputs by name, not by shape"
 
-    RF-DETR always adds an implicit no-object class, so the logits tensor's last dimension is
-    `num_classes + 1`. If `num_classes == 3`, that dimension is `4` — identical to the box
-    tensor's last dimension (`4`, `cxcywh`). Disambiguating outputs by shape instead of by name
-    (`"dets"` / `"labels"`) will silently swap boxes and logits at exactly `num_classes == 3`,
-    producing garbage detections while every other `num_classes` value looks fine. Always match
-    by name first.
+    RF-DETR always adds an implicit no-object class, so the logits tensor's last dimension is `num_classes + 1`. If `num_classes == 3`, that dimension is `4` — identical to the box tensor's last dimension (`4`, `cxcywh`). Disambiguating outputs by shape instead of by name (`"dets"` / `"labels"`) will silently swap boxes and logits at exactly `num_classes == 3`, producing garbage detections while every other `num_classes` value looks fine. Always match by name first.
 
 ```python
 import onnxruntime as ort
@@ -824,9 +726,7 @@ xyxy *= np.array([image.width, image.height, image.width, image.height], dtype=n
 boxes, labels, confidences = xyxy, class_ids[keep], scores[keep]
 ```
 
-For a fuller reference implementation (name-based matching with a documented shape-based
-fallback), see `_run_inference` in
-[`src/rfdetr/export/_onnx/inference.py`](https://github.com/roboflow/rf-detr/blob/develop/src/rfdetr/export/_onnx/inference.py).
+For a fuller reference implementation (name-based matching with a documented shape-based fallback), see `_run_inference` in [`src/rfdetr/export/_onnx/inference.py`](https://github.com/roboflow/rf-detr/blob/develop/src/rfdetr/export/_onnx/inference.py).
 
 ## Next Steps
 
@@ -834,8 +734,7 @@ After exporting your model, you may want to:
 
 - [Deploy to Roboflow](deploy.md) for cloud-based inference and workflow integration
 
-- Use [`inference-models`](https://github.com/roboflow/inference/tree/main/inference_models) for
-    multi-backend inference (PyTorch, ONNX, TensorRT) with automatic backend selection
+- Use [`inference-models`](https://github.com/roboflow/inference/tree/main/inference_models) for multi-backend inference (PyTorch, ONNX, TensorRT) with automatic backend selection
 
 - Deploy TFLite models on mobile/edge devices with TensorFlow Lite
 

--- a/docs/learn/run/detection.md
+++ b/docs/learn/run/detection.md
@@ -62,13 +62,9 @@ Perform inference on an image using either the `rfdetr` package or the `inferenc
 
 !!! note "Using COCO classes vs. fine-tuned model classes"
 
-    `COCO_CLASSES` works for COCO-pretrained models (80 COCO classes, indexed 0-79).
-    For fine-tuned models, use `detections.data["class_name"]` instead — it resolves
-    class names from the checkpoint and works for both COCO and custom datasets.
+    `COCO_CLASSES` works for COCO-pretrained models (80 COCO classes, indexed 0-79). For fine-tuned models, use `detections.data["class_name"]` instead — it resolves class names from the checkpoint and works for both COCO and custom datasets.
 
-For memory-constrained inference-only deployments with the `rfdetr` package, optimize the loaded model in place before
-calling `predict()`. Pass `dtype="float16"` to halve weight memory in addition to clearing the base model reference.
-This operation is irreversible — to restore the original model, create a new `RFDETR` instance:
+For memory-constrained inference-only deployments with the `rfdetr` package, optimize the loaded model in place before calling `predict()`. Pass `dtype="float16"` to halve weight memory in addition to clearing the base model reference. This operation is irreversible — to restore the original model, create a new `RFDETR` instance:
 
 ```python
 model.inference(compile=False, inplace=True, dtype="float16")

--- a/docs/learn/run/segmentation.md
+++ b/docs/learn/run/segmentation.md
@@ -58,9 +58,7 @@ Perform inference on an image using either the `rfdetr` package or the `inferenc
     annotated_image = sv.LabelAnnotator().annotate(annotated_image, detections)
     ```
 
-For memory-constrained inference-only deployments with the `rfdetr` package, optimize the loaded model in place before
-calling `predict()`. Pass `dtype="float16"` to halve weight memory in addition to clearing the base model reference.
-This operation is irreversible — to restore the original model, create a new `RFDETR` instance:
+For memory-constrained inference-only deployments with the `rfdetr` package, optimize the loaded model in place before calling `predict()`. Pass `dtype="float16"` to halve weight memory in addition to clearing the base model reference. This operation is irreversible — to restore the original model, create a new `RFDETR` instance:
 
 ```python
 model.inference(compile=False, inplace=True, dtype="float16")

--- a/docs/learn/train/advanced.md
+++ b/docs/learn/train/advanced.md
@@ -23,14 +23,7 @@ The training loop will automatically load:
 
 !!! warning "Lightweight checkpoints resume without optimizer/scheduler state"
 
-    The above applies to the trainer's own full checkpoints (`last.ckpt`, `checkpoint_<epoch>.ckpt`). The best-model
-    tracker also writes four lighter `.pth` files — `checkpoint_best_regular.pth`, `checkpoint_best_ema.pth`,
-    `checkpoint_best_total.pth`, `last_ema.pth` — that intentionally omit optimizer/scheduler state to stay small.
-    New files with matching configured callbacks can restore callback state (EMA and early stopping). Best-score
-    tracking additionally requires `output_dir` to be the exact directory where the checkpoint was written. Files
-    created before callback-state persistence (or with an empty callback section) restart callback state. The optimizer
-    and LR scheduler always start cold. `resume=` logs the applicable warning; pass a full trainer checkpoint instead
-    if you need optimizer/scheduler continuity.
+    The above applies to the trainer's own full checkpoints (`last.ckpt`, `checkpoint_<epoch>.ckpt`). The best-model tracker also writes four lighter `.pth` files — `checkpoint_best_regular.pth`, `checkpoint_best_ema.pth`, `checkpoint_best_total.pth`, `last_ema.pth` — that intentionally omit optimizer/scheduler state to stay small. New files with matching configured callbacks can restore callback state (EMA and early stopping). Best-score tracking additionally requires `output_dir` to be the exact directory where the checkpoint was written. Files created before callback-state persistence (or with an empty callback section) restart callback state. The optimizer and LR scheduler always start cold. `resume=` logs the applicable warning; pass a full trainer checkpoint instead if you need optimizer/scheduler continuity.
 
 === "Object Detection"
 
@@ -77,8 +70,7 @@ The training loop will automatically load:
 
 ## Early Stopping
 
-Early stopping monitors the validation task metric and halts training if improvements remain below a threshold for a
-set number of epochs. Detection and segmentation models use box mAP; keypoint preview models use COCO keypoint AP.
+Early stopping monitors the validation task metric and halts training if improvements remain below a threshold for a set number of epochs. Detection and segmentation models use box mAP; keypoint preview models use COCO keypoint AP.
 
 ### Basic Usage
 
@@ -189,12 +181,9 @@ torchrun --nproc_per_node=4 train.py
 
 !!! warning "Pass `devices=` explicitly"
 
-    `build_trainer()` defaults to `devices=1`. Without overriding this, training silently
-    runs on a single GPU even when `torchrun` launches multiple processes.
+    `build_trainer()` defaults to `devices=1`. Without overriding this, training silently runs on a single GPU even when `torchrun` launches multiple processes.
 
-    Pass `devices="auto"` to use all GPUs visible to the process, or pass an explicit
-    integer (e.g. `devices=4`). These values are forwarded to `build_trainer` via
-    `**trainer_kwargs`:
+    Pass `devices="auto"` to use all GPUs visible to the process, or pass an explicit integer (e.g. `devices=4`). These values are forwarded to `build_trainer` via `**trainer_kwargs`:
 
     ```python
     model.train(
@@ -247,9 +236,7 @@ Run this command on each node, changing `--node_rank` accordingly.
 
 ### Keypoint / Pose models
 
-Keypoint models (`RFDETRKeypointPreview`) train under `DistributedDataParallel` on multiple GPUs and
-multiple nodes exactly like detection models — build a script and launch it with `torchrun`, setting
-`devices=` (e.g. `"auto"` or an integer like `8`):
+Keypoint models (`RFDETRKeypointPreview`) train under `DistributedDataParallel` on multiple GPUs and multiple nodes exactly like detection models — build a script and launch it with `torchrun`, setting `devices=` (e.g. `"auto"` or an integer like `8`):
 
 ```python
 # train_pose.py
@@ -274,15 +261,9 @@ torchrun --nproc_per_node=8 train_pose.py
 
 !!! note "Prefer `grad_accum_steps=1` on multi-GPU for keypoints"
 
-    Keypoint models use **manual optimization** so the per-step box-count loss normalization is
-    computed over the full accumulated batch. As a result, gradients synchronize on **every**
-    microbatch rather than only at the end of an accumulation window. Training with
-    `grad_accum_steps > 1` on multiple GPUs is still numerically correct, but performs one
-    `all_reduce` per microbatch (i.e. `grad_accum_steps`× the necessary communication). For best
-    throughput, scale with more GPUs / a larger per-GPU `batch_size` and keep `grad_accum_steps=1`.
+    Keypoint models use **manual optimization** so the per-step box-count loss normalization is computed over the full accumulated batch. As a result, gradients synchronize on **every** microbatch rather than only at the end of an accumulation window. Training with `grad_accum_steps > 1` on multiple GPUs is still numerically correct, but performs one `all_reduce` per microbatch (i.e. `grad_accum_steps`× the necessary communication). For best throughput, scale with more GPUs / a larger per-GPU `batch_size` and keep `grad_accum_steps=1`.
 
-    Sharded strategies (FSDP / DeepSpeed) are **not** supported for keypoint models — use `ddp`
-    (or `strategy="auto"` with `devices > 1`).
+    Sharded strategies (FSDP / DeepSpeed) are **not** supported for keypoint models — use `ddp` (or `strategy="auto"` with `devices > 1`).
 
 ### Advanced multi-GPU options (PTL API)
 
@@ -345,18 +326,14 @@ To disable all augmentations, pass an empty dict:
 model.train(dataset_dir="path/to/dataset", aug_config={})
 ```
 
-`aug_config` controls only the augmentation stack (Albumentations on CPU, or the
-equivalent Kornia pipeline when `augmentation_backend="kornia"`/`"auto"`). The training
-resize pipeline's independent resize → crop → resize branch (Option B) is controlled
-separately by `scale_jitter`:
+`aug_config` controls only the augmentation stack (Albumentations on CPU, or the equivalent Kornia pipeline when `augmentation_backend="kornia"`/`"auto"`). The training resize pipeline's independent resize → crop → resize branch (Option B) is controlled separately by `scale_jitter`:
 
 ```python
 # Keep aug_config's default augmentation stack, but disable random crop/scale jitter
 model.train(dataset_dir="path/to/dataset", scale_jitter=False)
 ```
 
-`scale_jitter` defaults to `True`. Set it to `False` to use direct resize only —
-no random crop, so annotations near image borders are never clipped.
+`scale_jitter` defaults to `True`. Set it to `False` to use direct resize only — no random crop, so annotations near image borders are never clipped.
 
 ---
 

--- a/docs/learn/train/augmentations.md
+++ b/docs/learn/train/augmentations.md
@@ -56,11 +56,7 @@ model.train(
 
 To disable all optional training augmentation including the torchvision default horizontal flip: `aug_config={}`.
 
-`aug_config` controls only the augmentation stack — the torchvision-native default, or the
-Albumentations/Kornia stack when a non-empty `aug_config` is passed. To also disable
-the independent resize → crop → resize branch (Option B) in the training resize
-pipeline — so no spatial clipping occurs and annotations near image borders stay
-intact — pass `scale_jitter=False` to `model.train()`.
+`aug_config` controls only the augmentation stack — the torchvision-native default, or the Albumentations/Kornia stack when a non-empty `aug_config` is passed. To also disable the independent resize → crop → resize branch (Option B) in the training resize pipeline — so no spatial clipping occurs and annotations near image borders stay intact — pass `scale_jitter=False` to `model.train()`.
 
 ## Built-in Presets
 

--- a/docs/learn/train/dataset-formats.md
+++ b/docs/learn/train/dataset-formats.md
@@ -146,8 +146,7 @@ The `segmentation` field contains a list of polygons, where each polygon is a fl
 
 ### Keypoint Annotations
 
-For training the keypoint preview model, use COCO JSON keypoint annotations. Roboflow-style COCO exports are supported
-when the split files are named `train/_annotations.coco.json` and `valid/_annotations.coco.json`.
+For training the keypoint preview model, use COCO JSON keypoint annotations. Roboflow-style COCO exports are supported when the split files are named `train/_annotations.coco.json` and `valid/_annotations.coco.json`.
 
 Each keypoint annotation must include a bounding box plus COCO keypoint fields:
 
@@ -192,13 +191,9 @@ The category should declare the keypoint schema:
 }
 ```
 
-The `keypoints` array above is shortened for readability. In a valid COCO person-keypoint annotation it contains
-`17 * 3` values: `x`, `y`, and visibility for each keypoint.
+The `keypoints` array above is shortened for readability. In a valid COCO person-keypoint annotation it contains `17 * 3` values: `x`, `y`, and visibility for each keypoint.
 
-The keypoint preview model is pretrained on COCO person-style keypoints. Its default COCO schema is `[17]`, so
-keypoint-bearing categories are mapped onto the active keypoint label slot during COCO loading. Legacy checkpoints may
-still report a background-first `[0, 17]` schema, which RF-DETR accepts for compatibility. Custom keypoint training can
-also use YOLO pose labels, described below.
+The keypoint preview model is pretrained on COCO person-style keypoints. Its default COCO schema is `[17]`, so keypoint-bearing categories are mapped onto the active keypoint label slot during COCO loading. Legacy checkpoints may still report a background-first `[0, 17]` schema, which RF-DETR accepts for compatibility. Custom keypoint training can also use YOLO pose labels, described below.
 
 ---
 
@@ -324,8 +319,7 @@ The coordinates after the class ID represent the polygon vertices in normalized 
 
 ### Pose Labels (YOLO Pose)
 
-For keypoint preview training, RF-DETR supports Ultralytics YOLO pose labels in the same directory layout shown above.
-The `data.yaml` file must declare `kpt_shape`:
+For keypoint preview training, RF-DETR supports Ultralytics YOLO pose labels in the same directory layout shown above. The `data.yaml` file must declare `kpt_shape`:
 
 ```yaml
 names:
@@ -340,9 +334,7 @@ kpt_names:
     - right_eye
 ```
 
-`kpt_names` is optional. When omitted, RF-DETR creates placeholder names such as `keypoint_0`. `flip_idx` is an
-Ultralytics-style length-`K` permutation used to infer RF-DETR's flat `keypoint_flip_pairs` for horizontal-flip
-augmentation.
+`kpt_names` is optional. When omitted, RF-DETR creates placeholder names such as `keypoint_0`. `flip_idx` is an Ultralytics-style length-`K` permutation used to infer RF-DETR's flat `keypoint_flip_pairs` for horizontal-flip augmentation.
 
 Each pose label row contains a bounding box followed by keypoints:
 
@@ -356,8 +348,7 @@ For `kpt_shape: [K, 2]`, omit the visibility value:
 <class_id> <x_center> <y_center> <width> <height> <px1> <py1> ... <pxK> <pyK>
 ```
 
-All box and keypoint coordinates are normalized to `[0, 1]`. RF-DETR converts keypoints to COCO-style `(x, y, visibility)` tensors internally. For `[K, 3]`, the visibility values are preserved. For `[K, 2]`, visibility is
-synthesized: nonzero points are marked visible (`2`) and `(0, 0)` points are marked absent (`0`).
+All box and keypoint coordinates are normalized to `[0, 1]`. RF-DETR converts keypoints to COCO-style `(x, y, visibility)` tensors internally. For `[K, 3]`, the visibility values are preserved. For `[K, 2]`, visibility is synthesized: nonzero points are marked visible (`2`) and `(0, 0)` points are marked absent (`0`).
 
 Use the YOLO schema helper when you want to configure a model explicitly:
 
@@ -385,8 +376,7 @@ model.train(
 
 !!! note "flip_idx and keypoint_flip_pairs"
 
-    `flip_idx` is a permutation, while `keypoint_flip_pairs` is a flat pair list. During `model.train()`, RF-DETR infers
-    the pair list automatically from `flip_idx` when no explicit `keypoint_flip_pairs` is provided.
+    `flip_idx` is a permutation, while `keypoint_flip_pairs` is a flat pair list. During `model.train()`, RF-DETR infers the pair list automatically from `flip_idx` when no explicit `keypoint_flip_pairs` is provided.
 
 ---
 

--- a/docs/learn/train/index.md
+++ b/docs/learn/train/index.md
@@ -148,9 +148,7 @@ RF-DETR **automatically detects** whether your dataset is in COCO or YOLO format
 | **COCO** | Looks for `train/_annotations.coco.json` | [COCO Format Guide](dataset-formats.md#coco-format) |
 | **YOLO** | Looks for `data.yaml` + `train/images/`  | [YOLO Format Guide](dataset-formats.md#yolo-format) |
 
-For keypoint preview training, use COCO keypoint JSON or YOLO pose labels. YOLO pose datasets must declare
-`kpt_shape` in `data.yaml`; detection-only YOLO datasets still fail clearly in keypoint mode instead of being treated as
-pose labels.
+For keypoint preview training, use COCO keypoint JSON or YOLO pose labels. YOLO pose datasets must declare `kpt_shape` in `data.yaml`; detection-only YOLO datasets still fail clearly in keypoint mode instead of being treated as pose labels.
 
 [Roboflow](https://roboflow.com/annotate) allows you to create object detection datasets from scratch and export them in either COCO JSON or YOLO format for training. You can also explore [Roboflow Universe](https://universe.roboflow.com/) to find pre-labeled datasets for a range of use cases.
 
@@ -201,13 +199,9 @@ During training, multiple model checkpoints are saved to the output directory:
 
 - `checkpoint_best_regular.pth` – best checkpoint based on validation score, using the raw (non-EMA) model weights.
 
-- `checkpoint_best_total.pth` – final checkpoint selected for inference and benchmarking. It contains model weights,
-    epoch/PTL metadata, and callback state when available, but no optimizer or scheduler state. It is chosen as the
-    better of the EMA and non-EMA models based on validation performance.
+- `checkpoint_best_total.pth` – final checkpoint selected for inference and benchmarking. It contains model weights, epoch/PTL metadata, and callback state when available, but no optimizer or scheduler state. It is chosen as the better of the EMA and non-EMA models based on validation performance.
 
-For detection and segmentation models, the validation score is box mAP (`val/mAP_50_95`). For keypoint preview models,
-best-checkpoint selection uses COCO keypoint AP (`val/keypoint_map_50_95`) and checkpoints persist the model keypoint
-schema so `RFDETR.from_checkpoint()` can reconstruct the same label/keypoint slots.
+For detection and segmentation models, the validation score is box mAP (`val/mAP_50_95`). For keypoint preview models, best-checkpoint selection uses COCO keypoint AP (`val/keypoint_map_50_95`) and checkpoints persist the model keypoint schema so `RFDETR.from_checkpoint()` can reconstruct the same label/keypoint slots.
 
 ??? note "Checkpoint file sizes"
 
@@ -243,9 +237,7 @@ schema so `RFDETR.from_checkpoint()` can reconstruct the same label/keypoint slo
 
 ## Evaluate a Fine-Tuned Model
 
-`model.evaluate()` runs a single evaluation pass over a dataset split and returns (and prints) the COCO metrics — mAP,
-mAR, and the macro-F1 sweep. It works both right after `model.train()` and on a model loaded from a checkpoint; the
-weights already in memory are evaluated, so no checkpoint file is re-loaded.
+`model.evaluate()` runs a single evaluation pass over a dataset split and returns (and prints) the COCO metrics — mAP, mAR, and the macro-F1 sweep. It works both right after `model.train()` and on a model loaded from a checkpoint; the weights already in memory are evaluated, so no checkpoint file is re-loaded.
 
 ```python
 from rfdetr import RFDETRMedium
@@ -256,17 +248,10 @@ metrics = model.evaluate(dataset_dir="<DATASET_PATH>", split="test")
 print(metrics["test/mAP_50_95"])
 ```
 
-- `split="test"` evaluates the `test/` folder on Roboflow-exported datasets (`dataset_file="roboflow"`, the default).
-    For other dataset formats (COCO, YOLO, Objects365) there is no dedicated test split, so `split="test"` silently
-    evaluates the `valid/` folder instead — the returned metric keys are still prefixed `test/*`, so double-check
-    `dataset_file` before treating `test/mAP_50_95` as held-out-test performance on a non-Roboflow dataset.
-    `split="val"` always evaluates `valid/` directly.
-- The detection head is never adapted to the dataset — the model is evaluated exactly as configured. If the dataset's
-    class count differs from the model's `num_classes`, a warning is emitted and evaluation proceeds unchanged.
+- `split="test"` evaluates the `test/` folder on Roboflow-exported datasets (`dataset_file="roboflow"`, the default). For other dataset formats (COCO, YOLO, Objects365) there is no dedicated test split, so `split="test"` silently evaluates the `valid/` folder instead — the returned metric keys are still prefixed `test/*`, so double-check `dataset_file` before treating `test/mAP_50_95` as held-out-test performance on a non-Roboflow dataset. `split="val"` always evaluates `valid/` directly.
+- The detection head is never adapted to the dataset — the model is evaluated exactly as configured. If the dataset's class count differs from the model's `num_classes`, a warning is emitted and evaluation proceeds unchanged.
 - Evaluation writes no checkpoints or logs to `output_dir`.
-- `evaluate()` accepts the same keyword arguments as `train()` for convenience, but training-only fields (`epochs`,
-    `lr`, `ema`, `early_stopping`, logger flags, etc.) have no effect — evaluation runs through an eval-only trainer
-    that never builds those callbacks.
+- `evaluate()` accepts the same keyword arguments as `train()` for convenience, but training-only fields (`epochs`, `lr`, `ema`, `early_stopping`, logger flags, etc.) have no effect — evaluation runs through an eval-only trainer that never builds those callbacks.
 
 ## Next Steps
 

--- a/docs/learn/train/loggers.md
+++ b/docs/learn/train/loggers.md
@@ -20,9 +20,7 @@ TensorBoard logging is enabled by default. Pass `tensorboard=False` to disable i
 
 !!! note "Missing package behaviour"
 
-    If the `tensorboard` package is not installed, training continues without error — a
-    `UserWarning` is emitted and TensorBoard logging is silently suppressed. Install
-    `rfdetr[loggers]` to avoid this.
+    If the `tensorboard` package is not installed, training continues without error — a `UserWarning` is emitted and TensorBoard logging is silently suppressed. Install `rfdetr[loggers]` to avoid this.
 
 ### Setup
 
@@ -309,8 +307,6 @@ trainer.loggers.append(CSVLogger(save_dir="output", name="extra"))
 trainer.fit(module, datamodule)
 ```
 
-CSVLogger is always active (it requires no extra packages). All logged metric keys — `train/loss`, `val/mAP_50_95`,
-`val/keypoint_map_50_95`, `val/F1`, `val/ema_mAP_50_95`, `val/AP/<class>`, etc. — are written to every logger in the
-list.
+CSVLogger is always active (it requires no extra packages). All logged metric keys — `train/loss`, `val/mAP_50_95`, `val/keypoint_map_50_95`, `val/F1`, `val/ema_mAP_50_95`, `val/AP/<class>`, etc. — are written to every logger in the list.
 
 → **[Full list of logged metrics](customization.md#logged-metrics-reference)**

--- a/docs/learn/train/training-parameters.md
+++ b/docs/learn/train/training-parameters.md
@@ -138,8 +138,7 @@ During training, multiple checkpoints are saved:
 | `checkpoint_best_total.pth`   | Final best model; lightweight callback state when available  |
 | `last_ema.pth`                | Final EMA weights; lightweight callback state when available |
 
-Best validation performance uses the task metric for the model family: box mAP for detection/segmentation and COCO
-keypoint AP for keypoint preview.
+Best validation performance uses the task metric for the model family: box mAP for detection/segmentation and COCO keypoint AP for keypoint preview.
 
 ## Early Stopping Parameters
 
@@ -173,10 +172,7 @@ This configuration will:
 
 !!! note "Transfer learning with `pretrain_weights`"
 
-    When fine-tuning from `pretrain_weights`, the pretrained model's epoch-0 validation metric can be artificially high
-    relative to the training trajectory on the new dataset. This causes `checkpoint_best_total.pth` to always contain
-    the untrained pretrained weights and may trigger early stopping prematurely. Use `skip_best_epochs` to defer
-    best-checkpoint selection and patience counting until the model has had time to adapt.
+    When fine-tuning from `pretrain_weights`, the pretrained model's epoch-0 validation metric can be artificially high relative to the training trajectory on the new dataset. This causes `checkpoint_best_total.pth` to always contain the untrained pretrained weights and may trigger early stopping prematurely. Use `skip_best_epochs` to defer best-checkpoint selection and patience counting until the model has had time to adapt.
 
 ## Logging Parameters
 

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -75,8 +75,7 @@ Use the resources below to learn how to train, build with, and deploy RF-DETR mo
 
     ---
 
-    ![](https://blog.roboflow.com/content/images/size/w1000/format/webp/2025/03/img-blog-nycerebro--2--min.png)
-    Learn how to deploy RF-DETR as a scalable inference server using LitServe, the AI model serving framework from Lightning AI.
+    ![](https://blog.roboflow.com/content/images/size/w1000/format/webp/2025/03/img-blog-nycerebro--2--min.png) Learn how to deploy RF-DETR as a scalable inference server using LitServe, the AI model serving framework from Lightning AI.
 
     [:octicons-arrow-right-24: Open the Studio](https://lightning.ai/bhimrajyadav/studios/deploy-rf-detr-a-sota-real-time-object-detection-model-using-litserve)
 

--- a/tests/legacy/README.md
+++ b/tests/legacy/README.md
@@ -1,49 +1,23 @@
 # Legacy Checkpoint Backward-Compatibility Tests
 
-Verifies that the *current* codebase can load RF-DETR checkpoints produced by every past
-stable minor release listed in `checkpoint_versions.txt`. Runs as a dedicated GitHub Actions
-workflow (`.github/workflows/ci-legacy-checkpoints.yml`), separate from the standard CPU/GPU
-test suites (both exclude `tests/legacy/` via `--ignore`).
+Verifies that the *current* codebase can load RF-DETR checkpoints produced by every past stable minor release listed in `checkpoint_versions.txt`. Runs as a dedicated GitHub Actions workflow (`.github/workflows/ci-legacy-checkpoints.yml`), separate from the standard CPU/GPU test suites (both exclude `tests/legacy/` via `--ignore`).
 
 ## How it works
 
 1. `get-versions` job reads `checkpoint_versions.txt` and exposes it as a matrix.
-2. `generate` job (one per version) installs that historical `rfdetr` release from its frozen
-    dependency set, runs `generate_checkpoint.py` to produce a `.pth` checkpoint in that
-    version's save format, and uploads it as a workflow artifact.
-3. `test-compat` job downloads every generated checkpoint, installs the *current* (dev) code,
-    and runs `test_checkpoint_compat.py` against each one — asserting a successful load, correct
-    model structure, and (for `--use-pretrained` checkpoints) that a reference prediction is
-    reproduced after reload.
+2. `generate` job (one per version) installs that historical `rfdetr` release from its frozen dependency set, runs `generate_checkpoint.py` to produce a `.pth` checkpoint in that version's save format, and uploads it as a workflow artifact.
+3. `test-compat` job downloads every generated checkpoint, installs the *current* (dev) code, and runs `test_checkpoint_compat.py` against each one — asserting a successful load, correct model structure, and (for `--use-pretrained` checkpoints) that a reference prediction is reproduced after reload.
 
 ## Adding a new legacy version
 
-1. Add the version to `checkpoint_versions.txt` (one per line; comment lines and blank lines
-    are ignored).
-2. Add a matching `frozen_dependencies/req-<version>.txt` pinning `rfdetr==<version>` plus any
-    transitive dependency pin needed to keep the install reproducible (see an existing
-    `req-*.txt` for the header/format convention). `test_every_version_has_matching_frozen_requirements_file`
-    in `test_checkpoint_compat.py` fails locally if this file is missing, instead of only
-    failing much later at CI matrix install time.
-3. Run `uv run --no-sync pytest tests/legacy/ -v` locally once checkpoints are available (or
-    rely on the CI workflow, which generates them).
+1. Add the version to `checkpoint_versions.txt` (one per line; comment lines and blank lines are ignored).
+2. Add a matching `frozen_dependencies/req-<version>.txt` pinning `rfdetr==<version>` plus any transitive dependency pin needed to keep the install reproducible (see an existing `req-*.txt` for the header/format convention). `test_every_version_has_matching_frozen_requirements_file` in `test_checkpoint_compat.py` fails locally if this file is missing, instead of only failing much later at CI matrix install time.
+3. Run `uv run --no-sync pytest tests/legacy/ -v` locally once checkpoints are available (or rely on the CI workflow, which generates them).
 
 ## Why `frozen_dependencies/` is a *partial* freeze, not a full lockfile
 
-Each `req-<version>.txt` pins `rfdetr==<version>` and a bounded `transformers` range (the
-narrowest range still compatible with that historical release, documented per-file), but
-leaves `numpy`/`torch`/`supervision`/`pillow` unpinned. This is deliberate: those are shared,
-frequently-updated dependencies where full pinning would require maintaining N separate lock
-files indefinitely. The tradeoff is that a future major bump in one of the unpinned packages
-could occasionally break an older `generate` job for reasons unrelated to the checkpoint-format
-compatibility this suite exists to test — if that happens, add a targeted pin to the affected
-version's `req-*.txt` (see `req-1.4.3.txt` for an example of a targeted `transformers` bound
-added for exactly this reason).
+Each `req-<version>.txt` pins `rfdetr==<version>` and a bounded `transformers` range (the narrowest range still compatible with that historical release, documented per-file), but leaves `numpy`/`torch`/`supervision`/`pillow` unpinned. This is deliberate: those are shared, frequently-updated dependencies where full pinning would require maintaining N separate lock files indefinitely. The tradeoff is that a future major bump in one of the unpinned packages could occasionally break an older `generate` job for reasons unrelated to the checkpoint-format compatibility this suite exists to test — if that happens, add a targeted pin to the affected version's `req-*.txt` (see `req-1.4.3.txt` for an example of a targeted `transformers` bound added for exactly this reason).
 
 ## Pretrained-checkpoint fetch: skip vs. fail
 
-`generate_checkpoint.py --use-pretrained` downloads real COCO-pretrained weights. Network/5xx/
-timeout/DNS errors during that fetch are treated as infra outages (skip), while a genuine
-permanent absence (e.g. a 404 for a removed asset) still fails the test — a blanket skip would
-silently green a real regression. This mirrors the reference-image fetch's existing MD5-guard
-skip-vs-fail posture in `generate_checkpoint.py`.
+`generate_checkpoint.py --use-pretrained` downloads real COCO-pretrained weights. Network/5xx/ timeout/DNS errors during that fetch are treated as infra outages (skip), while a genuine permanent absence (e.g. a 404 for a removed asset) still fails the test — a blanket skip would silently green a real regression. This mirrors the reference-image fetch's existing MD5-guard skip-vs-fail posture in `generate_checkpoint.py`.


### PR DESCRIPTION
This pull request makes a minor update to the `.pre-commit-config.yaml` file, specifically changing the arguments passed to the `mdformat` pre-commit hook to disable line wrapping.

* Updated the `mdformat` hook arguments to include `--wrap=no`, ensuring that markdown files are not automatically wrapped during formatting.