### PR TITLE
chore: type-check namespace module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -406,7 +406,6 @@ overrides = [
   # Modules with pre-existing type errors — ignored until incrementally fixed.
   { module = [
     "rfdetr",
-    "rfdetr._namespace",
     "rfdetr.config",
     "rfdetr.datasets._develop",
     "rfdetr.datasets.coco",


### PR DESCRIPTION
## Summary

- remove the stale mypy exclusion for `rfdetr._namespace`
- keep the module covered by strict type checking

Part of #564.

## Test

- `mypy --config-file pyproject.toml --ignore-missing-imports --follow-imports=skip src/rfdetr/_namespace.py`
- TOML parse check
- `git diff --check`