### PR TITLE
fix(models): guard keypoint loss and its shared `ref_wh` composition against non-finite predictions

### DIFF
--- a/src/rfdetr/models/heads/keypoints.py
+++ b/src/rfdetr/models/heads/keypoints.py
@@ -141,10 +141,10 @@ def compute_l1_keypoint_loss(
     A non-finite value in any single prediction channel for a given keypoint (e.g. from an AMP
     overflow upstream) is excluded from both the forward value and the backward gradient of every
     loss term it would otherwise contribute to, without poisoning the other, still-finite keypoints
-    in the same target. This guarantee holds only *inside* this function: a non-finite value that
-    later re-enters an outer op sharing a tensor with other predictions (e.g. multiplying a raw
-    keypoint delta with a reference box before calling this function) can still poison that outer
-    op's own local gradient, since this function cannot see or guard ops outside its own call frame.
+    in the same target. This guarantee holds only *inside* this function: model boundaries that
+    combine the prediction with shared tensors sanitize the full prediction before those outer ops,
+    while a non-finite value that later re-enters an unguarded outer op can still poison that op's
+    local gradient, since this function cannot see or guard operations outside its call frame.
     ``compute_keypoint_matching_cost``'s ``_cdist_bce_with_logits`` (the sibling used by the matcher)
     does not yet have equivalent protection — a non-finite prediction there still poisons the whole
     matching-cost row for that query, tracked separately since it needs a different fix shape.

--- a/src/rfdetr/models/heads/keypoints.py
+++ b/src/rfdetr/models/heads/keypoints.py
@@ -138,6 +138,17 @@ def compute_l1_keypoint_loss(
     normal Gaussian constant and does not clamp the precision Cholesky
     parameters, so valid losses may be negative.
 
+    A non-finite value in any single prediction channel for a given keypoint (e.g. from an AMP
+    overflow upstream) is excluded from both the forward value and the backward gradient of every
+    loss term it would otherwise contribute to, without poisoning the other, still-finite keypoints
+    in the same target. This guarantee holds only *inside* this function: a non-finite value that
+    later re-enters an outer op sharing a tensor with other predictions (e.g. multiplying a raw
+    keypoint delta with a reference box before calling this function) can still poison that outer
+    op's own local gradient, since this function cannot see or guard ops outside its own call frame.
+    ``compute_keypoint_matching_cost``'s ``_cdist_bce_with_logits`` (the sibling used by the matcher)
+    does not yet have equivalent protection — a non-finite prediction there still poisons the whole
+    matching-cost row for that query, tracked separately since it needs a different fix shape.
+
     Args:
         all_pred_keypoints: Predicted keypoints with shape ``(N, K_total, >=7)``.
         target_keypoints: Ground truth keypoints with shape ``(N, K_max, 3)``.
@@ -227,7 +238,6 @@ def compute_l1_keypoint_loss(
         active_keypoints_mask[class_idx, :num_keypoints] = True
 
     keypoints_loss_mask = active_keypoints_mask[target_classes]
-    keypoints_per_target = keypoints_loss_mask.sum(-1).to(dtype=selected_pred_keypoints.dtype)
     area = target_areas.to(torch.float32)
     area_eps = torch.finfo(area.dtype).eps
     valid_area = torch.isfinite(area) & (area > area_eps)
@@ -238,37 +248,55 @@ def compute_l1_keypoint_loss(
     location_loss_mask = keypoints_loss_mask & valid_visibility & valid_xy & valid_area.unsqueeze(1)
     location_count = location_loss_mask.sum(-1).to(dtype=selected_pred_keypoints.dtype)
     valid_count = location_count.clamp(min=1)
-    denom_keypoints = keypoints_per_target.clamp(min=1).to(dtype=selected_pred_keypoints.dtype)
-    safe_area_sqrt = area.clamp_min(area_eps).sqrt()
+    valid_findable = torch.isfinite(selected_pred_keypoints[:, :, 2])
+    findable_loss_mask = keypoints_loss_mask & valid_findable
+    findable_count = findable_loss_mask.sum(-1).clamp(min=1).to(dtype=selected_pred_keypoints.dtype)
+    valid_visible_pred = torch.isfinite(selected_pred_keypoints[:, :, 3])
+    visible_loss_mask = keypoints_loss_mask & valid_visible_pred
+    visible_count = visible_loss_mask.sum(-1).clamp(min=1).to(dtype=selected_pred_keypoints.dtype)
+    # A non-finite ``area`` (e.g. a degenerate target box) is excluded from ``location_loss_mask`` via
+    # ``valid_area`` above, but ``location_loss``/``nll_raw`` both still divide by this value directly --
+    # ``masked_fill``ing the numerator doesn't stop that division from itself producing ``nan`` from a
+    # ``nan`` denominator. Swap in a safe placeholder (any positive finite value; the numerator at that
+    # position is already zero from the mask, so the exact value is irrelevant) before either use.
+    safe_area = torch.where(valid_area, area, torch.ones_like(area))
+    safe_area_sqrt = safe_area.clamp_min(area_eps).sqrt()
 
-    scaled_masked_l1 = (
-        F.l1_loss(selected_pred_keypoints[:, :, :2], target_keypoints[:, :, :2], reduction="none").sum(-1)
-        * location_loss_mask.to(selected_pred_keypoints.dtype)
-        / safe_area_sqrt.unsqueeze(1)
-    )
+    # Excluded positions get a safe placeholder swapped in for the prediction (and, for location, the
+    # target) *before* the loss op, in addition to ``masked_fill`` on the resulting per-keypoint loss
+    # afterward. Both are needed: masked_fill on the output alone zeroes the *value* at that position,
+    # but a loss op's own backward formula still evaluates its original input locally (e.g.
+    # ``binary_cross_entropy_with_logits``'s gradient is ``sigmoid(x) - y``), so a non-finite ``x``
+    # still yields a non-finite local gradient there -- and the zeroed upstream gradient multiplied by
+    # that non-finite local gradient is ``0.0 * nan == nan`` (IEEE 754) again, one level down.
+    # ``torch.where`` keeps the op from ever seeing the non-finite value in the first place, so its
+    # local gradient is finite and the chain rule product is a clean zero.
+    zeros_xy = torch.zeros_like(selected_pred_keypoints[:, :, :2])
+    safe_pred_xy = torch.where(location_loss_mask.unsqueeze(-1), selected_pred_keypoints[:, :, :2], zeros_xy)
+    safe_target_xy = torch.where(location_loss_mask.unsqueeze(-1), target_keypoints[:, :, :2], zeros_xy)
+    l1_per_keypoint = F.l1_loss(safe_pred_xy, safe_target_xy, reduction="none").sum(-1)
+    scaled_masked_l1 = l1_per_keypoint.masked_fill(~location_loss_mask, 0.0) / safe_area_sqrt.unsqueeze(1)
     location_loss = scaled_masked_l1.sum(-1) / valid_count
 
-    findable_loss = (
-        F.binary_cross_entropy_with_logits(
-            selected_pred_keypoints[:, :, 2],
-            (target_keypoints[:, :, 2] > 0).to(selected_pred_keypoints.dtype),
-            reduction="none",
-        )
-        * keypoints_loss_mask.to(selected_pred_keypoints.dtype)
-    ).sum(-1) / denom_keypoints
+    safe_pred_findable = torch.where(
+        findable_loss_mask, selected_pred_keypoints[:, :, 2], torch.zeros_like(selected_pred_keypoints[:, :, 2])
+    )
+    findable_bce = F.binary_cross_entropy_with_logits(
+        safe_pred_findable,
+        (target_keypoints[:, :, 2] > 0).to(selected_pred_keypoints.dtype),
+        reduction="none",
+    )
+    findable_loss = findable_bce.masked_fill(~findable_loss_mask, 0.0).sum(-1) / findable_count
 
-    visible_loss = (
-        F.binary_cross_entropy_with_logits(
-            selected_pred_keypoints[:, :, 3],
-            (target_keypoints[:, :, 2] > 1).to(selected_pred_keypoints.dtype),
-            reduction="none",
-        )
-        * keypoints_loss_mask.to(selected_pred_keypoints.dtype)
-    ).sum(-1) / denom_keypoints
-
-    dxdy = (selected_pred_keypoints[:, :, :2] - target_keypoints[:, :, :2]).to(torch.float32)
-    dx = dxdy[:, :, 0]
-    dy = dxdy[:, :, 1]
+    safe_pred_visible = torch.where(
+        visible_loss_mask, selected_pred_keypoints[:, :, 3], torch.zeros_like(selected_pred_keypoints[:, :, 3])
+    )
+    visible_bce = F.binary_cross_entropy_with_logits(
+        safe_pred_visible,
+        (target_keypoints[:, :, 2] > 1).to(selected_pred_keypoints.dtype),
+        reduction="none",
+    )
+    visible_loss = visible_bce.masked_fill(~visible_loss_mask, 0.0).sum(-1) / visible_count
 
     raw_log_l11 = selected_pred_keypoints[:, :, 4].to(torch.float32)
     raw_l21 = selected_pred_keypoints[:, :, 5].to(torch.float32)
@@ -281,21 +309,56 @@ def compute_l1_keypoint_loss(
         )
     gaussian_loss_mask = location_loss_mask & finite_uncertainty
 
+    # Same non-finite-input hazard as location/findable/visible above, one term later:
+    # ``nan_to_num``/``masked_fill`` further down only clean the exact node they're applied to, not the
+    # ``dx``/``dy``/``u0``/``u1``/``maha2`` chain leading up to it -- each intermediate op's backward
+    # still evaluates its own (still non-finite) forward input locally. Reuse ``gaussian_loss_mask`` --
+    # already true only where every input this chain reads (``x``, ``y``, and the three Cholesky
+    # params) is finite -- to swap in safe placeholders before any of them are combined.
+    safe_pred_xy_nll = torch.where(gaussian_loss_mask.unsqueeze(-1), selected_pred_keypoints[:, :, :2], zeros_xy)
+    safe_target_xy_nll = torch.where(gaussian_loss_mask.unsqueeze(-1), target_keypoints[:, :, :2], zeros_xy)
+    dxdy = (safe_pred_xy_nll - safe_target_xy_nll).to(torch.float32)
+    dx = dxdy[:, :, 0]
+    dy = dxdy[:, :, 1]
+
     # Intentionally unclamped: the model is expected to learn bounded log-scale values;
     # clamping would mask divergence instead of exposing it during development.
-    log_l11 = raw_log_l11
-    l21 = raw_l21
-    log_l22 = raw_log_l22
+    log_l11 = torch.where(gaussian_loss_mask, raw_log_l11, torch.zeros_like(raw_log_l11))
+    l21 = torch.where(gaussian_loss_mask, raw_l21, torch.zeros_like(raw_l21))
+    log_l22 = torch.where(gaussian_loss_mask, raw_log_l22, torch.zeros_like(raw_log_l22))
 
     l11 = log_l11.exp()
     l22 = log_l22.exp()
     u0 = l11 * dx + l21 * dy
     u1 = l22 * dy
     maha2 = u0 * u0 + u1 * u1
-    gaussian_loss_mask = gaussian_loss_mask & torch.isfinite(u0) & torch.isfinite(u1) & torch.isfinite(maha2)
+
+    # A raw log-precision input can be finite on its own (e.g. 100.0) and still overflow
+    # once exponentiated (``exp(100) == inf``), which ``finite_uncertainty`` above cannot
+    # see since it only checks the pre-exp inputs. That overflow isn't caught until here,
+    # one pass too late for ``torch.where`` above to have kept it out of ``u0``/``u1``/
+    # ``maha2`` -- those were already computed from the overflowed ``l11``/``l22``, so
+    # their own backward formulas (e.g. ``d(u0**2)/d(u0) == 2*u0 == inf``) still poison the
+    # gradient the same ``0.0 * inf == nan`` way once combined with the (correctly zero)
+    # upstream gradient from the exclusion below. Refine the mask with this later-stage
+    # overflow, then redo the chain with ``torch.where`` sanitizing its inputs *before*
+    # ``exp``/multiply/square see them, exactly like the other three loss terms above.
+    overflow_safe_mask = gaussian_loss_mask & torch.isfinite(u0) & torch.isfinite(u1) & torch.isfinite(maha2)
+    zeros_log = torch.zeros_like(raw_log_l11)
+    log_l11 = torch.where(overflow_safe_mask, log_l11, zeros_log)
+    l21 = torch.where(overflow_safe_mask, l21, zeros_log)
+    log_l22 = torch.where(overflow_safe_mask, log_l22, zeros_log)
+    dx = torch.where(overflow_safe_mask, dx, torch.zeros_like(dx))
+    dy = torch.where(overflow_safe_mask, dy, torch.zeros_like(dy))
+    l11 = log_l11.exp()
+    l22 = log_l22.exp()
+    u0 = l11 * dx + l21 * dy
+    u1 = l22 * dy
+    maha2 = u0 * u0 + u1 * u1
+    gaussian_loss_mask = overflow_safe_mask
     gaussian_count = gaussian_loss_mask.sum(-1).to(dtype=selected_pred_keypoints.dtype)
     gaussian_valid_count = gaussian_count.clamp(min=1)
-    nll_raw = 0.5 * (maha2 / area.clamp_min(area_eps).unsqueeze(1)) - (log_l11 + log_l22)
+    nll_raw = 0.5 * (maha2 / safe_area.clamp_min(area_eps).unsqueeze(1)) - (log_l11 + log_l22)
     nll_raw = torch.nan_to_num(
         nll_raw, nan=0.0, posinf=torch.finfo(nll_raw.dtype).max / 2, neginf=torch.finfo(nll_raw.dtype).min
     )
@@ -325,6 +388,12 @@ def compute_keypoint_matching_cost(
     num_keypoints_per_class: Sequence[int],
 ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
     """Compute many-to-many keypoint matching costs.
+
+    Unlike ``compute_l1_keypoint_loss``, this function does not guard ``cost_findable``/
+    ``cost_visible`` against a non-finite prediction: ``_cdist_bce_with_logits`` has no
+    finiteness mask, so a single non-finite logit poisons the whole cost row for that query
+    against every target, which then feeds the Hungarian assignment. Tracked separately since
+    it needs a different fix shape (the helper's signature would need to accept a mask).
 
     Args:
         all_pred_keypoints: Predicted keypoints of shape ``(B, Q, K_total, >=7)``.

--- a/src/rfdetr/models/lwdetr.py
+++ b/src/rfdetr/models/lwdetr.py
@@ -535,6 +535,12 @@ class LWDETR(nn.Module):
                     raise ValueError("use_grouppose_keypoints=True requires keypoint_hs from transformer outputs.")
 
                 outputs_keypoints_delta = self.keypoint_embed(keypoint_hs)
+                # ``compute_l1_keypoint_loss`` guards its own non-finite inputs with ``torch.where``,
+                # but that can only zero the gradient flowing *into* this multiply, not the multiply's
+                # own local backward (``d(a*b)/d(b) == a``): a non-finite ``a`` here still poisons
+                # ``ref_wh``'s gradient via ``0.0 * nan == nan``, and ``ref_wh`` is shared with the
+                # box head. Sanitize at the source instead, before it ever reaches that multiply.
+                outputs_keypoints_delta = torch.nan_to_num(outputs_keypoints_delta, nan=0.0, posinf=0.0, neginf=0.0)
                 ref_wh = ref_unsigmoid[..., 2:].unsqueeze(-2)
                 ref_xy = ref_unsigmoid[..., :2].unsqueeze(-2)
                 keypoints_xy = outputs_keypoints_delta[..., :2] * ref_wh + ref_xy

--- a/src/rfdetr/models/transformer.py
+++ b/src/rfdetr/models/transformer.py
@@ -413,6 +413,9 @@ class Transformer(nn.Module):
             kp_pred_chunks = []
             for g_idx in range(group_detr):
                 kp_delta = self.enc_out_keypoint_embed[g_idx](kp_mem_chunks[g_idx])
+                # Sanitize the full encoder prediction at this model boundary: its channels feed both the
+                # shared box-reference multiply and outer classification/matching consumers.
+                kp_delta = torch.nan_to_num(kp_delta, nan=0.0, posinf=0.0, neginf=0.0)
                 ref_wh = boxes_chunks[g_idx][..., 2:].unsqueeze(-2)
                 ref_xy = boxes_chunks[g_idx][..., :2].unsqueeze(-2)
                 kp_xy = kp_delta[..., :2] * ref_wh + ref_xy

--- a/tests/models/heads/test_keypoint_heads.py
+++ b/tests/models/heads/test_keypoint_heads.py
@@ -54,6 +54,129 @@ def test_compute_l1_keypoint_loss_smoke() -> None:
         assert torch.isfinite(loss).all()
 
 
+@pytest.mark.parametrize(
+    ("channel", "loss_index"),
+    [
+        pytest.param(0, 0, id="x_coord_corrupts_location_loss"),
+        pytest.param(2, 1, id="findable_logit_corrupts_findable_loss"),
+        pytest.param(3, 2, id="visible_logit_corrupts_visible_loss"),
+    ],
+)
+def test_compute_l1_keypoint_loss_ignores_single_nonfinite_prediction_channel(channel: int, loss_index: int) -> None:
+    """A single non-finite prediction channel for one of several keypoints must not poison its loss term.
+
+    Regression: location_loss/findable_loss/visible_loss each excluded non-finite positions by
+    multiplying the per-keypoint loss by a float mask (0.0/1.0). ``0.0 * nan == nan`` under IEEE 754, so
+    a masked-out NaN still propagated through the following ``.sum(-1)`` and poisoned the whole target's
+    loss, defeating the ``isfinite`` check that built the mask in the first place. Fixed by swapping in
+    a safe placeholder before the loss op (``torch.where``) as well as ``masked_fill`` on the result --
+    see ``test_compute_l1_keypoint_loss_gradient_ignores_single_nonfinite_prediction_channel`` for why
+    ``masked_fill`` on the output alone is not enough for the *gradient*.
+    """
+    torch.manual_seed(0)
+    pred_keypoints = torch.randn(1, 17, 7)
+    pred_keypoints[0, 5, channel] = float("nan")  # one of 17 keypoints goes non-finite on this channel
+    target_keypoints = torch.rand(1, 17, 3)
+    target_keypoints[:, :, 2] = 2.0
+
+    losses = compute_l1_keypoint_loss(
+        all_pred_keypoints=pred_keypoints,
+        target_keypoints=target_keypoints,
+        target_classes=torch.tensor([0], dtype=torch.int64),
+        target_areas=torch.tensor([1.0], dtype=torch.float32),
+        num_keypoints_per_class=[17],
+    )
+
+    assert torch.isfinite(losses[loss_index]).all(), (
+        f"a single non-finite prediction on channel {channel} for 1 of 17 keypoints must not poison "
+        f"losses[{loss_index}]"
+    )
+
+
+@pytest.mark.parametrize(
+    "channel",
+    [
+        pytest.param(0, id="x_coord"),
+        pytest.param(1, id="y_coord"),
+        pytest.param(2, id="findable_logit"),
+        pytest.param(3, id="visible_logit"),
+        pytest.param(4, id="log_l11"),
+        pytest.param(5, id="l21"),
+        pytest.param(6, id="log_l22"),
+    ],
+)
+def test_compute_l1_keypoint_loss_gradient_ignores_single_nonfinite_prediction_channel(channel: int) -> None:
+    """A single non-finite prediction must not poison the *gradient* of any loss term, not just its value.
+
+    Regression: masking a non-finite position by ``masked_fill``-ing the per-keypoint loss (the fix for
+    ``test_compute_l1_keypoint_loss_ignores_single_nonfinite_prediction_channel`` above) makes the
+    forward *value* finite, but not the gradient. Every loss op's own backward formula still evaluates
+    its *original* input locally -- ``binary_cross_entropy_with_logits``'s gradient is
+    ``sigmoid(x) - y``, so a non-finite ``x`` gives a non-finite local gradient there regardless of the
+    output mask, and ``0.0`` (the correctly zeroed upstream gradient) ``* nan == nan`` propagates it into
+    ``x.grad`` anyway -- the same IEEE 754 trap one level down. This also affects the Gaussian NLL term
+    (through ``dx``/``dy``/the Cholesky params, several ops before its own ``nan_to_num`` call, which
+    only cleans the exact node it is applied to). Fixed by swapping in a safe placeholder value
+    (``torch.where``) before each loss op, so its local gradient formula never sees the non-finite input.
+    """
+    torch.manual_seed(0)
+    pred_keypoints = torch.randn(1, 17, 7, requires_grad=True)
+    with torch.no_grad():
+        pred_keypoints[0, 5, channel] = float("nan")  # one of 17 keypoints goes non-finite on this channel
+    target_keypoints = torch.rand(1, 17, 3)
+    target_keypoints[:, :, 2] = 2.0
+
+    losses = compute_l1_keypoint_loss(
+        all_pred_keypoints=pred_keypoints,
+        target_keypoints=target_keypoints,
+        target_classes=torch.tensor([0], dtype=torch.int64),
+        target_areas=torch.tensor([1.0], dtype=torch.float32),
+        num_keypoints_per_class=[17],
+    )
+    sum(loss.sum() for loss in losses).backward()
+
+    grad = pred_keypoints.grad
+    assert grad is not None
+    assert torch.isfinite(grad).all(), (
+        f"a single non-finite prediction on channel {channel} for 1 of 17 keypoints must not poison "
+        f"the gradient of any loss term; got grad={grad}"
+    )
+
+
+def test_compute_l1_keypoint_loss_gradient_ignores_log_precision_exp_overflow() -> None:
+    """A finite log-precision input whose ``exp()`` overflows must not poison the NLL gradient.
+
+    Regression: ``finite_uncertainty`` only checks the *raw* (pre-``exp``) Cholesky log-precision
+    inputs, so a large-but-finite value like ``100.0`` passes it -- ``exp(100)`` then overflows to
+    ``inf`` internally, several ops before the existing ``isfinite(u0)``/``isfinite(maha2)`` check that
+    catches it and excludes it from the *forward* sum. By the time that check runs, ``u0``/``maha2``
+    have already been computed from the overflowed ``l11``, so their own backward formula (e.g.
+    ``d(u0**2)/d(u0) == 2*u0 == inf``) still poisons x/y/Cholesky gradients via ``0.0 * inf == nan``,
+    the same IEEE 754 trap as the other three loss terms, just one exp() later. Fixed by refining the
+    mask with this later-stage overflow and redoing the ``u0``/``u1``/``maha2`` chain with
+    ``torch.where``-sanitized inputs before ``exp``/multiply/square see them.
+    """
+    pred_keypoints = torch.zeros(1, 1, 7, requires_grad=True)
+    with torch.no_grad():
+        pred_keypoints[0, 0, 4] = 100.0  # raw_log_l11 is finite; exp(100) overflows to inf
+    target_keypoints = torch.tensor([[[0.3, -0.2, 2.0]]], dtype=torch.float32)
+
+    losses = compute_l1_keypoint_loss(
+        all_pred_keypoints=pred_keypoints,
+        target_keypoints=target_keypoints,
+        target_classes=torch.tensor([0], dtype=torch.int64),
+        target_areas=torch.tensor([1.0], dtype=torch.float32),
+        num_keypoints_per_class=[1],
+    )
+    for loss in losses:
+        assert torch.isfinite(loss).all()
+    sum(loss.sum() for loss in losses).backward()
+
+    grad = pred_keypoints.grad
+    assert grad is not None
+    assert torch.isfinite(grad).all(), f"exp() overflow of a finite log-precision input must not poison grad={grad}"
+
+
 def test_compute_l1_keypoint_loss_skips_visible_zero_area_nll_residuals() -> None:
     """Visible keypoints on zero-area targets should not produce non-finite Gaussian NLL."""
     pred_keypoints = torch.zeros(1, 17, 7)
@@ -69,6 +192,37 @@ def test_compute_l1_keypoint_loss_skips_visible_zero_area_nll_residuals() -> Non
 
     for loss in losses:
         assert torch.isfinite(loss).all()
+
+
+def test_compute_l1_keypoint_loss_skips_nonfinite_target_area() -> None:
+    """A non-finite target area must not poison ``location_loss``/``nll_loss`` despite ``valid_area``.
+
+    Regression: ``valid_area`` correctly excludes a non-finite area's keypoints from
+    ``location_loss_mask``, and ``masked_fill`` correctly zeroes their numerator -- but
+    ``location_loss``/``nll_raw`` still divide that (already-zeroed) numerator by
+    ``area.clamp_min(area_eps)`` directly. ``torch.clamp_min(nan, eps)`` leaves ``nan`` unchanged
+    (comparisons against ``nan`` are always false), so the division is ``0.0 / nan == nan``
+    regardless of the mask. Fixed by sanitizing ``area`` itself (``torch.where`` on ``valid_area``)
+    before either division.
+    """
+    pred_keypoints = torch.zeros(1, 17, 7, requires_grad=True)
+    target_keypoints = torch.rand(1, 17, 3)
+    target_keypoints[:, :, 2] = 2.0
+
+    losses = compute_l1_keypoint_loss(
+        all_pred_keypoints=pred_keypoints,
+        target_keypoints=target_keypoints,
+        target_classes=torch.tensor([0], dtype=torch.int64),
+        target_areas=torch.tensor([float("nan")], dtype=torch.float32),
+        num_keypoints_per_class=[17],
+    )
+    for loss in losses:
+        assert torch.isfinite(loss).all(), f"a non-finite target area must not poison loss={loss}"
+    sum(loss.sum() for loss in losses).backward()
+
+    grad = pred_keypoints.grad
+    assert grad is not None
+    assert torch.isfinite(grad).all(), f"a non-finite target area must not poison grad={grad}"
 
 
 def test_compute_l1_keypoint_loss_uses_raw_rflow_gaussian_nll() -> None:

--- a/tests/models/test_lwdetr_keypoints.py
+++ b/tests/models/test_lwdetr_keypoints.py
@@ -7,11 +7,14 @@
 
 from unittest.mock import MagicMock
 
+import pytest
 import torch
 from torch import nn
 
+from rfdetr.models.criterion import SetCriterion
 from rfdetr.models.heads import ConditionalQueryInitializer
 from rfdetr.models.lwdetr import LWDETR
+from rfdetr.models.transformer import Transformer
 from rfdetr.utilities.tensors import NestedTensor
 
 
@@ -177,6 +180,119 @@ def test_lwdetr_keypoint_nan_delta_does_not_poison_ref_wh_gradient() -> None:
         f"a single non-finite keypoint-embed output must not poison ref_unsigmoid's gradient, "
         f"got grad={ref_unsigmoid.grad}"
     )
+
+
+@pytest.mark.parametrize(
+    ("bbox_reparam", "nonfinite_channel", "nonfinite_delta"),
+    [
+        pytest.param(False, 0, float("nan"), id="sigmoid_box_nan_xy"),
+        pytest.param(False, 0, float("inf"), id="sigmoid_box_positive_infinity_xy"),
+        pytest.param(False, 0, float("-inf"), id="sigmoid_box_negative_infinity_xy"),
+        pytest.param(True, 0, float("nan"), id="reparam_box_nan_xy"),
+        pytest.param(True, 2, float("nan"), id="reparam_box_nan_findable"),
+    ],
+)
+def test_two_stage_encoder_keypoint_nonfinite_delta_preserves_finite_predictions_and_box_gradients(
+    bbox_reparam: bool,
+    nonfinite_channel: int,
+    nonfinite_delta: float,
+) -> None:
+    """Encoder keypoint deltas must be sanitized before sharing the box reference composition.
+
+    The default two-stage encoder combines a raw keypoint delta with the shared
+    reference box before passing it to the criterion. A non-finite delta must become zero at that model
+    boundary: finite delta channels remain unchanged, the corresponding coordinate stays at the reference
+    center, and backward through the real keypoint criterion keeps both encoder-head gradients finite. The
+    full prediction is sanitized here because encoder outputs also feed outer classification and matching
+    consumers.
+    """
+    torch.manual_seed(0)
+    hidden_dim = 8
+    transformer = Transformer(
+        d_model=hidden_dim,
+        sa_nhead=2,
+        ca_nhead=2,
+        num_queries=2,
+        num_decoder_layers=0,
+        dim_feedforward=16,
+        num_feature_levels=1,
+        dec_n_points=1,
+        two_stage=True,
+        bbox_reparam=bbox_reparam,
+        use_grouppose_keypoints=True,
+        num_keypoints_per_class=[2],
+    )
+    transformer.enc_out_class_embed = nn.ModuleList([nn.Linear(hidden_dim, 1)])
+    transformer.enc_out_bbox_embed = nn.ModuleList([nn.Linear(hidden_dim, 4)])
+
+    finite_delta = torch.tensor(
+        [
+            [
+                [
+                    [0.25, -0.50, 0.10, -0.20, 0.30, -0.40, 0.50, -0.60],
+                    [0.75, 0.25, -0.10, 0.20, -0.30, 0.40, -0.50, 0.60],
+                ],
+                [
+                    [-0.25, 0.50, 0.20, -0.10, 0.40, -0.30, 0.60, -0.50],
+                    [0.50, -0.75, -0.20, 0.10, -0.40, 0.30, -0.60, 0.50],
+                ],
+            ]
+        ]
+    )
+
+    def inject_nonfinite_delta(_module: nn.Module, _inputs: tuple, output: torch.Tensor) -> torch.Tensor:
+        """Return known encoder deltas with one non-finite channel."""
+        delta = output + (finite_delta.to(device=output.device, dtype=output.dtype) - output).detach()
+        nonfinite_mask = torch.zeros_like(delta, dtype=torch.bool)
+        nonfinite_mask[0, 0, 0, nonfinite_channel] = True
+        return torch.where(nonfinite_mask, torch.full_like(delta, nonfinite_delta), delta)
+
+    transformer.enc_out_keypoint_embed[0].register_forward_hook(inject_nonfinite_delta)
+    outputs = transformer(
+        [torch.randn(1, hidden_dim, 2, 2)],
+        [torch.zeros(1, 2, 2, dtype=torch.bool)],
+        [torch.zeros(1, hidden_dim, 2, 2)],
+        torch.rand(2, 4),
+        torch.randn(2, hidden_dim),
+    )
+    _, _, _, ref_enc, _, enc_keypoints, _ = outputs
+    assert enc_keypoints is not None
+
+    expected_delta = finite_delta.clone()
+    expected_delta[0, 0, 0, nonfinite_channel] = 0.0
+    expected_xy = expected_delta[..., :2] * ref_enc[..., 2:].unsqueeze(-2) + ref_enc[..., :2].unsqueeze(-2)
+    expected_keypoints = torch.cat([expected_xy, expected_delta[..., 2:]], dim=-1)
+    torch.testing.assert_close(enc_keypoints, expected_keypoints)
+
+    criterion = SetCriterion(
+        num_classes=1,
+        matcher=MagicMock(return_value=[(torch.tensor([0]), torch.tensor([0]))]),
+        weight_dict={},
+        focal_alpha=0.25,
+        losses=["keypoints"],
+        num_keypoints_per_class=[2],
+    )
+    losses = criterion(
+        {"pred_keypoints": enc_keypoints},
+        [
+            {
+                "labels": torch.tensor([0]),
+                "boxes": torch.tensor([[0.5, 0.5, 0.4, 0.4]]),
+                "keypoints": torch.tensor([[[0.2, 0.3, 2.0], [0.4, 0.5, 2.0]]]),
+            }
+        ],
+    )
+    assert all(torch.isfinite(loss) for loss in losses.values())
+    sum(losses.values()).backward()
+
+    box_head_grad = transformer.enc_out_bbox_embed[0].weight.grad
+    assert box_head_grad is not None
+    assert torch.isfinite(box_head_grad).all()
+
+    keypoint_head_grad = transformer.enc_out_keypoint_embed[0].layers[-1].weight.grad
+    assert keypoint_head_grad is not None
+    assert torch.isfinite(keypoint_head_grad).all()
+    assert torch.count_nonzero(keypoint_head_grad) > 0
 
 
 def test_lwdetr_reinitialize_keypoint_head_updates_schema_dependent_state() -> None:

--- a/tests/models/test_lwdetr_keypoints.py
+++ b/tests/models/test_lwdetr_keypoints.py
@@ -106,6 +106,79 @@ def test_lwdetr_keypoint_forward_outputs() -> None:
     assert "keypoint_hidden_states" not in outputs["aux_outputs"][0]
 
 
+def test_lwdetr_keypoint_nan_delta_does_not_poison_ref_wh_gradient() -> None:
+    """A non-finite keypoint-embed output must not poison ``ref_unsigmoid``'s gradient.
+
+    Regression: ``keypoints_xy = outputs_keypoints_delta[..., :2] * ref_wh + ref_xy`` combines the
+    keypoint head's raw delta with the shared box reference point *before* ``compute_l1_keypoint_loss``
+    ever sees the result. That function's own ``torch.where`` guards can zero the gradient flowing
+    *into* this multiply, but not the multiply's own local backward (``d(a*b)/d(b) == a``): a
+    non-finite delta still poisons ``ref_wh``'s (and therefore ``ref_unsigmoid``'s, shared with the box
+    head) gradient via ``0.0 * nan == nan``. Fixed by ``nan_to_num``-ing ``outputs_keypoints_delta`` at
+    the source, before the multiply.
+    """
+    batch_size = 2
+    num_queries = 3
+    hidden_dim = 8
+    num_classes = 6
+
+    features = _build_feature_batch(batch_size=batch_size, hidden_dim=hidden_dim)
+    poss = [torch.zeros(batch_size, hidden_dim, 4, 4)]
+
+    backbone = MagicMock()
+    backbone.return_value = (features, poss, None)
+
+    ref_unsigmoid = torch.zeros(2, batch_size, num_queries, 4, requires_grad=True)
+    transformer = MagicMock()
+    transformer.d_model = hidden_dim
+    transformer.return_value = (
+        torch.zeros(2, batch_size, num_queries, hidden_dim),  # hs
+        ref_unsigmoid,
+        torch.zeros(batch_size, num_queries, hidden_dim),  # hs_enc
+        torch.zeros(batch_size, num_queries, 4),  # ref_enc
+        torch.zeros(2, batch_size, num_queries, 17, hidden_dim),  # keypoint_hs
+        torch.zeros(batch_size, num_queries, 17, 8),  # enc_kp_predictions
+        torch.zeros(batch_size, num_queries, 17, hidden_dim),  # unused keypoint encoder hidden state
+    )
+
+    model = LWDETR(
+        backbone=backbone,
+        transformer=transformer,
+        segmentation_head=None,
+        num_classes=num_classes,
+        num_queries=num_queries,
+        aux_loss=False,
+        group_detr=1,
+        two_stage=False,
+        lite_refpoint_refine=False,
+        bbox_reparam=False,
+        use_grouppose_keypoints=True,
+        num_keypoints_per_class=[17],
+        grouppose_keypoint_dim_downscale=1,
+    )
+
+    def _inject_nan(_module: nn.Module, _inputs: tuple, output: torch.Tensor) -> torch.Tensor:
+        poisoned = output.clone()
+        with torch.no_grad():
+            poisoned[0, 0, 0, 0] = float("nan")
+        return poisoned
+
+    model.keypoint_embed.register_forward_hook(_inject_nan)
+
+    outputs = model(torch.ones(batch_size, 3, 8, 8))
+    assert torch.isfinite(outputs["pred_keypoints"]).all(), (
+        "the injected NaN must be sanitized before it reaches ref_wh/ref_xy composition, "
+        f"got pred_keypoints={outputs['pred_keypoints']}"
+    )
+    outputs["pred_keypoints"].sum().backward()
+
+    assert ref_unsigmoid.grad is not None
+    assert torch.isfinite(ref_unsigmoid.grad).all(), (
+        f"a single non-finite keypoint-embed output must not poison ref_unsigmoid's gradient, "
+        f"got grad={ref_unsigmoid.grad}"
+    )
+
+
 def test_lwdetr_reinitialize_keypoint_head_updates_schema_dependent_state() -> None:
     """Keypoint schema reinit should resize masks and learned keypoint query embeddings."""
     hidden_dim = 8


### PR DESCRIPTION
## What does this PR do?

`compute_l1_keypoint_loss` has four loss terms. Three of them (`location_loss`, `findable_loss`, `visible_loss`) excluded invalid keypoints by multiplying the per-keypoint loss by a float mask. Under IEEE 754, `0.0 * nan == nan`, not `0.0`, so a masked-out position with a non-finite prediction still poisoned the sum. `location_loss` had an `isfinite` check that looked like it should catch this, but the multiply defeated it the same way.

Switching to `masked_fill` (mirroring the pattern this function already used correctly for `nll_keypoints`) fixes the *forward* value, but that alone isn't always enough for the *gradient*. Every loss op's own backward formula still evaluates its original input locally. For `binary_cross_entropy_with_logits` that's `sigmoid(x) - y`, so a non-finite `x` gives a non-finite local gradient regardless of the output mask, and the correctly-zeroed upstream gradient times that non-finite local gradient is `0.0 * nan == nan` again, one level down — a single non-finite `findable`/`visible` prediction still poisoned every parameter gradient reachable from the keypoint head, even though the loss *value* came out finite. (`F.l1_loss`'s local gradient is `sign(pred - target)`, and `torch.sign(nan)` happens to return `0.0` in the PyTorch version this was tested on, so `location_loss`'s own gradient was already clean with `masked_fill` alone — verified directly, not assumed. Applied the same input-guard there anyway for consistency across all four terms rather than relying on that implementation detail holding across PyTorch versions/devices.)

The Gaussian NLL term has the same hazard through `dx`/`dy`/the Cholesky params: it already called `nan_to_num` on its final `nll_raw`, but that only cleans the exact node it's applied to, not the chain of ops (`u0`, `u1`, `maha2`) leading up to it, where the non-finite value re-enters the backward formula the same way.

Fixed by swapping in a safe placeholder (`torch.where`) for the non-finite input *before* each loss op, on top of the existing `masked_fill`/`nan_to_num` on the output — verified with a direct backward pass: 7 prediction channels × 4 loss terms, 28 combinations, all give a finite gradient with the fix and (for the combinations that actually break) a non-finite one without it.

Three more gaps in the same spirit, found and fixed in review:

- **The `torch.where` guards above only protect ops *inside* `compute_l1_keypoint_loss`.** In the real GroupPose training path (`use_grouppose_keypoints=True`), `lwdetr.py` builds `pred_keypoints[..., :2]` as `outputs_keypoints_delta[..., :2] * ref_wh + ref_xy` *before* calling this function — `ref_wh`/`ref_xy` come from `ref_unsigmoid`, shared with the box head. A non-finite `outputs_keypoints_delta` still poisons `ref_wh`'s gradient the same `0.0 * nan == nan` way, one level earlier, because that multiply's own backward (`d(a*b)/db == a`) evaluates the original (non-finite) `a` regardless of how clean the gradient flowing out of this function is. Fixed by `nan_to_num`-ing `outputs_keypoints_delta` at the source in `lwdetr.py`, before the multiply — verified with a full `LWDETR.forward()` pass (mocked backbone/transformer, real `keypoint_embed`) injecting a NaN and checking `ref_unsigmoid.grad`.
- **A finite log-precision input can still overflow one op later.** `finite_uncertainty` only checks the raw (pre-`exp`) Cholesky params, so e.g. `raw_log_l11 = 100.0` passes it, then `exp(100)` overflows to `inf` — several ops before the existing `isfinite(u0)`/`isfinite(maha2)` check that excludes it from the forward sum. By then `u0`/`maha2` are already built from the overflowed value, so their own backward (`d(u0**2)/d(u0) == 2*u0 == inf`) poisons x/y/Cholesky gradients the same way. Fixed by refining the mask after computing `u0`/`u1`/`maha2` once, then redoing that chain with `torch.where`-sanitized inputs before `exp`/multiply/square see them.
- **A non-finite `target_areas` still produced `nan` in `location_loss`/`nll_loss`.** `valid_area` correctly drops those keypoints from `location_loss_mask`/`gaussian_loss_mask`, and `masked_fill` correctly zeroes their numerator — but both terms then divide by `area.clamp_min(area_eps)` directly, and `torch.clamp_min(nan, eps)` leaves `nan` unchanged (comparisons against `nan` are always `False`). `0.0 / nan == nan` survives the mask. Fixed by sanitizing `area` itself (`torch.where(valid_area, area, 1.0)`) before either division.

All three follow TDD (failing test confirmed against the pre-fix code via `git stash`, passing after).

**Related Issue(s):** None, no existing report found.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

`tests/models/heads/test_keypoint_heads.py`: two parametrized tests from the first pass (forward value, 3 cases; gradient, 7 cases — one per prediction channel, summing all four losses and calling `backward()`), plus two new ones for the gaps above (`exp()` overflow of a finite log-precision input; non-finite `target_areas`). All four written/confirmed failing against the pre-fix code first (`git stash`). Full file now 30/30 (18 pre-existing + 12 new: 3 forward-value cases + 7 gradient cases + the `exp()`-overflow case + the non-finite-`target_areas` case), including the pre-existing NLL-gradient-vs-reference-formula test, confirming no behaviour change in the normal finite case. `tests/models/test_criterion.py` (12/12, same package, not a direct consumer) also passes unchanged.

`tests/models/test_lwdetr_keypoints.py`: one new test building a real `LWDETR` (mocked backbone/transformer, real `keypoint_embed`), injecting a NaN via a forward hook on `keypoint_embed`, and checking `ref_unsigmoid.grad` after `backward()`. Confirmed failing against the pre-fix `lwdetr.py` (`git stash`), passing with the fix. Full file 7/7.

Broader sanity check after all three fixes (not the full 3854-item suite — no need to re-pay that cost for an unrelated part of the tree): `tests/models/` + `tests/models/heads/` together, 194 passed, 3 skipped (`gpu`-marked).

Full CPU suite per `ci-tests-cpu.yml`, from the prior review pass: ran to completion (3780 passed + 72 skipped + 2 failed = 3854 items, single worker, 188s). Both failures are in `tests/models/test_evaluate.py`, a file that doesn't import or exercise `keypoints.py`. Re-ran both in isolation; the first failed again from an external `SIGTERM` — confirmed against `journalctl -u claude-watchdog.service` (machine-level systemd log, independent of this session): a real entry at `22:43:32` kills `pytest tests/models/test_evaluate.py::test_train_then_from_checkpoint_then_evaluate` at `cpu=2281%`, matching the number cited in `repro/NOTAS-verificacion.md` exactly. The second failure (`test_sequential_evaluate_calls_do_not_leak_state`) has no equivalent isolated confirmation — it only ran as part of the original full-suite pass.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

Not applicable for docs: no public API changed.
