### PR TITLE
Fix missing legends in training metric plots

### DIFF
--- a/src/rfdetr/visualize/training.py
+++ b/src/rfdetr/visualize/training.py
@@ -314,8 +314,7 @@ def _plot_metric_groups(
                 )
             else:
                 ax.set_yscale("log")
-        if subplot_title == "Loss":
-            _place_legend_below_axes(ax)
+        _place_legend_below_axes(ax)
 
     for idx in range(n_groups, len(axes_flat)):
         axes_flat[idx].set_visible(False)

--- a/tests/visualize/test_training.py
+++ b/tests/visualize/test_training.py
@@ -408,3 +408,36 @@ class TestSeabornErrorBands:
         poly_collections = [c for c in loss_ax.collections if isinstance(c, PolyCollection)]
         assert len(poly_collections) >= 1, "Expected error-band patch for multi-step train/loss"
         plt.close(figure)
+
+
+def test_plot_metrics_adds_legends_to_all_populated_subplots(tmp_path: Path) -> None:
+    """Ensure that every populated metric has a legend."""
+    pytest.importorskip("matplotlib")
+    from matplotlib import pyplot as plt
+
+    pd = pytest.importorskip("pandas")
+    metrics_csv = tmp_path / "metrics.csv"
+
+    pd.DataFrame(
+        {
+            "epoch": [0, 1],
+            "train/loss": [2.0, 1.5],
+            "val/mAP_50": [0.10, 0.20],
+        }
+    ).to_csv(metrics_csv, index=False)
+
+    figure = plot_metrics(str(metrics_csv))
+
+    visible_axes = [ax for ax in figure.axes if ax.get_visible()]
+
+    axes_by_title = {ax.get_title(): ax for ax in visible_axes}
+
+    assert set(axes_by_title) == {"Loss", "Detection AP@0.50"}
+
+    loss_ax = axes_by_title["Loss"]
+    detection_ax = axes_by_title["Detection AP@0.50"]
+
+    assert loss_ax.get_legend() is not None, "Loss subplot should have legend"
+    assert detection_ax.get_legend() is not None, "Detection AP@0.50 subplot should have legend"
+
+    plt.close(figure)


### PR DESCRIPTION
## What does this PR do?

adds legend to every populated training metric subplot, not just loss
add regression coverage for loss and detection ap subplots

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have tested this change locally
- [check ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

- `uv run --no-sync pytest tests/visualize/test_training.py`
- `SKIP=mypy uv run --no-sync pre-commit run --all-files`
This just tests to make sure that each axes has a legend using .get_legend()

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
fixes 1326
