### PR TITLE
fix(export): pass CUDA device to ONNX Runtime benchmark

### DIFF
--- a/src/rfdetr/export/benchmark.py
+++ b/src/rfdetr/export/benchmark.py
@@ -507,7 +507,10 @@ def main(
     if path.endswith(".onnx"):
         import onnxruntime as nxrun
 
-        sess = nxrun.InferenceSession(path, providers=["CUDAExecutionProvider"])
+        sess = nxrun.InferenceSession(
+            path,
+            providers=[("CUDAExecutionProvider", {"device_id": device})],
+        )
         infer_onnx(sess, coco_evaluator, time_profile, prefix, img_list, device=f"cuda:{device}", repeats=repeats)
     elif path.endswith((".trt", ".engine")):
         model = TRTInference(path, sync_mode=True, device=f"cuda:{device}")

--- a/tests/inference/test_trt_inference.py
+++ b/tests/inference/test_trt_inference.py
@@ -4,12 +4,15 @@
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
 
+import sys
+from types import ModuleType
 from unittest.mock import Mock
 
 import pytest
 import torch
 from PIL import Image
 
+import rfdetr.export.benchmark as benchmark
 from rfdetr.export.benchmark import TRTInference, infer_transforms
 
 
@@ -53,6 +56,43 @@ class TestTRTInference:
         assert image_tensor.shape == (3, 640, 640)
         assert image_tensor.dtype == torch.float32
         assert target is None
+
+
+class TestBenchmarkMain:
+    @pytest.mark.parametrize(
+        ("device", "expected_torch_device"),
+        [
+            pytest.param(0, "cuda:0", id="default-device"),
+            pytest.param(7, "cuda:7", id="non-default-device"),
+        ],
+    )
+    def test_onnx_benchmark_uses_requested_cuda_device(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        device: int,
+        expected_torch_device: str,
+    ) -> None:
+        """ONNX Runtime and PyTorch should use the requested CUDA device."""
+        session = Mock()
+        inference_session = Mock(return_value=session)
+        onnxruntime = ModuleType("onnxruntime")
+        onnxruntime.InferenceSession = inference_session  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "onnxruntime", onnxruntime)
+
+        monkeypatch.setattr(benchmark, "get_image_list", Mock(return_value=[]))
+        infer_onnx = Mock()
+        monkeypatch.setattr(benchmark, "infer_onnx", infer_onnx)
+
+        benchmark.main("model.onnx", device=device, disable_eval=True)
+
+        inference_session.assert_called_once_with(
+            "model.onnx",
+            providers=[("CUDAExecutionProvider", {"device_id": device})],
+        )
+        infer_onnx.assert_called_once()
+        assert infer_onnx.call_args.args[0] is session
+        assert infer_onnx.call_args.kwargs["device"] == expected_torch_device
+        assert infer_onnx.call_args.kwargs["repeats"] == 1
 
 
 class TestBenchmarkShapeParameterization:


### PR DESCRIPTION
## Why

The ONNX benchmark documents `device` as the CUDA device index and routes PyTorch post-processing to `cuda:{device}`, but the ONNX Runtime session did not receive that device index.

Because the CUDA Execution Provider defaults `device_id` to `0`, requesting a non-default logical device could run ONNX model execution on logical GPU 0 and PyTorch post-processing on another GPU.

A two-GPU Tesla T4 reproduction with `device=1` confirmed that the current implementation selected ORT device 0 and allocated memory on both GPUs.

Fixes #1345

## What changed

- pass the requested logical CUDA index to the ONNX Runtime CUDA Execution Provider
- add regression coverage for both the default device and a non-default logical device
- verify that ONNX Runtime and PyTorch post-processing receive the same requested device index

## Verification

- regression test against the unmodified parent:
  - 2 expected failures because the provider omitted `device_id`
- hard-coded `device_id=0` mutant:
  - rejected by the non-default-device regression case
- focused benchmark tests:
  - `13 passed`
- full CPU suite:
  - `3910 passed, 76 skipped`
- `git diff --check`
- applicable formatting, Ruff, docformatter, codespell, license, and security pre-commit hooks passed

Real CUDA validation:

- RTX 4090:
  - CUDA Execution Provider active
  - six profiled CUDA nodes
  - identical parent/candidate raw and post-processing outputs
- 2 × Tesla T4, requested `device=1`, two repetitions:
  - parent reported `device_id=0`
  - this branch reported `device_id=1`
  - parent memory delta: `[126, 140]` MiB across GPUs 0 and 1
  - this branch memory delta: `[0, 162]` MiB
  - 18 profiled CUDA node events per run
  - identical raw and post-processing output hashes across both implementations and repetitions

Known local baseline:

- project-wide mypy reports four errors in unchanged files:
  `src/rfdetr/export/_topk.py:31-32` and
  `src/rfdetr/evaluation/coco_eval.py:178,190`
- the same four errors reproduce on the clean parent

## Not verified

- the full upstream CUDA/TensorRT CI matrix
- TensorRT engine execution
- Jetson
- a full RF-DETR checkpoint/COCO benchmark

The hardware tests used the exact production session-construction and post-processing path with deterministic ONNX graphs to isolate CUDA device routing.

## Risks / rollback

The change is limited to one existing ONNX Runtime provider option. The default `device=0` behavior is preserved. The TensorRT path is unchanged.

Reverting the commit restores the previous provider configuration.

## Migrations / external effects

None.

## Screenshots / preview

Not applicable; this changes CUDA device routing in the command-line benchmark.