### PR TITLE
Type-check rfdetr.datasets.synthetic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -408,7 +408,6 @@ overrides = [
     "rfdetr",
     "rfdetr.config",
     "rfdetr.datasets.coco",
-    "rfdetr.datasets.synthetic",
     "rfdetr.datasets.transforms",
   ], ignore_errors = true },
 ]

--- a/src/rfdetr/datasets/synthetic.py
+++ b/src/rfdetr/datasets/synthetic.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Literal
 
 import numpy as np
+from numpy.typing import NDArray
 from PIL import Image
 from supervision import Color, Detections, box_iou_batch, draw_filled_polygon
 from tqdm.auto import tqdm
@@ -42,7 +43,7 @@ class DatasetSplitRatios:
     val: float = 0.2
     test: float = 0.1
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Validate that ratios sum to approximately 1.0 and are non-negative."""
         total = self.train + self.val + self.test
         if any(r < 0 for r in [self.train, self.val, self.test]):
@@ -223,8 +224,8 @@ def generate_synthetic_sample(
     color_names = list(SYNTHETIC_COLORS.keys())
     num_objects = random.randint(min_objects, max_objects)
 
-    xyxys = []
-    class_ids = []
+    xyxys: list[NDArray[np.float64]] = []
+    class_ids: list[int] = []
     polygons: list[list[float]] = []
     failed_attempts = 0
     max_failed_attempts = 3  # Allow some failures before reducing target count
@@ -374,10 +375,22 @@ def _write_coco_json(
                 )
         else:
             polygon_data = np.empty(0, dtype=object)
+        # Detections.class_id is Optional. Every detection written here needs one, so a
+        # missing array with detections present is a caller error rather than something to
+        # default silently; with no detections the loop below never runs and an empty array
+        # keeps the type non-optional without a narrowing assert.
+        detection_class_ids = detections.class_id
+        if detection_class_ids is None:
+            if len(detections):
+                raise ValueError(
+                    f"Detections for image index {img_id} (file: {file_path}) have no class_id, "
+                    "which is required to write COCO annotations"
+                )
+            detection_class_ids = np.empty((0,), dtype=int)
         for det_idx in range(len(detections)):
             x1, y1, x2, y2 = (float(v) for v in detections.xyxy[det_idx])
             w, h_box = x2 - x1, y2 - y1
-            class_id = int(detections.class_id[det_idx])
+            class_id = int(detection_class_ids[det_idx])
             if class_id < 0 or class_id >= len(classes):
                 raise ValueError(
                     f"Invalid class_id {class_id} for detection index {det_idx} "


### PR DESCRIPTION
Refs #564. Takes `rfdetr.datasets.synthetic` off the `ignore_errors` list — claimed on the issue first, and nothing else was open against it.

## Three real errors

**`__post_init__` had no return annotation** — `-> None`.

**`xyxys` and `class_ids` had no element type.** Annotated from what they actually collect: `bbox_from_polygon` is a float64 array, `category_id` is an `int` from a `.index()` call.

**`Detections.class_id` is `Optional` and was indexed without a guard.** This is the only one with a behaviour question attached, so:

```python
detection_class_ids = detections.class_id
if detection_class_ids is None:
    if len(detections):
        raise ValueError(...)
    detection_class_ids = np.empty((0,), dtype=int)
```

Raising when detections are present is the honest option — a COCO annotation cannot be written without a class id, and defaulting to `0` would put wrong labels in the file rather than failing. With no detections the loop never runs, and the empty array keeps the type non-optional without a narrowing `assert`.

Conventions followed from the modules already done: `from numpy.typing import NDArray` with a parameterised dtype, as in `datasets/yolo.py` and `evaluation/f1_sweep.py`.

## A note on the error count, since it might not match yours

Running mypy here first reported eight errors, four of which were:

```
error: Module "supervision" does not explicitly export attribute "Color"  [attr-defined]
```

Those were my environment, not this module — my `supervision` was 0.25.1 against the `>=0.29.0` pin in `pyproject.toml`, and 0.25.1 has no `__all__`. `datasets/save_grids.py`, which is already off the ignore list, produced the same four. Upgrading to 0.30.0 cleared them, so nothing in this PR works around them.

## Verification

```
mypy src/rfdetr/datasets/synthetic.py   ->  no errors
ruff check / ruff format --check        ->  clean
```

`pytest` cannot collect in my environment — `transformers` here is missing `BackboneConfigMixin`, which is unrelated to this diff and blocks any test that imports the package root. CI will be the better check on `tests/datasets/test_synthetic.py`.

Four modules left after this one: `rfdetr`, `rfdetr.config`, `rfdetr.datasets.coco`, `rfdetr.datasets.transforms`. Happy to keep going if the approach here looks right.
