### PR TITLE
Read a scalar CLAHE `clip_limit` as a range, matching albumentations

### DIFF
--- a/src/rfdetr/datasets/aug_configs.py
+++ b/src/rfdetr/datasets/aug_configs.py
@@ -89,7 +89,7 @@ or torchvision defaults. Install it with ``pip install 'rfdetr[augment]'``.
 | ``Blur`` | ``K.RandomBoxBlur`` | Box blur; ``blur_limit`` rounded up to odd, pair collapses to its upper bound |
 | ``Sharpen`` | ``K.RandomSharpness`` | ``sharpness = 1.0 + alpha`` (1.0-pivoted); ``lightness``/``method`` ignored |
 | ``Equalize`` | ``K.RandomEqualize`` | Only ``p`` honored; ``mode``/``by_channels``/``mask`` ignored |
-| ``CLAHE`` | ``K.RandomClahe`` | ``clip_limit`` and ``tile_grid_size`` map directly |
+| ``CLAHE`` | ``K.RandomClahe`` | Scalar ``clip_limit=v`` -> ``(1, v)``; pairs and ``tile_grid_size`` pass through |
 | ``Perspective`` | ``K.RandomPerspective`` | Approximate; see the note below. ``keep_size=False`` raises |
 
 ``Perspective`` is the one entry in the table that is not a faithful mapping. Albumentations samples each

--- a/src/rfdetr/datasets/kornia_transforms.py
+++ b/src/rfdetr/datasets/kornia_transforms.py
@@ -594,18 +594,47 @@ def _make_equalize(params: dict[str, Any]) -> Any:
     return RandomEqualize(p=params.get("p", 0.5))
 
 
+def _as_clahe_clip_limit(value: Any) -> tuple[float, float]:
+    """Normalise ``CLAHE``'s ``clip_limit`` the way Albumentations does.
+
+    Albumentations applies ``to_tuple(clip_limit, low=1)``, so a scalar ``v`` means the range ``(1, v)``. This differs
+    from :func:`_as_range`, which expands a scalar to the degenerate ``(v, v)``; using that here would change the
+    distribution rather than the units.
+
+    Args:
+        value: A scalar, a 1-element sequence, or a 2-element ``(min, max)`` pair.
+
+    Returns:
+        The ``(min, max)`` pair Albumentations would sample from for the same config.
+
+    Examples:
+        >>> _as_clahe_clip_limit(4.0)
+        (1.0, 4.0)
+        >>> _as_clahe_clip_limit((2.0, 6.0))
+        (2.0, 6.0)
+    """
+    if isinstance(value, (list, tuple)) and len(value) == 2:
+        return (float(value[0]), float(value[1]))
+    low, high = _as_range(value)
+    # A scalar (or 1-element sequence) arrives here as the degenerate (v, v).
+    return (1.0, high) if low == high else (low, high)
+
+
 def _make_clahe(params: dict[str, Any]) -> Any:
     """Build a ``K.RandomClahe`` from aug_config ``CLAHE`` params.
 
-    Both parameters map directly: Albumentations' ``clip_limit`` (a scalar or a pair) becomes Kornia's ``clip_limit``
-    range, and ``tile_grid_size`` becomes ``grid_size``.
+    ``tile_grid_size`` becomes ``grid_size`` directly. ``clip_limit`` needs care: Albumentations reads a scalar ``v``
+    as the range ``(1, v)`` and samples from it, not as the fixed value ``v``. Passing it through :func:`_as_range`
+    would produce the degenerate ``(v, v)`` and pin the GPU path to maximum contrast enhancement on every sample while
+    the CPU path varied it — and since ``4.0`` is the default on both sides, that divergence applied to the default
+    configuration rather than only to unusual ones. A pair is already a range and is used as given.
     """
     import kornia.augmentation as kornia_augmentation
 
     random_clahe = cast(Any, kornia_augmentation).RandomClahe
     grid = params.get("tile_grid_size", (8, 8))
     return random_clahe(
-        clip_limit=_as_range(params.get("clip_limit", 4.0)),
+        clip_limit=_as_clahe_clip_limit(params.get("clip_limit", 4.0)),
         grid_size=(int(grid[0]), int(grid[1])),
         p=params.get("p", 0.5),
     )

--- a/src/rfdetr/datasets/kornia_transforms.py
+++ b/src/rfdetr/datasets/kornia_transforms.py
@@ -623,10 +623,10 @@ def _as_clahe_clip_limit(value: Any) -> tuple[float, float]:
 def _make_clahe(params: dict[str, Any]) -> Any:
     """Build a ``K.RandomClahe`` from aug_config ``CLAHE`` params.
 
-    ``tile_grid_size`` becomes ``grid_size`` directly. ``clip_limit`` needs care: Albumentations reads a scalar ``v``
-    as the range ``(1, v)`` and samples from it, not as the fixed value ``v``. Passing it through :func:`_as_range`
-    would produce the degenerate ``(v, v)`` and pin the GPU path to maximum contrast enhancement on every sample while
-    the CPU path varied it — and since ``4.0`` is the default on both sides, that divergence applied to the default
+    ``tile_grid_size`` becomes ``grid_size`` directly. ``clip_limit`` needs care: Albumentations reads a scalar ``v`` as
+    the range ``(1, v)`` and samples from it, not as the fixed value ``v``. Passing it through :func:`_as_range` would
+    produce the degenerate ``(v, v)`` and pin the GPU path to maximum contrast enhancement on every sample while the CPU
+    path varied it — and since ``4.0`` is the default on both sides, that divergence applied to the default
     configuration rather than only to unusual ones. A pair is already a range and is used as given.
     """
     import kornia.augmentation as kornia_augmentation

--- a/src/rfdetr/datasets/kornia_transforms.py
+++ b/src/rfdetr/datasets/kornia_transforms.py
@@ -602,10 +602,16 @@ def _as_clahe_clip_limit(value: Any) -> tuple[float, float]:
     distribution rather than the units.
 
     Args:
-        value: A scalar, a 1-element sequence, or a 2-element ``(min, max)`` pair.
+        value: A scalar, or a 2-element ``(min, max)`` pair.
 
     Returns:
         The ``(min, max)`` pair Albumentations would sample from for the same config.
+
+    Raises:
+        ValueError: If *value* is a sequence of any length other than two. Albumentations validates ``clip_limit`` as
+            either a float or an exact 2-tuple and rejects ``[4.0]``, so accepting it here (as a scalar, via
+            :func:`_as_range`) would make the same config train on the GPU backend and fail on the CPU one. The point
+            of this helper is that the two agree.
 
     Examples:
         >>> _as_clahe_clip_limit(4.0)
@@ -613,11 +619,16 @@ def _as_clahe_clip_limit(value: Any) -> tuple[float, float]:
         >>> _as_clahe_clip_limit((2.0, 6.0))
         (2.0, 6.0)
     """
-    if isinstance(value, (list, tuple)) and len(value) == 2:
+    if isinstance(value, (list, tuple)):
+        if len(value) != 2:
+            raise ValueError(
+                "CLAHE clip_limit must be a scalar or a 2-element (min, max) pair; "
+                f"got a {len(value)}-element sequence: {value!r}. Albumentations rejects this too, so the CPU "
+                "(albumentations) backend would fail on the same config."
+            )
         return (float(value[0]), float(value[1]))
-    low, high = _as_range(value)
-    # A scalar (or 1-element sequence) arrives here as the degenerate (v, v).
-    return (1.0, high) if low == high else (low, high)
+    # A scalar means the range (1, v), which is what `to_tuple(v, low=1)` produces.
+    return (1.0, float(value))
 
 
 def _make_clahe(params: dict[str, Any]) -> Any:

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -469,8 +469,7 @@ class TestBuildKorniaPipeline:
         """A one-element sequence is not a scalar.
 
         Albumentations validates `clip_limit` as a float or an exact 2-tuple and raises on `[4.0]`. Reading it as a
-        scalar here would accept a config the CPU backend refuses, which is the divergence this helper exists to
-        remove.
+        scalar here would accept a config the CPU backend refuses, which is the divergence this helper exists to remove.
         """
         from rfdetr.datasets.kornia_transforms import build_kornia_pipeline
 

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -426,7 +426,9 @@ class TestBuildKorniaPipeline:
         ],
         ids=["default", "scalar-default-value", "scalar", "pair", "pair-non-default"],
     )
-    def test_clahe_scalar_clip_limit_is_a_range_not_a_fixed_value(self, configured, expected) -> None:
+    def test_clahe_scalar_clip_limit_is_a_range_not_a_fixed_value(
+        self, configured: float | tuple[float, float] | None, expected: tuple[float, float]
+    ) -> None:
         """Albumentations reads a scalar clip_limit as (1, v), so the GPU path must too.
 
         Passing it through `_as_range` produced the degenerate (v, v), which pins every sample to maximum contrast
@@ -441,20 +443,39 @@ class TestBuildKorniaPipeline:
 
         assert tuple(transform.clip_limit) == pytest.approx(expected)
 
-    def test_clahe_clip_limit_matches_albumentations(self) -> None:
+    @pytest.mark.parametrize(
+        "configured",
+        [4.0, 2.0, (2.0, 6.0)],
+        ids=["scalar-default-value", "scalar", "pair"],
+    )
+    def test_clahe_clip_limit_matches_albumentations(self, configured: float | tuple[float, float]) -> None:
         """The contract stated directly: same config, same range on both backends."""
         albumentations = pytest.importorskip("albumentations")
 
         from rfdetr.datasets.kornia_transforms import build_kornia_pipeline
 
-        for configured in (4.0, 2.0, (2.0, 6.0)):
-            pipeline = build_kornia_pipeline({"CLAHE": {"clip_limit": configured}}, 560)
-            transform = next(iter(pipeline.children()))
-            cpu = albumentations.CLAHE(clip_limit=configured)
+        pipeline = build_kornia_pipeline({"CLAHE": {"clip_limit": configured}}, 560)
+        transform = next(iter(pipeline.children()))
+        cpu = albumentations.CLAHE(clip_limit=configured)
 
-            assert tuple(transform.clip_limit) == pytest.approx(tuple(cpu.clip_limit)), (
-                f"backends disagree for clip_limit={configured!r}"
-            )
+        assert tuple(transform.clip_limit) == pytest.approx(tuple(cpu.clip_limit)), (
+            f"backends disagree for clip_limit={configured!r}"
+        )
+
+    @pytest.mark.parametrize("configured", [[4.0], (4.0,), (1.0, 2.0, 3.0)], ids=["one-list", "one-tuple", "three"])
+    def test_clahe_rejects_sequences_that_albumentations_rejects(
+        self, configured: tuple[float, ...] | list[float]
+    ) -> None:
+        """A one-element sequence is not a scalar.
+
+        Albumentations validates `clip_limit` as a float or an exact 2-tuple and raises on `[4.0]`. Reading it as a
+        scalar here would accept a config the CPU backend refuses, which is the divergence this helper exists to
+        remove.
+        """
+        from rfdetr.datasets.kornia_transforms import build_kornia_pipeline
+
+        with pytest.raises(ValueError, match="2-element"):
+            build_kornia_pipeline({"CLAHE": {"clip_limit": configured}}, 560)
 
     def test_hue_saturation_value_still_unsupported(self):
         """Deliberately out of scope: albumentations shifts additively, Kornia scales multiplicatively."""

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -418,13 +418,12 @@ class TestBuildKorniaPipeline:
     @pytest.mark.parametrize(
         "configured,expected",
         [
-            (None, (1.0, 4.0)),
-            (4.0, (1.0, 4.0)),
-            (2.0, (1.0, 2.0)),
-            ((1.0, 4.0), (1.0, 4.0)),
-            ((2.0, 6.0), (2.0, 6.0)),
+            pytest.param(None, (1.0, 4.0), id="default"),
+            pytest.param(4.0, (1.0, 4.0), id="scalar-default-value"),
+            pytest.param(2.0, (1.0, 2.0), id="scalar"),
+            pytest.param((1.0, 4.0), (1.0, 4.0), id="pair"),
+            pytest.param((2.0, 6.0), (2.0, 6.0), id="pair-non-default"),
         ],
-        ids=["default", "scalar-default-value", "scalar", "pair", "pair-non-default"],
     )
     def test_clahe_scalar_clip_limit_is_a_range_not_a_fixed_value(
         self, configured: float | tuple[float, float] | None, expected: tuple[float, float]
@@ -445,8 +444,12 @@ class TestBuildKorniaPipeline:
 
     @pytest.mark.parametrize(
         "configured",
-        [4.0, 2.0, (2.0, 6.0), [1.0, 4.0]],
-        ids=["scalar-default-value", "scalar", "pair", "list-pair"],
+        [
+            pytest.param(4.0, id="scalar-default-value"),
+            pytest.param(2.0, id="scalar"),
+            pytest.param((2.0, 6.0), id="pair"),
+            pytest.param([1.0, 4.0], id="list-pair"),
+        ],
     )
     def test_clahe_clip_limit_matches_albumentations(
         self, configured: float | tuple[float, float] | list[float]
@@ -464,7 +467,14 @@ class TestBuildKorniaPipeline:
             f"backends disagree for clip_limit={configured!r}"
         )
 
-    @pytest.mark.parametrize("configured", [[4.0], (4.0,), (1.0, 2.0, 3.0)], ids=["one-list", "one-tuple", "three"])
+    @pytest.mark.parametrize(
+        "configured",
+        [
+            pytest.param([4.0], id="one-list"),
+            pytest.param((4.0,), id="one-tuple"),
+            pytest.param((1.0, 2.0, 3.0), id="three"),
+        ],
+    )
     def test_clahe_rejects_sequences_that_albumentations_rejects(
         self, configured: tuple[float, ...] | list[float]
     ) -> None:

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -429,9 +429,9 @@ class TestBuildKorniaPipeline:
     def test_clahe_scalar_clip_limit_is_a_range_not_a_fixed_value(self, configured, expected) -> None:
         """Albumentations reads a scalar clip_limit as (1, v), so the GPU path must too.
 
-        Passing it through `_as_range` produced the degenerate (v, v), which pins every
-        sample to maximum contrast enhancement while the CPU path varies it. 4.0 is the
-        default on both sides, so that divergence applied with no user config at all.
+        Passing it through `_as_range` produced the degenerate (v, v), which pins every sample to maximum contrast
+        enhancement while the CPU path varies it. 4.0 is the default on both sides, so that divergence applied with no
+        user config at all.
         """
         from rfdetr.datasets.kornia_transforms import build_kornia_pipeline
 

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -415,6 +415,47 @@ class TestBuildKorniaPipeline:
         # `clip_limit` attribute (set directly from the constructor arg), so no private access needed.
         assert tuple(transform.clip_limit) == pytest.approx((2.0, 6.0))
 
+    @pytest.mark.parametrize(
+        "configured,expected",
+        [
+            (None, (1.0, 4.0)),
+            (4.0, (1.0, 4.0)),
+            (2.0, (1.0, 2.0)),
+            ((1.0, 4.0), (1.0, 4.0)),
+            ((2.0, 6.0), (2.0, 6.0)),
+        ],
+        ids=["default", "scalar-default-value", "scalar", "pair", "pair-non-default"],
+    )
+    def test_clahe_scalar_clip_limit_is_a_range_not_a_fixed_value(self, configured, expected) -> None:
+        """Albumentations reads a scalar clip_limit as (1, v), so the GPU path must too.
+
+        Passing it through `_as_range` produced the degenerate (v, v), which pins every
+        sample to maximum contrast enhancement while the CPU path varies it. 4.0 is the
+        default on both sides, so that divergence applied with no user config at all.
+        """
+        from rfdetr.datasets.kornia_transforms import build_kornia_pipeline
+
+        params = {} if configured is None else {"clip_limit": configured}
+        pipeline = build_kornia_pipeline({"CLAHE": params}, 560)
+        transform = next(iter(pipeline.children()))
+
+        assert tuple(transform.clip_limit) == pytest.approx(expected)
+
+    def test_clahe_clip_limit_matches_albumentations(self) -> None:
+        """The contract stated directly: same config, same range on both backends."""
+        albumentations = pytest.importorskip("albumentations")
+
+        from rfdetr.datasets.kornia_transforms import build_kornia_pipeline
+
+        for configured in (4.0, 2.0, (2.0, 6.0)):
+            pipeline = build_kornia_pipeline({"CLAHE": {"clip_limit": configured}}, 560)
+            transform = next(iter(pipeline.children()))
+            cpu = albumentations.CLAHE(clip_limit=configured)
+
+            assert tuple(transform.clip_limit) == pytest.approx(tuple(cpu.clip_limit)), (
+                f"backends disagree for clip_limit={configured!r}"
+            )
+
     def test_hue_saturation_value_still_unsupported(self):
         """Deliberately out of scope: albumentations shifts additively, Kornia scales multiplicatively."""
         from rfdetr.datasets.kornia_transforms import build_kornia_pipeline

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -445,10 +445,12 @@ class TestBuildKorniaPipeline:
 
     @pytest.mark.parametrize(
         "configured",
-        [4.0, 2.0, (2.0, 6.0)],
-        ids=["scalar-default-value", "scalar", "pair"],
+        [4.0, 2.0, (2.0, 6.0), [1.0, 4.0]],
+        ids=["scalar-default-value", "scalar", "pair", "list-pair"],
     )
-    def test_clahe_clip_limit_matches_albumentations(self, configured: float | tuple[float, float]) -> None:
+    def test_clahe_clip_limit_matches_albumentations(
+        self, configured: float | tuple[float, float] | list[float]
+    ) -> None:
         """The contract stated directly: same config, same range on both backends."""
         albumentations = pytest.importorskip("albumentations")
 


### PR DESCRIPTION
Fixes #1349.

## The bug

Albumentations applies `to_tuple(clip_limit, low=1)`, so a scalar `v` means the **range** `(1, v)` and it samples from it per call. `_make_clahe` routed the value through `_as_range`, which expands a scalar to the degenerate `(v, v)`.

`4.0` is the default on both sides, so this applied with no user configuration at all:

| aug_config | before | after | albumentations |
|---|---|---|---|
| `{}` (default) | `(4.0, 4.0)` | `(1.0, 4.0)` | `(1.0, 4.0)` |
| `{"clip_limit": 4.0}` | `(4.0, 4.0)` | `(1.0, 4.0)` | `(1.0, 4.0)` |
| `{"clip_limit": 2.0}` | `(2.0, 2.0)` | `(1.0, 2.0)` | `(1.0, 2.0)` |
| `{"clip_limit": (2.0, 6.0)}` | `(2.0, 6.0)` | `(2.0, 6.0)` | `(2.0, 6.0)` |

Only the explicit-pair form agreed. Every scalar form, including the default, pinned the GPU path to maximum contrast enhancement on every sample while the CPU path varied it — a silent train/serve divergence with no warning, since from the code's point of view nothing was being collapsed.

This came in with #1277, which added the CLAHE mapping. Mine.

## The fix

A dedicated `_as_clahe_clip_limit` rather than a special case inside `_as_range`: the helper is correct about what it does and is used by transforms whose scalar semantics really are `(v, v)`. Changing it there would have fixed CLAHE and broken the others.

A pair is used as given, so only the scalar form changes.

## Scope

I checked the other `_as_range` call sites for the same class of mismatch:

- **`Sharpen`** (`alpha`) and **`GaussNoise`** (`std_range`) — albumentations rejects a scalar for both with `ValueError`, so there is no scalar form to disagree about. Safe.
- **`GaussianBlur`** (`sigma`) — albumentations expands a scalar `sigma_limit` to `(0, v)`, so the same gap exists, but only when a user passes a scalar; the configured default is already a pair. Left out of this PR deliberately — happy to fold it in here or do it separately, whichever you prefer.

## Verification

Nine assertions, all five configured forms plus direct parity against albumentations:

```
ok  param=None       -> (1.0, 4.0)
ok  param=4.0        -> (1.0, 4.0)
ok  param=2.0        -> (1.0, 2.0)
ok  param=(1.0, 4.0) -> (1.0, 4.0)
ok  param=(2.0, 6.0) -> (2.0, 6.0)
--- parity with albumentations ---
ok  clip_limit=4.0        kornia=(1.0, 4.0) albu=(1.0, 4.0)
ok  clip_limit=2.0        kornia=(1.0, 2.0) albu=(1.0, 2.0)
ok  clip_limit=(2.0, 6.0) kornia=(2.0, 6.0) albu=(2.0, 6.0)
```

The three scalar cases fail on the parent commit:

```
FAIL param=None  -> (4.0, 4.0)  expected (1.0, 4.0)
FAIL param=4.0   -> (4.0, 4.0)  expected (1.0, 4.0)
FAIL param=2.0   -> (2.0, 2.0)  expected (1.0, 2.0)
```

`test_clahe_maps_both_parameters` still passes — `grid_size` and the explicit pair are unaffected.

`ruff check` and `ruff format --check` clean on both files. `pytest` cannot collect the module in my environment (`transformers` is missing `BackboneConfigMixin`, unrelated to this diff), so I exercised the factory directly; CI here will be the better check.
