### PR TITLE
fix(training): model AdamW's optimizer-state memory in the auto-batch probe

### DIFF
--- a/docs/learn/train/customization.md
+++ b/docs/learn/train/customization.md
@@ -103,6 +103,8 @@ See [Training parameters — optimizer](training-parameters.md) for the full par
 
     If you need SAM or Lookahead, override `configure_optimizers` and set `self.automatic_optimization = False` in `RFDETRModelModule.__init__`. For standard use, pick a `torch.optim` optimizer by name or a drop-in `pytorch-optimizer` optimizer by import path (e.g. `"pytorch_optimizer.Lion"`).
 
+`batch_size="auto"` models the built-in AdamW optimizer's state memory only; with a different optimizer (as configured above) the probe's batch-size estimate may be too conservative or too permissive — see the runtime warning for details.
+
 ### Custom LR scheduler
 
 `TrainConfig.lr_scheduler` accepts either a **preset name / import path** (a string) or a **callable** (a class or `functools.partial`), mirroring `optimizer`, and selects the scheduler built in `configure_optimizers`.

--- a/docs/learn/train/training-parameters.md
+++ b/docs/learn/train/training-parameters.md
@@ -27,14 +27,17 @@ model.train(
 
 These are the essential parameters for training:
 
-| Parameter          | Type            | Default    | Description                                                                                                                                                                             |
-| ------------------ | --------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dataset_dir`      | `str`           | Required   | Path to your dataset directory. RF-DETR auto-detects if it's in COCO or YOLO format. See [Dataset Formats](dataset-formats.md).                                                         |
-| `output_dir`       | `str`           | `"output"` | Directory where training artifacts (checkpoints, logs) are saved.                                                                                                                       |
-| `epochs`           | `int`           | `100`      | Number of full passes over the training dataset.                                                                                                                                        |
-| `batch_size`       | `int or "auto"` | `4`        | Number of samples processed per iteration. Higher values require more GPU memory. Set to `"auto"` to probe the GPU for the largest safe batch size automatically.                       |
-| `grad_accum_steps` | `int`           | `4`        | Accumulates gradients over multiple mini-batches. Use with `batch_size` to achieve effective batch size.                                                                                |
-| `resume`           | `str`           | `None`     | Path to a saved checkpoint to continue training. Full `.ckpt` files restore model, optimizer, and scheduler state; lightweight best `.pth` files restart optimizer and scheduler state. |
+| Parameter                          | Type            | Default    | Description                                                                                                                                                                             |
+| ---------------------------------- | --------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dataset_dir`                      | `str`           | Required   | Path to your dataset directory. RF-DETR auto-detects if it's in COCO or YOLO format. See [Dataset Formats](dataset-formats.md).                                                         |
+| `output_dir`                       | `str`           | `"output"` | Directory where training artifacts (checkpoints, logs) are saved.                                                                                                                       |
+| `epochs`                           | `int`           | `100`      | Number of full passes over the training dataset.                                                                                                                                        |
+| `batch_size`                       | `int or "auto"` | `4`        | Number of samples processed per iteration. Higher values require more GPU memory. Set to `"auto"` to probe the GPU for the largest safe batch size automatically.                       |
+| `grad_accum_steps`                 | `int`           | `4`        | Accumulates gradients over multiple mini-batches. Use with `batch_size` to achieve effective batch size.                                                                                |
+| `auto_batch_target_effective`      | `int`           | `16`       | Only used when `batch_size="auto"`. Per-device effective batch size the probe search targets (before scaling by `devices * num_nodes`).                                                 |
+| `auto_batch_max_targets_per_image` | `int`           | `100`      | Only used when `batch_size="auto"`. Synthetic target count per image the probe uses to simulate worst-case matcher/loss memory.                                                         |
+| `auto_batch_ema_headroom`          | `float`         | `0.7`      | Only used when `batch_size="auto"` and `use_ema=True`. Fraction of the probed batch size reserved as headroom for the EMA model's extra memory use. Must be in `(0, 1]`.                |
+| `resume`                           | `str`           | `None`     | Path to a saved checkpoint to continue training. Full `.ckpt` files restore model, optimizer, and scheduler state; lightweight best `.pth` files restart optimizer and scheduler state. |
 
 ### Understanding Batch Size
 

--- a/src/rfdetr/training/auto_batch.py
+++ b/src/rfdetr/training/auto_batch.py
@@ -28,6 +28,7 @@ import torch
 from rfdetr.config import ModelConfig, TrainConfig
 from rfdetr.datasets.coco import compute_multi_scale_scales
 from rfdetr.models import build_criterion_from_config
+from rfdetr.training.module_model import _is_builtin_fused_adamw
 from rfdetr.utilities.logger import get_logger
 from rfdetr.utilities.tensors import NestedTensor
 
@@ -98,6 +99,41 @@ def _make_synthetic_batch(
     return samples, targets
 
 
+def _build_shadow_optimizer(
+    trainable_params: list[torch.nn.Parameter],
+    lr: float,
+    weight_decay: float,
+    optimizer_kwargs: dict[str, Any] | None = None,
+) -> tuple[torch.optim.Optimizer, list[torch.Tensor]]:
+    """Build an AdamW optimizer over throwaway tensors shaped like ``trainable_params``, for probing optimizer-state
+    memory without ever writing to the real model's weights.
+
+    ``optimizer.step()`` needs to run against *some* set of parameters to allocate AdamW's per-
+    parameter state (``exp_avg``/``exp_avg_sq``), but running it against the real model's own
+    parameters would apply a real (garbage, synthetic-data-derived) gradient update to weights that
+    may already hold a loaded pretrained checkpoint -- corrupting them before training even starts.
+    The shadow tensors this returns are separate GPU allocations of the same shape/dtype, so the
+    optimizer state they accumulate costs the same memory as the real optimizer eventually would,
+    without the update ever touching a real parameter.
+
+    Args:
+        trainable_params: The real model parameters being probed for (only used for shape/dtype/device).
+        lr: Learning rate for the shadow optimizer (does not affect state tensor size).
+        weight_decay: Weight decay for the shadow optimizer (does not affect state tensor size).
+        optimizer_kwargs: Extra AdamW kwargs from ``train_config.optimizer_kwargs`` (e.g. ``amsgrad=True``,
+            which adds a third ``max_exp_avg_sq`` state buffer). Only meaningful when the real training run
+            uses the built-in ``"adamw"`` path -- pass ``None`` otherwise, since these kwargs are AdamW-specific
+            and would raise for a different optimizer class.
+
+    Returns:
+        The shadow optimizer and the list of shadow tensors it steps, in the same order as
+        ``trainable_params`` so gradients can be paired up by index before each ``step()``.
+    """
+    shadow_params = [torch.zeros_like(p, requires_grad=True) for p in trainable_params]
+    optimizer = torch.optim.AdamW(shadow_params, lr=lr, weight_decay=weight_decay, **(optimizer_kwargs or {}))
+    return optimizer, shadow_params
+
+
 def _probe_step(
     model: torch.nn.Module,
     criterion: torch.nn.Module,
@@ -106,12 +142,24 @@ def _probe_step(
     device: torch.device,
     num_classes: int,
     amp: bool,
+    trainable_params: list[torch.nn.Parameter],
+    shadow_optimizer: torch.optim.Optimizer,
+    shadow_params: list[torch.Tensor],
     segmentation_head: bool = False,
     max_targets_per_image: int = 1,
     num_channels: int = 3,
     autocast_dtype: torch.dtype | None = None,
 ) -> bool:
-    """Run one forward + loss + backward; return True if successful, False on OOM."""
+    """Run one forward + loss + backward + shadow optimizer step; return True if successful, False on OOM.
+
+    The shadow step matters for the memory estimate, not just for realism: AdamW (and most stateful optimizers) allocate
+    their per-parameter state (``exp_avg``/``exp_avg_sq``, each the same size as the parameter itself) lazily, on the
+    first ``step()`` call -- forward+backward alone never touches that allocation.
+    ``shadow_optimizer``/``shadow_params`` are built once by the caller and reused across every probe iteration, so this
+    first call is the only one that pays the allocation; every later iteration (larger candidate batch sizes) competes
+    for GPU memory against that already- resident state, the same way a real second-and-later training step would. The
+    shadow tensors, not the real model parameters, receive the update, so this never mutates the model being probed.
+    """
     try:
         model.zero_grad(set_to_none=True)
         criterion.zero_grad(set_to_none=True)
@@ -144,6 +192,18 @@ def _probe_step(
             raise RuntimeError("auto-batch probe produced a non-finite training loss.")
 
         torch.autograd.backward(loss)
+        # Alias (not copy) each real parameter's freshly populated .grad onto its shadow counterpart:
+        # AdamW.step() only reads .grad, so sharing the tensor is enough to drive a real state update
+        # without allocating a second copy of every gradient.
+        for shadow_p, real_p in zip(shadow_params, trainable_params):
+            shadow_p.grad = real_p.grad
+        shadow_optimizer.step()
+        # Drop the alias immediately: shadow_p.grad is the only remaining reference to real_p's
+        # gradient tensor once model.zero_grad() below clears real_p.grad, so leaving it set would
+        # keep that tensor resident through the next iteration's backward() -- two gradient buffers
+        # (this iteration's stale one plus the next iteration's fresh one) alive at once instead of one.
+        for shadow_p in shadow_params:
+            shadow_p.grad = None
         model.zero_grad(set_to_none=True)
         criterion.zero_grad(set_to_none=True)
         return True
@@ -167,12 +227,21 @@ def probe_max_micro_batch(
     max_micro_batch: int = 128,
     num_channels: int = 3,
     autocast_dtype: torch.dtype | None = None,
+    optimizer_lr: float = 1e-4,
+    optimizer_weight_decay: float = 1e-4,
+    optimizer_kwargs: dict[str, Any] | None = None,
 ) -> int:
     """Find the largest per-device batch size that fits in memory for one train step.
 
     Uses exponential search (1, 2, 4, ...) up to the first failure, then binary search between the last successful size
     and the first failure to get the exact maximum. The returned value is floor(max_ok * safety_margin), so
     safety_margin in (0, 1] scales down the result for headroom (e.g. 0.9 keeps 10% margin).
+
+    Every probe iteration also runs a shadow AdamW step (see ``_build_shadow_optimizer``): forward and
+    backward alone never trigger the ``exp_avg``/``exp_avg_sq`` state AdamW allocates lazily on its
+    first real ``step()``, which is the same size as the trainable parameters themselves, so a probe
+    that skipped this would report a batch size that fits forward+backward but can still OOM training
+    on its first real optimizer step.
 
     Args:
         model: The model to probe (will be set to train mode).
@@ -186,6 +255,12 @@ def probe_max_micro_batch(
         safety_margin: Fraction of max batch to return (0 < safety_margin <= 1).
         max_micro_batch: Cap on batch size to try.
         num_channels: Number of input image channels (for synthetic probe images).
+        optimizer_lr: Learning rate for the shadow AdamW optimizer used to size its state (does not
+            affect the state tensors' shape/size, only included so the shadow optimizer is
+            constructible without a training config on hand).
+        optimizer_weight_decay: Weight decay for the shadow AdamW optimizer (same caveat as ``optimizer_lr``).
+        optimizer_kwargs: Extra AdamW kwargs from ``train_config.optimizer_kwargs`` (e.g. ``amsgrad=True``).
+            Pass only when the real run uses the built-in ``"adamw"`` path -- see ``_build_shadow_optimizer``.
 
     Returns:
         Safe micro-batch size (>= 1).
@@ -203,10 +278,18 @@ def probe_max_micro_batch(
 
     model_training = model.training
     criterion_training = criterion.training
-    model.train()
-    criterion.train()
 
+    shadow_optimizer: torch.optim.Optimizer | None = None
+    shadow_params: list[torch.Tensor] | None = None
     try:
+        model.train()
+        criterion.train()
+
+        trainable_params = [p for p in model.parameters() if p.requires_grad]
+        shadow_optimizer, shadow_params = _build_shadow_optimizer(
+            trainable_params, optimizer_lr, optimizer_weight_decay, optimizer_kwargs
+        )
+
         lower_ok = 0
         candidate = 1
         upper_fail = None
@@ -220,6 +303,9 @@ def probe_max_micro_batch(
                 device,
                 num_classes,
                 amp,
+                trainable_params,
+                shadow_optimizer,
+                shadow_params,
                 segmentation_head,
                 max_targets_per_image,
                 num_channels,
@@ -252,6 +338,9 @@ def probe_max_micro_batch(
                 device,
                 num_classes,
                 amp,
+                trainable_params,
+                shadow_optimizer,
+                shadow_params,
                 segmentation_head,
                 max_targets_per_image,
                 num_channels,
@@ -270,6 +359,13 @@ def probe_max_micro_batch(
         criterion.train(criterion_training)
         model.zero_grad(set_to_none=True)
         criterion.zero_grad(set_to_none=True)
+        # shadow_optimizer/shadow_params may still be None if _build_shadow_optimizer itself OOM'd
+        # (e.g. allocating the shadow parameter tensors for a very large model) -- guard so this
+        # cleanup still restores train-mode and clears the CUDA cache on that path.
+        if shadow_optimizer is not None:
+            del shadow_optimizer
+        if shadow_params is not None:
+            del shadow_params
         torch.cuda.empty_cache()
 
 
@@ -307,6 +403,12 @@ def resolve_auto_batch_config(
     device, segmentation flag, resolution, and the chosen values; also logs that the probe is train-step-only and that
     eval/test may use more memory.
 
+    The optimizer-state memory the probe accounts for (see probe_max_micro_batch) is always modeled as AdamW's, since
+    that is the only optimizer the shadow step builds. When train_config.optimizer selects anything else (e.g. "sgd",
+    a pytorch-optimizer name, or a custom callable/dotted path -- all supported by configure_optimizers), this logs a
+    warning: the real optimizer's state memory may differ from AdamW's, so the resulting batch size can be too
+    conservative or too permissive.
+
     Args:
         model_context: Object with .device and .model (e.g. RFDETR.model from get_model()).
         model_config: Architecture config (resolution, num_classes, amp, segmentation_head).
@@ -343,6 +445,23 @@ def resolve_auto_batch_config(
 
     max_targets_per_image = getattr(train_config, "auto_batch_max_targets_per_image", 100)
 
+    optimizer_cfg = getattr(train_config, "optimizer", "adamw")
+    is_builtin_adamw = _is_builtin_fused_adamw(optimizer_cfg)
+    if is_builtin_adamw:
+        # Same kwargs configure_optimizers passes to the real AdamW (module_model.py); forwarding
+        # them here matters because some (e.g. amsgrad=True) add a third per-parameter state buffer
+        # that the shadow optimizer would otherwise silently miss.
+        shadow_optimizer_kwargs = getattr(train_config, "optimizer_kwargs", {})
+    else:
+        shadow_optimizer_kwargs = None
+        logger.warning(
+            "[auto-batch] optimizer=%r is not the built-in 'adamw'; the probe only models AdamW's "
+            "exp_avg/exp_avg_sq optimizer-state memory (see _build_shadow_optimizer), so this "
+            "batch-size estimate may be too conservative or too permissive for the optimizer "
+            "actually configured for training.",
+            optimizer_cfg,
+        )
+
     criterion, _ = build_criterion_from_config(model_config, train_config)
     criterion = criterion.to(device)
 
@@ -370,6 +489,9 @@ def resolve_auto_batch_config(
         max_micro_batch=max_micro_batch,
         num_channels=getattr(model_config, "num_channels", 3),
         autocast_dtype=probe_autocast_dtype,
+        optimizer_lr=train_config.lr,
+        optimizer_weight_decay=train_config.weight_decay,
+        optimizer_kwargs=shadow_optimizer_kwargs,
     )
 
     use_ema = getattr(train_config, "use_ema", False)

--- a/src/rfdetr/training/auto_batch.py
+++ b/src/rfdetr/training/auto_batch.py
@@ -188,7 +188,9 @@ def _build_shadow_optimizer(
     Raises:
         TypeError: If ``optimizer_kwargs`` carries an argument ``torch.optim.AdamW`` does not accept.
     """
-    shadow_params = [torch.zeros_like(p, requires_grad=True) for p in trainable_params]
+    # No requires_grad: nothing here is ever backpropagated through. torch.optim only asks its params to be
+    # leaves (zeros_like already returns one) and step() runs under no_grad, so the flag would buy nothing.
+    shadow_params = [torch.zeros_like(p) for p in trainable_params]
     # Merge rather than splat both sets side by side: a dotted-path config keeps its lr/weight_decay/fused inside
     # optimizer_kwargs (see the Args note above), so passing them separately would raise "got multiple values for
     # keyword argument". The caller's dict wins, since that is what the real optimizer will be built with.
@@ -405,6 +407,11 @@ def probe_max_micro_batch(
         criterion.train()
 
         trainable_params = [p for p in model.parameters() if p.requires_grad]
+        if not trainable_params:
+            raise RuntimeError(
+                "auto-batch probing requires at least one trainable parameter; every model parameter has "
+                "requires_grad=False."
+            )
         try:
             shadow_optimizer, shadow_params = _build_shadow_optimizer(
                 trainable_params, optimizer_lr, optimizer_weight_decay, optimizer_kwargs, optimizer_fused
@@ -500,9 +507,13 @@ def probe_max_micro_batch(
         criterion.train(criterion_training)
         model.zero_grad(set_to_none=True)
         criterion.zero_grad(set_to_none=True)
-        # shadow_optimizer/shadow_params may still be None if _build_shadow_optimizer itself OOM'd
-        # (e.g. allocating the shadow parameter tensors for a very large model) -- guard so this
-        # cleanup still restores train-mode and clears the CUDA cache on that path.
+        # Drop the shadow state's last references before empty_cache(), while this frame is still alive
+        # and would otherwise keep both names bound: only already-unreferenced memory can be returned to
+        # the driver, so releasing them after the call would free nothing this call gets to see.
+        # The guards are not about `del` legality -- deleting a None-bound name is fine -- but about the
+        # closure: `_probe` captures both names, so an unconditional `del` reads as an undefined
+        # reference to it (ruff F821), and rebinding to None instead costs mypy's narrowing at the same
+        # spot. Conditional deletes are the one form both accept; keep them conditional.
         if shadow_optimizer is not None:
             del shadow_optimizer
         if shadow_params is not None:

--- a/src/rfdetr/training/auto_batch.py
+++ b/src/rfdetr/training/auto_batch.py
@@ -104,6 +104,7 @@ def _build_shadow_optimizer(
     lr: float,
     weight_decay: float,
     optimizer_kwargs: dict[str, Any] | None = None,
+    fused: bool | None = None,
 ) -> tuple[torch.optim.Optimizer, list[torch.Tensor]]:
     """Build an AdamW optimizer over throwaway tensors shaped like ``trainable_params``, for probing optimizer-state
     memory without ever writing to the real model's weights.
@@ -124,13 +125,19 @@ def _build_shadow_optimizer(
             which adds a third ``max_exp_avg_sq`` state buffer). Only meaningful when the real training run
             uses the built-in ``"adamw"`` path -- pass ``None`` otherwise, since these kwargs are AdamW-specific
             and would raise for a different optimizer class.
+        fused: Whether to build a fused AdamW, matching ``RFDETRModelModule._use_fused_optimizer`` for the real
+            optimizer (``module_model.py``). The fused and foreach/single-tensor implementations differ in
+            step-time temporary memory, so leaving this unset (``None``, torch's own default selection) can
+            make the probe's memory profile diverge from the real optimizer's -- in either direction.
 
     Returns:
         The shadow optimizer and the list of shadow tensors it steps, in the same order as
         ``trainable_params`` so gradients can be paired up by index before each ``step()``.
     """
     shadow_params = [torch.zeros_like(p, requires_grad=True) for p in trainable_params]
-    optimizer = torch.optim.AdamW(shadow_params, lr=lr, weight_decay=weight_decay, **(optimizer_kwargs or {}))
+    optimizer = torch.optim.AdamW(
+        shadow_params, lr=lr, weight_decay=weight_decay, fused=fused, **(optimizer_kwargs or {})
+    )
     return optimizer, shadow_params
 
 
@@ -157,7 +164,7 @@ def _probe_step(
     first ``step()`` call -- forward+backward alone never touches that allocation.
     ``shadow_optimizer``/``shadow_params`` are built once by the caller and reused across every probe iteration, so this
     first call is the only one that pays the allocation; every later iteration (larger candidate batch sizes) competes
-    for GPU memory against that already- resident state, the same way a real second-and-later training step would. The
+    for GPU memory against that already-resident state, the same way a real second-and-later training step would. The
     shadow tensors, not the real model parameters, receive the update, so this never mutates the model being probed.
     """
     try:
@@ -197,13 +204,16 @@ def _probe_step(
         # without allocating a second copy of every gradient.
         for shadow_p, real_p in zip(shadow_params, trainable_params):
             shadow_p.grad = real_p.grad
-        shadow_optimizer.step()
-        # Drop the alias immediately: shadow_p.grad is the only remaining reference to real_p's
-        # gradient tensor once model.zero_grad() below clears real_p.grad, so leaving it set would
-        # keep that tensor resident through the next iteration's backward() -- two gradient buffers
-        # (this iteration's stale one plus the next iteration's fresh one) alive at once instead of one.
-        for shadow_p in shadow_params:
-            shadow_p.grad = None
+        try:
+            shadow_optimizer.step()
+        finally:
+            # Drop the alias whether step() succeeded or raised (e.g. OOM inside AdamW's own state
+            # allocation): shadow_p.grad is the only remaining reference to real_p's gradient tensor
+            # once model.zero_grad() below clears real_p.grad, so leaving it set on an OOM would keep
+            # that tensor resident -- unreachable by empty_cache() -- through every later probe
+            # iteration for the rest of this search, not just the next one.
+            for shadow_p in shadow_params:
+                shadow_p.grad = None
         model.zero_grad(set_to_none=True)
         criterion.zero_grad(set_to_none=True)
         return True
@@ -230,6 +240,7 @@ def probe_max_micro_batch(
     optimizer_lr: float = 1e-4,
     optimizer_weight_decay: float = 1e-4,
     optimizer_kwargs: dict[str, Any] | None = None,
+    optimizer_fused: bool | None = None,
 ) -> int:
     """Find the largest per-device batch size that fits in memory for one train step.
 
@@ -239,9 +250,9 @@ def probe_max_micro_batch(
 
     Every probe iteration also runs a shadow AdamW step (see ``_build_shadow_optimizer``): forward and
     backward alone never trigger the ``exp_avg``/``exp_avg_sq`` state AdamW allocates lazily on its
-    first real ``step()``, which is the same size as the trainable parameters themselves, so a probe
-    that skipped this would report a batch size that fits forward+backward but can still OOM training
-    on its first real optimizer step.
+    first real ``step()`` -- each buffer the same size as the trainable parameters themselves, so the
+    combined state is 2x that size (3x with ``amsgrad``) -- so a probe that skipped this would report a
+    batch size that fits forward+backward but can still OOM training on its first real optimizer step.
 
     Args:
         model: The model to probe (will be set to train mode).
@@ -261,6 +272,10 @@ def probe_max_micro_batch(
         optimizer_weight_decay: Weight decay for the shadow AdamW optimizer (same caveat as ``optimizer_lr``).
         optimizer_kwargs: Extra AdamW kwargs from ``train_config.optimizer_kwargs`` (e.g. ``amsgrad=True``).
             Pass only when the real run uses the built-in ``"adamw"`` path -- see ``_build_shadow_optimizer``.
+        optimizer_fused: Whether the real training run will use fused AdamW (mirrors
+            ``RFDETRModelModule._use_fused_optimizer``). Forwarded to ``_build_shadow_optimizer`` so the shadow
+            optimizer's step-time temporary memory matches the real one's, since fused and foreach/single-tensor
+            AdamW allocate different amounts of scratch memory during ``step()``.
 
     Returns:
         Safe micro-batch size (>= 1).
@@ -287,18 +302,14 @@ def probe_max_micro_batch(
 
         trainable_params = [p for p in model.parameters() if p.requires_grad]
         shadow_optimizer, shadow_params = _build_shadow_optimizer(
-            trainable_params, optimizer_lr, optimizer_weight_decay, optimizer_kwargs
+            trainable_params, optimizer_lr, optimizer_weight_decay, optimizer_kwargs, optimizer_fused
         )
 
-        lower_ok = 0
-        candidate = 1
-        upper_fail = None
-
-        while candidate <= max_micro_batch:
-            if _probe_step(
+        def _probe(candidate_size: int) -> bool:
+            return _probe_step(
                 model,
                 criterion,
-                candidate,
+                candidate_size,
                 resolution,
                 device,
                 num_classes,
@@ -310,18 +321,39 @@ def probe_max_micro_batch(
                 max_targets_per_image,
                 num_channels,
                 autocast_dtype,
-            ):
+            )
+
+        # shadow_optimizer.step() allocates AdamW's exp_avg/exp_avg_sq state lazily, on its first-ever
+        # call. That first call is necessarily made without the state resident yet -- unlike every real
+        # training step from the second one onward, which always runs forward+backward with that state
+        # already occupying memory. So a lone success at micro_batch_size=1 only proves the batch fits
+        # *before* the state exists; it says nothing about whether it still fits once the state is
+        # resident, which matters because the exponential search below can terminate immediately (if
+        # candidate=2 already fails) without ever re-probing batch=1 under that steady-state condition.
+        # Probe batch=1 twice up front so its own "safe" verdict is measured the same way every other
+        # candidate's is: with the state already resident.
+        if not _probe(1):
+            raise RuntimeError(
+                "auto-batch probe failed at micro_batch_size=1. "
+                "Try lowering resolution or enabling gradient_checkpointing."
+            )
+        if not _probe(1):
+            raise RuntimeError(
+                "auto-batch probe failed at micro_batch_size=1 once optimizer state is resident. "
+                "Try lowering resolution or enabling gradient_checkpointing."
+            )
+
+        lower_ok = 1
+        candidate = 2
+        upper_fail = None
+
+        while candidate <= max_micro_batch:
+            if _probe(candidate):
                 lower_ok = candidate
                 candidate *= 2
             else:
                 upper_fail = candidate
                 break
-
-        if lower_ok < 1:
-            raise RuntimeError(
-                "auto-batch probe failed at micro_batch_size=1. "
-                "Try lowering resolution or enabling gradient_checkpointing."
-            )
 
         if upper_fail is None:
             upper_fail = max_micro_batch + 1
@@ -330,22 +362,7 @@ def probe_max_micro_batch(
         hi = min(upper_fail - 1, max_micro_batch)
         while lo <= hi:
             mid = (lo + hi) // 2
-            if _probe_step(
-                model,
-                criterion,
-                mid,
-                resolution,
-                device,
-                num_classes,
-                amp,
-                trainable_params,
-                shadow_optimizer,
-                shadow_params,
-                segmentation_head,
-                max_targets_per_image,
-                num_channels,
-                autocast_dtype,
-            ):
+            if _probe(mid):
                 lower_ok = mid
                 lo = mid + 1
             else:
@@ -407,7 +424,9 @@ def resolve_auto_batch_config(
     that is the only optimizer the shadow step builds. When train_config.optimizer selects anything else (e.g. "sgd",
     a pytorch-optimizer name, or a custom callable/dotted path -- all supported by configure_optimizers), this logs a
     warning: the real optimizer's state memory may differ from AdamW's, so the resulting batch size can be too
-    conservative or too permissive.
+    conservative or too permissive. Also re-derives whether the real run will use fused AdamW (see
+    RFDETRModelModule._use_fused_optimizer) so the shadow optimizer's step-time temporary memory matches it --
+    fused and foreach/single-tensor AdamW have different scratch-memory profiles during step().
 
     Args:
         model_context: Object with .device and .model (e.g. RFDETR.model from get_model()).
@@ -476,6 +495,20 @@ def resolve_auto_batch_config(
     else:
         probe_autocast_dtype = None
 
+    # Mirrors RFDETRModelModule._use_fused_optimizer (module_model.py), which build_trainer's
+    # real AdamW reads at construction time -- but that Lightning module doesn't exist yet at
+    # probe time, so re-derive its two conditions instead of calling it directly: (1) the
+    # built-in "adamw" path (already computed above as is_builtin_adamw), and (2) the resolved
+    # precision is a bf16 variant, which for this function's CUDA-only autocast resolution above
+    # is exactly the case where probe_autocast_dtype came out to torch.bfloat16 (see
+    # trainer.py's _resolve_precision: bf16-mixed iff CUDA + bf16-capable + amp_dtype in
+    # {"auto", "bf16"}, the same inputs probe_autocast_dtype was derived from).
+    use_fused_optimizer = (
+        is_builtin_adamw
+        and bool(getattr(model_config, "fused_optimizer", True))
+        and probe_autocast_dtype is torch.bfloat16
+    )
+
     safe_micro_batch = probe_max_micro_batch(
         model=model_context.model,
         criterion=criterion,
@@ -492,6 +525,7 @@ def resolve_auto_batch_config(
         optimizer_lr=train_config.lr,
         optimizer_weight_decay=train_config.weight_decay,
         optimizer_kwargs=shadow_optimizer_kwargs,
+        optimizer_fused=use_fused_optimizer,
     )
 
     use_ema = getattr(train_config, "use_ema", False)

--- a/src/rfdetr/training/auto_batch.py
+++ b/src/rfdetr/training/auto_batch.py
@@ -99,6 +99,39 @@ def _make_synthetic_batch(
     return samples, targets
 
 
+def _is_adamw_shaped(optimizer_cfg: object) -> bool:
+    """Return whether a configured optimizer allocates the same per-parameter state as ``torch.optim.AdamW``.
+
+    Deliberately broader than ``module_model._is_builtin_fused_adamw``, which answers a different question (does this
+    config select RF-DETR's managed fused-kernel path?) and must stay narrow. For a memory estimate the only thing that
+    matters is whether the real optimizer keeps ``exp_avg``/``exp_avg_sq`` per parameter, which a dotted path importing
+    ``torch.optim.AdamW`` does just as much as the built-in ``"adamw"`` short name.
+
+    Args:
+        optimizer_cfg: The ``TrainConfig.optimizer`` value; a callable's state layout is unknowable here, so it
+            reports ``False``.
+
+    Returns:
+        ``True`` for the ``"adamw"`` short name (case-insensitive) and for a dotted path naming ``torch.optim.AdamW``.
+
+    Examples:
+        >>> _is_adamw_shaped("AdamW")
+        True
+        >>> _is_adamw_shaped("torch.optim.AdamW")
+        True
+        >>> _is_adamw_shaped("torch.optim.SGD")
+        False
+    """
+    if not isinstance(optimizer_cfg, str):
+        return False
+    name = optimizer_cfg.strip()
+    if "." in name:
+        # A dotted value is an import path, so it has to match one exactly: capitalization is part of the attribute
+        # name, and "torch.optim.adamw" alone names the module rather than the class.
+        return name in {"torch.optim.AdamW", "torch.optim.adamw.AdamW"}
+    return name.lower() == "adamw"
+
+
 def _build_shadow_optimizer(
     trainable_params: list[torch.nn.Parameter],
     lr: float,
@@ -123,8 +156,11 @@ def _build_shadow_optimizer(
         weight_decay: Weight decay for the shadow optimizer (does not affect state tensor size).
         optimizer_kwargs: Extra AdamW kwargs from ``train_config.optimizer_kwargs`` (e.g. ``amsgrad=True``,
             which adds a third ``max_exp_avg_sq`` state buffer). Only meaningful when the real training run
-            uses the built-in ``"adamw"`` path -- pass ``None`` otherwise, since these kwargs are AdamW-specific
-            and would raise for a different optimizer class.
+            uses an AdamW-shaped optimizer (see ``_is_adamw_shaped``) -- pass ``None`` otherwise, since these
+            kwargs are AdamW-specific and would raise for a different optimizer class. Keys given here override
+            ``lr``/``weight_decay``/``fused`` below: on the dotted-path config (``"torch.optim.AdamW"``)
+            ``configure_optimizers`` builds the real optimizer from this dict alone, injecting no lr or
+            weight_decay of its own (``module_model.py``), so this dict is where that run's real values live.
         fused: Whether to build a fused AdamW, matching ``RFDETRModelModule._use_fused_optimizer`` for the real
             optimizer (``module_model.py``). The fused and foreach/single-tensor implementations differ in
             step-time temporary memory, so leaving this unset (``None``, torch's own default selection) can
@@ -133,11 +169,23 @@ def _build_shadow_optimizer(
     Returns:
         The shadow optimizer and the list of shadow tensors it steps, in the same order as
         ``trainable_params`` so gradients can be paired up by index before each ``step()``.
+
+    Raises:
+        TypeError: If ``optimizer_kwargs`` carries an argument ``torch.optim.AdamW`` does not accept.
     """
     shadow_params = [torch.zeros_like(p, requires_grad=True) for p in trainable_params]
-    optimizer = torch.optim.AdamW(
-        shadow_params, lr=lr, weight_decay=weight_decay, fused=fused, **(optimizer_kwargs or {})
-    )
+    # Merge rather than splat both sets side by side: a dotted-path config keeps its lr/weight_decay/fused inside
+    # optimizer_kwargs (see the Args note above), so passing them separately would raise "got multiple values for
+    # keyword argument". The caller's dict wins, since that is what the real optimizer will be built with.
+    adamw_kwargs: dict[str, Any] = {"lr": lr, "weight_decay": weight_decay, "fused": fused}
+    adamw_kwargs.update(optimizer_kwargs or {})
+    try:
+        optimizer = torch.optim.AdamW(shadow_params, **adamw_kwargs)
+    except TypeError as exc:
+        raise TypeError(
+            f"Failed to initialize the auto-batch probe's shadow 'adamw' optimizer: {exc}. "
+            "Check optimizer_kwargs for arguments supported by torch.optim.AdamW."
+        ) from exc
     return optimizer, shadow_params
 
 
@@ -149,6 +197,7 @@ def _probe_step(
     device: torch.device,
     num_classes: int,
     amp: bool,
+    *,
     trainable_params: list[torch.nn.Parameter],
     shadow_optimizer: torch.optim.Optimizer,
     shadow_params: list[torch.Tensor],
@@ -202,7 +251,7 @@ def _probe_step(
         # Alias (not copy) each real parameter's freshly populated .grad onto its shadow counterpart:
         # AdamW.step() only reads .grad, so sharing the tensor is enough to drive a real state update
         # without allocating a second copy of every gradient.
-        for shadow_p, real_p in zip(shadow_params, trainable_params):
+        for shadow_p, real_p in zip(shadow_params, trainable_params, strict=True):
             shadow_p.grad = real_p.grad
         try:
             shadow_optimizer.step()
@@ -268,7 +317,9 @@ def probe_max_micro_batch(
         num_channels: Number of input image channels (for synthetic probe images).
         optimizer_lr: Learning rate for the shadow AdamW optimizer used to size its state (does not
             affect the state tensors' shape/size, only included so the shadow optimizer is
-            constructible without a training config on hand).
+            constructible without a training config on hand). Not derived from ``train_config``:
+            ``resolve_auto_batch_config`` leaves this and ``optimizer_weight_decay`` at their defaults,
+            since neither changes the memory the probe measures.
         optimizer_weight_decay: Weight decay for the shadow AdamW optimizer (same caveat as ``optimizer_lr``).
         optimizer_kwargs: Extra AdamW kwargs from ``train_config.optimizer_kwargs`` (e.g. ``amsgrad=True``).
             Pass only when the real run uses the built-in ``"adamw"`` path -- see ``_build_shadow_optimizer``.
@@ -314,13 +365,13 @@ def probe_max_micro_batch(
                 device,
                 num_classes,
                 amp,
-                trainable_params,
-                shadow_optimizer,
-                shadow_params,
-                segmentation_head,
-                max_targets_per_image,
-                num_channels,
-                autocast_dtype,
+                trainable_params=trainable_params,
+                shadow_optimizer=shadow_optimizer,
+                shadow_params=shadow_params,
+                segmentation_head=segmentation_head,
+                max_targets_per_image=max_targets_per_image,
+                num_channels=num_channels,
+                autocast_dtype=autocast_dtype,
             )
 
         # shadow_optimizer.step() allocates AdamW's exp_avg/exp_avg_sq state lazily, on its first-ever
@@ -421,10 +472,11 @@ def resolve_auto_batch_config(
     eval/test may use more memory.
 
     The optimizer-state memory the probe accounts for (see probe_max_micro_batch) is always modeled as AdamW's, since
-    that is the only optimizer the shadow step builds. When train_config.optimizer selects anything else (e.g. "sgd",
-    a pytorch-optimizer name, or a custom callable/dotted path -- all supported by configure_optimizers), this logs a
-    warning: the real optimizer's state memory may differ from AdamW's, so the resulting batch size can be too
-    conservative or too permissive. Also re-derives whether the real run will use fused AdamW (see
+    that is the only optimizer the shadow step builds. When train_config.optimizer selects something that is not
+    AdamW-shaped (e.g. "sgd", a pytorch-optimizer name, or a custom callable -- all supported by configure_optimizers;
+    see _is_adamw_shaped for what still counts as AdamW), this logs a warning: the real optimizer's state memory may
+    differ from AdamW's, so the resulting batch size can be too conservative or too permissive. Also re-derives whether
+    the real run will use fused AdamW (see
     RFDETRModelModule._use_fused_optimizer) so the shadow optimizer's step-time temporary memory matches it --
     fused and foreach/single-tensor AdamW have different scratch-memory profiles during step().
 
@@ -465,8 +517,12 @@ def resolve_auto_batch_config(
     max_targets_per_image = getattr(train_config, "auto_batch_max_targets_per_image", 100)
 
     optimizer_cfg = getattr(train_config, "optimizer", "adamw")
-    is_builtin_adamw = _is_builtin_fused_adamw(optimizer_cfg)
-    if is_builtin_adamw:
+    # Whether the real optimizer's *state* is AdamW-shaped -- a broader question than which optimizer
+    # gets RF-DETR's fused kernel (derived separately below from _is_builtin_fused_adamw), so this uses
+    # its own local predicate: "torch.optim.AdamW" allocates exactly the state the shadow models, while
+    # never being eligible for the managed fused path.
+    is_adamw_shaped = _is_adamw_shaped(optimizer_cfg)
+    if is_adamw_shaped:
         # Same kwargs configure_optimizers passes to the real AdamW (module_model.py); forwarding
         # them here matters because some (e.g. amsgrad=True) add a third per-parameter state buffer
         # that the shadow optimizer would otherwise silently miss.
@@ -474,7 +530,7 @@ def resolve_auto_batch_config(
     else:
         shadow_optimizer_kwargs = None
         logger.warning(
-            "[auto-batch] optimizer=%r is not the built-in 'adamw'; the probe only models AdamW's "
+            "[auto-batch] optimizer=%r does not allocate AdamW-shaped state; the probe only models AdamW's "
             "exp_avg/exp_avg_sq optimizer-state memory (see _build_shadow_optimizer), so this "
             "batch-size estimate may be too conservative or too permissive for the optimizer "
             "actually configured for training.",
@@ -498,13 +554,15 @@ def resolve_auto_batch_config(
     # Mirrors RFDETRModelModule._use_fused_optimizer (module_model.py), which build_trainer's
     # real AdamW reads at construction time -- but that Lightning module doesn't exist yet at
     # probe time, so re-derive its two conditions instead of calling it directly: (1) the
-    # built-in "adamw" path (already computed above as is_builtin_adamw), and (2) the resolved
-    # precision is a bf16 variant, which for this function's CUDA-only autocast resolution above
-    # is exactly the case where probe_autocast_dtype came out to torch.bfloat16 (see
-    # trainer.py's _resolve_precision: bf16-mixed iff CUDA + bf16-capable + amp_dtype in
-    # {"auto", "bf16"}, the same inputs probe_autocast_dtype was derived from).
+    # built-in "adamw" path, which is _is_builtin_fused_adamw's own narrow question and stays on
+    # that predicate rather than the broader state-shape one above -- only the short name reaches
+    # the managed fused kernel, so a dotted-path config must not be silently upgraded to fused --
+    # and (2) the resolved precision is a bf16 variant, which for this function's CUDA-only
+    # autocast resolution above is exactly the case where probe_autocast_dtype came out to
+    # torch.bfloat16 (see trainer.py's _resolve_precision: bf16-mixed iff CUDA + bf16-capable +
+    # amp_dtype in {"auto", "bf16"}, the same inputs probe_autocast_dtype was derived from).
     use_fused_optimizer = (
-        is_builtin_adamw
+        _is_builtin_fused_adamw(optimizer_cfg)
         and bool(getattr(model_config, "fused_optimizer", True))
         and probe_autocast_dtype is torch.bfloat16
     )
@@ -522,8 +580,6 @@ def resolve_auto_batch_config(
         max_micro_batch=max_micro_batch,
         num_channels=getattr(model_config, "num_channels", 3),
         autocast_dtype=probe_autocast_dtype,
-        optimizer_lr=train_config.lr,
-        optimizer_weight_decay=train_config.weight_decay,
         optimizer_kwargs=shadow_optimizer_kwargs,
         optimizer_fused=use_fused_optimizer,
     )

--- a/src/rfdetr/training/auto_batch.py
+++ b/src/rfdetr/training/auto_batch.py
@@ -150,6 +150,16 @@ def _build_shadow_optimizer(
     optimizer state they accumulate costs the same memory as the real optimizer eventually would,
     without the update ever touching a real parameter.
 
+    That separateness is also what this design costs: the shadow copies are allocated alongside the
+    model's own already-resident parameters, so the probe holds one extra copy of the trainable
+    parameters that real training never holds. On the non-fused path (amp off, fp16, or
+    ``fused_optimizer=False``) there is a second, transient divergence: the shadow optimizer steps a
+    single parameter group, so ``_foreach_sqrt`` builds one whole-model-sized temporary, where real
+    training's per-layer-group parameter dicts (``get_param_dict``, ``module_model.py``) keep that
+    temporary per-group. Both make the probe stricter than the run it sizes rather than more
+    permissive, and the transient one does not arise at all whenever the probe runs fused -- the
+    common bf16-on-CUDA default.
+
     Args:
         trainable_params: The real model parameters being probed for (only used for shape/dtype/device).
         lr: Learning rate for the shadow optimizer (does not affect state tensor size).
@@ -205,6 +215,7 @@ def _probe_step(
     max_targets_per_image: int = 1,
     num_channels: int = 3,
     autocast_dtype: torch.dtype | None = None,
+    warn_missing_grads: bool = False,
 ) -> bool:
     """Run one forward + loss + backward + shadow optimizer step; return True if successful, False on OOM.
 
@@ -215,6 +226,11 @@ def _probe_step(
     first call is the only one that pays the allocation; every later iteration (larger candidate batch sizes) competes
     for GPU memory against that already-resident state, the same way a real second-and-later training step would. The
     shadow tensors, not the real model parameters, receive the update, so this never mutates the model being probed.
+
+    ``warn_missing_grads`` asks this step to report parameters the synthetic batch never reached: AdamW allocates state
+    only for parameters that carry a gradient, so those are absent from the estimate. The caller sets it for the first
+    step only (every later iteration would recount the same parameters), and the report is emitted only if that step
+    goes on to succeed.
     """
     try:
         model.zero_grad(set_to_none=True)
@@ -253,6 +269,7 @@ def _probe_step(
         # without allocating a second copy of every gradient.
         for shadow_p, real_p in zip(shadow_params, trainable_params, strict=True):
             shadow_p.grad = real_p.grad
+        missing_grads = sum(1 for real_p in trainable_params if real_p.grad is None) if warn_missing_grads else 0
         try:
             shadow_optimizer.step()
         finally:
@@ -265,6 +282,13 @@ def _probe_step(
                 shadow_p.grad = None
         model.zero_grad(set_to_none=True)
         criterion.zero_grad(set_to_none=True)
+        if missing_grads:
+            logger.warning(
+                "[auto-batch] %d/%d trainable params received no gradient from the synthetic probe batch; their "
+                "optimizer state is not modeled, so the returned batch size may be too permissive.",
+                missing_grads,
+                len(trainable_params),
+            )
         return True
     except RuntimeError as exc:
         if _is_cuda_oom(exc):
@@ -352,12 +376,28 @@ def probe_max_micro_batch(
         criterion.train()
 
         trainable_params = [p for p in model.parameters() if p.requires_grad]
-        shadow_optimizer, shadow_params = _build_shadow_optimizer(
-            trainable_params, optimizer_lr, optimizer_weight_decay, optimizer_kwargs, optimizer_fused
-        )
+        try:
+            shadow_optimizer, shadow_params = _build_shadow_optimizer(
+                trainable_params, optimizer_lr, optimizer_weight_decay, optimizer_kwargs, optimizer_fused
+            )
+        except RuntimeError as exc:
+            if not _is_cuda_oom(exc):
+                raise
+            # Without this the first thing a user sees is a bare CUDA OOM from inside torch.zeros_like,
+            # with nothing tying it to auto-batch probing or naming a lever to pull.
+            raise RuntimeError(
+                "auto-batch probe ran out of memory allocating the shadow optimizer's parameter copies, before "
+                "any micro_batch_size was tried; that allocation needs one extra copy of the trainable "
+                "parameters. Try freeing GPU memory, lowering resolution, or enabling gradient_checkpointing."
+            ) from exc
+
+        # Armed until one step actually completes: only a successful step proves its gradients were the
+        # real ones, and every step after it would recount the same parameters.
+        warn_missing_grads = True
 
         def _probe(candidate_size: int) -> bool:
-            return _probe_step(
+            nonlocal warn_missing_grads
+            ok = _probe_step(
                 model,
                 criterion,
                 candidate_size,
@@ -372,7 +412,11 @@ def probe_max_micro_batch(
                 max_targets_per_image=max_targets_per_image,
                 num_channels=num_channels,
                 autocast_dtype=autocast_dtype,
+                warn_missing_grads=warn_missing_grads,
             )
+            if ok:
+                warn_missing_grads = False
+            return ok
 
         # shadow_optimizer.step() allocates AdamW's exp_avg/exp_avg_sq state lazily, on its first-ever
         # call. That first call is necessarily made without the state resident yet -- unlike every real

--- a/src/rfdetr/training/auto_batch.py
+++ b/src/rfdetr/training/auto_batch.py
@@ -15,6 +15,11 @@ Probe assumptions (worst-case so training does not OOM):
 - EMA: When use_ema is True, an EMA copy of the model is kept in memory. We
   apply auto_batch_ema_headroom (e.g. 0.7) to the probed batch size so the effective safe batch leaves room for the EMA
   model.
+- Optimizer state: AdamW allocates exp_avg/exp_avg_sq lazily, on its first
+  step() rather than at construction, each the same size as the trainable parameters -- so the combined state is 2x
+  that size, 3x with amsgrad. The probe runs a shadow AdamW step (see _build_shadow_optimizer) so that memory is part
+  of the estimate instead of first appearing on training's own first optimizer step. Only AdamW-shaped optimizers are
+  modeled this way (see _is_adamw_shaped); anything else gets the runtime warning in resolve_auto_batch_config.
 """
 
 from __future__ import annotations
@@ -142,8 +147,8 @@ def _build_shadow_optimizer(
     """Build an AdamW optimizer over throwaway tensors shaped like ``trainable_params``, for probing optimizer-state
     memory without ever writing to the real model's weights.
 
-    ``optimizer.step()`` needs to run against *some* set of parameters to allocate AdamW's per-
-    parameter state (``exp_avg``/``exp_avg_sq``), but running it against the real model's own
+    ``optimizer.step()`` needs to run against *some* set of parameters to allocate
+    AdamW's per-parameter state (``exp_avg``/``exp_avg_sq``), but running it against the real model's own
     parameters would apply a real (garbage, synthetic-data-derived) gradient update to weights that
     may already hold a loaded pretrained checkpoint -- corrupting them before training even starts.
     The shadow tensors this returns are separate GPU allocations of the same shape/dtype, so the
@@ -231,6 +236,30 @@ def _probe_step(
     only for parameters that carry a gradient, so those are absent from the estimate. The caller sets it for the first
     step only (every later iteration would recount the same parameters), and the report is emitted only if that step
     goes on to succeed.
+
+    Args:
+        model: The model to probe; already in train mode, and left untouched apart from its gradients.
+        criterion: The loss criterion (must match model output and target format).
+        micro_batch_size: Per-device batch size to attempt in this single step.
+        resolution: Input spatial size (square) for the synthetic images.
+        device: CUDA device the synthetic batch is allocated on.
+        num_classes: Number of classes, used to pick synthetic target labels.
+        amp: Whether to run the forward under autocast.
+        trainable_params: The model's ``requires_grad`` parameters, in the order ``shadow_params`` was built from --
+            index i of one must correspond to index i of the other, which the aliasing loop asserts.
+        shadow_optimizer: The AdamW built over ``shadow_params``; stepped here so its state is allocated and stays
+            resident for later iterations.
+        shadow_params: Throwaway tensors mirroring ``trainable_params``, which take the update in their place.
+        segmentation_head: If True, synthetic targets include "masks" so loss_masks is exercised.
+        max_targets_per_image: Number of synthetic targets per image (worst-case matcher and loss memory).
+        num_channels: Number of input image channels for the synthetic images.
+        autocast_dtype: Explicit autocast dtype; ``None`` leaves torch's own default for the device.
+        warn_missing_grads: Whether to report parameters that received no gradient (see above). Off by default so
+            only the caller's chosen step reports.
+
+    Returns:
+        True if the step ran to completion, False if it hit a CUDA OOM (the signal that this ``micro_batch_size``
+        does not fit). Any other RuntimeError propagates.
     """
     try:
         model.zero_grad(set_to_none=True)

--- a/tests/training/test_auto_batch.py
+++ b/tests/training/test_auto_batch.py
@@ -139,6 +139,33 @@ def test_probe_max_micro_batch_warms_up_state_before_exponential_search():
     assert calls.count(1) == 2
 
 
+def test_probe_max_micro_batch_raises_before_building_shadow_optimizer_when_no_trainable_params():
+    """A fully-frozen model (every parameter requires_grad=False) drives the real (unmocked) guard that fails fast with
+    a dedicated RuntimeError before ever reaching _build_shadow_optimizer's torch.optim.AdamW([]) call, and still
+    restores train-mode on this early-exit path."""
+    model = _TinyModule()
+    model.w.requires_grad_(False)
+    criterion = _TinyModule()
+    model.eval()
+    criterion.eval()
+
+    with (
+        patch("rfdetr.training.auto_batch.torch.cuda.empty_cache"),
+        pytest.raises(RuntimeError, match=r"requires at least one trainable parameter; .*requires_grad=False\."),
+    ):
+        auto_batch.probe_max_micro_batch(
+            model=model,
+            criterion=criterion,
+            resolution=64,
+            device=torch.device("cuda"),
+            num_classes=5,
+            amp=False,
+        )
+
+    assert model.training is False
+    assert criterion.training is False
+
+
 def test_probe_step_raises_when_loss_keys_do_not_overlap_weight_keys():
     """_probe_step must fail fast when weighted loss would be empty."""
 
@@ -181,6 +208,27 @@ def test_probe_step_raises_when_loss_keys_do_not_overlap_weight_keys():
             trainable_params=trainable_params,
             shadow_optimizer=shadow_optimizer,
             shadow_params=shadow_params,
+        )
+
+
+def test_probe_step_rejects_trainable_params_shadow_args_passed_positionally():
+    """trainable_params/shadow_optimizer/shadow_params (and every parameter after them) are keyword-only -- a caller
+    still passing them positionally must get a TypeError, not have them silently bound to the wrong parameter."""
+    model = _TinyModule()
+    criterion = _TinyModule()
+
+    with pytest.raises(TypeError):
+        auto_batch._probe_step(
+            model,
+            criterion,
+            1,
+            64,
+            torch.device("cpu"),
+            5,
+            False,
+            [],  # trainable_params passed positionally -- must raise, not bind
+            None,
+            [],
         )
 
 
@@ -371,6 +419,128 @@ class TestProbeStepShadowOptimizer:
             assert shadow_p.grad is None
 
 
+class _CpuAsCuda(str):
+    """A ``str`` subclass equal to ``"cpu"`` whose ``.type`` reports ``"cuda"``.
+
+    ``probe_max_micro_batch`` hard-requires ``device.type == "cuda"`` before it will run at all, but every
+    downstream tensor factory call (``torch.randn(..., device=...)`` and friends) accepts any string that names a
+    real device -- so this lets a CPU-only test satisfy the guard while every actual tensor op still runs on CPU,
+    driving the real search loop without a GPU.
+
+    Examples:
+        >>> device = _CpuAsCuda("cpu")
+        >>> device.type
+        'cuda'
+        >>> torch.zeros(1, device=device).device.type
+        'cpu'
+    """
+
+    @property
+    def type(self) -> str:
+        return "cuda"
+
+
+class _PartiallyUsedDummyModel(torch.nn.Module):
+    """A model with two trainable parameters where only one participates in the forward pass, so the other's ``.grad``
+    stays ``None`` after ``backward()`` -- the scenario ``warn_missing_grads`` exists to report."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.used = torch.nn.Parameter(torch.ones(3))
+        self.unused = torch.nn.Parameter(torch.ones(2))
+
+    def forward(self, samples, targets):
+        return {"pred": self.used.sum() * len(targets)}
+
+
+def test_probe_max_micro_batch_drives_real_search_loop_end_to_end():
+    """A CPU-only run of the actual (unmocked) probe_max_micro_batch search loop -- real _probe_step and
+    _build_shadow_optimizer calls, not mocked stand-ins -- must drive at least two candidate batch sizes past the warm-
+    up re-probe and produce the same safe batch size the exponential/binary search math predicts."""
+    device = _CpuAsCuda("cpu")
+    model = _WorkingDummyModel()
+    criterion = _WorkingDummyCriterion()
+
+    with patch("rfdetr.training.auto_batch._probe_step", wraps=auto_batch._probe_step) as spy_probe_step:
+        safe = auto_batch.probe_max_micro_batch(
+            model=model,
+            criterion=criterion,
+            resolution=8,
+            device=device,
+            num_classes=5,
+            amp=False,
+            safety_margin=1.0,
+            max_micro_batch=4,
+        )
+
+    assert safe == 4
+    # 1 (warm-up), 1 (state-resident re-probe), 2, 4 -- four real candidates, driven by the real loop.
+    candidate_sizes = [call.args[2] for call in spy_probe_step.call_args_list]
+    assert candidate_sizes == [1, 1, 2, 4]
+
+
+def test_probe_max_micro_batch_builds_shadow_optimizer_exactly_once():
+    """_build_shadow_optimizer allocates one extra copy of the trainable parameters and (via the first real step())
+    AdamW's exp_avg/exp_avg_sq state -- a probe that rebuilt it per candidate batch size would pay both costs on every
+    iteration instead of once for the whole search."""
+    device = _CpuAsCuda("cpu")
+    model = _WorkingDummyModel()
+    criterion = _WorkingDummyCriterion()
+
+    with patch(
+        "rfdetr.training.auto_batch._build_shadow_optimizer",
+        wraps=auto_batch._build_shadow_optimizer,
+    ) as spy_build_shadow_optimizer:
+        safe = auto_batch.probe_max_micro_batch(
+            model=model,
+            criterion=criterion,
+            resolution=8,
+            device=device,
+            num_classes=5,
+            amp=False,
+            safety_margin=1.0,
+            max_micro_batch=4,
+        )
+
+    assert safe == 4
+    assert spy_build_shadow_optimizer.call_count == 1
+
+
+def test_probe_step_warns_once_with_correct_missing_grad_count_when_armed():
+    """warn_missing_grads=True must report exactly the trainable params the synthetic forward pass never reached -- here
+    1 of 2 -- since AdamW only allocates state for params that carry a gradient, so an unreported miss would silently
+    under-count the probe's optimizer-state memory estimate."""
+    model = _PartiallyUsedDummyModel()
+    criterion = _WorkingDummyCriterion()
+    trainable_params = list(model.parameters())
+    shadow_optimizer, shadow_params = auto_batch._build_shadow_optimizer(trainable_params, lr=1e-2, weight_decay=0.0)
+
+    with (
+        patch(
+            "rfdetr.training.auto_batch._make_synthetic_batch",
+            return_value=(MagicMock(), [{}]),
+        ),
+        patch("rfdetr.training.auto_batch.logger.warning") as mock_warning,
+    ):
+        ok = auto_batch._probe_step(
+            model=model,
+            criterion=criterion,
+            micro_batch_size=1,
+            resolution=64,
+            device=torch.device("cpu"),
+            num_classes=5,
+            amp=False,
+            trainable_params=trainable_params,
+            shadow_optimizer=shadow_optimizer,
+            shadow_params=shadow_params,
+            warn_missing_grads=True,
+        )
+
+    assert ok is True
+    mock_warning.assert_called_once()
+    assert mock_warning.call_args.args[1:] == (1, 2)
+
+
 def test_build_shadow_optimizer_forwards_optimizer_kwargs():
     """train_config.optimizer_kwargs (e.g. amsgrad=True, which adds a third max_exp_avg_sq state buffer per
     parameter -- see torch.optim.AdamW) must reach the shadow AdamW, the same way configure_optimizers forwards
@@ -385,6 +555,17 @@ def test_build_shadow_optimizer_forwards_optimizer_kwargs():
     optimizer.step()
 
     assert "max_exp_avg_sq" in optimizer.state[shadow_params[0]]
+
+
+def test_build_shadow_optimizer_does_not_raise_when_optimizer_kwargs_also_sets_lr():
+    """optimizer_kwargs must merge into (not be splatted alongside) the lr/weight_decay/fused defaults: a dotted- path
+    config keeps its own lr inside optimizer_kwargs (see the docstring's merge-precedence note), so splatting both would
+    raise "got multiple values for keyword argument 'lr'" instead of the caller's value winning."""
+    params = [torch.nn.Parameter(torch.zeros(3))]
+
+    optimizer, _ = auto_batch._build_shadow_optimizer(params, lr=1e-4, weight_decay=1e-4, optimizer_kwargs={"lr": 5e-2})
+
+    assert optimizer.param_groups[0]["lr"] == 5e-2
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="fused AdamW requires CUDA")
@@ -522,6 +703,34 @@ def test_resolve_auto_batch_config_forwards_optimizer_kwargs_for_builtin_adamw()
         lr=1e-4,
         weight_decay=1e-4,
         optimizer="adamw",
+        optimizer_kwargs={"amsgrad": True},
+    )
+    criterion = MagicMock()
+    criterion.to.return_value = criterion
+
+    with (
+        patch("rfdetr.training.auto_batch.torch.cuda.is_available", return_value=True),
+        patch("rfdetr.training.auto_batch.build_criterion_from_config", return_value=(criterion, None)),
+        patch("rfdetr.training.auto_batch.probe_max_micro_batch", return_value=5) as mock_probe,
+        patch("rfdetr.training.auto_batch.torch.cuda.get_device_name", return_value="Fake GPU"),
+    ):
+        auto_batch.resolve_auto_batch_config(model_context, model_config, train_config)
+
+    assert mock_probe.call_args.kwargs["optimizer_kwargs"] == {"amsgrad": True}
+
+
+def test_resolve_auto_batch_config_forwards_optimizer_kwargs_for_dotted_path_adamw():
+    """optimizer="torch.optim.AdamW" is AdamW-shaped just like the built-in "adamw" short name (see _is_adamw_shaped),
+    so optimizer_kwargs must reach the shadow optimizer for this dotted-path spelling too -- previously it was silently
+    dropped for any spelling other than the short name."""
+    model_context = SimpleNamespace(device=torch.device("cuda"), model=MagicMock())
+    model_config = SimpleNamespace(resolution=64, num_classes=5, amp=False, segmentation_head=True)
+    train_config = SimpleNamespace(
+        batch_size="auto",
+        auto_batch_target_effective=16,
+        lr=1e-4,
+        weight_decay=1e-4,
+        optimizer="torch.optim.AdamW",
         optimizer_kwargs={"amsgrad": True},
     )
     criterion = MagicMock()

--- a/tests/training/test_auto_batch.py
+++ b/tests/training/test_auto_batch.py
@@ -71,6 +71,74 @@ def test_probe_max_micro_batch_raises_if_one_is_not_safe():
         )
 
 
+def test_probe_max_micro_batch_reprobes_batch_one_with_state_resident():
+    """shadow_optimizer.step() allocates AdamW's exp_avg/exp_avg_sq state lazily on its first-ever call, so a lone
+    success at micro_batch_size=1 only proves the batch fits *before* that state exists -- not once it's resident, which
+    is what every real training step from the second one onward looks like.
+
+    probe_max_micro_batch must re-probe batch=1 a second time (with the state now resident) and fail loudly if that re-
+    probe doesn't hold, instead of silently returning a "safe" batch size that was never actually validated under
+    steady-state memory.
+    """
+    model = _TinyModule()
+    criterion = _TinyModule()
+    calls: list[int] = []
+
+    def _fake_probe(*args, **kwargs):
+        micro_batch_size = args[2]
+        calls.append(micro_batch_size)
+        # First-ever call (state not yet resident) succeeds; the re-probe (state resident) fails.
+        return len(calls) == 1
+
+    with (
+        patch("rfdetr.training.auto_batch._probe_step", side_effect=_fake_probe),
+        patch("rfdetr.training.auto_batch.torch.cuda.empty_cache"),
+        pytest.raises(RuntimeError, match="optimizer state is resident"),
+    ):
+        auto_batch.probe_max_micro_batch(
+            model=model,
+            criterion=criterion,
+            resolution=64,
+            device=torch.device("cuda"),
+            num_classes=5,
+            amp=False,
+        )
+
+    assert calls == [1, 1]
+
+
+def test_probe_max_micro_batch_warms_up_state_before_exponential_search():
+    """Once batch=1 survives both the state-allocating call and the state-resident re-probe, the exponential search must
+    start from candidate=2 -- not re-probe 1 a third time, and not skip probing larger candidates under the now-resident
+    state."""
+    model = _TinyModule()
+    criterion = _TinyModule()
+    calls: list[int] = []
+
+    def _fake_probe(*args, **kwargs):
+        micro_batch_size = args[2]
+        calls.append(micro_batch_size)
+        return micro_batch_size <= 4
+
+    with (
+        patch("rfdetr.training.auto_batch._probe_step", side_effect=_fake_probe),
+        patch("rfdetr.training.auto_batch.torch.cuda.empty_cache"),
+    ):
+        safe = auto_batch.probe_max_micro_batch(
+            model=model,
+            criterion=criterion,
+            resolution=64,
+            device=torch.device("cuda"),
+            num_classes=5,
+            amp=False,
+            safety_margin=1.0,
+        )
+
+    assert safe == 4
+    assert calls[:2] == [1, 1]
+    assert calls.count(1) == 2
+
+
 def test_probe_step_raises_when_loss_keys_do_not_overlap_weight_keys():
     """_probe_step must fail fast when weighted loss would be empty."""
 
@@ -267,6 +335,41 @@ class TestProbeStepShadowOptimizer:
         for shadow_p in shadow_params:
             assert shadow_p.grad is None
 
+    def test_shadow_grad_cleared_when_step_itself_ooms(self) -> None:
+        """A CUDA OOM raised by shadow_optimizer.step() itself (not by forward/backward) must still clear
+        shadow_p.grad -- otherwise the alias is the only remaining reference keeping that iteration's real
+        gradient tensor alive, unreachable by torch.cuda.empty_cache(), for the rest of the search."""
+
+        class _OomOnStep:
+            def step(self) -> None:
+                raise RuntimeError("CUDA out of memory.")
+
+        model = _WorkingDummyModel()
+        criterion = _WorkingDummyCriterion()
+        trainable_params = list(model.parameters())
+        _, shadow_params = auto_batch._build_shadow_optimizer(trainable_params, lr=1e-2, weight_decay=0.0)
+
+        with patch(
+            "rfdetr.training.auto_batch._make_synthetic_batch",
+            return_value=(MagicMock(), [{}]),
+        ):
+            ok = auto_batch._probe_step(
+                model=model,
+                criterion=criterion,
+                micro_batch_size=1,
+                resolution=64,
+                device=torch.device("cpu"),
+                num_classes=5,
+                amp=False,
+                trainable_params=trainable_params,
+                shadow_optimizer=_OomOnStep(),
+                shadow_params=shadow_params,
+            )
+
+        assert ok is False
+        for shadow_p in shadow_params:
+            assert shadow_p.grad is None
+
 
 def test_build_shadow_optimizer_forwards_optimizer_kwargs():
     """train_config.optimizer_kwargs (e.g. amsgrad=True, which adds a third max_exp_avg_sq state buffer per
@@ -282,6 +385,18 @@ def test_build_shadow_optimizer_forwards_optimizer_kwargs():
     optimizer.step()
 
     assert "max_exp_avg_sq" in optimizer.state[shadow_params[0]]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="fused AdamW requires CUDA")
+def test_build_shadow_optimizer_forwards_fused():
+    """Fused must reach the shadow AdamW so its step-time temporary memory matches the real optimizer's fused vs.
+
+    foreach/single-tensor implementation (see RFDETRModelModule._use_fused_optimizer).
+    """
+    params = [torch.nn.Parameter(torch.zeros(3, device="cuda"))]
+    optimizer, _ = auto_batch._build_shadow_optimizer(params, lr=1e-3, weight_decay=0.0, fused=True)
+
+    assert optimizer.defaults["fused"] is True
 
 
 def test_probe_max_micro_batch_restores_train_mode_when_shadow_optimizer_build_fails():
@@ -450,6 +565,94 @@ def test_resolve_auto_batch_config_does_not_forward_optimizer_kwargs_for_non_ada
         auto_batch.resolve_auto_batch_config(model_context, model_config, train_config)
 
     assert mock_probe.call_args.kwargs["optimizer_kwargs"] is None
+
+
+def test_resolve_auto_batch_config_forwards_fused_when_bf16_and_builtin_adamw():
+    """When the real run would use bf16-mixed precision with the built-in adamw optimizer and
+    model_config.fused_optimizer=True (RFDETRModelModule._use_fused_optimizer's own conditions), the shadow optimizer
+    must be built fused too -- otherwise its step-time temporary memory (foreach/single-tensor) can diverge from what
+    the real fused AdamW actually needs."""
+    model_context = SimpleNamespace(device=torch.device("cuda"), model=MagicMock())
+    model_config = SimpleNamespace(resolution=64, num_classes=5, amp=True, segmentation_head=True, fused_optimizer=True)
+    train_config = SimpleNamespace(
+        batch_size="auto",
+        auto_batch_target_effective=16,
+        lr=1e-4,
+        weight_decay=1e-4,
+        optimizer="adamw",
+        amp_dtype="auto",
+    )
+    criterion = MagicMock()
+    criterion.to.return_value = criterion
+
+    with (
+        patch("rfdetr.training.auto_batch.torch.cuda.is_available", return_value=True),
+        patch("rfdetr.training.auto_batch.torch.cuda.is_bf16_supported", return_value=True),
+        patch("rfdetr.training.auto_batch.build_criterion_from_config", return_value=(criterion, None)),
+        patch("rfdetr.training.auto_batch.probe_max_micro_batch", return_value=5) as mock_probe,
+        patch("rfdetr.training.auto_batch.torch.cuda.get_device_name", return_value="Fake GPU"),
+    ):
+        auto_batch.resolve_auto_batch_config(model_context, model_config, train_config)
+
+    assert mock_probe.call_args.kwargs["optimizer_fused"] is True
+
+
+def test_resolve_auto_batch_config_does_not_force_fused_for_fp16():
+    """amp_dtype='fp16' resolves to '16-mixed' precision, not a bf16 variant -- fused AdamW is only safe under
+    bf16-mixed (see RFDETRModelModule._use_fused_optimizer), so the shadow optimizer must not be forced fused."""
+    model_context = SimpleNamespace(device=torch.device("cuda"), model=MagicMock())
+    model_config = SimpleNamespace(resolution=64, num_classes=5, amp=True, segmentation_head=True, fused_optimizer=True)
+    train_config = SimpleNamespace(
+        batch_size="auto",
+        auto_batch_target_effective=16,
+        lr=1e-4,
+        weight_decay=1e-4,
+        optimizer="adamw",
+        amp_dtype="fp16",
+    )
+    criterion = MagicMock()
+    criterion.to.return_value = criterion
+
+    with (
+        patch("rfdetr.training.auto_batch.torch.cuda.is_available", return_value=True),
+        patch("rfdetr.training.auto_batch.torch.cuda.is_bf16_supported", return_value=True),
+        patch("rfdetr.training.auto_batch.build_criterion_from_config", return_value=(criterion, None)),
+        patch("rfdetr.training.auto_batch.probe_max_micro_batch", return_value=5) as mock_probe,
+        patch("rfdetr.training.auto_batch.torch.cuda.get_device_name", return_value="Fake GPU"),
+    ):
+        auto_batch.resolve_auto_batch_config(model_context, model_config, train_config)
+
+    assert mock_probe.call_args.kwargs["optimizer_fused"] is False
+
+
+def test_resolve_auto_batch_config_does_not_force_fused_when_model_config_disables_it():
+    """model_config.fused_optimizer=False must be honored the same way RFDETRModelModule._use_fused_optimizer honors it
+    for the real optimizer."""
+    model_context = SimpleNamespace(device=torch.device("cuda"), model=MagicMock())
+    model_config = SimpleNamespace(
+        resolution=64, num_classes=5, amp=True, segmentation_head=True, fused_optimizer=False
+    )
+    train_config = SimpleNamespace(
+        batch_size="auto",
+        auto_batch_target_effective=16,
+        lr=1e-4,
+        weight_decay=1e-4,
+        optimizer="adamw",
+        amp_dtype="auto",
+    )
+    criterion = MagicMock()
+    criterion.to.return_value = criterion
+
+    with (
+        patch("rfdetr.training.auto_batch.torch.cuda.is_available", return_value=True),
+        patch("rfdetr.training.auto_batch.torch.cuda.is_bf16_supported", return_value=True),
+        patch("rfdetr.training.auto_batch.build_criterion_from_config", return_value=(criterion, None)),
+        patch("rfdetr.training.auto_batch.probe_max_micro_batch", return_value=5) as mock_probe,
+        patch("rfdetr.training.auto_batch.torch.cuda.get_device_name", return_value="Fake GPU"),
+    ):
+        auto_batch.resolve_auto_batch_config(model_context, model_config, train_config)
+
+    assert mock_probe.call_args.kwargs["optimizer_fused"] is False
 
 
 @patch("rfdetr.detr.is_main_process", return_value=False)

--- a/tests/training/test_auto_batch.py
+++ b/tests/training/test_auto_batch.py
@@ -710,6 +710,7 @@ def test_train_auto_batch_ensures_model_on_device_before_resolve(
     assert call_order == ["ensure", "resolve"]
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for segmentation probe")
 def test_probe_step_with_real_segmentation_criterion(tmp_path):
     """Run one probe step with real segmentation model and criterion so loss_masks and t['masks'] are exercised."""

--- a/tests/training/test_auto_batch.py
+++ b/tests/training/test_auto_batch.py
@@ -83,11 +83,17 @@ def test_probe_step_raises_when_loss_keys_do_not_overlap_weight_keys():
             return {"loss_ce": torch.tensor(1.0)}
 
     class _DummyModel(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.w = torch.nn.Parameter(torch.ones(1))
+
         def forward(self, samples, targets):
             return {}
 
     model = _DummyModel()
     criterion = _DummyCriterion()
+    trainable_params = list(model.parameters())
+    shadow_optimizer, shadow_params = auto_batch._build_shadow_optimizer(trainable_params, lr=1e-4, weight_decay=1e-4)
 
     with (
         patch(
@@ -104,7 +110,206 @@ def test_probe_step_raises_when_loss_keys_do_not_overlap_weight_keys():
             device=torch.device("cpu"),
             num_classes=5,
             amp=False,
+            trainable_params=trainable_params,
+            shadow_optimizer=shadow_optimizer,
+            shadow_params=shadow_params,
         )
+
+
+class _WorkingDummyModel(torch.nn.Module):
+    """A minimal model whose output is differentiable w.r.t.
+
+    its own parameter, so a full forward+backward+shadow-optimizer-step probe cycle can run without a real RF-DETR
+    model.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.w = torch.nn.Parameter(torch.ones(3))
+
+    def forward(self, samples, targets):
+        return {"pred": self.w.sum() * len(targets)}
+
+
+class _WorkingDummyCriterion(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.weight_dict = {"loss_ce": 1.0}
+
+    def forward(self, outputs, targets):
+        return {"loss_ce": outputs["pred"] ** 2}
+
+
+class TestProbeStepShadowOptimizer:
+    """_probe_step's shadow-optimizer step must allocate real AdamW state (so the probe accounts for the memory
+    training's first real optimizer.step() will need) without ever writing to the real model's own parameters (which may
+    already hold a loaded pretrained checkpoint)."""
+
+    def _run_one_probe_step(self) -> tuple[_WorkingDummyModel, torch.optim.Optimizer, list[torch.Tensor]]:
+        """Run one real (non-mocked) forward+backward+shadow-optimizer-step probe cycle on ``_WorkingDummyModel``.
+
+        Shared setup for the tests in this class: builds a fresh model/criterion/shadow optimizer, patches only
+        ``_make_synthetic_batch`` (batch construction, not the forward/backward/step mechanic under test), and
+        asserts the probe step itself succeeded before handing the state back for each test to inspect.
+
+        Returns:
+            The model, the shadow optimizer, and its shadow parameters, all post-step.
+
+        Examples:
+            >>> model, shadow_optimizer, shadow_params = TestProbeStepShadowOptimizer()._run_one_probe_step()
+            >>> len(shadow_optimizer.state) == len(shadow_params) > 0
+            True
+        """
+        model = _WorkingDummyModel()
+        criterion = _WorkingDummyCriterion()
+        trainable_params = list(model.parameters())
+        shadow_optimizer, shadow_params = auto_batch._build_shadow_optimizer(
+            trainable_params, lr=1e-2, weight_decay=0.0
+        )
+        with patch(
+            "rfdetr.training.auto_batch._make_synthetic_batch",
+            return_value=(MagicMock(), [{}]),
+        ):
+            ok = auto_batch._probe_step(
+                model=model,
+                criterion=criterion,
+                micro_batch_size=1,
+                resolution=64,
+                device=torch.device("cpu"),
+                num_classes=5,
+                amp=False,
+                trainable_params=trainable_params,
+                shadow_optimizer=shadow_optimizer,
+                shadow_params=shadow_params,
+            )
+        assert ok is True
+        return model, shadow_optimizer, shadow_params
+
+    def test_does_not_mutate_real_model_parameters(self) -> None:
+        """The shadow optimizer step must update the shadow tensors, not the real model -- a probe that corrupted a
+        loaded pretrained checkpoint's weights before training even started would be far worse than the memory-
+        underestimation bug it fixes."""
+        model = _WorkingDummyModel()
+        before = model.w.detach().clone()
+        criterion = _WorkingDummyCriterion()
+        trainable_params = list(model.parameters())
+        shadow_optimizer, shadow_params = auto_batch._build_shadow_optimizer(
+            trainable_params, lr=1e-2, weight_decay=0.0
+        )
+
+        with patch(
+            "rfdetr.training.auto_batch._make_synthetic_batch",
+            return_value=(MagicMock(), [{}]),
+        ):
+            auto_batch._probe_step(
+                model=model,
+                criterion=criterion,
+                micro_batch_size=1,
+                resolution=64,
+                device=torch.device("cpu"),
+                num_classes=5,
+                amp=False,
+                trainable_params=trainable_params,
+                shadow_optimizer=shadow_optimizer,
+                shadow_params=shadow_params,
+            )
+
+        assert torch.equal(model.w.detach(), before), "the real model parameter must be unchanged"
+
+    def test_populates_shadow_optimizer_state(self) -> None:
+        """AdamW allocates exp_avg/exp_avg_sq lazily on the first step() -- pins that the shadow step actually triggers
+        that allocation instead of being a no-op (e.g. from a grad-aliasing bug that left shadow_params.grad as None,
+        which AdamW silently skips)."""
+        _, shadow_optimizer, shadow_params = self._run_one_probe_step()
+
+        assert len(shadow_optimizer.state) == len(shadow_params) > 0
+        for shadow_p in shadow_params:
+            state = shadow_optimizer.state[shadow_p]
+            assert "exp_avg" in state
+            assert "exp_avg_sq" in state
+            assert state["exp_avg"].shape == shadow_p.shape
+
+    def test_shadow_optimizer_state_reused_not_reallocated_across_iterations(self) -> None:
+        """A second probe iteration (the next candidate batch size in the same search) must reuse the already-allocated
+        exp_avg/exp_avg_sq tensors, not allocate fresh ones -- otherwise every probe iteration would pay the allocation
+        cost this fix exists to move to the first iteration only."""
+        model, shadow_optimizer, shadow_params = self._run_one_probe_step()
+        criterion = _WorkingDummyCriterion()
+        exp_avg_id_before = id(shadow_optimizer.state[shadow_params[0]]["exp_avg"])
+
+        with patch(
+            "rfdetr.training.auto_batch._make_synthetic_batch",
+            return_value=(MagicMock(), [{}]),
+        ):
+            auto_batch._probe_step(
+                model=model,
+                criterion=criterion,
+                micro_batch_size=2,
+                resolution=64,
+                device=torch.device("cpu"),
+                num_classes=5,
+                amp=False,
+                trainable_params=list(model.parameters()),
+                shadow_optimizer=shadow_optimizer,
+                shadow_params=shadow_params,
+            )
+
+        exp_avg_id_after = id(shadow_optimizer.state[shadow_params[0]]["exp_avg"])
+        assert exp_avg_id_after == exp_avg_id_before
+
+    def test_shadow_grad_cleared_after_step(self) -> None:
+        """shadow_p.grad must not outlive the shadow_optimizer.step() that consumes it: leaving the alias set keeps this
+        iteration's real-gradient tensor resident (via shadow_p.grad, its only remaining reference once
+        model.zero_grad() clears real_p.grad) through the next iteration's backward() -- two gradient buffers alive at
+        once instead of one."""
+        _, _, shadow_params = self._run_one_probe_step()
+
+        for shadow_p in shadow_params:
+            assert shadow_p.grad is None
+
+
+def test_build_shadow_optimizer_forwards_optimizer_kwargs():
+    """train_config.optimizer_kwargs (e.g. amsgrad=True, which adds a third max_exp_avg_sq state buffer per
+    parameter -- see torch.optim.AdamW) must reach the shadow AdamW, the same way configure_optimizers forwards
+    them to the real one (module_model.py). Without this, the probe silently under-counts optimizer-state memory
+    for any AdamW variant beyond the plain defaults, which is the dangerous direction: it can report a batch size
+    that OOMs on the real optimizer.step()."""
+    params = [torch.nn.Parameter(torch.zeros(3))]
+    optimizer, shadow_params = auto_batch._build_shadow_optimizer(
+        params, lr=1e-3, weight_decay=0.0, optimizer_kwargs={"amsgrad": True}
+    )
+    shadow_params[0].grad = torch.ones_like(shadow_params[0])
+    optimizer.step()
+
+    assert "max_exp_avg_sq" in optimizer.state[shadow_params[0]]
+
+
+def test_probe_max_micro_batch_restores_train_mode_when_shadow_optimizer_build_fails():
+    """If _build_shadow_optimizer itself raises (e.g. OOM allocating the shadow parameter tensors for a very
+    large model), the model/criterion train-mode flip from the start of probe_max_micro_batch must still be
+    undone -- a probe that mutates the caller's eval-mode model and then crashes without restoring it would leave
+    the model silently in the wrong mode for whatever runs next."""
+    model = _TinyModule()
+    criterion = _TinyModule()
+    model.eval()
+    criterion.eval()
+
+    with (
+        patch("rfdetr.training.auto_batch._build_shadow_optimizer", side_effect=RuntimeError("boom")),
+        patch("rfdetr.training.auto_batch.torch.cuda.empty_cache"),
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        auto_batch.probe_max_micro_batch(
+            model=model,
+            criterion=criterion,
+            resolution=64,
+            device=torch.device("cuda"),
+            num_classes=5,
+            amp=False,
+        )
+
+    assert model.training is False
+    assert criterion.training is False
 
 
 def test_resolve_auto_batch_config_requires_cuda():
@@ -122,7 +327,7 @@ def test_resolve_auto_batch_config_requires_cuda():
 def test_resolve_auto_batch_config_returns_expected_values():
     model_context = SimpleNamespace(device=torch.device("cuda"), model=MagicMock())
     model_config = SimpleNamespace(resolution=64, num_classes=5, amp=False, segmentation_head=True)
-    train_config = SimpleNamespace(batch_size="auto", auto_batch_target_effective=16)
+    train_config = SimpleNamespace(batch_size="auto", auto_batch_target_effective=16, lr=1e-4, weight_decay=1e-4)
     criterion = MagicMock()
     criterion.to.return_value = criterion
 
@@ -139,6 +344,112 @@ def test_resolve_auto_batch_config_returns_expected_values():
     assert result.recommended_grad_accum_steps == 4
     assert result.effective_batch_size == 20
     assert result.device_name == "Fake GPU"
+
+
+def test_resolve_auto_batch_config_warns_when_optimizer_is_not_builtin_adamw():
+    """The shadow optimizer probe always models AdamW's state memory (see _build_shadow_optimizer); a
+    train_config.optimizer other than the built-in "adamw" (e.g. "sgd", a pytorch-optimizer name, a custom
+    callable/dotted path -- all supported by configure_optimizers) makes that estimate unreliable and must be surfaced,
+    not silently assumed correct."""
+    model_context = SimpleNamespace(device=torch.device("cuda"), model=MagicMock())
+    model_config = SimpleNamespace(resolution=64, num_classes=5, amp=False, segmentation_head=True)
+    train_config = SimpleNamespace(
+        batch_size="auto", auto_batch_target_effective=16, lr=1e-4, weight_decay=1e-4, optimizer="sgd"
+    )
+    criterion = MagicMock()
+    criterion.to.return_value = criterion
+
+    with (
+        patch("rfdetr.training.auto_batch.torch.cuda.is_available", return_value=True),
+        patch("rfdetr.training.auto_batch.build_criterion_from_config", return_value=(criterion, None)),
+        patch("rfdetr.training.auto_batch.probe_max_micro_batch", return_value=5),
+        patch("rfdetr.training.auto_batch.torch.cuda.get_device_name", return_value="Fake GPU"),
+        patch("rfdetr.training.auto_batch.logger.warning") as mock_warning,
+    ):
+        auto_batch.resolve_auto_batch_config(model_context, model_config, train_config)
+
+    assert mock_warning.call_count == 1
+    assert mock_warning.call_args.args[1] == "sgd"
+
+
+def test_resolve_auto_batch_config_does_not_warn_for_builtin_adamw():
+    """The default (and explicit "adamw") config is exactly what the shadow optimizer models, so no warning should
+    fire -- a spurious warning on the common path would train users to ignore it."""
+    model_context = SimpleNamespace(device=torch.device("cuda"), model=MagicMock())
+    model_config = SimpleNamespace(resolution=64, num_classes=5, amp=False, segmentation_head=True)
+    train_config = SimpleNamespace(
+        batch_size="auto", auto_batch_target_effective=16, lr=1e-4, weight_decay=1e-4, optimizer="adamw"
+    )
+    criterion = MagicMock()
+    criterion.to.return_value = criterion
+
+    with (
+        patch("rfdetr.training.auto_batch.torch.cuda.is_available", return_value=True),
+        patch("rfdetr.training.auto_batch.build_criterion_from_config", return_value=(criterion, None)),
+        patch("rfdetr.training.auto_batch.probe_max_micro_batch", return_value=5),
+        patch("rfdetr.training.auto_batch.torch.cuda.get_device_name", return_value="Fake GPU"),
+        patch("rfdetr.training.auto_batch.logger.warning") as mock_warning,
+    ):
+        auto_batch.resolve_auto_batch_config(model_context, model_config, train_config)
+
+    mock_warning.assert_not_called()
+
+
+def test_resolve_auto_batch_config_forwards_optimizer_kwargs_for_builtin_adamw():
+    """train_config.optimizer_kwargs (e.g. amsgrad=True) must reach the shadow optimizer when optimizer="adamw", the
+    same kwargs configure_optimizers forwards to the real AdamW -- otherwise the probe silently ignores an optimizer-
+    state-affecting setting the real training run actually uses."""
+    model_context = SimpleNamespace(device=torch.device("cuda"), model=MagicMock())
+    model_config = SimpleNamespace(resolution=64, num_classes=5, amp=False, segmentation_head=True)
+    train_config = SimpleNamespace(
+        batch_size="auto",
+        auto_batch_target_effective=16,
+        lr=1e-4,
+        weight_decay=1e-4,
+        optimizer="adamw",
+        optimizer_kwargs={"amsgrad": True},
+    )
+    criterion = MagicMock()
+    criterion.to.return_value = criterion
+
+    with (
+        patch("rfdetr.training.auto_batch.torch.cuda.is_available", return_value=True),
+        patch("rfdetr.training.auto_batch.build_criterion_from_config", return_value=(criterion, None)),
+        patch("rfdetr.training.auto_batch.probe_max_micro_batch", return_value=5) as mock_probe,
+        patch("rfdetr.training.auto_batch.torch.cuda.get_device_name", return_value="Fake GPU"),
+    ):
+        auto_batch.resolve_auto_batch_config(model_context, model_config, train_config)
+
+    assert mock_probe.call_args.kwargs["optimizer_kwargs"] == {"amsgrad": True}
+
+
+def test_resolve_auto_batch_config_does_not_forward_optimizer_kwargs_for_non_adamw():
+    """A non-"adamw" optimizer already gets the mismatched-optimizer warning; forwarding its optimizer_kwargs (which are
+    specific to that other optimizer's constructor, e.g. Lion's) into the AdamW-only shadow optimizer would raise a
+    TypeError instead of just producing an imprecise estimate."""
+    model_context = SimpleNamespace(device=torch.device("cuda"), model=MagicMock())
+    model_config = SimpleNamespace(resolution=64, num_classes=5, amp=False, segmentation_head=True)
+    train_config = SimpleNamespace(
+        batch_size="auto",
+        auto_batch_target_effective=16,
+        lr=1e-4,
+        weight_decay=1e-4,
+        optimizer="sgd",
+        optimizer_kwargs={"momentum": 0.9},
+    )
+    criterion = MagicMock()
+    criterion.to.return_value = criterion
+
+    with (
+        patch("rfdetr.training.auto_batch.torch.cuda.is_available", return_value=True),
+        patch("rfdetr.training.auto_batch.build_criterion_from_config", return_value=(criterion, None)),
+        patch("rfdetr.training.auto_batch.probe_max_micro_batch", return_value=5) as mock_probe,
+        patch("rfdetr.training.auto_batch.torch.cuda.get_device_name", return_value="Fake GPU"),
+        patch("rfdetr.training.auto_batch.logger.warning"),
+    ):
+        auto_batch.resolve_auto_batch_config(model_context, model_config, train_config)
+
+    assert mock_probe.call_args.kwargs["optimizer_kwargs"] is None
 
 
 @patch("rfdetr.detr.is_main_process", return_value=False)
@@ -217,6 +528,10 @@ def test_probe_step_with_real_segmentation_criterion(tmp_path):
     device = torch.device("cuda")
     model = model.to(device)
     criterion = criterion.to(device)
+    trainable_params = [p for p in model.parameters() if p.requires_grad]
+    shadow_optimizer, shadow_params = auto_batch._build_shadow_optimizer(
+        trainable_params, lr=tc.lr, weight_decay=tc.weight_decay
+    )
 
     ok = auto_batch._probe_step(
         model=model,
@@ -226,6 +541,9 @@ def test_probe_step_with_real_segmentation_criterion(tmp_path):
         device=device,
         num_classes=mc.num_classes,
         amp=False,
+        trainable_params=trainable_params,
+        shadow_optimizer=shadow_optimizer,
+        shadow_params=shadow_params,
         segmentation_head=True,
     )
     assert ok is True


### PR DESCRIPTION
## What does this PR do?

`_probe_step`, the core of the `batch_size="auto"` probe, runs forward + loss + `backward()`, but it never called `optimizer.step()`. AdamW (RF-DETR's default, and the only optimizer this fix models) allocates its per-parameter state (`exp_avg`, `exp_avg_sq`, same size as the parameter) lazily, on the first real `step()` call — not at construction, not during forward/backward. So a probe that skips that first step only reports a batch size that's safe for forward+backward, not for the full training step that follows, which does include that first `optimizer.step()`.

My first instinct was to call `optimizer.step()` directly on the model's real parameters, but that's worse than the bug it fixes: it corrupts the weights (possibly a pretrained checkpoint) with an update derived from synthetic-data gradients, before training even starts. I caught this before running anything and checked it deliberately .. reverted to that naive version, confirmed a dummy model's weight moved from `1.0` to `0.9899` after one probe call, and only kept the fix once a test caught that exact corruption.

The fix uses shadow parameters (`_build_shadow_optimizer`): tensors matching the real trainable parameters' shape/dtype/device, but entirely separate, optimized by their own AdamW. Each real gradient (computed against the real model via `backward()`) gets aliased — referenced, not copied — onto its shadow counterpart before every `shadow_optimizer.step()`. That allocates the same `exp_avg`/`exp_avg_sq` memory a real AdamW would, without touching the real model's weights. The shadow optimizer is built once per `probe_max_micro_batch` call and reused, so its state gets allocated on the first successful iteration and stays resident for the rest of the search — the same way real training's optimizer state is allocated once and stays resident for the whole run.

**Known limitation, and I'm calling it out instead of assuming it away:** `configure_optimizers` also supports `train_config.optimizer="sgd"`, third-party names via `pytorch-optimizer` (e.g. `"pytorch_optimizer.Lion"`), and arbitrary dotted-path/callable optimizers — all documented in `docs/learn/train/customization.md`. The shadow step only models AdamW's state (`exp_avg` + `exp_avg_sq`, 2x parameter memory). A different optimizer's real state won't match that (SGD without momentum: 0x; Lion: 1x). So `resolve_auto_batch_config` now logs a warning whenever `train_config.optimizer` isn't the built-in `"adamw"`, to make that blind spot visible instead of silently assuming it's correct. Fully modeling every configurable optimizer's state shape would mean duplicating `configure_optimizers`'s optimizer-resolution logic (native/dotted-path/callable, signature-aware kwarg injection) inside the probe — scoping that out to keep the diff to the AdamW default path, which is what most people run.

**Three correctness fixes from a second review pass, before opening this PR:**

1. `_build_shadow_optimizer` now forwards `train_config.optimizer_kwargs` into the shadow AdamW (only when `optimizer="adamw"`, same guard as the warning above). Without this, `amsgrad=True` — which adds a third `max_exp_avg_sq` state buffer per parameter — was invisible to the probe: `_is_builtin_fused_adamw` only checks the optimizer *name*, so no warning fired either. The estimate under-counted memory, and in the direction that can actually OOM real training.
2. `_probe_step` now clears `shadow_p.grad` right after `shadow_optimizer.step()` consumes it. Before this fix, the aliased reference to that iteration's real gradient tensor stayed alive on `shadow_p.grad` until the *next* iteration's gradient-pairing loop overwrote it. So for one brief window — this iteration's stale gradient plus the next one freshly computed — two full sets of gradient tensors were resident instead of one. That makes the probe pessimistic during exactly the backward pass it's trying to size correctly.
3. `probe_max_micro_batch` now builds the shadow optimizer *inside* the `try/finally`. It used to flip `model.train()`/`criterion.train()` and build the shadow optimizer (a fresh GPU allocation per trainable parameter) before the `try` started. An OOM at that allocation step — plausible for a large model, since it's exactly the memory this PR is about — would propagate without ever restoring the caller's original train/eval mode.

**Related Issue(s):** None, no existing report found.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

Three new tests in `tests/training/test_auto_batch.py` (`TestProbeStepShadowOptimizer`): `test_does_not_mutate_real_model_parameters` (fails against the naive direct-step version, passes with the shadow-parameter fix), `test_populates_shadow_optimizer_state` (confirms the shadow step actually allocates `exp_avg`/`exp_avg_sq`, not a silent no-op from a grad-aliasing bug), and `test_shadow_optimizer_state_reused_not_reallocated_across_iterations` (confirms the same state tensors get reused across probe iterations, not rebuilt each time). `_run_one_probe_step`, the private helper these three share, got its own docstring + doctest, per this repo's rule for non-`test_*` helpers used by tests. Also updated three existing tests: two direct `_probe_step` callers for its new required arguments, plus `test_resolve_auto_batch_config_returns_expected_values`'s mock `train_config`, which was missing the `lr`/`weight_decay` attributes the fix now reads. Two more tests cover the non-AdamW warning: `test_resolve_auto_batch_config_warns_when_optimizer_is_not_builtin_adamw` and `test_resolve_auto_batch_config_does_not_warn_for_builtin_adamw`.

Five more tests for the three correctness fixes above: `test_shadow_grad_cleared_after_step` (grad-aliasing leak), `test_build_shadow_optimizer_forwards_optimizer_kwargs` + `test_resolve_auto_batch_config_forwards_optimizer_kwargs_for_builtin_adamw` / `_does_not_forward_optimizer_kwargs_for_non_adamw` (`optimizer_kwargs` threading, both the positive and negative case — a non-AdamW optimizer's kwargs must NOT reach the AdamW-only shadow optimizer), and `test_probe_max_micro_batch_restores_train_mode_when_shadow_optimizer_build_fails` (train-mode restored even when the shadow optimizer's own construction raises).

I measured real GPU memory on an RTX 4060 (`repro/measure_optimizer_memory_gap.py`, a real `RFDETRSmall` model, 32,111,170 trainable params = 128.4 MB in fp32). Currently-allocated CUDA memory (not peak, which gets dominated by transient activations at this scale) was 314.5 MB right before the shadow step and 703.8 MB right after — a 389.3 MB delta, 3.03x trainable-param memory (shadow params 1x + `exp_avg` 1x + `exp_avg_sq` 1x = 3x, matching the analytical prediction). Deterministic, identical across 2 runs. This measurement predates the three correctness fixes above and isn't affected by them: none of them change steady-state resident memory (the grad-clearing fix removes a transient double-buffer during backward, not a resident allocation; the `optimizer_kwargs` and try/finally fixes are correctness/scope fixes, not memory-shape changes for the plain-AdamW case measured here).

A secondary, weaker measurement (`repro/compare_old_vs_new_probe_at_oom_boundary.py`): with `safety_margin=1.0` on the same real model, the old algorithm (reproduced exactly via monkeypatch) reports `safe_micro_batch=8`, the new one reports `7` — the boundary moved in the expected, more-conservative direction. I also tried to reproduce a real OOM at batch=8 with a real `optimizer.step()` on a model clone, and it didn't crash in this particular run, likely because CUDA's caching allocator had enough fragmented headroom at this scale. This is weaker evidence than the direct memory measurement above, so I'm reporting it as such, not hiding it.

`test_auto_batch.py`: 19/19 (13 from the original fix + 5 from the second review pass + 1 doctest). Full `tests/training/`: 1010 passed, 5 skipped — run in a separate torch 2.9.1/Python 3.11 venv (`envs/venv`, the project's default, currently fails to import `rfdetr` at all, on an unrelated `torch.int1`/torchao version mismatch predating this PR).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

Not applicable for docs: no public API changed (`probe_max_micro_batch`'s two new keyword arguments, `optimizer_lr`/`optimizer_weight_decay`, are additive with defaults).
