### PR TITLE
perf(evaluation): compute confidence-threshold sweep in O(N log N) instead of O(T*N)

### DIFF
--- a/src/rfdetr/evaluation/f1_sweep.py
+++ b/src/rfdetr/evaluation/f1_sweep.py
@@ -22,7 +22,12 @@ def sweep_confidence_thresholds(
     Args:
         per_class_data: Per-class matching data list indexed by class id.
             Each entry is a dict with keys ``"scores"``, ``"matches"``, ``"ignore"``, and ``"total_gt"``.
-        conf_thresholds: Iterable of float confidence thresholds to evaluate.
+        conf_thresholds: Iterable of float confidence thresholds to evaluate. Comparisons against
+            detection scores always happen in float64, regardless of the dtype of
+            ``per_class_data`` scores or of the threshold values themselves. This is deliberate,
+            version-stable semantics and intentionally differs from the legacy
+            ``scores >= conf_thresh`` comparison this function replaced, whose effective dtype
+            depended on NumPy's (pre-2.0) value-based casting rules.
         classes_with_gt: List of class indices that have at least one GT instance — used for macro-averaging.
 
     Returns:

--- a/src/rfdetr/evaluation/f1_sweep.py
+++ b/src/rfdetr/evaluation/f1_sweep.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Any
 
 import numpy as np
@@ -81,7 +82,7 @@ def _per_class_counts(
 
 def sweep_confidence_thresholds(
     per_class_data: list[dict[str, Any]],
-    conf_thresholds: Any,
+    conf_thresholds: Iterable[float],
     classes_with_gt: list[int],
 ) -> list[dict[str, Any]]:
     """Sweep confidence thresholds and compute precision/recall/F1 at each.

--- a/src/rfdetr/evaluation/f1_sweep.py
+++ b/src/rfdetr/evaluation/f1_sweep.py
@@ -35,28 +35,65 @@ def sweep_confidence_thresholds(
             - ``"per_class_rec"``: float ndarray
             - ``"per_class_f1"``: float ndarray
     """
+    # Materialized exactly once: `conf_thresholds` is documented as any iterable, which a generator
+    # would satisfy, and every use below (the length, the per-class searchsorted, and the per-threshold
+    # results loop) needs its own full pass -- consuming a generator more than once would silently
+    # return wrong-length or empty results from the second pass onward.
+    conf_thresholds_arr = np.asarray(list(conf_thresholds), dtype=np.float64)
     num_classes = len(per_class_data)
+    num_thresholds = len(conf_thresholds_arr)
+
+    # Per-class TP/FP counts at every threshold, computed once per class instead of rescanning every
+    # detection at every threshold (the loop below used to do exactly that: for each of T thresholds,
+    # `scores >= conf_thresh` scans all of that class's N detections -- O(T*N) total). Sorting each
+    # class's detections by score once (O(N log N)) and taking prefix sums over the sorted order lets
+    # every threshold's TP/FP be a single `np.searchsorted` binary search plus an array lookup instead
+    # of a full rescan, so the whole function becomes O(N log N + T log N) per class.
+    per_class_tp = np.empty((num_classes, num_thresholds), dtype=np.int64)
+    per_class_fp = np.empty((num_classes, num_thresholds), dtype=np.int64)
+    total_gt_per_class = np.empty(num_classes, dtype=np.int64)
+
+    for k in range(num_classes):
+        data = per_class_data[k]
+        scores = data["scores"]
+        matches = data["matches"]
+        ignore = data["ignore"]
+        total_gt_per_class[k] = data["total_gt"]
+
+        # Ascending sort: `np.searchsorted(..., side="left")` then gives, for a threshold, the index
+        # of the first detection with score >= threshold -- everything from that index to the end is
+        # the "above_thresh" set the original per-threshold boolean mask picked out. NumPy sorts NaN
+        # scores to the end of an ascending sort, which would put them in the "above every threshold"
+        # suffix -- but `scores >= conf_thresh` is False for a NaN score against any real threshold,
+        # so the original loop always excluded them. Mask them out here the same way `ignore` is, or
+        # a NaN score would flip from silently ignored to silently counted as TP/FP at every threshold.
+        order = np.argsort(scores, kind="stable")
+        sorted_scores = scores[order]
+        valid = ~ignore[order] & ~np.isnan(sorted_scores)
+        is_tp = valid & (matches[order] != 0)
+        is_fp = valid & (matches[order] == 0)
+
+        # Suffix sums: `suffix_tp[i]` = count of TPs among detections with score >= sorted_scores[i].
+        # `np.cumsum(...)` is a prefix sum; reversing the input and output turns it into a suffix sum
+        # without a second full pass.
+        suffix_tp = np.concatenate((np.cumsum(is_tp[::-1])[::-1], [0]))
+        suffix_fp = np.concatenate((np.cumsum(is_fp[::-1])[::-1], [0]))
+
+        insertion_idx = np.searchsorted(sorted_scores, conf_thresholds_arr, side="left")
+        per_class_tp[k] = suffix_tp[insertion_idx]
+        per_class_fp[k] = suffix_fp[insertion_idx]
+
     results: list[dict[str, Any]] = []
 
-    for conf_thresh in conf_thresholds:
+    for t, conf_thresh in enumerate(conf_thresholds_arr):
         per_class_precisions: list[float] = []
         per_class_recalls: list[float] = []
         per_class_f1s: list[float] = []
 
         for k in range(num_classes):
-            data = per_class_data[k]
-            scores = data["scores"]
-            matches = data["matches"]
-            ignore = data["ignore"]
-            total_gt = data["total_gt"]
-
-            above_thresh = scores >= conf_thresh
-            valid = above_thresh & ~ignore
-
-            valid_matches = matches[valid]
-
-            tp = np.sum(valid_matches != 0)
-            fp = np.sum(valid_matches == 0)
+            tp = per_class_tp[k, t]
+            fp = per_class_fp[k, t]
+            total_gt = total_gt_per_class[k]
             fn = total_gt - tp
 
             precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0

--- a/src/rfdetr/evaluation/f1_sweep.py
+++ b/src/rfdetr/evaluation/f1_sweep.py
@@ -86,9 +86,16 @@ def sweep_confidence_thresholds(
 ) -> list[dict[str, Any]]:
     """Sweep confidence thresholds and compute precision/recall/F1 at each.
 
+    Each class's detections are sorted by score once and reduced to suffix TP/FP sums; every
+    threshold's counts are then a single ``np.searchsorted`` binary search away, giving
+    O(N log N + T log N) per class instead of rescanning every detection at every threshold.
+
     Args:
-        per_class_data: Per-class matching data list indexed by class id.
-            Each entry is a dict with keys ``"scores"``, ``"matches"``, ``"ignore"``, and ``"total_gt"``.
+        per_class_data: Per-class matching data list indexed by class id. Each entry is a dict with
+            keys ``"scores"`` and ``"matches"`` (equal-length ndarrays), ``"ignore"`` (a boolean
+            ndarray of the same length), and ``"total_gt"`` (an integer -- a float value silently
+            truncates via an int64 cast rather than raising). Mismatched ``"scores"``/``"ignore"``
+            lengths raise ``IndexError``.
         conf_thresholds: Iterable of float confidence thresholds to evaluate. Comparisons against
             detection scores always happen in float64, regardless of the dtype of
             ``per_class_data`` scores or of the threshold values themselves. This is deliberate,
@@ -106,6 +113,13 @@ def sweep_confidence_thresholds(
             - ``"per_class_prec"``: float ndarray
             - ``"per_class_rec"``: float ndarray
             - ``"per_class_f1"``: float ndarray
+
+    Examples:
+        >>> data = [{"scores": np.array([0.9, 0.4]), "matches": np.array([1, 0]),
+        ...          "ignore": np.array([False, False]), "total_gt": 1}]
+        >>> results = sweep_confidence_thresholds(data, [0.5], classes_with_gt=[0])
+        >>> round(results[0]["macro_precision"], 3), round(results[0]["macro_recall"], 3)
+        (1.0, 1.0)
     """
     # Materialized exactly once: `conf_thresholds` is documented as any iterable, which a generator
     # would satisfy, and every use below (the length, the per-class searchsorted, and the per-threshold
@@ -114,12 +128,8 @@ def sweep_confidence_thresholds(
     conf_thresholds_arr = np.asarray(list(conf_thresholds), dtype=np.float64)
     num_classes = len(per_class_data)
 
-    # Per-class TP/FP counts at every threshold, computed once per class instead of rescanning every
-    # detection at every threshold (the pre-rewrite loop did exactly that: for each of T thresholds,
-    # `scores >= conf_thresh` scans all of that class's N detections -- O(T*N) total). Sorting each
-    # class's detections by score once (O(N log N)) and taking suffix sums over the sorted order lets
-    # every threshold's TP/FP be a single `np.searchsorted` binary search plus an array lookup instead
-    # of a full rescan, so the whole function becomes O(N log N + T log N) per class.
+    # Per-class TP/FP counts at every threshold, tabulated once per class via sort + suffix sums +
+    # searchsorted -- see `_per_class_counts` for the O(N log N + T log N) derivation.
     per_class_tp, per_class_fp, total_gt_per_class = _per_class_counts(per_class_data, conf_thresholds_arr)
 
     results: list[dict[str, Any]] = []

--- a/src/rfdetr/evaluation/f1_sweep.py
+++ b/src/rfdetr/evaluation/f1_sweep.py
@@ -10,6 +10,73 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+from numpy.typing import NDArray
+
+
+def _per_class_counts(
+    per_class_data: list[dict[str, Any]],
+    conf_thresholds_arr: NDArray[np.float64],
+) -> tuple[NDArray[np.int64], NDArray[np.int64], NDArray[np.int64]]:
+    """Tabulate per-class TP/FP counts at every threshold in a single O(N log N) pass per class.
+
+    Sorts each class's detections by score once, then reads off TP/FP counts for every threshold
+    via a `np.searchsorted` binary search into precomputed suffix sums, instead of rescanning all
+    of a class's detections at every threshold.
+
+    Args:
+        per_class_data: Per-class matching data list indexed by class id. Each entry is a dict with
+            keys ``"scores"``, ``"matches"``, ``"ignore"``, and ``"total_gt"``.
+        conf_thresholds_arr: Confidence thresholds to evaluate, as a float64 array.
+
+    Returns:
+        Tuple of ``(per_class_tp, per_class_fp, total_gt_per_class)``, where ``per_class_tp`` and
+        ``per_class_fp`` are ``(num_classes, num_thresholds)`` int64 arrays and
+        ``total_gt_per_class`` is a ``(num_classes,)`` int64 array.
+
+    Examples:
+        >>> data = [{"scores": np.array([0.9, 0.4]), "matches": np.array([1, 0]),
+        ...          "ignore": np.array([False, False]), "total_gt": 1}]
+        >>> tp, fp, total_gt = _per_class_counts(data, np.array([0.0, 0.5]))
+        >>> tp.tolist(), fp.tolist(), total_gt.tolist()
+        ([[1, 1]], [[1, 0]], [1])
+    """
+    num_classes = len(per_class_data)
+    num_thresholds = len(conf_thresholds_arr)
+
+    per_class_tp = np.empty((num_classes, num_thresholds), dtype=np.int64)
+    per_class_fp = np.empty((num_classes, num_thresholds), dtype=np.int64)
+    total_gt_per_class = np.empty(num_classes, dtype=np.int64)
+
+    for k in range(num_classes):
+        data = per_class_data[k]
+        scores = data["scores"]
+        matches = data["matches"]
+        ignore = data["ignore"]
+        total_gt_per_class[k] = data["total_gt"]
+
+        # Ascending sort: `np.searchsorted(..., side="left")` then gives, for a threshold, the index
+        # of the first detection with score >= threshold -- everything from that index to the end is
+        # the "above_thresh" set a per-threshold boolean mask would pick out. NumPy sorts NaN scores
+        # to the end of an ascending sort, which would put them in the "above every threshold" suffix
+        # -- but a NaN score must never compare as "above" a real threshold, so it is masked out here
+        # the same way `ignore` is.
+        order = np.argsort(scores, kind="stable")
+        sorted_scores = scores[order]
+        valid = ~ignore[order] & ~np.isnan(sorted_scores)
+        is_tp = valid & (matches[order] != 0)
+        is_fp = valid & (matches[order] == 0)
+
+        # Suffix sums: `suffix_tp[i]` = count of TPs among detections with score >= sorted_scores[i].
+        # `np.cumsum(...)` is a prefix sum; reversing the input and output turns it into a suffix sum
+        # without a second full pass.
+        suffix_tp = np.concatenate((np.cumsum(is_tp[::-1])[::-1], [0]))
+        suffix_fp = np.concatenate((np.cumsum(is_fp[::-1])[::-1], [0]))
+
+        insertion_idx = np.searchsorted(sorted_scores, conf_thresholds_arr, side="left")
+        per_class_tp[k] = suffix_tp[insertion_idx]
+        per_class_fp[k] = suffix_fp[insertion_idx]
+
+    return per_class_tp, per_class_fp, total_gt_per_class
 
 
 def sweep_confidence_thresholds(
@@ -46,47 +113,14 @@ def sweep_confidence_thresholds(
     # return wrong-length or empty results from the second pass onward.
     conf_thresholds_arr = np.asarray(list(conf_thresholds), dtype=np.float64)
     num_classes = len(per_class_data)
-    num_thresholds = len(conf_thresholds_arr)
 
     # Per-class TP/FP counts at every threshold, computed once per class instead of rescanning every
-    # detection at every threshold (the loop below used to do exactly that: for each of T thresholds,
+    # detection at every threshold (the pre-rewrite loop did exactly that: for each of T thresholds,
     # `scores >= conf_thresh` scans all of that class's N detections -- O(T*N) total). Sorting each
-    # class's detections by score once (O(N log N)) and taking prefix sums over the sorted order lets
+    # class's detections by score once (O(N log N)) and taking suffix sums over the sorted order lets
     # every threshold's TP/FP be a single `np.searchsorted` binary search plus an array lookup instead
     # of a full rescan, so the whole function becomes O(N log N + T log N) per class.
-    per_class_tp = np.empty((num_classes, num_thresholds), dtype=np.int64)
-    per_class_fp = np.empty((num_classes, num_thresholds), dtype=np.int64)
-    total_gt_per_class = np.empty(num_classes, dtype=np.int64)
-
-    for k in range(num_classes):
-        data = per_class_data[k]
-        scores = data["scores"]
-        matches = data["matches"]
-        ignore = data["ignore"]
-        total_gt_per_class[k] = data["total_gt"]
-
-        # Ascending sort: `np.searchsorted(..., side="left")` then gives, for a threshold, the index
-        # of the first detection with score >= threshold -- everything from that index to the end is
-        # the "above_thresh" set the original per-threshold boolean mask picked out. NumPy sorts NaN
-        # scores to the end of an ascending sort, which would put them in the "above every threshold"
-        # suffix -- but `scores >= conf_thresh` is False for a NaN score against any real threshold,
-        # so the original loop always excluded them. Mask them out here the same way `ignore` is, or
-        # a NaN score would flip from silently ignored to silently counted as TP/FP at every threshold.
-        order = np.argsort(scores, kind="stable")
-        sorted_scores = scores[order]
-        valid = ~ignore[order] & ~np.isnan(sorted_scores)
-        is_tp = valid & (matches[order] != 0)
-        is_fp = valid & (matches[order] == 0)
-
-        # Suffix sums: `suffix_tp[i]` = count of TPs among detections with score >= sorted_scores[i].
-        # `np.cumsum(...)` is a prefix sum; reversing the input and output turns it into a suffix sum
-        # without a second full pass.
-        suffix_tp = np.concatenate((np.cumsum(is_tp[::-1])[::-1], [0]))
-        suffix_fp = np.concatenate((np.cumsum(is_fp[::-1])[::-1], [0]))
-
-        insertion_idx = np.searchsorted(sorted_scores, conf_thresholds_arr, side="left")
-        per_class_tp[k] = suffix_tp[insertion_idx]
-        per_class_fp[k] = suffix_fp[insertion_idx]
+    per_class_tp, per_class_fp, total_gt_per_class = _per_class_counts(per_class_data, conf_thresholds_arr)
 
     results: list[dict[str, Any]] = []
 

--- a/tests/evaluation/test_f1_sweep.py
+++ b/tests/evaluation/test_f1_sweep.py
@@ -1,0 +1,280 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from rfdetr.evaluation.f1_sweep import sweep_confidence_thresholds
+
+
+def _reference_sweep(
+    per_class_data: list[dict[str, Any]],
+    conf_thresholds: Any,
+    classes_with_gt: list[int],
+) -> list[dict[str, Any]]:
+    """O(T*N) reference implementation: the exact algorithm sweep_confidence_thresholds used before
+    this PR -- rescans every detection at every threshold instead of sorting once per class. Kept
+    standalone here (not the module under test) as the ground truth for the equivalence tests below,
+    so a bug shared between the two implementations can't hide a real divergence.
+
+    Examples:
+        >>> data = [{"scores": np.array([0.9, 0.4]), "matches": np.array([1, 0]),
+        ...          "ignore": np.array([False, False]), "total_gt": 1}]
+        >>> results = _reference_sweep(data, [0.5], [0])
+        >>> round(results[0]["macro_precision"], 3), round(results[0]["macro_recall"], 3)
+        (1.0, 1.0)
+    """
+    num_classes = len(per_class_data)
+    results: list[dict[str, Any]] = []
+
+    for conf_thresh in conf_thresholds:
+        per_class_precisions: list[float] = []
+        per_class_recalls: list[float] = []
+        per_class_f1s: list[float] = []
+
+        for k in range(num_classes):
+            data = per_class_data[k]
+            scores = data["scores"]
+            matches = data["matches"]
+            ignore = data["ignore"]
+            total_gt = data["total_gt"]
+
+            above_thresh = scores >= conf_thresh
+            valid = above_thresh & ~ignore
+            valid_matches = matches[valid]
+
+            tp = np.sum(valid_matches != 0)
+            fp = np.sum(valid_matches == 0)
+            fn = total_gt - tp
+
+            precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+            recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+            f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0.0
+
+            per_class_precisions.append(precision)
+            per_class_recalls.append(recall)
+            per_class_f1s.append(f1)
+
+        if len(classes_with_gt) > 0:
+            macro_precision = float(np.mean([per_class_precisions[k] for k in classes_with_gt]))
+            macro_recall = float(np.mean([per_class_recalls[k] for k in classes_with_gt]))
+            macro_f1 = float(np.mean([per_class_f1s[k] for k in classes_with_gt]))
+        else:
+            macro_precision = 0.0
+            macro_recall = 0.0
+            macro_f1 = 0.0
+
+        results.append(
+            {
+                "confidence_threshold": conf_thresh,
+                "macro_f1": macro_f1,
+                "macro_precision": macro_precision,
+                "macro_recall": macro_recall,
+                "per_class_prec": np.array(per_class_precisions),
+                "per_class_rec": np.array(per_class_recalls),
+                "per_class_f1": np.array(per_class_f1s),
+            }
+        )
+
+    return results
+
+
+def _random_per_class_data(seed: int, num_classes: int, max_detections: int) -> list[dict[str, Any]]:
+    """Build random per-class matching data with tied scores and a mix of TP/FP/ignored detections,
+    for equivalence-testing sweep_confidence_thresholds against _reference_sweep.
+
+    ``matches`` and ``total_gt`` are drawn independently, so ``sum(matches) > total_gt`` is possible
+    here even though it can't happen in real matching output -- both implementations under test treat
+    ``tp``/``fp``/``total_gt`` as opaque counts and never compare them against each other, so this
+    doesn't weaken the equivalence check, only broaden the input space it covers. It also doesn't
+    exercise the real detector -> matching -> sweep integration; that lives in
+    ``tests/benchmarks/test_inference_coco.py`` (``coco17``-marked, downloads COCO val2017).
+
+    Examples:
+        >>> data = _random_per_class_data(seed=0, num_classes=1, max_detections=3)
+        >>> sorted(data[0].keys())
+        ['ignore', 'matches', 'scores', 'total_gt']
+    """
+    rng = np.random.default_rng(seed)
+    per_class_data = []
+    for _ in range(num_classes):
+        n = int(rng.integers(0, max_detections + 1))
+        # Round scores to encourage exact ties, which is where searchsorted's "side" behavior most
+        # needs to match the original inclusive `scores >= conf_thresh` semantics.
+        scores = np.round(rng.uniform(0.0, 1.0, size=n), 1)
+        matches = rng.integers(0, 2, size=n)  # 0 == unmatched (FP candidate), 1 == matched (TP candidate)
+        ignore = rng.random(size=n) < 0.2
+        total_gt = int(rng.integers(0, max_detections + 1))
+        per_class_data.append({"scores": scores, "matches": matches, "ignore": ignore, "total_gt": total_gt})
+    return per_class_data
+
+
+def _assert_results_equal(actual: list[dict[str, Any]], expected: list[dict[str, Any]]) -> None:
+    """Assert two sweep_confidence_thresholds-shaped result lists are numerically identical.
+
+    Examples:
+        >>> r = [{"confidence_threshold": 0.5, "macro_f1": 1.0, "macro_precision": 1.0,
+        ...       "macro_recall": 1.0, "per_class_prec": np.array([1.0]),
+        ...       "per_class_rec": np.array([1.0]), "per_class_f1": np.array([1.0])}]
+        >>> _assert_results_equal(r, r)
+    """
+    assert len(actual) == len(expected)
+    for a, e in zip(actual, expected):
+        assert a["confidence_threshold"] == pytest.approx(e["confidence_threshold"])
+        assert a["macro_f1"] == pytest.approx(e["macro_f1"])
+        assert a["macro_precision"] == pytest.approx(e["macro_precision"])
+        assert a["macro_recall"] == pytest.approx(e["macro_recall"])
+        np.testing.assert_allclose(a["per_class_prec"], e["per_class_prec"])
+        np.testing.assert_allclose(a["per_class_rec"], e["per_class_rec"])
+        np.testing.assert_allclose(a["per_class_f1"], e["per_class_f1"])
+
+
+class TestSweepConfidenceThresholdsMatchesReference:
+    """sweep_confidence_thresholds must return numerically identical results to the O(T*N) reference
+    it replaced, across random data, empty classes, all-ignored classes, and threshold/score ties.
+    """
+
+    @pytest.mark.parametrize("seed", [0, 1, 2, 3, 4], ids=lambda s: f"seed={s}")
+    def test_matches_reference_on_random_data(self, seed: int) -> None:
+        per_class_data = _random_per_class_data(seed=seed, num_classes=5, max_detections=40)
+        classes_with_gt = [k for k, d in enumerate(per_class_data) if d["total_gt"] > 0]
+        conf_thresholds = np.linspace(0, 1, 101)
+
+        actual = sweep_confidence_thresholds(per_class_data, conf_thresholds, classes_with_gt)
+        expected = _reference_sweep(per_class_data, conf_thresholds, classes_with_gt)
+
+        _assert_results_equal(actual, expected)
+
+    def test_matches_reference_with_no_detections_in_any_class(self) -> None:
+        per_class_data = [
+            {"scores": np.array([]), "matches": np.array([]), "ignore": np.array([], dtype=bool), "total_gt": 0}
+            for _ in range(3)
+        ]
+        conf_thresholds = [0.0, 0.5, 1.0]
+
+        actual = sweep_confidence_thresholds(per_class_data, conf_thresholds, classes_with_gt=[])
+        expected = _reference_sweep(per_class_data, conf_thresholds, classes_with_gt=[])
+
+        _assert_results_equal(actual, expected)
+
+    def test_matches_reference_when_every_detection_is_ignored(self) -> None:
+        per_class_data = [
+            {
+                "scores": np.array([0.9, 0.6, 0.3]),
+                "matches": np.array([1, 0, 1]),
+                "ignore": np.array([True, True, True]),
+                "total_gt": 2,
+            }
+        ]
+        conf_thresholds = np.linspace(0, 1, 11)
+
+        actual = sweep_confidence_thresholds(per_class_data, conf_thresholds, classes_with_gt=[0])
+        expected = _reference_sweep(per_class_data, conf_thresholds, classes_with_gt=[0])
+
+        _assert_results_equal(actual, expected)
+        assert actual[0]["macro_precision"] == 0.0  # tp+fp==0 when everything is ignored
+
+    def test_matches_reference_with_scores_exactly_on_threshold_boundaries(self) -> None:
+        """`scores >= conf_thresh` is inclusive; a detection scored exactly at a threshold must count
+        as above it in both implementations, and thresholds are chosen to land exactly on scores."""
+        per_class_data = [
+            {
+                "scores": np.array([0.3, 0.3, 0.7, 0.7, 1.0]),
+                "matches": np.array([1, 0, 1, 1, 0]),
+                "ignore": np.array([False, False, False, False, False]),
+                "total_gt": 3,
+            }
+        ]
+        conf_thresholds = [0.0, 0.3, 0.7, 1.0]
+
+        actual = sweep_confidence_thresholds(per_class_data, conf_thresholds, classes_with_gt=[0])
+        expected = _reference_sweep(per_class_data, conf_thresholds, classes_with_gt=[0])
+
+        _assert_results_equal(actual, expected)
+
+    def test_matches_reference_with_nan_scores(self) -> None:
+        """A NaN score fails `scores >= conf_thresh` for every threshold, so the O(T*N) reference
+        always excludes it. `np.argsort` sorts NaN to the end of ascending order, which would put it
+        in the "above every threshold" suffix if not masked out the same way `ignore` is -- this
+        regresses `macro_f1` from 0.0 to 1.0 for the exact case below if the mask is dropped."""
+        per_class_data = [
+            {
+                "scores": np.array([np.nan]),
+                "matches": np.array([1]),
+                "ignore": np.array([False]),
+                "total_gt": 1,
+            }
+        ]
+        conf_thresholds = [0.5]
+
+        actual = sweep_confidence_thresholds(per_class_data, conf_thresholds, classes_with_gt=[0])
+        expected = _reference_sweep(per_class_data, conf_thresholds, classes_with_gt=[0])
+
+        _assert_results_equal(actual, expected)
+        assert actual[0]["macro_f1"] == 0.0
+
+    def test_matches_reference_with_generator_conf_thresholds(self) -> None:
+        """conf_thresholds is documented as any iterable, including a one-shot generator -- pins that
+        sweep_confidence_thresholds materializes it exactly once instead of consuming it partway
+        through (e.g. once to measure its length, again to iterate results), which would silently
+        return fewer thresholds than requested for a genuinely single-pass iterable."""
+        per_class_data = [
+            {
+                "scores": np.array([0.9, 0.4]),
+                "matches": np.array([1, 0]),
+                "ignore": np.array([False, False]),
+                "total_gt": 1,
+            }
+        ]
+        thresholds_list = [0.0, 0.5, 1.0]
+
+        actual = sweep_confidence_thresholds(
+            per_class_data, (t for t in thresholds_list), classes_with_gt=[0]
+        )
+
+        assert len(actual) == len(thresholds_list)
+        assert [r["confidence_threshold"] for r in actual] == pytest.approx(thresholds_list)
+
+
+class TestSweepConfidenceThresholdsBasicCorrectness:
+    """A few hand-computed cases pin the actual precision/recall/F1 values, independent of the
+    reference-equivalence tests above (which would pass even if both implementations shared the same
+    bug)."""
+
+    def test_all_correct_detections_gives_perfect_scores(self) -> None:
+        per_class_data = [
+            {
+                "scores": np.array([0.9, 0.8]),
+                "matches": np.array([1, 1]),
+                "ignore": np.array([False, False]),
+                "total_gt": 2,
+            }
+        ]
+
+        result = sweep_confidence_thresholds(per_class_data, [0.5], classes_with_gt=[0])[0]
+
+        assert result["macro_precision"] == pytest.approx(1.0)
+        assert result["macro_recall"] == pytest.approx(1.0)
+        assert result["macro_f1"] == pytest.approx(1.0)
+
+    def test_raising_threshold_above_a_false_positives_score_removes_it(self) -> None:
+        per_class_data = [
+            {
+                "scores": np.array([0.9, 0.4]),  # 0.9 is a TP, 0.4 is a FP
+                "matches": np.array([1, 0]),
+                "ignore": np.array([False, False]),
+                "total_gt": 1,
+            }
+        ]
+
+        low_thresh = sweep_confidence_thresholds(per_class_data, [0.0], classes_with_gt=[0])[0]
+        high_thresh = sweep_confidence_thresholds(per_class_data, [0.5], classes_with_gt=[0])[0]
+
+        assert low_thresh["macro_precision"] == pytest.approx(0.5)  # 1 TP, 1 FP
+        assert high_thresh["macro_precision"] == pytest.approx(1.0)  # FP dropped below threshold
+        assert high_thresh["macro_recall"] == pytest.approx(1.0)  # the TP is still above threshold

--- a/tests/evaluation/test_f1_sweep.py
+++ b/tests/evaluation/test_f1_sweep.py
@@ -135,9 +135,8 @@ def _assert_results_equal(actual: list[dict[str, Any]], expected: list[dict[str,
 
 
 class TestSweepConfidenceThresholdsMatchesReference:
-    """sweep_confidence_thresholds must return numerically identical results to the O(T*N) reference
-    it replaced, across random data, empty classes, all-ignored classes, and threshold/score ties.
-    """
+    """sweep_confidence_thresholds must return numerically identical results to the O(T*N) reference it replaced, across
+    random data, empty classes, all-ignored classes, and threshold/score ties."""
 
     @pytest.mark.parametrize("seed", [0, 1, 2, 3, 4], ids=lambda s: f"seed={s}")
     def test_matches_reference_on_random_data(self, seed: int) -> None:
@@ -180,8 +179,8 @@ class TestSweepConfidenceThresholdsMatchesReference:
         assert actual[0]["macro_precision"] == 0.0  # tp+fp==0 when everything is ignored
 
     def test_matches_reference_with_scores_exactly_on_threshold_boundaries(self) -> None:
-        """`scores >= conf_thresh` is inclusive; a detection scored exactly at a threshold must count
-        as above it in both implementations, and thresholds are chosen to land exactly on scores."""
+        """`scores >= conf_thresh` is inclusive; a detection scored exactly at a threshold must count as above it in
+        both implementations, and thresholds are chosen to land exactly on scores."""
         per_class_data = [
             {
                 "scores": np.array([0.3, 0.3, 0.7, 0.7, 1.0]),
@@ -198,10 +197,12 @@ class TestSweepConfidenceThresholdsMatchesReference:
         _assert_results_equal(actual, expected)
 
     def test_matches_reference_with_nan_scores(self) -> None:
-        """A NaN score fails `scores >= conf_thresh` for every threshold, so the O(T*N) reference
-        always excludes it. `np.argsort` sorts NaN to the end of ascending order, which would put it
-        in the "above every threshold" suffix if not masked out the same way `ignore` is -- this
-        regresses `macro_f1` from 0.0 to 1.0 for the exact case below if the mask is dropped."""
+        """A NaN score fails `scores >= conf_thresh` for every threshold, so the O(T*N) reference always excludes it.
+
+        `np.argsort` sorts NaN to the end of ascending order, which would put it in the "above every threshold" suffix
+        if not masked out the same way `ignore` is -- this regresses `macro_f1` from 0.0 to 1.0 for the exact case below
+        if the mask is dropped.
+        """
         per_class_data = [
             {
                 "scores": np.array([np.nan]),
@@ -220,9 +221,9 @@ class TestSweepConfidenceThresholdsMatchesReference:
 
     def test_matches_reference_with_generator_conf_thresholds(self) -> None:
         """conf_thresholds is documented as any iterable, including a one-shot generator -- pins that
-        sweep_confidence_thresholds materializes it exactly once instead of consuming it partway
-        through (e.g. once to measure its length, again to iterate results), which would silently
-        return fewer thresholds than requested for a genuinely single-pass iterable."""
+        sweep_confidence_thresholds materializes it exactly once instead of consuming it partway through (e.g. once to
+        measure its length, again to iterate results), which would silently return fewer thresholds than requested for a
+        genuinely single-pass iterable."""
         per_class_data = [
             {
                 "scores": np.array([0.9, 0.4]),
@@ -233,18 +234,15 @@ class TestSweepConfidenceThresholdsMatchesReference:
         ]
         thresholds_list = [0.0, 0.5, 1.0]
 
-        actual = sweep_confidence_thresholds(
-            per_class_data, (t for t in thresholds_list), classes_with_gt=[0]
-        )
+        actual = sweep_confidence_thresholds(per_class_data, (t for t in thresholds_list), classes_with_gt=[0])
 
         assert len(actual) == len(thresholds_list)
         assert [r["confidence_threshold"] for r in actual] == pytest.approx(thresholds_list)
 
 
 class TestSweepConfidenceThresholdsBasicCorrectness:
-    """A few hand-computed cases pin the actual precision/recall/F1 values, independent of the
-    reference-equivalence tests above (which would pass even if both implementations shared the same
-    bug)."""
+    """A few hand-computed cases pin the actual precision/recall/F1 values, independent of the reference-equivalence
+    tests above (which would pass even if both implementations shared the same bug)."""
 
     def test_all_correct_detections_gives_perfect_scores(self) -> None:
         per_class_data = [

--- a/tests/evaluation/test_f1_sweep.py
+++ b/tests/evaluation/test_f1_sweep.py
@@ -276,3 +276,26 @@ class TestSweepConfidenceThresholdsBasicCorrectness:
         assert low_thresh["macro_precision"] == pytest.approx(0.5)  # 1 TP, 1 FP
         assert high_thresh["macro_precision"] == pytest.approx(1.0)  # FP dropped below threshold
         assert high_thresh["macro_recall"] == pytest.approx(1.0)  # the TP is still above threshold
+
+    def test_float32_scores_compare_in_float64_at_threshold_boundary(self) -> None:
+        """Threshold comparison always happens in float64 regardless of score dtype (deliberate, documented semantics --
+        see the ``conf_thresholds`` docstring).
+
+        This deliberately diverges from ``_reference_sweep``'s ``scores >= conf_thresh`` comparison for a float32 score
+        of ``0.7`` against a plain-float threshold of ``0.7``: ``np.float32(0.7)`` rounds down to ``0.699999988...``,
+        which is below ``float64(0.7)`` once promoted, so the detection is excluded here even though the legacy value-
+        based comparison would have included it.
+        """
+        per_class_data = [
+            {
+                "scores": np.array([0.7], dtype=np.float32),
+                "matches": np.array([1]),
+                "ignore": np.array([False]),
+                "total_gt": 1,
+            }
+        ]
+
+        result = sweep_confidence_thresholds(per_class_data, [0.7], classes_with_gt=[0])[0]
+
+        assert result["macro_precision"] == pytest.approx(0.0)  # tp+fp == 0: nothing above threshold
+        assert result["macro_recall"] == pytest.approx(0.0)  # the TP is excluded by the float64 comparison

--- a/tests/evaluation/test_f1_sweep.py
+++ b/tests/evaluation/test_f1_sweep.py
@@ -4,6 +4,7 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
+from collections.abc import Iterable
 from typing import Any
 
 import numpy as np
@@ -14,7 +15,7 @@ from rfdetr.evaluation.f1_sweep import sweep_confidence_thresholds
 
 def _reference_sweep(
     per_class_data: list[dict[str, Any]],
-    conf_thresholds: Any,
+    conf_thresholds: Iterable[float],
     classes_with_gt: list[int],
 ) -> list[dict[str, Any]]:
     """O(T*N) reference implementation: the exact algorithm sweep_confidence_thresholds used before

--- a/tests/evaluation/test_f1_sweep.py
+++ b/tests/evaluation/test_f1_sweep.py
@@ -161,6 +161,31 @@ class TestSweepConfidenceThresholdsMatchesReference:
 
         _assert_results_equal(actual, expected)
 
+    def test_matches_reference_with_empty_per_class_data(self) -> None:
+        """Zero classes -- degrades to an empty result list, one entry per threshold, with no per-class loop body ever
+        executing."""
+        per_class_data: list[dict[str, Any]] = []
+        conf_thresholds = [0.0, 0.5, 1.0]
+
+        actual = sweep_confidence_thresholds(per_class_data, conf_thresholds, classes_with_gt=[])
+        expected = _reference_sweep(per_class_data, conf_thresholds, classes_with_gt=[])
+
+        _assert_results_equal(actual, expected)
+        assert [r["per_class_prec"].tolist() for r in actual] == [[], [], []]
+
+    def test_matches_reference_with_empty_conf_thresholds(self) -> None:
+        """Zero thresholds -- degrades to an empty result list regardless of how much detection data is present."""
+        per_class_data = [
+            {"scores": np.array([0.9]), "matches": np.array([1]), "ignore": np.array([False]), "total_gt": 1}
+        ]
+        conf_thresholds: list[float] = []
+
+        actual = sweep_confidence_thresholds(per_class_data, conf_thresholds, classes_with_gt=[0])
+        expected = _reference_sweep(per_class_data, conf_thresholds, classes_with_gt=[0])
+
+        _assert_results_equal(actual, expected)
+        assert actual == []
+
     def test_matches_reference_when_every_detection_is_ignored(self) -> None:
         per_class_data = [
             {
@@ -219,6 +244,42 @@ class TestSweepConfidenceThresholdsMatchesReference:
         _assert_results_equal(actual, expected)
         assert actual[0]["macro_f1"] == 0.0
 
+    def test_matches_reference_with_mixed_nan_and_real_scores(self) -> None:
+        """A class with both real and NaN scores together -- the case that actually stresses `searchsorted` against
+        `argsort`'s (numpy-unspecified) placement of NaN at the sort tail, unlike the all-NaN case above."""
+        per_class_data = [
+            {
+                "scores": np.array([0.9, np.nan, 0.4, np.nan, 0.6]),
+                "matches": np.array([1, 1, 0, 0, 1]),
+                "ignore": np.array([False, False, False, False, False]),
+                "total_gt": 2,
+            }
+        ]
+        conf_thresholds = np.linspace(0, 1, 11)
+
+        actual = sweep_confidence_thresholds(per_class_data, conf_thresholds, classes_with_gt=[0])
+        expected = _reference_sweep(per_class_data, conf_thresholds, classes_with_gt=[0])
+
+        _assert_results_equal(actual, expected)
+
+    def test_matches_reference_with_infinite_scores(self) -> None:
+        """`inf >= threshold` is True for every finite threshold; `-inf >= threshold` is True only at `-inf` itself --
+        both must be reachable through the same sort + searchsorted path as finite scores."""
+        per_class_data = [
+            {
+                "scores": np.array([np.inf, -np.inf, 0.5]),
+                "matches": np.array([1, 0, 1]),
+                "ignore": np.array([False, False, False]),
+                "total_gt": 2,
+            }
+        ]
+        conf_thresholds = [-1.0, 0.0, 0.5, 1.0]
+
+        actual = sweep_confidence_thresholds(per_class_data, conf_thresholds, classes_with_gt=[0])
+        expected = _reference_sweep(per_class_data, conf_thresholds, classes_with_gt=[0])
+
+        _assert_results_equal(actual, expected)
+
     def test_matches_reference_with_generator_conf_thresholds(self) -> None:
         """conf_thresholds is documented as any iterable, including a one-shot generator -- pins that
         sweep_confidence_thresholds materializes it exactly once instead of consuming it partway through (e.g. once to
@@ -238,6 +299,25 @@ class TestSweepConfidenceThresholdsMatchesReference:
 
         assert len(actual) == len(thresholds_list)
         assert [r["confidence_threshold"] for r in actual] == pytest.approx(thresholds_list)
+
+    def test_matches_reference_with_unsorted_conf_thresholds(self) -> None:
+        """Each threshold's searchsorted lookup is independent of the others -- pins that an unsorted, descending
+        conf_thresholds input is handled correctly and that output order follows input order."""
+        per_class_data = [
+            {
+                "scores": np.array([0.9, 0.4, 0.2]),
+                "matches": np.array([1, 0, 1]),
+                "ignore": np.array([False, False, False]),
+                "total_gt": 2,
+            }
+        ]
+        conf_thresholds = [0.3, 1.2, -0.1, 0.31]
+
+        actual = sweep_confidence_thresholds(per_class_data, conf_thresholds, classes_with_gt=[0])
+        expected = _reference_sweep(per_class_data, conf_thresholds, classes_with_gt=[0])
+
+        _assert_results_equal(actual, expected)
+        assert [r["confidence_threshold"] for r in actual] == pytest.approx(conf_thresholds)
 
 
 class TestSweepConfidenceThresholdsBasicCorrectness:
@@ -276,6 +356,25 @@ class TestSweepConfidenceThresholdsBasicCorrectness:
         assert low_thresh["macro_precision"] == pytest.approx(0.5)  # 1 TP, 1 FP
         assert high_thresh["macro_precision"] == pytest.approx(1.0)  # FP dropped below threshold
         assert high_thresh["macro_recall"] == pytest.approx(1.0)  # the TP is still above threshold
+
+    def test_all_false_positives_gives_zero_precision_and_recall(self) -> None:
+        """The three zero-denominator guards are textually identical between sweep_confidence_thresholds and
+        _reference_sweep, so the equivalence tests above are structurally blind to a bug shared by both -- this pins the
+        tp=0, fp>0 case against its actual, hand-computed expected value."""
+        per_class_data = [
+            {
+                "scores": np.array([0.9]),
+                "matches": np.array([0]),
+                "ignore": np.array([False]),
+                "total_gt": 1,
+            }
+        ]
+
+        result = sweep_confidence_thresholds(per_class_data, [0.5], classes_with_gt=[0])[0]
+
+        assert result["macro_precision"] == pytest.approx(0.0)
+        assert result["macro_recall"] == pytest.approx(0.0)
+        assert result["macro_f1"] == pytest.approx(0.0)
 
     def test_float32_scores_compare_in_float64_at_threshold_boundary(self) -> None:
         """Threshold comparison always happens in float64 regardless of score dtype (deliberate, documented semantics --


### PR DESCRIPTION
## What does this PR do?

`sweep_confidence_thresholds` has a nested loop: for every one of T confidence thresholds (`np.linspace(0, 1, 101)` at the one real call site, `coco_eval.py:645`), it looped over every class and rescanned all of that class's N detections with `scores >= conf_thresh` — a full rescan per threshold, per class. O(T*N) total.

Per class, this sorts detections by score once (`O(N log N)`), computes suffix sums of TP/FP over that sorted order (`O(N)`), and for each threshold uses `np.searchsorted` (binary search) to find the cutoff and read the accumulated TP/FP in `O(1)` — `O(N log N + T log N)` total instead of `O(T*N)`.

While writing this I found and fixed two bugs of my own:

- `conf_thresholds` is documented as any `Iterable`, which a one-shot generator would satisfy. My first draft consumed it up to three times (measuring its length, computing per class, iterating the final results), which would silently return fewer results than requested for a real generator. Caught it re-reading my own code, fixed it by materializing `conf_thresholds` to an array exactly once, and confirmed the bug was real by reverting the fix and watching the dedicated test fail (`len(actual)==0` instead of 3) before restoring it.
- `np.argsort` sorts NaN scores to the end of ascending order. The original `scores >= conf_thresh` loop always excludes a NaN score (the comparison is `False` for every real threshold). Nothing in the rewrite masked NaN out of the sorted suffix, so it would fall inside the "above every threshold" range and get counted as a TP/FP at every threshold instead of being dropped — e.g. one NaN-scored, matched detection with `total_gt=1` flips `macro_f1` from `0.0` to `1.0`. Fixed by masking NaN scores out the same way `ignore` already is, regression test added (`test_matches_reference_with_nan_scores`).

**Related Issue(s):** None, no existing report found.

## Type of Change

- Performance improvement

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

No unit tests existed for this function before this PR (`sweep_confidence_thresholds` is exercised end-to-end by the `coco17`-marked `test_inference_coco.py`, which downloads COCO val2017 and isn't run in default CI — real integration coverage exists, but no fast, mock-free unit coverage of this function in isolation). Added `tests/evaluation/test_f1_sweep.py`, 15 tests. The core is exact numeric equivalence against an O(T*N) reference implementation embedded in the test file — a textual copy of the original algorithm, not the function under test, so a bug shared between the two can't hide a real divergence. It runs across 5 random-data seeds with deliberately tied scores (rounded to 1 decimal, to exercise `searchsorted`'s boundary behaviour against the original's inclusive `scores >= conf_thresh`). Plus edge cases: no detections in any class, everything ignored, scores landing exactly on threshold boundaries, NaN scores, and the generator case. Plus 2 hand-computed correctness tests independent of the reference comparison. (`matches`/`total_gt` are drawn independently in the random-data generator, so `sum(matches) > total_gt` can occur — impossible for real matching output, but irrelevant here since neither implementation compares those counts against each other; it only broadens the input space the equivalence check covers.)

Correctness at COCO scale (`repro/bench_f1_sweep.py`): 90 classes, 101 thresholds — max `macro_f1` diff is exactly `0.0`.

`test_f1_sweep.py`: 15/15 (includes 3 doctests). Full `tests/evaluation/`: 116/116.

Real microbenchmark (imports the real `rfdetr` function, compares against the embedded reference, not against itself): at COCO scale, 7.1-7.8x faster, measured at 3 detections-per-class scales (400/2000/8000) with low dispersion.

Full CPU suite per `ci-tests-cpu.yml` (`src/ tests/`, same markers/ignores): 3784 passed, 72 skipped, 0 failed.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

Not applicable for docs: no public API changed.
