### PR TITLE
refactor: type-check package root

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -405,7 +405,6 @@ overrides = [
   { module = ["rfdetr.utilities.console"], warn_unused_ignores = false },
   # Modules with pre-existing type errors — ignored until incrementally fixed.
   { module = [
-    "rfdetr",
     "rfdetr.config",
     "rfdetr.datasets.coco",
     "rfdetr.datasets.synthetic",

--- a/src/rfdetr/__init__.py
+++ b/src/rfdetr/__init__.py
@@ -20,6 +20,8 @@ import importlib.machinery
 import importlib.util
 import os
 import sys
+from collections.abc import Sequence
+from types import ModuleType
 from typing import Any
 
 # np.complex_ was removed in NumPy 2.0 (June 2024) but some transitive dependencies (e.g. older tensorflow, chumpy)
@@ -36,7 +38,7 @@ except ImportError:
 if _IS_NUMPY_INSTALLED and not hasattr(numpy, "complex_"):
     _complex128 = getattr(numpy, "complex128", None)
     if _complex128 is not None:
-        numpy.complex_ = _complex128
+        setattr(numpy, "complex_", _complex128)
 
 
 from rfdetr.detr import RFDETR
@@ -114,8 +116,8 @@ class _RemovedModuleFinder(importlib.abc.MetaPathFinder):
     def find_spec(
         self,
         fullname: str,
-        path: list[str] | None,
-        target: object | None = None,
+        path: Sequence[str] | None,
+        target: ModuleType | None = None,
     ) -> importlib.machinery.ModuleSpec | None:
         """Return a failing spec with a migration hint for removed legacy modules."""
         if not fullname.startswith(f"{__name__}."):
@@ -136,10 +138,10 @@ _REMOVED_MODULE_FINDER = _RemovedModuleFinder()
 
 if not getattr(sys, "_rfdetr_removed_finder", False):
     sys.meta_path.insert(0, _REMOVED_MODULE_FINDER)
-    sys._rfdetr_removed_finder = True
+    setattr(sys, "_rfdetr_removed_finder", True)
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> Any:
     """Lazily resolve training/PTL and plus-only exports and handle removed-module aliases.
 
     This hook is only invoked on explicit attribute access (e.g. ``rfdetr.RFDETRModelModule``) and supports three


### PR DESCRIPTION
## Summary

- remove the stale mypy exclusion for the `rfdetr` package root
- match the removed-module finder signature to `MetaPathFinder`
- type dynamic compatibility assignments and lazy package exports

Part of #564.

## Test

- `uv run --no-sync mypy src/rfdetr/ --no-error-summary` in the CI Python 3.10 environment
- `uv run --no-sync pytest tests/utilities/test_package.py -q` (31 passed)
- `SKIP=mypy pre-commit run --all-files` (all remaining hooks passed)