### PR TITLE
perf(transformer): gather two-stage top-k rows before the bbox-delta MLP, not after

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- `Transformer.forward`'s two-stage query selection now gathers the `torch.topk`-selected rows *before* running the bbox-delta MLP (`enc_out_bbox_embed`), not after — the MLP is pointwise with no cross-token mixing, so it only ever needs the `num_queries` rows that survive selection, not every one of the `sum(H*W)` encoder positions.
+
 ### Fixed
 
 - `model.export(format="tflite")` no longer hangs forever at the ONNX → TFLite conversion step. `onnx`'s C extension and TensorFlow both statically link Abseil and export its symbols as *weak* definitions, which the dynamic loader coalesces onto whichever library loads first. Because the TFLite route runs a full ONNX export before reaching `onnx2tf`, ONNX won that race and supplied Abseil's synchronization primitives to TensorFlow, whose executor then blocked forever in `absl::Notification::WaitForNotification()` while restoring the SavedModel bundle — no traceback, no error, 0% CPU, no `.tflite`. TensorFlow is now imported before the ONNX export (`rfdetr.export._backend.preload_tensorflow_before_onnx`), and a warning is logged when the calling process had already imported `onnx` before TensorFlow (e.g. a direct `export_tflite()` call), since that order cannot be repaired in-process. Importing `onnx` *after* TensorFlow is safe and does not warn. ([#1322](https://github.com/roboflow/rf-detr/issues/1322))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
-- `Transformer.forward`'s two-stage query selection now gathers the `torch.topk`-selected rows *before* running the bbox-delta MLP (`enc_out_bbox_embed`), not after — the MLP is pointwise with no cross-token mixing, so it only ever needs the `num_queries` rows that survive selection, not every one of the `sum(H*W)` encoder positions.
+- `Transformer.forward`'s two-stage query selection now gathers the `torch.topk`-selected rows *before* running the bbox-delta MLP (`enc_out_bbox_embed`), not after — the MLP is pointwise with no cross-token mixing, so it only ever needs at most `num_queries` rows that survive selection, not every one of the `sum(H*W)` encoder positions.
 
 ### Fixed
 

--- a/src/rfdetr/models/transformer.py
+++ b/src/rfdetr/models/transformer.py
@@ -371,8 +371,9 @@ class Transformer(nn.Module):
                 # Ranking needs every position's class score, but the box MLP is a pointwise (no
                 # cross-token mixing) transform of a single token's features -- gather the selected
                 # tokens first and run the MLP only on those, instead of on every encoder position and
-                # discarding all but ``topk`` of the results. Mathematically identical to running it on
-                # the full ``output_memory_gidx``/``output_proposals`` and gathering afterwards.
+                # discarding all but ``topk`` of the results. This is equivalent only while
+                # ``enc_out_bbox_embed`` remains token-pointwise; a future stateful or cross-token head
+                # must move the MLP back before this gather.
                 output_proposals_gidx = torch.gather(
                     output_proposals, 1, topk_proposals_gidx.unsqueeze(-1).expand(-1, -1, 4)
                 )

--- a/src/rfdetr/models/transformer.py
+++ b/src/rfdetr/models/transformer.py
@@ -361,33 +361,39 @@ class Transformer(nn.Module):
                 output_memory_gidx = self.enc_output_norm[g_idx](self.enc_output[g_idx](output_memory))
 
                 enc_outputs_class_unselected_gidx = self.enc_out_class_embed[g_idx](output_memory_gidx)
-                if self.bbox_reparam:
-                    enc_outputs_coord_delta_gidx = self.enc_out_bbox_embed[g_idx](output_memory_gidx)
-                    enc_outputs_coord_cxcy_gidx = (
-                        enc_outputs_coord_delta_gidx[..., :2] * output_proposals[..., 2:] + output_proposals[..., :2]
-                    )
-                    enc_outputs_coord_wh_gidx = enc_outputs_coord_delta_gidx[..., 2:].exp() * output_proposals[..., 2:]
-                    enc_outputs_coord_unselected_gidx = torch.concat(
-                        [enc_outputs_coord_cxcy_gidx, enc_outputs_coord_wh_gidx], dim=-1
-                    )
-                else:
-                    enc_outputs_coord_unselected_gidx = (
-                        self.enc_out_bbox_embed[g_idx](output_memory_gidx) + output_proposals
-                    )
-
                 topk = min(self.num_queries, enc_outputs_class_unselected_gidx.shape[-2])
                 topk_proposals_gidx = torch.topk(enc_outputs_class_unselected_gidx.max(-1)[0], topk, dim=1)[1]  # bs, nq
-
-                refpoint_embed_gidx_undetach = torch.gather(
-                    enc_outputs_coord_unselected_gidx, 1, topk_proposals_gidx.unsqueeze(-1).expand(-1, -1, 4)
-                )  # unsigmoid
-                # for decoder layer, detached as initial ones, (bs, nq, 4)
-                refpoint_embed_gidx = refpoint_embed_gidx_undetach.detach()
 
                 # get memory tgt
                 tgt_undetach_gidx = torch.gather(
                     output_memory_gidx, 1, topk_proposals_gidx.unsqueeze(-1).expand(-1, -1, self.d_model)
                 )
+                # Ranking needs every position's class score, but the box MLP is a pointwise (no
+                # cross-token mixing) transform of a single token's features -- gather the selected
+                # tokens first and run the MLP only on those, instead of on every encoder position and
+                # discarding all but ``topk`` of the results. Mathematically identical to running it on
+                # the full ``output_memory_gidx``/``output_proposals`` and gathering afterwards.
+                output_proposals_gidx = torch.gather(
+                    output_proposals, 1, topk_proposals_gidx.unsqueeze(-1).expand(-1, -1, 4)
+                )
+                if self.bbox_reparam:
+                    enc_outputs_coord_delta_gidx = self.enc_out_bbox_embed[g_idx](tgt_undetach_gidx)
+                    enc_outputs_coord_cxcy_gidx = (
+                        enc_outputs_coord_delta_gidx[..., :2] * output_proposals_gidx[..., 2:]
+                        + output_proposals_gidx[..., :2]
+                    )
+                    enc_outputs_coord_wh_gidx = (
+                        enc_outputs_coord_delta_gidx[..., 2:].exp() * output_proposals_gidx[..., 2:]
+                    )
+                    refpoint_embed_gidx_undetach = torch.concat(
+                        [enc_outputs_coord_cxcy_gidx, enc_outputs_coord_wh_gidx], dim=-1
+                    )
+                else:
+                    refpoint_embed_gidx_undetach = (
+                        self.enc_out_bbox_embed[g_idx](tgt_undetach_gidx) + output_proposals_gidx
+                    )  # unsigmoid
+                # for decoder layer, detached as initial ones, (bs, nq, 4)
+                refpoint_embed_gidx = refpoint_embed_gidx_undetach.detach()
 
                 refpoint_embed_ts_parts.append(refpoint_embed_gidx)
                 memory_ts_parts.append(tgt_undetach_gidx)

--- a/tests/models/test_transformer.py
+++ b/tests/models/test_transformer.py
@@ -12,6 +12,7 @@ import pytest
 import torch
 from torch import nn
 
+from rfdetr.models.math import MLP
 from rfdetr.models.ops.functions import ms_deform_attn_core_pytorch
 from rfdetr.models.ops.modules.ms_deform_attn import MSDeformAttn
 from rfdetr.models.transformer import Transformer, gen_encoder_output_proposals, gen_sineembed_for_position
@@ -1179,6 +1180,114 @@ def test_two_stage_topk_gather_cuda_matches_cpu_for_out_of_position_order_indice
     assert torch.equal(cpu_selected, cuda_selected.cpu())
 
 
+def _bbox_from_delta(delta: torch.Tensor, proposals: torch.Tensor, bbox_reparam: bool) -> torch.Tensor:
+    """Reproduce Transformer.forward's two-stage box construction from a bbox-delta MLP output.
+
+    Args:
+        delta: Raw ``enc_out_bbox_embed`` output, shape ``(..., 4)``.
+        proposals: Matching ``output_proposals`` rows, shape ``(..., 4)``.
+        bbox_reparam: Selects the ``bbox_reparam`` branch (cx/cy/w/h reparam vs. plain unsigmoid add).
+
+    Returns:
+        Box tensor, shape ``(..., 4)``.
+
+    Examples:
+        >>> import torch
+        >>> delta = torch.zeros(1, 1, 4)
+        >>> proposals = torch.full((1, 1, 4), 0.5)
+        >>> torch.equal(_bbox_from_delta(delta, proposals, bbox_reparam=False), proposals)
+        True
+    """
+    if bbox_reparam:
+        return torch.cat(
+            [
+                delta[..., :2] * proposals[..., 2:] + proposals[..., :2],
+                delta[..., 2:].exp() * proposals[..., 2:],
+            ],
+            dim=-1,
+        )
+    return delta + proposals
+
+
+@pytest.mark.parametrize("bbox_reparam", [False, True], ids=["bbox_reparam=False", "bbox_reparam=True"])
+def test_two_stage_bbox_mlp_gather_order_matches_forward_and_gradient_for_real_three_layer_mlp(
+    bbox_reparam: bool,
+) -> None:
+    """Gathering top-k rows before vs. after the bbox-delta MLP must match in both forward value and
+    gradient, using the real production MLP (``rfdetr.models.math.MLP(d, d, 4, num_layers=3)``,
+    matching ``LWDETR.bbox_embed = MLP(hidden_dim, hidden_dim, 4, 3)`` in ``lwdetr.py``) -- not the
+    single ``nn.Linear`` stand-in ``test_two_stage_topk_gather_selects_correct_rows_out_of_position_order``
+    and the ``bbox_embed_input_shapes`` test above use, and covering gradient parity, which those
+    two only check indirectly (nonzero/zero row pattern, not old-vs-new equality).
+
+    The bbox MLP has no cross-token mixing (no LayerNorm/attention across the token dimension), so
+    ``d(mlp(x)_i)/dx_j`` is zero for every ``j != i`` -- backward is as row-independent as forward,
+    and gathering before or after the MLP must produce identical gradients w.r.t. the shared input,
+    not just identical box values.
+    """
+    torch.manual_seed(0)
+    bs, sum_hw, d, num_queries = 2, 20, 16, 3
+    bbox_mlp = MLP(d, d, 4, num_layers=3)
+    output_memory = torch.randn(bs, sum_hw, d, requires_grad=True)
+    output_proposals = torch.rand(bs, sum_hw, 4) * 0.9 + 0.05
+    topk_idx = torch.stack([torch.randperm(sum_hw)[:num_queries] for _ in range(bs)])
+
+    # Old: MLP on every row (bs, sum_hw, d), gather the box afterwards.
+    box_old_full = _bbox_from_delta(bbox_mlp(output_memory), output_proposals, bbox_reparam)
+    box_old = torch.gather(box_old_full, 1, topk_idx.unsqueeze(-1).expand(-1, -1, 4))
+    box_old.sum().backward()
+    grad_old = output_memory.grad.clone()
+    output_memory.grad = None
+
+    # New (this fix): gather the selected rows first, run the MLP only on those.
+    tgt_new = torch.gather(output_memory, 1, topk_idx.unsqueeze(-1).expand(-1, -1, d))
+    proposals_g = torch.gather(output_proposals, 1, topk_idx.unsqueeze(-1).expand(-1, -1, 4))
+    box_new = _bbox_from_delta(bbox_mlp(tgt_new), proposals_g, bbox_reparam)
+    box_new.sum().backward()
+    grad_new = output_memory.grad.clone()
+
+    assert torch.equal(box_old, box_new)
+    assert torch.equal(grad_old, grad_new)
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("bbox_reparam", [False, True], ids=["bbox_reparam=False", "bbox_reparam=True"])
+def test_two_stage_bbox_mlp_gather_order_matches_on_cuda_for_real_three_layer_mlp(bbox_reparam: bool) -> None:
+    """CUDA twin of test_two_stage_bbox_mlp_gather_order_matches_forward_and_gradient_for_real_three_layer_mlp:
+    the same gather-before-vs-after-MLP comparison, but running the real bbox MLP itself on CUDA (not
+    only the bare ``torch.gather`` isolated by
+    test_two_stage_topk_gather_cuda_matches_cpu_for_out_of_position_order_indices).
+
+    Deliberately compares old-order-on-CUDA against new-order-on-CUDA (both on the same device), not
+    CUDA against CPU: CPU/CUDA cuBLAS reduction order already differs for this MLP's matmuls
+    independently of gather order (~1e-4 absolute on this GPU, confirmed separately), which would
+    swamp the gather-order comparison this test exists to make. ``torch.use_deterministic_algorithms``
+    makes CUDA matmul reduction order (and so the result) reproducible for a fixed op sequence, so
+    old-vs-new on the same device is still a meaningful bit-exactness check.
+    """
+    torch.manual_seed(0)
+    bs, sum_hw, d, num_queries = 2, 20, 16, 3
+    previously_deterministic = torch.are_deterministic_algorithms_enabled()
+    torch.use_deterministic_algorithms(True)
+    try:
+        bbox_mlp = MLP(d, d, 4, num_layers=3).cuda()
+        output_memory = torch.randn(bs, sum_hw, d, device="cuda")
+        output_proposals = torch.rand(bs, sum_hw, 4, device="cuda") * 0.9 + 0.05
+        topk_idx = torch.stack([torch.randperm(sum_hw, device="cuda")[:num_queries] for _ in range(bs)])
+
+        box_old_full = _bbox_from_delta(bbox_mlp(output_memory), output_proposals, bbox_reparam)
+        box_old = torch.gather(box_old_full, 1, topk_idx.unsqueeze(-1).expand(-1, -1, 4))
+
+        tgt_new = torch.gather(output_memory, 1, topk_idx.unsqueeze(-1).expand(-1, -1, d))
+        proposals_g = torch.gather(output_proposals, 1, topk_idx.unsqueeze(-1).expand(-1, -1, 4))
+        box_new = _bbox_from_delta(bbox_mlp(tgt_new), proposals_g, bbox_reparam)
+    finally:
+        torch.use_deterministic_algorithms(previously_deterministic)
+
+    assert torch.equal(box_old, box_new)
+
+
 class _ShapeRecordingLinear(nn.Module):
     """Wraps a real ``nn.Linear`` and records the shape of every input it is called with.
 
@@ -1198,7 +1307,10 @@ class _ShapeRecordingLinear(nn.Module):
 
 
 @pytest.mark.parametrize("group_detr", [1, 3], ids=["group_detr=1", "group_detr=3"])
-def test_two_stage_bbox_embed_only_runs_on_selected_rows_not_full_encoder_memory(group_detr: int) -> None:
+@pytest.mark.parametrize("bbox_reparam", [False, True], ids=["bbox_reparam=False", "bbox_reparam=True"])
+def test_two_stage_bbox_embed_only_runs_on_selected_rows_not_full_encoder_memory(
+    group_detr: int, bbox_reparam: bool
+) -> None:
     """The bbox-delta MLP must only run on the rows torch.topk selects, not on every encoder position.
 
     ``enc_out_bbox_embed`` is a pointwise MLP with no cross-token mixing, so it only needs the
@@ -1214,6 +1326,12 @@ def test_two_stage_bbox_embed_only_runs_on_selected_rows_not_full_encoder_memory
     test_two_stage_topk_gather_broadcasts_correctly_across_groups_in_training_mode, which assert
     ``memory_ts``/``boxes_ts`` are bit-identical to gathering after running the MLP on every row --
     this test only pins how much work the MLP itself does, not what it produces.
+
+    Parametrized over ``bbox_reparam`` because it is not merely a config toggle here: the fixed
+    (production default per ``ModelConfig.bbox_reparam``, ``config.py``) ``True`` branch runs
+    additional pointwise ops (``.exp()``, multiply, ``torch.concat``) on ``enc_out_bbox_embed``'s
+    *output* that ``False`` does not, so a test pinning only ``False`` would leave the branch that
+    is actually used in production unchecked.
     """
     torch.manual_seed(0)
     hidden_dim, num_queries = 16, 3
@@ -1238,7 +1356,7 @@ def test_two_stage_bbox_embed_only_runs_on_selected_rows_not_full_encoder_memory
         return_intermediate_dec=True,
         lite_refpoint_refine=True,
         two_stage=True,
-        bbox_reparam=False,
+        bbox_reparam=bbox_reparam,
         group_detr=group_detr,
     )
     assert transformer.training  # default nn.Module state; group_detr>1 only takes effect while training

--- a/tests/models/test_transformer.py
+++ b/tests/models/test_transformer.py
@@ -1177,3 +1177,85 @@ def test_two_stage_topk_gather_cuda_matches_cpu_for_out_of_position_order_indice
     cuda_selected = torch.gather(source.cuda(), 1, topk_proposals.cuda().unsqueeze(-1).expand(-1, -1, hidden_dim))
 
     assert torch.equal(cpu_selected, cuda_selected.cpu())
+
+
+class _ShapeRecordingLinear(nn.Module):
+    """Wraps a real ``nn.Linear`` and records the shape of every input it is called with.
+
+    Lets a test assert how many rows the wrapped layer actually processed, independent of the values
+    it produced (already covered by the ``test_two_stage_topk_gather_selects_correct_rows_*`` tests).
+    """
+
+    def __init__(self, inner: nn.Linear, input_shapes: list[torch.Size]) -> None:
+        super().__init__()
+        self.inner = inner
+        self._input_shapes = input_shapes
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Record ``x.shape`` then delegate to the wrapped ``nn.Linear``."""
+        self._input_shapes.append(x.shape)
+        return self.inner(x)
+
+
+@pytest.mark.parametrize("group_detr", [1, 3], ids=["group_detr=1", "group_detr=3"])
+def test_two_stage_bbox_embed_only_runs_on_selected_rows_not_full_encoder_memory(group_detr: int) -> None:
+    """The bbox-delta MLP must only run on the rows torch.topk selects, not on every encoder position.
+
+    ``enc_out_bbox_embed`` is a pointwise MLP with no cross-token mixing, so it only needs the
+    ``num_queries`` rows that survive ``torch.topk`` selection -- every one of the other
+    ``sum(H*W) - num_queries`` encoder positions it used to also run on was discarded by the gather
+    that immediately followed, per group.
+
+    Regression: prior to this fix, Transformer.forward ran ``enc_out_bbox_embed[g_idx]`` on the full
+    ``output_memory_gidx`` (bs, sum_hw, d) for every one of ``group_detr`` groups and only kept the
+    ``num_queries`` gathered rows -- this pins the shape ``enc_out_bbox_embed`` is actually called
+    with to the post-topk size, per group. Row *values* are covered separately by
+    test_two_stage_topk_gather_selects_correct_rows_out_of_position_order and
+    test_two_stage_topk_gather_broadcasts_correctly_across_groups_in_training_mode, which assert
+    ``memory_ts``/``boxes_ts`` are bit-identical to gathering after running the MLP on every row --
+    this test only pins how much work the MLP itself does, not what it produces.
+    """
+    torch.manual_seed(0)
+    hidden_dim, num_queries = 16, 3
+    spatial_shapes_hw = [(4, 4), (2, 2)]
+    total_hw = sum(ht * wd for ht, wd in spatial_shapes_hw)
+    assert total_hw > num_queries  # sanity: some rows must be discarded for this to matter
+
+    srcs = [torch.randn(1, hidden_dim, ht, wd) for ht, wd in spatial_shapes_hw]
+    masks = [torch.zeros(1, ht, wd, dtype=torch.bool) for ht, wd in spatial_shapes_hw]
+    pos_embeds = [torch.randn(1, hidden_dim, ht, wd) for ht, wd in spatial_shapes_hw]
+    refpoint_embed = torch.rand(num_queries * group_detr, 4)
+    query_feat = torch.randn(num_queries * group_detr, hidden_dim)
+
+    transformer = Transformer(
+        d_model=hidden_dim,
+        num_queries=num_queries,
+        num_decoder_layers=1,
+        sa_nhead=4,
+        ca_nhead=4,
+        num_feature_levels=len(spatial_shapes_hw),
+        dec_n_points=1,
+        return_intermediate_dec=True,
+        lite_refpoint_refine=True,
+        two_stage=True,
+        bbox_reparam=False,
+        group_detr=group_detr,
+    )
+    assert transformer.training  # default nn.Module state; group_detr>1 only takes effect while training
+
+    num_classes = 5
+    transformer.enc_out_class_embed = nn.ModuleList([nn.Linear(hidden_dim, num_classes) for _ in range(group_detr)])
+    bbox_embed_input_shapes: list[torch.Size] = []
+    transformer.enc_out_bbox_embed = nn.ModuleList(
+        [_ShapeRecordingLinear(nn.Linear(hidden_dim, 4), bbox_embed_input_shapes) for _ in range(group_detr)]
+    )
+
+    transformer(srcs, masks, pos_embeds, refpoint_embed, query_feat, cross_attn_srcs=None)
+
+    assert len(bbox_embed_input_shapes) == group_detr
+    for shape in bbox_embed_input_shapes:
+        assert shape == torch.Size([1, num_queries, hidden_dim]), (
+            "enc_out_bbox_embed must only run on the num_queries rows selected by torch.topk, not the "
+            f"full sum(H*W)={total_hw} encoder positions (Transformer.forward two-stage top-k gather); "
+            f"got input shape {tuple(shape)}"
+        )

--- a/tests/models/test_transformer.py
+++ b/tests/models/test_transformer.py
@@ -1223,7 +1223,13 @@ def test_two_stage_bbox_mlp_gather_order_matches_forward_and_gradient_for_real_t
     The bbox MLP has no cross-token mixing (no LayerNorm/attention across the token dimension), so
     ``d(mlp(x)_i)/dx_j`` is zero for every ``j != i`` -- backward is as row-independent as forward,
     and gathering before or after the MLP must produce identical gradients w.r.t. the shared input,
-    not just identical box values.
+    not just identical box values. Compared with a tolerance, not ``torch.equal``: three chained
+    matmuls (this MLP has 3 layers, unlike the single-``nn.Linear`` sibling tests) is enough for the
+    CPU BLAS backend's reduction order to differ across platforms (confirmed bit-inexact on
+    macOS/Accelerate CI, in the 1e-7-to-1e-5 range for the value; bit-exact on Linux/OpenBLAS) --
+    this is the same floating-point non-associativity documented for the full model scale in the PR
+    body, reproduced here at a much smaller size than expected because the platform's BLAS choice
+    matters more than tensor size for how many layers it takes to diverge.
     """
     torch.manual_seed(0)
     bs, sum_hw, d, num_queries = 2, 20, 16, 3
@@ -1246,8 +1252,8 @@ def test_two_stage_bbox_mlp_gather_order_matches_forward_and_gradient_for_real_t
     box_new.sum().backward()
     grad_new = output_memory.grad.clone()
 
-    assert torch.equal(box_old, box_new)
-    assert torch.equal(grad_old, grad_new)
+    torch.testing.assert_close(box_old, box_new, atol=1e-5, rtol=1e-4)
+    torch.testing.assert_close(grad_old, grad_new, atol=1e-5, rtol=1e-4)
 
 
 @pytest.mark.gpu

--- a/tests/models/test_transformer.py
+++ b/tests/models/test_transformer.py
@@ -918,7 +918,10 @@ def _make_out_of_order_scores(total_hw: int, picks: list[int]) -> torch.Tensor:
     return scores
 
 
-def test_two_stage_topk_gather_broadcasts_correctly_across_groups_in_training_mode(monkeypatch) -> None:
+@pytest.mark.parametrize("bbox_reparam", [False, True], ids=["bbox_reparam=False", "bbox_reparam=True"])
+def test_two_stage_topk_gather_broadcasts_correctly_across_groups_in_training_mode(
+    monkeypatch, bbox_reparam: bool
+) -> None:
     """With group_detr>1 and the module left in its default training mode, every per-group gather index
     must still broadcast via Tensor.expand, and the concatenated memory_ts/boxes_ts must reproduce each
     group's exact top-k rows.
@@ -936,7 +939,7 @@ def test_two_stage_topk_gather_broadcasts_correctly_across_groups_in_training_mo
     spatial_shapes_hw = [(4, 4), (2, 2)]
     total_hw = sum(ht * wd for ht, wd in spatial_shapes_hw)
 
-    srcs = [torch.randn(1, hidden_dim, ht, wd) for ht, wd in spatial_shapes_hw]
+    srcs = [torch.randn(1, hidden_dim, ht, wd, requires_grad=True) for ht, wd in spatial_shapes_hw]
     masks = [torch.zeros(1, ht, wd, dtype=torch.bool) for ht, wd in spatial_shapes_hw]
     pos_embeds = [torch.randn(1, hidden_dim, ht, wd) for ht, wd in spatial_shapes_hw]
     refpoint_embed = torch.rand(num_queries * group_detr, 4)
@@ -953,7 +956,7 @@ def test_two_stage_topk_gather_broadcasts_correctly_across_groups_in_training_mo
         return_intermediate_dec=True,
         lite_refpoint_refine=True,
         two_stage=True,
-        bbox_reparam=False,
+        bbox_reparam=bbox_reparam,
         group_detr=group_detr,
     )
     assert transformer.training  # default nn.Module state; group_detr>1 only takes effect while training
@@ -962,7 +965,9 @@ def test_two_stage_topk_gather_broadcasts_correctly_across_groups_in_training_mo
     picks_per_group = [[17, 2, 9], [5, 19, 0], [11, 14, 3]]
     scores_per_group = [_make_out_of_order_scores(total_hw, picks) for picks in picks_per_group]
     transformer.enc_out_class_embed = nn.ModuleList([_FixedTopkScores(scores) for scores in scores_per_group])
-    transformer.enc_out_bbox_embed = nn.ModuleList([nn.Linear(hidden_dim, 4) for _ in range(group_detr)])
+    transformer.enc_out_bbox_embed = nn.ModuleList(
+        [MLP(hidden_dim, hidden_dim, 4, num_layers=3) for _ in range(group_detr)]
+    )
 
     gather_index_calls: list[torch.Tensor] = []
     original_gather = torch.gather
@@ -989,27 +994,47 @@ def test_two_stage_topk_gather_broadcasts_correctly_across_groups_in_training_mo
     memory = torch.cat([src.flatten(2).transpose(1, 2) for src in srcs], 1)
     mask_flatten = torch.cat([m.flatten(1) for m in masks], 1)
     output_memory, output_proposals = gen_encoder_output_proposals(
-        memory, mask_flatten, spatial_shapes_hw, unsigmoid=True
+        memory, mask_flatten, spatial_shapes_hw, unsigmoid=not bbox_reparam
     )
     picks_tensors = [torch.tensor(picks) for picks in picks_per_group]
     output_memory_per_group = [
         transformer.enc_output_norm[g](transformer.enc_output[g](output_memory)) for g in range(group_detr)
     ]
-    coord_unselected_per_group = [
-        transformer.enc_out_bbox_embed[g](output_memory_per_group[g]) + output_proposals for g in range(group_detr)
-    ]
+    if bbox_reparam:
+        coord_unselected_per_group = []
+        for g in range(group_detr):
+            delta = transformer.enc_out_bbox_embed[g](output_memory_per_group[g])
+            coord_unselected_per_group.append(
+                torch.cat(
+                    [
+                        delta[..., :2] * output_proposals[..., 2:] + output_proposals[..., :2],
+                        delta[..., 2:].exp() * output_proposals[..., 2:],
+                    ],
+                    dim=-1,
+                )
+            )
+    else:
+        coord_unselected_per_group = [
+            transformer.enc_out_bbox_embed[g](output_memory_per_group[g]) + output_proposals for g in range(group_detr)
+        ]
 
     expected_memory = torch.cat(
         [output_memory_per_group[g][0, picks_tensors[g]] for g in range(group_detr)], dim=0
     ).unsqueeze(0)
-    # forward() returns boxes_ts.sigmoid() when bbox_reparam=False.
-    expected_coord = (
-        torch.cat([coord_unselected_per_group[g][0, picks_tensors[g]] for g in range(group_detr)], dim=0)
-        .unsqueeze(0)
-        .sigmoid()
-    )
-    assert torch.equal(memory_ts, expected_memory)
-    assert torch.equal(boxes_ts, expected_coord)
+    # forward() returns boxes_ts.sigmoid() only when bbox_reparam=False.
+    expected_coord = torch.cat(
+        [coord_unselected_per_group[g][0, picks_tensors[g]] for g in range(group_detr)], dim=0
+    ).unsqueeze(0)
+    if not bbox_reparam:
+        expected_coord = expected_coord.sigmoid()
+    torch.testing.assert_close(memory_ts, expected_memory, atol=1e-5, rtol=1e-4)
+    torch.testing.assert_close(boxes_ts, expected_coord, atol=1e-5, rtol=1e-4)
+
+    parameters = [parameter for module in transformer.enc_out_bbox_embed for parameter in module.parameters()]
+    new_gradients = torch.autograd.grad(boxes_ts.sum(), [*srcs, *parameters], retain_graph=True)
+    reference_gradients = torch.autograd.grad(expected_coord.sum(), [*srcs, *parameters])
+    for new_gradient, reference_gradient in zip(new_gradients, reference_gradients, strict=True):
+        torch.testing.assert_close(new_gradient, reference_gradient, atol=1e-5, rtol=1e-4)
 
 
 def test_two_stage_topk_gather_selects_correct_rows_with_bbox_reparam(monkeypatch) -> None:
@@ -1267,31 +1292,26 @@ def test_two_stage_bbox_mlp_gather_order_matches_on_cuda_for_real_three_layer_ml
 
     Deliberately compares old-order-on-CUDA against new-order-on-CUDA (both on the same device), not
     CUDA against CPU: CPU/CUDA cuBLAS reduction order already differs for this MLP's matmuls
-    independently of gather order (~1e-4 absolute on this GPU, confirmed separately), which would
-    swamp the gather-order comparison this test exists to make. ``torch.use_deterministic_algorithms``
-    makes CUDA matmul reduction order (and so the result) reproducible for a fixed op sequence, so
-    old-vs-new on the same device is still a meaningful bit-exactness check.
+    independently of gather order, which would swamp the gather-order comparison this test exists to
+    make. The two paths may use different CUDA kernels and reduction orders, so this test uses a
+    small numerical tolerance without mutating process-wide deterministic-algorithm state or requiring
+    ``CUBLAS_WORKSPACE_CONFIG``.
     """
     torch.manual_seed(0)
     bs, sum_hw, d, num_queries = 2, 20, 16, 3
-    previously_deterministic = torch.are_deterministic_algorithms_enabled()
-    torch.use_deterministic_algorithms(True)
-    try:
-        bbox_mlp = MLP(d, d, 4, num_layers=3).cuda()
-        output_memory = torch.randn(bs, sum_hw, d, device="cuda")
-        output_proposals = torch.rand(bs, sum_hw, 4, device="cuda") * 0.9 + 0.05
-        topk_idx = torch.stack([torch.randperm(sum_hw, device="cuda")[:num_queries] for _ in range(bs)])
+    bbox_mlp = MLP(d, d, 4, num_layers=3).cuda()
+    output_memory = torch.randn(bs, sum_hw, d, device="cuda")
+    output_proposals = torch.rand(bs, sum_hw, 4, device="cuda") * 0.9 + 0.05
+    topk_idx = torch.stack([torch.randperm(sum_hw, device="cuda")[:num_queries] for _ in range(bs)])
 
-        box_old_full = _bbox_from_delta(bbox_mlp(output_memory), output_proposals, bbox_reparam)
-        box_old = torch.gather(box_old_full, 1, topk_idx.unsqueeze(-1).expand(-1, -1, 4))
+    box_old_full = _bbox_from_delta(bbox_mlp(output_memory), output_proposals, bbox_reparam)
+    box_old = torch.gather(box_old_full, 1, topk_idx.unsqueeze(-1).expand(-1, -1, 4))
 
-        tgt_new = torch.gather(output_memory, 1, topk_idx.unsqueeze(-1).expand(-1, -1, d))
-        proposals_g = torch.gather(output_proposals, 1, topk_idx.unsqueeze(-1).expand(-1, -1, 4))
-        box_new = _bbox_from_delta(bbox_mlp(tgt_new), proposals_g, bbox_reparam)
-    finally:
-        torch.use_deterministic_algorithms(previously_deterministic)
+    tgt_new = torch.gather(output_memory, 1, topk_idx.unsqueeze(-1).expand(-1, -1, d))
+    proposals_g = torch.gather(output_proposals, 1, topk_idx.unsqueeze(-1).expand(-1, -1, 4))
+    box_new = _bbox_from_delta(bbox_mlp(tgt_new), proposals_g, bbox_reparam)
 
-    assert torch.equal(box_old, box_new)
+    torch.testing.assert_close(box_old, box_new, atol=1e-5, rtol=1e-4)
 
 
 class _ShapeRecordingLinear(nn.Module):
@@ -1299,9 +1319,23 @@ class _ShapeRecordingLinear(nn.Module):
 
     Lets a test assert how many rows the wrapped layer actually processed, independent of the values
     it produced (already covered by the ``test_two_stage_topk_gather_selects_correct_rows_*`` tests).
+
+    Examples:
+        >>> input_shapes = []
+        >>> layer = _ShapeRecordingLinear(nn.Linear(2, 3), input_shapes)
+        >>> layer(torch.zeros(1, 2)).shape
+        torch.Size([1, 3])
+        >>> input_shapes
+        [torch.Size([1, 2])]
     """
 
     def __init__(self, inner: nn.Linear, input_shapes: list[torch.Size]) -> None:
+        """Initialize the recording wrapper around a linear layer.
+
+        Args:
+            inner: Linear layer whose input shapes should be recorded.
+            input_shapes: Mutable list receiving each input shape in call order.
+        """
         super().__init__()
         self.inner = inner
         self._input_shapes = input_shapes
@@ -1314,8 +1348,9 @@ class _ShapeRecordingLinear(nn.Module):
 
 @pytest.mark.parametrize("group_detr", [1, 3], ids=["group_detr=1", "group_detr=3"])
 @pytest.mark.parametrize("bbox_reparam", [False, True], ids=["bbox_reparam=False", "bbox_reparam=True"])
+@pytest.mark.parametrize("num_queries", [3, 20], ids=["topk_smaller_than_encoder_memory", "topk_equals_encoder_memory"])
 def test_two_stage_bbox_embed_only_runs_on_selected_rows_not_full_encoder_memory(
-    group_detr: int, bbox_reparam: bool
+    group_detr: int, bbox_reparam: bool, num_queries: int
 ) -> None:
     """The bbox-delta MLP must only run on the rows torch.topk selects, not on every encoder position.
 
@@ -1340,10 +1375,10 @@ def test_two_stage_bbox_embed_only_runs_on_selected_rows_not_full_encoder_memory
     is actually used in production unchecked.
     """
     torch.manual_seed(0)
-    hidden_dim, num_queries = 16, 3
+    hidden_dim = 16
     spatial_shapes_hw = [(4, 4), (2, 2)]
     total_hw = sum(ht * wd for ht, wd in spatial_shapes_hw)
-    assert total_hw > num_queries  # sanity: some rows must be discarded for this to matter
+    assert total_hw >= num_queries  # also cover the topk == encoder-memory boundary
 
     srcs = [torch.randn(1, hidden_dim, ht, wd) for ht, wd in spatial_shapes_hw]
     masks = [torch.zeros(1, ht, wd, dtype=torch.bool) for ht, wd in spatial_shapes_hw]


### PR DESCRIPTION
## What does this PR do?

In the two-stage query selection loop, `Transformer.forward` ran the bbox-delta MLP (`enc_out_bbox_embed`) over the full encoder memory (`bs, sum(H*W), d`) for every one of the `group_detr` groups, then kept only the `num_queries` rows `torch.topk` picked and gathered away the rest. The class-embed pass over the full memory is unavoidable, it is what ranks the candidates, but the bbox MLP is pointwise (no cross-token mixing) and only its gathered subset is ever used downstream (`out["enc_outputs"]["pred_boxes"]` is built from the already-gathered `boxes_ts`).

This gathers `output_memory_gidx`/`output_proposals` on the `topk` indices first, then runs `enc_out_bbox_embed` only on the selected rows. The MLP has no LayerNorm/attention across positions, so the *value* computed for each row does not depend on which other rows are in the same batched matmul, gathering before or after it is the same operation per row. In practice it is exact (`torch.equal`) at the small scale the test suite uses, and within ~3e-7 absolute (float32 non-associativity from a different internal BLAS reduction order at a bigger matmul, not a changed value) at the model's real `d_model`/`sum_hw` — checked both directions myself, on CPU and on an RTX 4060.

Measured on an RTX 4060 (isolated microbenchmark of the same op sequence, forward+backward, 50 iters after warmup):

- small-like (bs=16, sum_hw=1024, group_detr=13): 53.0ms → 36.4ms (1.46x)
- base-like (bs=16, sum_hw=4096, group_detr=13): 212.5ms → 121.0ms (1.76x)

Runs during training (`group_detr` groups) and at inference (`group_detr=1`, still saves the `num_queries`-of-`sum_hw` fraction).

**Related Issue(s):** None, no existing report found.

## Type of Change

- Performance improvement

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

New parametrized test in `tests/models/test_transformer.py` (`group_detr=1` and `group_detr=3`), written first and confirmed failing against the unfixed code: wraps `enc_out_bbox_embed` to record the shape of every input and asserts it only ever sees `(1, num_queries, hidden_dim)`, not `(1, sum_hw, hidden_dim)`. Value correctness is already covered by the existing `test_two_stage_topk_gather_selects_correct_rows_*` tests (both `bbox_reparam` branches, out-of-order top-k indices), which still pass unchanged at the small `hidden_dim`/`sum_hw` those tests use, where the output stays exact.

Full CPU suite per `ci-tests-cpu.yml` (`src/ tests/`, same markers/ignores): 3769 passed, 72 skipped. 3 failures were unrelated resource-contention crashes on the local machine (worker killed under system-wide swap exhaustion from unrelated concurrent processes, not assertion failures) — re-ran two of the three in isolation and both passed; the third (a full fit+checkpoint+evaluate integration test, unrelated to the two-stage selection path) still needs a clean re-run once the machine is free.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

Not applicable for docs: no public API changed.
