### PR TITLE
refactor: enable mypy strict checking for rfdetr.datasets.synthetic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -408,7 +408,6 @@ overrides = [
   { module = [
     "rfdetr.config",
     "rfdetr.datasets.coco",
-    "rfdetr.datasets.synthetic",
     "rfdetr.datasets.transforms",
   ], ignore_errors = true },
 ]

--- a/src/rfdetr/datasets/synthetic.py
+++ b/src/rfdetr/datasets/synthetic.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Literal
 
 import numpy as np
+from numpy.typing import NDArray
 from PIL import Image
 from supervision import Color, Detections, box_iou_batch, draw_filled_polygon
 from tqdm.auto import tqdm
@@ -42,7 +43,7 @@ class DatasetSplitRatios:
     val: float = 0.2
     test: float = 0.1
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Validate that ratios sum to approximately 1.0 and are non-negative."""
         total = self.train + self.val + self.test
         if any(r < 0 for r in [self.train, self.val, self.test]):
@@ -118,8 +119,8 @@ SYNTHETIC_COLORS = {"red": Color.RED, "green": Color.GREEN, "blue": Color.BLUE}
 
 
 def draw_synthetic_shape(
-    img: np.ndarray, shape: str, color: Color, center: tuple[int, int], size: int
-) -> tuple[np.ndarray, list[float]]:
+    img: NDArray[np.uint8], shape: str, color: Color, center: tuple[int, int], size: int
+) -> tuple[NDArray[np.uint8], list[float]]:
     """Draw a geometric shape on an image and return its COCO polygon.
 
     The polygon is computed first, then used for both rendering and annotation, so the two are always identical.
@@ -165,7 +166,7 @@ def draw_synthetic_shape(
     return img, polygon
 
 
-def calculate_boundary_overlap(bbox: np.ndarray, img_size: int) -> float:
+def calculate_boundary_overlap(bbox: NDArray[np.float64], img_size: int) -> float:
     """Calculate how much of a bounding box is outside the image boundaries.
 
     Args:
@@ -200,7 +201,7 @@ def generate_synthetic_sample(
     min_size_ratio: float = 0.1,
     max_size_ratio: float = 0.3,
     overlap_threshold: float = 0.1,
-) -> tuple[np.ndarray, Detections]:
+) -> tuple[NDArray[np.uint8], Detections]:
     """Generate a single synthetic image and its detections.
 
     Args:
@@ -219,11 +220,11 @@ def generate_synthetic_sample(
         ``detections`` is an :class:`Detections` instance whose ``data["polygons"]`` field contains one flat ``[x1,
         y1, x2, y2, …]`` polygon list per detection, matching the geometry returned by :func:`draw_synthetic_shape`.
     """
-    img = np.ones((img_size, img_size, 3), dtype=np.uint8) * 128
+    img: NDArray[np.uint8] = np.ones((img_size, img_size, 3), dtype=np.uint8) * 128
     color_names = list(SYNTHETIC_COLORS.keys())
     num_objects = random.randint(min_objects, max_objects)
 
-    xyxys = []
+    xyxys: list[NDArray[np.float64]] = []
     class_ids = []
     polygons: list[list[float]] = []
     failed_attempts = 0
@@ -336,6 +337,7 @@ def _write_coco_json(
             no ``"polygons"`` key in its ``data`` dict.
         ValueError: If ``with_segmentation=True`` and the ``"polygons"`` array
             has fewer entries than there are detections for that image.
+        ValueError: If a detections entry has ``class_id`` set to ``None``.
         ValueError: If any detection has a ``class_id`` outside the range
             ``[0, len(classes))``.
     """
@@ -374,10 +376,16 @@ def _write_coco_json(
                 )
         else:
             polygon_data = np.empty(0, dtype=object)
+        detection_class_ids = detections.class_id
+        if detection_class_ids is None:
+            raise ValueError(
+                "every detections entry must have class_id set, but got None "
+                f"for image index {img_id} (file: {file_path})"
+            )
         for det_idx in range(len(detections)):
             x1, y1, x2, y2 = (float(v) for v in detections.xyxy[det_idx])
             w, h_box = x2 - x1, y2 - y1
-            class_id = int(detections.class_id[det_idx])
+            class_id = int(detection_class_ids[det_idx])
             if class_id < 0 or class_id >= len(classes):
                 raise ValueError(
                     f"Invalid class_id {class_id} for detection index {det_idx} "

--- a/tests/datasets/test_synthetic.py
+++ b/tests/datasets/test_synthetic.py
@@ -356,6 +356,20 @@ class TestGenerateCocoDatasetWithSegmentation:
                 img_size=64,
             )
 
+    def test_write_coco_json_raises_when_class_id_missing(self, tmp_path):
+        """Detections carrying no class_id must raise rather than subscript None."""
+        annotations_path = tmp_path / "_annotations.coco.json"
+        detections = sv.Detections(xyxy=np.array([[0.0, 0.0, 10.0, 10.0]], dtype=float))
+
+        with pytest.raises(ValueError, match="must have class_id set"):
+            _write_coco_json(
+                annotations_path=annotations_path,
+                classes=["shape"],
+                file_paths=["/tmp/synthetic.png"],
+                detections_list=[detections],
+                img_size=64,
+            )
+
     def test_creates_files(self, tmp_path):
         """with_segmentation=True must create the same directory/file structure as the default."""
         output_dir = tmp_path / "seg_dataset"


### PR DESCRIPTION
Part of #564. Removes `rfdetr.datasets.synthetic` from the `ignore_errors` list in `pyproject.toml` and fixes the errors that surfaced.

### Typing

Most were the `type-arg` errors tracked in the issue: bare `np.ndarray` annotations on `draw_synthetic_shape`, `calculate_boundary_overlap`, and `generate_synthetic_sample`.

I used `numpy.typing.NDArray` with concrete dtypes rather than `np.ndarray[Any, Any]`, following `rfdetr.datasets.yolo`. The convention came up twice in #564 without an explicit ruling, so I matched the most recently merged module. Dtypes are read off the code rather than guessed: images are `uint8` (`np.ones(..., dtype=np.uint8)`), boxes are `float64` (`np.array` over Python floats). Happy to switch to `np.ndarray[Any, Any]` if you would rather keep the older form here.

`generate_synthetic_sample`'s local `img` also needed an explicit annotation. `np.ones` with a literal 3-tuple infers `ndarray[tuple[int, int, int], ...]`, which will not accept the shape-generic array `draw_synthetic_shape` returns, so the reassignment inside the placement loop failed. Declaring `img` as `NDArray[np.uint8]` keeps the variable shape-generic.

The remaining two were a missing return annotation on `DatasetSplitRatios.__post_init__` and an element type for `xyxys`.

### One bug, surfaced by the annotations

Separate logical change, called out so it is easy to review or ask me to split.

`_write_coco_json` indexed `detections.class_id` without checking it:

```python
class_id = int(detections.class_id[det_idx])
```

`Detections.class_id` is `Optional` in supervision, and `_write_coco_json` takes an arbitrary `detections_list` from its caller. Detections built without class ids therefore raised `TypeError: 'NoneType' object is not subscriptable` at the subscript.

It now raises `ValueError` naming the offending image, matching how the function already reports mismatched list lengths and missing polygon entries. The docstring `Raises:` section is updated.

`test_write_coco_json_raises_when_class_id_missing` covers it. It fails on the unfixed module with the `TypeError` above and passes with the guard.

### Verification

Rebased on `develop` at 92189f6.

- `mypy src/rfdetr/ --no-error-summary`: clean, run against the versions the typing CI resolves (`mypy==1.19.1`, `numpy==2.2.6`, `supervision==0.30.0`)
- `pre-commit run --all-files`: all hooks pass
- `pytest tests/datasets/`: 400 passed against a 399-passed baseline on `develop`, same skips, same pre-existing local failures on both sides. The delta is the one new test

No runtime behaviour changes beyond the new guard.
