### PR TITLE
fix(training): skip BestModelCallback's EMA tracking during PTL's sanity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- `BestModelCallback` no longer treats PyTorch Lightning's pre-training sanity-check validation pass as a real epoch's result. Its EMA-checkpoint tracking and the `smooth_alpha` smoothing accumulator are custom bookkeeping that sit outside `ModelCheckpoint`'s own `trainer.sanity_checking` guard (the guard the regular-checkpoint path already inherits), so a positive sanity-check score — common when starting a new training run initialized with `pretrain_weights` from a checkpoint pretrained on a different dataset — could get written out as the permanent "best" `checkpoint_best_ema.pth` before a single real epoch ran, and real training could then never surpass it. Note this is distinct from PTL's own `resume`/`ckpt_path` restart, which PTL itself skips the sanity check for (`not val_loop.restarting`). ([#1348](https://github.com/roboflow/rf-detr/issues/1348))
+
 ## [1.9.3] — 2026-08-17
 
 ### Added

--- a/src/rfdetr/training/callbacks/best_model.py
+++ b/src/rfdetr/training/callbacks/best_model.py
@@ -493,12 +493,21 @@ class BestModelCallback(ModelCheckpoint):
 
         Delegates regular-model checkpoint management to the :class:`~pytorch_lightning.callbacks.ModelCheckpoint`
         parent (handles improvement detection, fast_dev_run/sanity guards, ``best_model_path`` and ``best_model_score``
-        bookkeeping).  EMA is tracked independently.
+        bookkeeping).  EMA is tracked independently, so the pre-training sanity-check guard below applies to both:
+        neither should treat the sanity-check validation pass as a real epoch's result.
 
         Args:
             trainer: The Lightning Trainer instance.
             pl_module: The ``RFDETRModelModule`` being trained.
         """
+        # PTL's pre-training sanity check runs this hook before any real epoch. The
+        # regular-checkpoint path below already no-ops during it via ModelCheckpoint's own
+        # trainer.sanity_checking guard (_should_skip_saving_checkpoint), but the EMA
+        # tracking and the smoothing accumulator are custom bookkeeping that don't inherit
+        # that guard, so a positive sanity-check score would otherwise get treated as a real
+        # improvement — see #1348.
+        if trainer.sanity_checking:
+            return
         # Stash before the skip guard — eligible epochs still need this reference
         # inside _save_checkpoint (which receives no pl_module param).
         self._current_pl_module = pl_module

--- a/tests/training/callbacks/test_best_model_callback.py
+++ b/tests/training/callbacks/test_best_model_callback.py
@@ -48,7 +48,7 @@ def _make_trainer(
             sanity-check pass (see #1348).
 
     Returns:
-        A ``MagicMock`` standing in for a :class:`~pytorch_lightning.Trainer`.
+        A mock standing in for a :class:`~pytorch_lightning.Trainer`.
 
     Examples:
         >>> trainer = _make_trainer({"val/mAP_50_95": 0.5}, current_epoch=2, sanity_checking=True)
@@ -343,7 +343,7 @@ class _SanityCheckEndProbe(Callback):
         """Store the checkpoint path to check for at sanity-check end.
 
         Args:
-            checkpoint_path: Path whose existence is snapshotted in ``on_sanity_check_end``.
+            checkpoint_path: File whose existence is snapshotted in ``on_sanity_check_end``.
         """
         super().__init__()
         self._checkpoint_path = checkpoint_path

--- a/tests/training/callbacks/test_best_model_callback.py
+++ b/tests/training/callbacks/test_best_model_callback.py
@@ -32,11 +32,30 @@ def _make_trainer(
     current_epoch: int = 1,
     is_global_zero: bool = True,
     callbacks: list[object] | None = None,
+    sanity_checking: bool = False,
 ) -> MagicMock:
     """Create a minimal mock Trainer with controllable callback_metrics.
 
     Sets the attributes required by ModelCheckpoint and EarlyStopping skip-guards so that callbacks run normally in unit
     tests.
+
+    Args:
+        metrics: Validation metric names mapped to values, exposed as ``trainer.callback_metrics``.
+        current_epoch: Value for ``trainer.current_epoch``.
+        is_global_zero: Value for ``trainer.is_global_zero``.
+        callbacks: Value for ``trainer.callbacks``; defaults to an empty list.
+        sanity_checking: Value for ``trainer.sanity_checking`` — True mimics PyTorch Lightning's pre-training
+            sanity-check pass (see #1348).
+
+    Returns:
+        A ``MagicMock`` standing in for a :class:`~pytorch_lightning.Trainer`.
+
+    Examples:
+        >>> trainer = _make_trainer({"val/mAP_50_95": 0.5}, current_epoch=2, sanity_checking=True)
+        >>> trainer.current_epoch, trainer.sanity_checking
+        (2, True)
+        >>> trainer.callback_metrics["val/mAP_50_95"].item()
+        0.5
     """
     trainer = MagicMock()
     trainer.callback_metrics = {k: torch.tensor(v) for k, v in metrics.items()}
@@ -47,7 +66,7 @@ def _make_trainer(
     # Required by ModelCheckpoint._should_skip_saving_checkpoint
     trainer.fast_dev_run = False
     trainer.state.fn = TrainerFn.FITTING
-    trainer.sanity_checking = False
+    trainer.sanity_checking = sanity_checking
     trainer.global_step = 1  # int; differs from _last_global_step_saved=0
     # Required by EarlyStopping._log_info (world_size > 1 check)
     trainer.world_size = 1
@@ -312,6 +331,35 @@ class _CallbackStateCaptureCallback(Callback):
             self.early_stop_wait_count = self._early_stop_callback.wait_count
 
 
+class _SanityCheckEndProbe(Callback):
+    """Snapshot whether a checkpoint path exists at the exact moment PTL's sanity check ends.
+
+    ``on_sanity_check_end`` fires between the sanity-check validation pass and the first real training epoch, so it
+    catches a checkpoint written from sanity-check contamination before a real epoch's own (possibly identical) score
+    could produce the same file for a legitimate reason.
+    """
+
+    def __init__(self, checkpoint_path: Path) -> None:
+        """Store the checkpoint path to check for at sanity-check end.
+
+        Args:
+            checkpoint_path: Path whose existence is snapshotted in ``on_sanity_check_end``.
+        """
+        super().__init__()
+        self._checkpoint_path = checkpoint_path
+        self.existed_after_sanity_check: bool | None = None
+
+    def on_sanity_check_end(self, trainer: Trainer, pl_module: LightningModule) -> None:
+        """Record whether ``checkpoint_path`` exists right as the sanity check ends.
+
+        Args:
+            trainer: Unused; required by the ``Callback`` hook signature.
+            pl_module: Unused; required by the ``Callback`` hook signature.
+        """
+        del trainer, pl_module
+        self.existed_after_sanity_check = self._checkpoint_path.exists()
+
+
 # ---------------------------------------------------------------------------
 # TestBestModelCallback
 # ---------------------------------------------------------------------------
@@ -496,6 +544,116 @@ class TestBestModelCallback:
         cb.on_validation_end(trainer, pl_module)
 
         assert (tmp_path / "checkpoint_best_ema.pth").exists()
+
+    def test_ema_checkpoint_not_written_during_sanity_check(self, tmp_path: Path) -> None:
+        """PTL's pre-training sanity check must not seed checkpoint_best_ema.pth.
+
+        Regression test for #1348: PyTorch Lightning's sanity-check validation pass (which runs before any real training
+        epoch) was landing straight into the EMA improvement check below, so any positive sanity-check score — common
+        when starting a new training run initialized with pretrain_weights from a checkpoint pretrained on a different
+        dataset — got written out as the permanent "best" EMA checkpoint before a single real epoch ran. The regular-
+        checkpoint path already skips this via ModelCheckpoint._should_skip_saving_checkpoint's own
+        trainer.sanity_checking guard; the EMA block reimplements its own saving logic and never inherited that guard.
+        """
+        cb = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
+        pl_module = _make_pl_module()
+        trainer = _make_trainer(
+            {"val/mAP_50_95": 0.1, "val/ema_mAP_50_95": 0.83},
+            current_epoch=0,
+            sanity_checking=True,
+        )
+
+        cb.on_validation_end(trainer, pl_module)
+
+        assert not (tmp_path / "checkpoint_best_ema.pth").exists()
+        assert cb._best_ema == 0.0
+
+    def test_ema_checkpoint_written_on_first_real_epoch_after_sanity_check(self, tmp_path: Path) -> None:
+        """A genuine epoch 0 right after the sanity check still saves the EMA checkpoint.
+
+        Confirms the sanity_checking guard is specific to the sanity-check pass, not a blanket "never write at epoch 0"
+        — the correct guard is trainer.sanity_checking, not trainer.current_epoch == 0.
+        """
+        cb = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95")
+        pl_module = _make_pl_module()
+
+        sanity_trainer = _make_trainer(
+            {"val/mAP_50_95": 0.1, "val/ema_mAP_50_95": 0.83},
+            current_epoch=0,
+            sanity_checking=True,
+        )
+        cb.on_validation_end(sanity_trainer, pl_module)
+
+        real_trainer = _make_trainer(
+            {"val/mAP_50_95": 0.2, "val/ema_mAP_50_95": 0.35},
+            current_epoch=0,
+            sanity_checking=False,
+        )
+        cb.on_validation_end(real_trainer, pl_module)
+
+        assert (tmp_path / "checkpoint_best_ema.pth").exists()
+        assert cb._best_ema == pytest.approx(0.35)
+
+    def test_smoothed_regular_not_updated_during_sanity_check(self, tmp_path: Path) -> None:
+        """The regular-monitor smoothing accumulator must not warm up from the sanity check.
+
+        Guards the secondary smoothing state (smooth_alpha > 0) alongside the EMA checkpoint above: both are custom
+        bookkeeping that sits outside ModelCheckpoint's own sanity-check guard.
+        """
+        cb = BestModelCallback(output_dir=str(tmp_path), smooth_alpha=0.9)
+        pl_module = _make_pl_module()
+        trainer = _make_trainer({"val/mAP_50_95": 0.83}, current_epoch=0, sanity_checking=True)
+
+        cb.on_validation_end(trainer, pl_module)
+
+        assert cb._smoothed_regular == 0.0
+
+    def test_ema_checkpoint_not_written_during_real_ptl_sanity_check(self, tmp_path: Path) -> None:
+        """End-to-end: an unmodified Trainer with the sanity check enabled must not seed checkpoint_best_ema.pth.
+
+        The three tests above call on_validation_end directly with trainer.sanity_checking mocked True — they pin the
+        callback's own guard logic but not the premise it depends on: that PyTorch Lightning actually invokes
+        on_validation_end with trainer.sanity_checking=True during its real sanity-check pass
+        (Trainer._run_sanity_check, which reuses the same evaluation loop as real validation). This test runs a real
+        Trainer with num_sanity_val_steps left enabled to close that gap, using a probe callback's on_sanity_check_end
+        hook to pin down that no checkpoint exists at that exact moment — before a same-valued real epoch 0 could
+        produce the same file for a legitimate reason.
+        """
+        x = torch.randn(8, 4)
+        y = torch.randn(8, 1)
+        train_loader = DataLoader(TensorDataset(x, y), batch_size=2)
+        val_loader = DataLoader(TensorDataset(x, y), batch_size=2)
+
+        checkpoint_path = tmp_path / "checkpoint_best_ema.pth"
+        save_cb = BestModelCallback(output_dir=str(tmp_path), monitor_ema="val/ema_mAP_50_95", run_test=False)
+        ema_cb = RFDETREMACallback()
+        probe = _SanityCheckEndProbe(checkpoint_path)
+        trainer = Trainer(
+            max_epochs=1,
+            accelerator="cpu",
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            logger=False,
+            num_sanity_val_steps=2,
+            limit_train_batches=2,
+            limit_val_batches=1,
+            callbacks=[save_cb, ema_cb, probe],
+            default_root_dir=str(tmp_path),
+        )
+        # Same value on every validation call (sanity check and the real epoch both log unconditionally) —
+        # reproduces #1348 exactly. The probe below, not the end-state checkpoint, is what pins the timing down.
+        trainer.fit(
+            _EmaMetricModule(regular_value=0.2, ema_value=0.83),
+            train_dataloaders=train_loader,
+            val_dataloaders=val_loader,
+        )
+
+        assert probe.existed_after_sanity_check is False, (
+            "checkpoint_best_ema.pth existed right after PTL's sanity check ended — the sanity-check validation pass "
+            "wrote it before any real epoch ran"
+        )
+        assert checkpoint_path.exists()
+        assert save_cb._best_ema == pytest.approx(0.83)
 
     def test_ema_checkpoint_saved_when_regular_monitor_absent(self, tmp_path: Path) -> None:
         """Under `eval_ema_only`, val/mAP_50_95 is never logged — only val/ema_mAP_50_95 is.


### PR DESCRIPTION
`BestModelCallback.on_validation_end` (`training/callbacks/best_model.py`) tracks the best EMA checkpoint with its own code, independent of PyTorch Lightning's `ModelCheckpoint` parent. That means it also doesn't inherit the parent's `trainer.sanity_checking` guard (`ModelCheckpoint._should_skip_saving_checkpoint`, which explicitly excludes the sanity check: `or trainer.sanity_checking  # don't save anything during sanity check`).

PTL's pre-training sanity check runs `on_validation_end` before any real epoch. `self._best_ema` starts at `0.0`, so any positive EMA score from that sanity pass beats it — easy to get when starting a new training run initialized with `pretrain_weights` from a checkpoint pretrained on a different dataset, as in #1348. So the score gets written to `checkpoint_best_ema.pth` as the permanent "best" checkpoint, with a misleading log line (`"Best EMA metric improved to 0.83 (epoch 0)"`) before training has run a single real epoch.

Note the scope: this is a fresh `pretrain_weights=` start, not PTL's own `resume=`/`ckpt_path=` restart — PTL's `_run_sanity_check` explicitly skips the sanity check when `val_loop.restarting` is true (`pytorch_lightning/trainer/trainer.py`, `_run_sanity_check`), which is exactly the state a real `ckpt_path=` resume sets. The reporter's own repro confirms this: "I've made a new training with pretrained weight from a similar (but outdated) dataset in the past."

**Changes**

- `best_model.py`: added `if trainer.sanity_checking: return` at the top of `on_validation_end`, before both the EMA-checkpoint block and the `smooth_alpha` smoothing accumulator. Same class of bug on the second one: no guard, no persisted checkpoint yet, but it does warm up the smoothing state from a sanity-check score. The regular-checkpoint path already no-ops during sanity-check via the parent class, so this doesn't change its behaviour, I checked `ModelCheckpoint._should_skip_saving_checkpoint`'s source to confirm.
- `test_best_model_callback.py`: 4 new tests. Sanity-check contamination is blocked, and a genuine epoch 0 right after the sanity check still saves correctly (control against a "skip epoch 0" over-fix). The smoothing accumulator isn't warmed up from the sanity check either. There's also an end-to-end test with an unmodified `Trainer` (sanity check left enabled) using an `on_sanity_check_end` probe callback to pin down that no checkpoint exists at the exact moment the real sanity check ends — that closes the gap the first three tests leave by only mocking `trainer.sanity_checking` directly. Also added the required `Args`/`Examples` doctest to the pre-existing `_make_trainer` test helper, since this PR extended its signature.
- `CHANGELOG.md`: `### Fixed` entry under `[Unreleased]`.

Fixes #1348.

Thanks @LeMinhNgan for the report and for sketching the same guard in your comment — I built on that with the smoothing-accumulator case and the "still works after the sanity check" control test.

**Validation**

- New tests confirmed red against unpatched `develop`, green after the fix (`repro/red_before_fix.log`, `repro/green_after_fix_targeted_file.log`).
- `tests/training/` full suite: 1058 passed, 8 skipped, 0 failed (`repro/green_training_full_suite.log`).
- `bin/rfdetr_precommit.sh`: 19/19 hooks clean, including `mypy --strict` (`repro/precommit_19_hooks.log`).
- Standalone repro independent of pytest, run against both the unpatched and patched code (`repro/manual_repro.py`, `repro/manual_repro_output.log`): unpatched writes the checkpoint at `_best_ema=0.83` from the sanity check alone, patched skips it and correctly saves `_best_ema=0.35` on the first real epoch that follows.
- Patch applies cleanly on `develop`.

**Risk**: low, single-file behaviour change plus tests. Only affects the moment `on_validation_end` runs during PTL's sanity check — the other call paths (real epochs, `on_fit_end`'s backfill logic, `smooth_alpha=0` default) stay unchanged, confirmed by the full `tests/training/` suite staying green.
