### PR TITLE
perf(callbacks): keep mAP state on CPU

### DIFF
--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -48,6 +48,9 @@ from rfdetr.utilities.logger import get_logger
 
 logger = get_logger()
 
+# torchmetrics 1.8.2 MeanAveragePrecision.update() reads only these fields. Re-verify this read set on upgrade.
+_METRIC_INPUT_FIELDS = frozenset({"boxes", "scores", "labels", "masks", "iscrowd", "area"})
+
 
 def _warn_missing_rich_once(warning_emitted: bool) -> bool:
     """Warn once when metric table rendering is skipped because Rich is unavailable.
@@ -1401,12 +1404,14 @@ class COCOEvalCallback(Callback):
             targets: Per-image target dicts normalized for ``MeanAveragePrecision``.
 
         Returns:
-            CPU copies of the prediction and target dicts, preserving every metric field and per-image order.
+            CPU copies of the supported mAP fields, preserving their per-image order.
         """
 
         def move_items(items: list[dict[str, Tensor]]) -> list[dict[str, Tensor]]:
-            # Do not pass accelerator tensors directly to `metric.update()`: TorchMetrics later calls `.cpu()` per
-            # annotation during `compute()`. Copying each field once per batch keeps its stored state on CPU instead.
-            return [{name: value.detach().cpu() for name, value in item.items()} for item in items]
+            # Excluding PostProcess-only fields avoids D2H copies that torchmetrics never consumes, such as keypoints.
+            return [
+                {name: value.detach().cpu() for name, value in item.items() if name in _METRIC_INPUT_FIELDS}
+                for item in items
+            ]
 
         return move_items(preds), move_items(targets)

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -313,7 +313,7 @@ class COCOEvalCallback(Callback):
         self._f1_local = init_matching_accumulator()
         self._reset_keypoint_split("val")
         self._reset_keypoint_split("val_ema")
-        self._prepare_ema_metric(trainer, pl_module)
+        self._prepare_ema_metric(trainer)
 
     def on_test_epoch_start(self, trainer: Any, pl_module: Any) -> None:
         """Reset ``_ema_has_updates`` before test to prevent stale validation state from triggering EMA compute.
@@ -331,7 +331,7 @@ class COCOEvalCallback(Callback):
         self.map_metric.reset()
         self._f1_local = init_matching_accumulator()
         self._reset_keypoint_split("test")
-        self._prepare_ema_metric(trainer, pl_module)
+        self._prepare_ema_metric(trainer)
 
     def on_train_batch_end(
         self,
@@ -351,6 +351,8 @@ class COCOEvalCallback(Callback):
             batch_idx: Batch index within the training epoch.
         """
         if getattr(getattr(pl_module, "train_config", None), "compute_train_metrics", False) is not True:
+            return
+        if self._eval_interval > 1 and not self._is_metric_epoch(trainer):
             return
         if not isinstance(outputs, dict) or "results" not in outputs or "targets" not in outputs:
             return
@@ -388,16 +390,29 @@ class COCOEvalCallback(Callback):
             self._f1_train_local = init_matching_accumulator()
             self._reset_keypoint_split("train")
             return
-        if self._eval_interval > 1:
-            current_epoch = int(getattr(trainer, "current_epoch", 0)) + 1
-            max_epochs = getattr(trainer, "max_epochs", None)
-            is_last_epoch = isinstance(max_epochs, int) and max_epochs > 0 and current_epoch >= max_epochs
-            if current_epoch % self._eval_interval != 0 and not is_last_epoch:
-                self.map_metric_train.reset()
-                self._f1_train_local = init_matching_accumulator()
-                self._reset_keypoint_split("train")
-                return
+        if self._eval_interval > 1 and not self._is_metric_epoch(trainer):
+            self.map_metric_train.reset()
+            self._f1_train_local = init_matching_accumulator()
+            self._reset_keypoint_split("train")
+            return
         self._compute_and_log(trainer, pl_module, "train", metric=self.map_metric_train)
+
+    def _is_metric_epoch(self, trainer: Any) -> bool:
+        """Decide whether the current epoch falls on an ``_eval_interval`` boundary (or is the final epoch).
+
+        Shared by :meth:`on_train_batch_end` (skip accumulation on non-eval epochs) and
+        :meth:`on_train_epoch_end` (skip compute/log and reset accumulators instead).
+
+        Args:
+            trainer: The PTL Trainer.
+
+        Returns:
+            ``True`` when this epoch should accumulate and log train metrics.
+        """
+        current_epoch = int(getattr(trainer, "current_epoch", 0)) + 1
+        max_epochs = getattr(trainer, "max_epochs", None)
+        is_last_epoch = isinstance(max_epochs, int) and max_epochs > 0 and current_epoch >= max_epochs
+        return current_epoch % self._eval_interval == 0 or is_last_epoch
 
     def on_validation_batch_end(
         self,
@@ -851,7 +866,7 @@ class COCOEvalCallback(Callback):
             for metric_logger, previous_level in previous_levels:
                 metric_logger.setLevel(previous_level)
 
-    def _prepare_ema_metric(self, trainer: Any, pl_module: Any) -> None:
+    def _prepare_ema_metric(self, trainer: Any) -> None:
         """Ensure ``map_metric_ema`` exists (and is reset) on EVERY rank when EMA is active.
 
         Driven by the rank-invariant presence of the EMA callback rather than by per-batch state, so any cross-rank
@@ -861,7 +876,6 @@ class COCOEvalCallback(Callback):
 
         Args:
             trainer: The PTL Trainer.
-            pl_module: The LightningModule passed by the callback lifecycle hook (unused).
         """
         self._ema_has_updates = False
         if self._get_ema_callback(trainer) is None:

--- a/src/rfdetr/training/callbacks/coco_eval.py
+++ b/src/rfdetr/training/callbacks/coco_eval.py
@@ -365,7 +365,8 @@ class COCOEvalCallback(Callback):
                 )
                 self._train_segm_skip_warned = True
             return
-        self.map_metric_train.update(preds, targets)
+        metric_preds, metric_targets = self._move_metric_inputs_to_cpu(preds, targets)
+        self.map_metric_train.update(metric_preds, metric_targets)
 
         iou_type = "segm" if self._use_segm_metrics else "bbox"
         batch_matching = build_matching_data(preds, targets, iou_threshold=0.5, iou_type=iou_type)
@@ -433,6 +434,7 @@ class COCOEvalCallback(Callback):
             return
         preds: list[dict[str, Tensor]] = self._convert_preds(outputs["results"])
         targets = self._convert_targets(outputs["targets"], preds if self._use_segm_metrics else None)
+        metric_preds, metric_targets = self._move_metric_inputs_to_cpu(preds, targets)
 
         # ema_cb._average_model availability is rank-invariant (EMA updates fire on the same
         # global step on every rank), so per-rank EMA-forward decisions stay consistent.
@@ -441,10 +443,10 @@ class COCOEvalCallback(Callback):
         used_ema_forward = self._eval_ema_only and ema_inner is not None
         if used_ema_forward:
             if self.map_metric_ema is not None:
-                self.map_metric_ema.update(preds, targets)
+                self.map_metric_ema.update(metric_preds, metric_targets)
                 self._ema_has_updates = True
         else:
-            self.map_metric.update(preds, targets)
+            self.map_metric.update(metric_preds, metric_targets)
 
         iou_type = "segm" if self._use_segm_metrics else "bbox"
         batch_matching = build_matching_data(preds, targets, iou_threshold=0.5, iou_type=iou_type)
@@ -470,7 +472,8 @@ class COCOEvalCallback(Callback):
                 ema_results = pl_module.postprocess(ema_outputs, orig_sizes)
             ema_preds = self._convert_preds(ema_results)
             ema_targets = self._convert_targets(outputs["targets"], ema_preds if self._use_segm_metrics else None)
-            self.map_metric_ema.update(ema_preds, ema_targets)
+            ema_metric_preds, ema_metric_targets = self._move_metric_inputs_to_cpu(ema_preds, ema_targets)
+            self.map_metric_ema.update(ema_metric_preds, ema_metric_targets)
             self._update_keypoint_oks_metric(
                 trainer,
                 {"results": ema_results, "targets": outputs["targets"]},
@@ -526,7 +529,8 @@ class COCOEvalCallback(Callback):
         preds: list[dict[str, Tensor]] = self._convert_preds(outputs["results"])
         targets = self._convert_targets(outputs["targets"], preds if self._use_segm_metrics else None)
 
-        self.map_metric.update(preds, targets)
+        metric_preds, metric_targets = self._move_metric_inputs_to_cpu(preds, targets)
+        self.map_metric.update(metric_preds, metric_targets)
 
         iou_type = "segm" if self._use_segm_metrics else "bbox"
         batch_matching = build_matching_data(preds, targets, iou_threshold=0.5, iou_type=iou_type)
@@ -854,7 +858,7 @@ class COCOEvalCallback(Callback):
 
         Args:
             trainer: The PTL Trainer.
-            pl_module: The LightningModule (provides the device for metric placement).
+            pl_module: The LightningModule passed by the callback lifecycle hook (unused).
         """
         self._ema_has_updates = False
         if self._get_ema_callback(trainer) is None:
@@ -868,7 +872,7 @@ class COCOEvalCallback(Callback):
                 max_detection_thresholds=[1, 10, self._max_dets],
                 backend="faster_coco_eval",
                 sync_on_compute=False,  # we merge state across ranks ourselves (see map_metric in setup)
-            ).to(pl_module.device)
+            )
         else:
             self.map_metric_ema.reset()
 
@@ -1381,3 +1385,28 @@ class COCOEvalCallback(Callback):
                 entry["iscrowd"] = t["iscrowd"]
             out.append(entry)
         return out
+
+    @staticmethod
+    def _move_metric_inputs_to_cpu(
+        preds: list[dict[str, Tensor]], targets: list[dict[str, Tensor]]
+    ) -> tuple[list[dict[str, Tensor]], list[dict[str, Tensor]]]:
+        """Return detached CPU copies of mAP inputs so TorchMetrics stores CPU metric state.
+
+        TorchMetrics converts every stored annotation to a Python COCO record during ``compute()``. Keeping this state
+        on CPU makes those internal ``.cpu()`` calls no-ops while leaving the original GPU tensors available to the
+        F1 and keypoint paths that run in the validation batch hook.
+
+        Args:
+            preds: Per-image prediction dicts normalized for ``MeanAveragePrecision``.
+            targets: Per-image target dicts normalized for ``MeanAveragePrecision``.
+
+        Returns:
+            CPU copies of the prediction and target dicts, preserving every metric field and per-image order.
+        """
+
+        def move_items(items: list[dict[str, Tensor]]) -> list[dict[str, Tensor]]:
+            # Do not pass accelerator tensors directly to `metric.update()`: TorchMetrics later calls `.cpu()` per
+            # annotation during `compute()`. Copying each field once per batch keeps its stored state on CPU instead.
+            return [{name: value.detach().cpu() for name, value in item.items()} for item in items]
+
+        return move_items(preds), move_items(targets)

--- a/tests/training/callbacks/test_coco_eval_callback.py
+++ b/tests/training/callbacks/test_coco_eval_callback.py
@@ -348,8 +348,7 @@ class TestMetricStateInputs:
     """CPU mAP state conversion at the TorchMetrics boundary."""
 
     def test_move_metric_inputs_to_cpu_preserves_metric_fields(self) -> None:
-        """CPU conversion preserves every prediction and target field, including masks, and detaches state that still
-        requires grad.
+        """CPU conversion retains only mAP fields, including masks, and detaches state that still requires grad.
 
         Feeds ``_move_metric_inputs_to_cpu`` the same shape it receives in production — ``_convert_preds``/
         ``_convert_targets`` output (``boxes``/``labels``/``masks``, no ``orig_size``) — instead of the raw pre-
@@ -362,6 +361,8 @@ class TestMetricStateInputs:
         raw_preds = _detection_preds(1)
         raw_preds[0]["boxes"].requires_grad_(True)
         raw_preds[0]["masks"] = torch.zeros(1, 4, 4, dtype=torch.bool)
+        raw_preds[0]["keypoints"] = torch.zeros(1, 1, 3)
+        raw_preds[0]["keypoint_precision_cholesky"] = torch.zeros(1, 1, 3, 3)
         raw_targets = _detection_targets()
         raw_targets[0]["masks"] = torch.zeros(1, 4, 4, dtype=torch.bool)
 
@@ -369,11 +370,13 @@ class TestMetricStateInputs:
         targets = cb._convert_targets(raw_targets, preds)
         metric_preds, metric_targets = cb._move_metric_inputs_to_cpu(preds, targets)
 
-        assert metric_preds[0].keys() == preds[0].keys()
+        assert metric_preds[0].keys() == {"boxes", "scores", "labels", "masks"}
         assert metric_targets[0].keys() == targets[0].keys()
         assert metric_preds[0] is not preds[0]
         assert metric_targets[0] is not targets[0]
         assert "orig_size" not in metric_targets[0]
+        assert "keypoints" not in metric_preds[0]
+        assert "keypoint_precision_cholesky" not in metric_preds[0]
         torch.testing.assert_close(metric_preds[0]["boxes"], preds[0]["boxes"].detach())
         torch.testing.assert_close(metric_targets[0]["boxes"], targets[0]["boxes"])
         torch.testing.assert_close(metric_preds[0]["masks"], preds[0]["masks"])

--- a/tests/training/callbacks/test_coco_eval_callback.py
+++ b/tests/training/callbacks/test_coco_eval_callback.py
@@ -157,10 +157,8 @@ class TestSetup:
         """The EMA metric mirrors the per-class computation flag."""
         cb = COCOEvalCallback(log_per_class_metrics=False)
         cb.setup(_make_trainer(), _make_pl_module(), stage="fit")
-        module = _make_pl_module()
-        module.device = torch.device("cpu")
         with patch.object(cb, "_get_ema_callback", return_value=MagicMock()):
-            cb._prepare_ema_metric(_make_trainer(), module)
+            cb._prepare_ema_metric(_make_trainer())
         assert cb.map_metric_ema is not None
         assert cb.map_metric_ema.class_metrics is False
 
@@ -168,11 +166,9 @@ class TestSetup:
         """The EMA metric itself remains on CPU because its accumulated state is CPU-only."""
         cb = COCOEvalCallback()
         cb.setup(_make_trainer(), _make_pl_module(), stage="fit")
-        module = _make_pl_module()
-        module.device = torch.device("meta")
 
         with patch.object(cb, "_get_ema_callback", return_value=MagicMock()):
-            cb._prepare_ema_metric(_make_trainer(), module)
+            cb._prepare_ema_metric(_make_trainer())
 
         assert cb.map_metric_ema is not None
         assert cb.map_metric_ema.device.type == "cpu"
@@ -558,6 +554,43 @@ class TestOnTrainBatchEnd:
         outputs = {"results": [], "targets": _detection_targets()}
 
         cb.on_train_batch_end(_make_trainer(), module, outputs, None, 0)
+
+        cb.map_metric_train.update.assert_called_once()
+
+    def test_train_batch_end_skips_accumulation_on_non_matching_epoch(self) -> None:
+        """With eval_interval>1, batches on non-interval epochs must not pay accumulation cost.
+
+        Regression guard: previously every train batch ran the CPU-syncing accumulation block even
+        on epochs whose accumulated state on_train_epoch_end discards unread, wasting a blocking
+        .cpu() sync (and matching-data work) on every skipped epoch.
+        """
+        cb = COCOEvalCallback(eval_interval=3)
+        trainer = _make_trainer()
+        trainer.current_epoch = 0  # epoch 1 (1-based) is not divisible by 3
+        trainer.max_epochs = 10
+        cb.setup(trainer, _make_pl_module(), stage="fit")
+        cb.map_metric_train = MagicMock(name="map_metric_train")
+        module = _make_pl_module()
+        module.train_config = SimpleNamespace(compute_train_metrics=True)
+        outputs = {"results": _detection_preds(1), "targets": _detection_targets()}
+
+        cb.on_train_batch_end(trainer, module, outputs, None, 0)
+
+        cb.map_metric_train.update.assert_not_called()
+
+    def test_train_batch_end_accumulates_on_matching_epoch(self) -> None:
+        """With eval_interval>1, batches on interval-aligned epochs still accumulate normally."""
+        cb = COCOEvalCallback(eval_interval=3)
+        trainer = _make_trainer()
+        trainer.current_epoch = 2  # epoch 3 (1-based) is divisible by 3
+        trainer.max_epochs = 10
+        cb.setup(trainer, _make_pl_module(), stage="fit")
+        cb.map_metric_train = MagicMock(name="map_metric_train")
+        module = _make_pl_module()
+        module.train_config = SimpleNamespace(compute_train_metrics=True)
+        outputs = {"results": _detection_preds(1), "targets": _detection_targets()}
+
+        cb.on_train_batch_end(trainer, module, outputs, None, 0)
 
         cb.map_metric_train.update.assert_called_once()
 

--- a/tests/training/callbacks/test_coco_eval_callback.py
+++ b/tests/training/callbacks/test_coco_eval_callback.py
@@ -348,20 +348,86 @@ class TestMetricStateInputs:
     """CPU mAP state conversion at the TorchMetrics boundary."""
 
     def test_move_metric_inputs_to_cpu_preserves_metric_fields(self) -> None:
-        """CPU conversion preserves every prediction and target field while detaching metric state."""
-        cb = COCOEvalCallback()
-        preds = _detection_preds(1)
-        targets = _detection_targets()
+        """CPU conversion preserves every prediction and target field, including masks, and detaches state that still
+        requires grad.
 
+        Feeds ``_move_metric_inputs_to_cpu`` the same shape it receives in production — ``_convert_preds``/
+        ``_convert_targets`` output (``boxes``/``labels``/``masks``, no ``orig_size``) — instead of the raw pre-
+        conversion target dict, which carries ``orig_size`` and never reaches the helper in production. ``boxes`` starts
+        with ``requires_grad=True`` so detachment is asserted directly: ``.cpu()`` on an already-CPU tensor returns a
+        storage-sharing alias, making a bare device-type check vacuous on CPU-only CI runners, but ``.detach()`` clears
+        ``requires_grad``/``grad_fn`` regardless of device.
+        """
+        cb = COCOEvalCallback()
+        raw_preds = _detection_preds(1)
+        raw_preds[0]["boxes"].requires_grad_(True)
+        raw_preds[0]["masks"] = torch.zeros(1, 4, 4, dtype=torch.bool)
+        raw_targets = _detection_targets()
+        raw_targets[0]["masks"] = torch.zeros(1, 4, 4, dtype=torch.bool)
+
+        preds = cb._convert_preds(raw_preds)
+        targets = cb._convert_targets(raw_targets, preds)
         metric_preds, metric_targets = cb._move_metric_inputs_to_cpu(preds, targets)
 
         assert metric_preds[0].keys() == preds[0].keys()
         assert metric_targets[0].keys() == targets[0].keys()
         assert metric_preds[0] is not preds[0]
         assert metric_targets[0] is not targets[0]
-        assert all(value.device.type == "cpu" for item in metric_preds + metric_targets for value in item.values())
-        torch.testing.assert_close(metric_preds[0]["boxes"], preds[0]["boxes"])
+        assert "orig_size" not in metric_targets[0]
+        torch.testing.assert_close(metric_preds[0]["boxes"], preds[0]["boxes"].detach())
         torch.testing.assert_close(metric_targets[0]["boxes"], targets[0]["boxes"])
+        torch.testing.assert_close(metric_preds[0]["masks"], preds[0]["masks"])
+        torch.testing.assert_close(metric_targets[0]["masks"], targets[0]["masks"])
+        assert preds[0]["boxes"].requires_grad is True
+        assert metric_preds[0]["boxes"].requires_grad is False
+        assert metric_preds[0]["boxes"].grad_fn is None
+
+
+class TestValidationBatchEndDeviceRouting:
+    """Device split between the CPU-resident mAP metric state and the GPU-original F1/keypoint inputs."""
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_build_matching_data_still_receives_cuda_tensors_while_map_metric_state_is_cpu(self) -> None:
+        """build_matching_data must keep receiving the original CUDA tensors while map_metric's stored state is CPU-
+        resident — no CPU-only test can encode this device split.
+
+        A future refactor that passes the CPU-converted ``metric_preds``/``metric_targets`` into ``build_matching_data``
+        instead of the GPU originals would silently move ``[N, H, W]`` mask/box IoU onto the accelerator's slower CPU
+        sibling, a regression far larger than this PR's sync-removal win, with green CPU-only tests and zero numerical
+        change.
+        """
+        cb = COCOEvalCallback()
+        trainer = _make_trainer()
+        module = _cpu_module()
+        cb.setup(trainer, module, stage="fit")
+
+        outputs = {
+            "results": [
+                {
+                    "boxes": torch.zeros(1, 4, device="cuda"),
+                    "scores": torch.zeros(1, device="cuda"),
+                    "labels": torch.zeros(1, dtype=torch.long, device="cuda"),
+                }
+            ],
+            "targets": [
+                {
+                    "boxes": torch.tensor([[0.5, 0.5, 0.1, 0.1]], device="cuda"),
+                    "labels": torch.tensor([1], device="cuda"),
+                    "orig_size": torch.tensor([100, 200]),
+                }
+            ],
+        }
+
+        with patch(
+            "rfdetr.training.callbacks.coco_eval.build_matching_data", wraps=build_matching_data
+        ) as matching_spy:
+            cb.on_validation_batch_end(trainer, module, outputs, None, 0)
+
+        matching_spy.assert_called_once()
+        matching_preds, matching_targets = matching_spy.call_args[0][:2]
+        assert all(value.is_cuda for item in matching_preds + matching_targets for value in item.values())
+        assert all(t.device.type == "cpu" for t in cb.map_metric.detection_box)
 
 
 class TestOnTrainBatchEnd:
@@ -379,6 +445,28 @@ class TestOnTrainBatchEnd:
         cb.on_train_batch_end(_make_trainer(), module, outputs, None, 0)
 
         cb.map_metric_train.update.assert_called_once()
+
+    def test_train_batch_end_uses_cpu_metric_inputs(self) -> None:
+        """map_metric_train.update must receive the CPU copies from _move_metric_inputs_to_cpu.
+
+        The train hot path runs this conversion on every batch; unit tests run CPU-only, so tensors are CPU either way
+        and a dropped conversion call is invisible to a call-count-only assertion. Only an explicit args check against
+        the mocked conversion output catches a silent revert.
+        """
+        cb = COCOEvalCallback()
+        cb.setup(_make_trainer(), _make_pl_module(), stage="fit")
+        cb.map_metric_train = MagicMock(name="map_metric_train")
+        module = _make_pl_module()
+        module.train_config = SimpleNamespace(compute_train_metrics=True)
+        cpu_preds = _detection_preds(1)
+        cpu_targets = _detection_targets()
+        outputs = {"results": _detection_preds(1), "targets": _detection_targets()}
+
+        with patch.object(cb, "_move_metric_inputs_to_cpu", return_value=(cpu_preds, cpu_targets)) as move_to_cpu:
+            cb.on_train_batch_end(_make_trainer(), module, outputs, None, 0)
+
+        move_to_cpu.assert_called_once()
+        cb.map_metric_train.update.assert_called_once_with(cpu_preds, cpu_targets)
 
     def test_train_metrics_do_not_use_test_hook(self) -> None:
         """Train mAP must be logged under train/* via the train epoch hook, not through test/* hooks."""
@@ -1461,6 +1549,58 @@ class TestValidationBatchEndEvalEmaOnly:
 
         ema_underlying.assert_called_once()
         cb.map_metric_ema.update.assert_called_once()
+
+    def test_eval_ema_only_true_routes_cpu_metric_inputs_to_ema_track(self) -> None:
+        """The used_ema_forward route must pass map_metric_ema.update the CPU-converted preds/targets from
+        _move_metric_inputs_to_cpu, not the pre-conversion tensors — a call-count-only assertion cannot catch a dropped
+        conversion on CPU-only CI, where tensors are CPU either way."""
+        ema_underlying = MagicMock(name="ema_underlying_model", return_value={"ema": True})
+        cb = COCOEvalCallback(eval_ema_only=True)
+        trainer = _make_trainer(callbacks=[self._ema_callback_with_underlying(ema_underlying)])
+        module = _cpu_module()
+        cb.setup(trainer, module, stage="fit")
+        cb.map_metric = MagicMock(name="map_metric")
+        cb.map_metric_ema = MagicMock(name="map_metric_ema")
+        cpu_preds = _detection_preds(0)
+        cpu_targets = _detection_targets()
+
+        outputs = {"results": _detection_preds(0), "targets": _detection_targets()}
+        batch = (torch.zeros(1), None)
+        with patch.object(cb, "_move_metric_inputs_to_cpu", return_value=(cpu_preds, cpu_targets)) as move_to_cpu:
+            cb.on_validation_batch_end(trainer, module, outputs, batch, 0)
+
+        move_to_cpu.assert_called_once()
+        cb.map_metric_ema.update.assert_called_once_with(cpu_preds, cpu_targets)
+
+    def test_eval_ema_only_false_routes_cpu_metric_inputs_to_duplicate_ema_forward(self) -> None:
+        """The duplicate independent EMA forward path (eval_ema_only=False) must route its own
+        _move_metric_inputs_to_cpu output to map_metric_ema.update, distinct from the base call's own conversion output
+        routed to map_metric.update — a call-count-only assertion cannot catch either conversion being dropped or the
+        two outputs being swapped."""
+        ema_underlying = MagicMock(name="ema_underlying_model", return_value={"ema": True})
+        cb = COCOEvalCallback(eval_ema_only=False)
+        trainer = _make_trainer(callbacks=[self._ema_callback_with_underlying(ema_underlying)])
+        module = _cpu_module()
+        cb.setup(trainer, module, stage="fit")
+        cb.map_metric = MagicMock(name="map_metric")
+        cb.map_metric_ema = MagicMock(name="map_metric_ema")
+        base_cpu_preds = _detection_preds(0)
+        base_cpu_targets = _detection_targets()
+        ema_cpu_preds = _detection_preds(0)
+        ema_cpu_targets = _detection_targets()
+
+        outputs = {"results": _detection_preds(0), "targets": _detection_targets()}
+        batch = (torch.zeros(1), None)
+        with patch.object(
+            cb,
+            "_move_metric_inputs_to_cpu",
+            side_effect=[(base_cpu_preds, base_cpu_targets), (ema_cpu_preds, ema_cpu_targets)],
+        ) as move_to_cpu:
+            cb.on_validation_batch_end(trainer, module, outputs, batch, 0)
+
+        assert move_to_cpu.call_count == 2
+        cb.map_metric.update.assert_called_once_with(base_cpu_preds, base_cpu_targets)
+        cb.map_metric_ema.update.assert_called_once_with(ema_cpu_preds, ema_cpu_targets)
 
     def test_on_validation_batch_end_resizes_native_gt_directly_to_prediction_grid(self) -> None:
         """Native-head evaluation must not round-trip transformed GT masks through ``orig_size``.

--- a/tests/training/callbacks/test_coco_eval_callback.py
+++ b/tests/training/callbacks/test_coco_eval_callback.py
@@ -164,6 +164,19 @@ class TestSetup:
         assert cb.map_metric_ema is not None
         assert cb.map_metric_ema.class_metrics is False
 
+    def test_ema_metric_stays_on_cpu_when_module_uses_an_accelerator(self) -> None:
+        """The EMA metric itself remains on CPU because its accumulated state is CPU-only."""
+        cb = COCOEvalCallback()
+        cb.setup(_make_trainer(), _make_pl_module(), stage="fit")
+        module = _make_pl_module()
+        module.device = torch.device("meta")
+
+        with patch.object(cb, "_get_ema_callback", return_value=MagicMock()):
+            cb._prepare_ema_metric(_make_trainer(), module)
+
+        assert cb.map_metric_ema is not None
+        assert cb.map_metric_ema.device.type == "cpu"
+
     def test_keypoint_mode_does_not_enable_torchmetrics_keypoint_iou(self) -> None:
         """Keypoint mode must keep torchmetrics on bbox-only iou_type."""
         cb = COCOEvalCallback(segmentation=True)
@@ -260,6 +273,21 @@ class TestBatchEndCommon:
 
         assert cb.map_metric.update.call_count == 1
 
+    def test_map_metric_update_receives_cpu_state_inputs(self, hook, stage) -> None:
+        """Metric updates must receive the CPU copies that avoid per-annotation device synchronizations."""
+        cb = COCOEvalCallback()
+        cb.setup(_make_trainer(), _make_pl_module(), stage=stage)
+        cb.map_metric = MagicMock(name="map_metric")
+        cpu_preds = _detection_preds(0)
+        cpu_targets = _detection_targets()
+        outputs = {"results": _detection_preds(0), "targets": _detection_targets()}
+
+        with patch.object(cb, "_move_metric_inputs_to_cpu", return_value=(cpu_preds, cpu_targets)) as move_to_cpu:
+            getattr(cb, hook)(_make_trainer(), _make_pl_module(), outputs, None, 0)
+
+        move_to_cpu.assert_called_once()
+        cb.map_metric.update.assert_called_once_with(cpu_preds, cpu_targets)
+
     def test_f1_accumulator_grows_across_batches(self, hook, stage) -> None:
         """Calling the batch-end hook twice accumulates more GT in F1 state."""
         cb = COCOEvalCallback()
@@ -314,6 +342,26 @@ class TestOnTestBatchEnd:
 
         # Must not raise with explicit dataloader_idx=0
         cb.on_test_batch_end(_make_trainer(), _make_pl_module(), outputs, None, 0, dataloader_idx=0)
+
+
+class TestMetricStateInputs:
+    """CPU mAP state conversion at the TorchMetrics boundary."""
+
+    def test_move_metric_inputs_to_cpu_preserves_metric_fields(self) -> None:
+        """CPU conversion preserves every prediction and target field while detaching metric state."""
+        cb = COCOEvalCallback()
+        preds = _detection_preds(1)
+        targets = _detection_targets()
+
+        metric_preds, metric_targets = cb._move_metric_inputs_to_cpu(preds, targets)
+
+        assert metric_preds[0].keys() == preds[0].keys()
+        assert metric_targets[0].keys() == targets[0].keys()
+        assert metric_preds[0] is not preds[0]
+        assert metric_targets[0] is not targets[0]
+        assert all(value.device.type == "cpu" for item in metric_preds + metric_targets for value in item.values())
+        torch.testing.assert_close(metric_preds[0]["boxes"], preds[0]["boxes"])
+        torch.testing.assert_close(metric_targets[0]["boxes"], targets[0]["boxes"])
 
 
 class TestOnTrainBatchEnd:


### PR DESCRIPTION
Changes:
- Route train, validation, test, and EMA MeanAveragePrecision updates through detached CPU metric inputs.
- Keep the EMA metric CPU-resident and add CPU-state routing and field-preservation regressions.

Impact:
- Avoid TorchMetrics per-annotation device-to-host synchronizations during mAP finalization while preserving F1, keypoint, and DDP merge paths.
- Make the CPU metric-state boundary explicit and protected across callback update routes.

Verification:
- pre-commit run --all-files: passed.
- Shared gates: ruff lint, ruff format, mypy, 120 callback tests, and git diff --check: passed.

Residual limits:
- CUDA sync-count and epoch-time acceptance measurements remain deferred.
- Real multi-rank NCCL/Gloo runtime confirmation remains deferred.
