### PR TITLE
feat(augment): support `ShiftScaleRotate` on the Kornia backend

### DIFF
--- a/src/rfdetr/datasets/aug_configs.py
+++ b/src/rfdetr/datasets/aug_configs.py
@@ -108,8 +108,11 @@ apply. Its limits are deltas rather than absolute ranges, so they are converted 
 ``scale_limit`` is biased by 1 in Albumentations, meaning it samples from ``(1 + low, 1 + high)``, so the
 default ``(-0.1, 0.1)`` is a scale between ``0.9`` and ``1.1``; that pivot is applied here. All three limits
 also read a scalar ``v`` as the symmetric ``(-v, v)``. ``shift_limit_x`` and ``shift_limit_y`` map onto
-Kornia's per-axis ``translate``. ``interpolation``, ``border_mode``, ``mask_interpolation``, ``fill``,
-``fill_mask`` and ``rotate_method`` have no equivalent and are ignored with a warning. Note that
+Kornia's per-axis ``translate``; ``None`` uses the shared ``shift_limit``. Kornia can sample only symmetric shift
+ranges, so an asymmetric Albumentations pair such as ``(0.1, 0.2)`` becomes ``(-0.2, 0.2)`` and emits a warning.
+Use the Albumentations backend when that distribution must be preserved. ``interpolation``, ``border_mode``,
+``mask_interpolation``, ``fill``, ``fill_mask`` and ``rotate_method`` have no equivalent and are ignored with a warning.
+Note that
 Albumentations itself deprecates ``ShiftScaleRotate`` in favour of ``Affine``, which this backend already
 supports; new configs should prefer ``Affine``.
 

--- a/src/rfdetr/datasets/aug_configs.py
+++ b/src/rfdetr/datasets/aug_configs.py
@@ -91,6 +91,7 @@ or torchvision defaults. Install it with ``pip install 'rfdetr[augment]'``.
 | ``Equalize`` | ``K.RandomEqualize`` | Only ``p`` honored; ``mode``/``by_channels``/``mask`` ignored |
 | ``CLAHE`` | ``K.RandomClahe`` | ``clip_limit`` and ``tile_grid_size`` map directly |
 | ``Perspective`` | ``K.RandomPerspective`` | Approximate; see the note below. ``keep_size=False`` raises |
+| ``ShiftScaleRotate`` | ``K.RandomAffine`` | Limits are deltas, not absolute ranges; see the note below |
 
 ``Perspective`` is the one entry in the table that is not a faithful mapping. Albumentations samples each
 corner offset from ``abs(N(0, scale))``, Kornia samples uniformly from ``distortion_scale``, so the two
@@ -101,9 +102,20 @@ config, not only for a range. ``keep_size=False`` raises rather than silently re
 ``mask_interpolation``, ``border_mode``, ``fill`` and ``fill_mask`` are ignored. Use the Albumentations
 backend when the exact Albumentations semantics matter.
 
+``ShiftScaleRotate`` maps onto the same ``K.RandomAffine`` as ``Affine``, which is what makes it safe here:
+it preserves the output resolution, so the padding-mask constraint that keeps the crops unsupported does not
+apply. Its limits are deltas rather than absolute ranges, so they are converted rather than forwarded.
+``scale_limit`` is biased by 1 in Albumentations, meaning it samples from ``(1 + low, 1 + high)``, so the
+default ``(-0.1, 0.1)`` is a scale between ``0.9`` and ``1.1``; that pivot is applied here. All three limits
+also read a scalar ``v`` as the symmetric ``(-v, v)``. ``shift_limit_x`` and ``shift_limit_y`` map onto
+Kornia's per-axis ``translate``. ``interpolation``, ``border_mode``, ``mask_interpolation``, ``fill``,
+``fill_mask`` and ``rotate_method`` have no equivalent and are ignored with a warning. Note that
+Albumentations itself deprecates ``ShiftScaleRotate`` in favour of ``Affine``, which this backend already
+supports; new configs should prefer ``Affine``.
+
 Not yet supported on Kornia: ``HueSaturationValue`` (Albumentations shifts hue/saturation/value additively,
 Kornia's ``ColorJiggle`` scales them multiplicatively, so there is no faithful mapping), and the geometric
-group ``ShiftScaleRotate``, ``RandomCrop``, ``CenterCrop``, ``RandomResizedCrop``,
+group ``RandomCrop``, ``CenterCrop``, ``RandomResizedCrop``,
 ``ElasticTransform`` and ``GridDistortion``, whose CPU behavior is not faithfully mapped by the current
 Kornia pipeline. These still work on the Albumentations backend.
 

--- a/src/rfdetr/datasets/kornia_transforms.py
+++ b/src/rfdetr/datasets/kornia_transforms.py
@@ -422,6 +422,78 @@ def _make_affine(params: dict[str, Any]) -> Any:
     )
 
 
+#: Albumentations ``ShiftScaleRotate`` options with no ``K.RandomAffine`` equivalent.
+_SHIFT_SCALE_ROTATE_IGNORED_KEYS = (
+    "interpolation",
+    "border_mode",
+    "mask_interpolation",
+    "fill",
+    "fill_mask",
+    "rotate_method",
+)
+
+
+def _as_symmetric_range(value: Any) -> tuple[float, float]:
+    """Normalise an Albumentations ``*_limit`` value to a ``(min, max)`` pair.
+
+    These parameters expand a scalar ``v`` symmetrically to ``(-v, v)`` rather than to the degenerate ``(v, v)``
+    :func:`_as_range` produces, so they need their own normalisation.
+    """
+    if isinstance(value, (list, tuple)):
+        return _as_range(value)
+    return (-float(value), float(value))
+
+
+def _make_shift_scale_rotate(params: dict[str, Any]) -> Any:
+    """Build a ``K.RandomAffine`` from aug_config ``ShiftScaleRotate`` params.
+
+    Albumentations itself calls this "a special case of Affine transform" and deprecates it in favour of ``Affine``,
+    which this backend already supports. It is mapped anyway because the CPU path still accepts the name, so a config
+    using it trains on a CPU box and raises on a GPU box; new configs should prefer ``Affine``.
+
+    The three limits do **not** pass through to :func:`_make_affine`'s parameters unchanged, which is the whole reason
+    this needs its own builder rather than an alias:
+
+    - ``scale_limit`` is a delta biased by 1, not an absolute multiplier. Albumentations samples from
+      ``(1 + low, 1 + high)``, so the documented default ``(-0.1, 0.1)`` means a scale between ``0.9`` and ``1.1``.
+      Kornia's ``scale`` is the absolute multiplier range, so the pivot is applied here. Forwarding the raw value
+      would ask Kornia to scale the image to between a tenth of its size and nothing at all. This is the same
+      1.0-pivot that :func:`_make_sharpen` applies to ``alpha``.
+    - ``shift_limit`` is a signed fraction range, while Kornia's ``translate`` is a non-negative per-axis maximum
+      sampled symmetrically, so it is converted the same way :func:`_make_affine` converts ``translate_percent``.
+      ``shift_limit_x`` and ``shift_limit_y`` override it per axis, which Kornia's ``(tx, ty)`` pair expresses
+      directly.
+    - all three accept a scalar as a symmetric range, unlike the ``(v, v)`` reading :func:`_as_range` gives.
+    """
+    from kornia.augmentation import RandomAffine
+
+    ignored = [k for k in _SHIFT_SCALE_ROTATE_IGNORED_KEYS if k in params]
+    if ignored:
+        logger.warning(
+            "GPU augmentation (Kornia) ShiftScaleRotate ignores %s "
+            "(Kornia's RandomAffine exposes only the geometric parameters). "
+            "CPU augmentation (albumentations) honors them.",
+            ", ".join(repr(k) for k in ignored),
+        )
+
+    shift = _as_symmetric_range(params.get("shift_limit", (-0.0625, 0.0625)))
+    shift_x = _as_symmetric_range(params["shift_limit_x"]) if "shift_limit_x" in params else shift
+    shift_y = _as_symmetric_range(params["shift_limit_y"]) if "shift_limit_y" in params else shift
+    translate = (
+        max(abs(shift_x[0]), abs(shift_x[1])),
+        max(abs(shift_y[0]), abs(shift_y[1])),
+    )
+
+    scale_low, scale_high = _as_symmetric_range(params.get("scale_limit", (-0.1, 0.1)))
+
+    return RandomAffine(
+        degrees=_as_symmetric_range(params.get("rotate_limit", (-45, 45))),
+        translate=translate,
+        scale=(1.0 + scale_low, 1.0 + scale_high),
+        p=params.get("p", 0.5),
+    )
+
+
 def _make_color_jitter(params: dict[str, Any]) -> Any:
     """Build a ``K.ColorJiggle`` from aug_config ``ColorJitter`` params.
 
@@ -687,6 +759,7 @@ _REGISTRY: dict[str, Callable[[dict[str, Any]], Any]] = {
     "VerticalFlip": _make_vertical_flip,
     "Rotate": _make_rotate,
     "Affine": _make_affine,
+    "ShiftScaleRotate": _make_shift_scale_rotate,
     "ColorJitter": _make_color_jitter,
     "ToGray": _make_to_gray,
     "RandomBrightnessContrast": _make_random_brightness_contrast,

--- a/src/rfdetr/datasets/kornia_transforms.py
+++ b/src/rfdetr/datasets/kornia_transforms.py
@@ -461,8 +461,9 @@ def _make_shift_scale_rotate(params: dict[str, Any]) -> Any:
       1.0-pivot that :func:`_make_sharpen` applies to ``alpha``.
     - ``shift_limit`` is a signed fraction range, while Kornia's ``translate`` is a non-negative per-axis maximum
       sampled symmetrically, so it is converted the same way :func:`_make_affine` converts ``translate_percent``.
-      ``shift_limit_x`` and ``shift_limit_y`` override it per axis, which Kornia's ``(tx, ty)`` pair expresses
-      directly.
+      ``shift_limit_x`` and ``shift_limit_y`` override it per axis, with ``None`` preserving the shared limit as it
+      does on the Albumentations backend. Kornia cannot represent an asymmetric shift interval, so this builder uses
+      the greatest absolute bound and logs that distributional approximation.
     - all three accept a scalar as a symmetric range, unlike the ``(v, v)`` reading :func:`_as_range` gives.
     """
     from kornia.augmentation import RandomAffine
@@ -477,8 +478,24 @@ def _make_shift_scale_rotate(params: dict[str, Any]) -> Any:
         )
 
     shift = _as_symmetric_range(params.get("shift_limit", (-0.0625, 0.0625)))
-    shift_x = _as_symmetric_range(params["shift_limit_x"]) if "shift_limit_x" in params else shift
-    shift_y = _as_symmetric_range(params["shift_limit_y"]) if "shift_limit_y" in params else shift
+    shift_x_value = params.get("shift_limit_x")
+    shift_y_value = params.get("shift_limit_y")
+    shift_x = _as_symmetric_range(shift_x_value) if shift_x_value is not None else shift
+    shift_y = _as_symmetric_range(shift_y_value) if shift_y_value is not None else shift
+    configured_limits = (
+        ("shift_limit", shift, "shift_limit" in params),
+        ("shift_limit_x", shift_x, shift_x_value is not None),
+        ("shift_limit_y", shift_y, shift_y_value is not None),
+    )
+    asymmetric_limits = [
+        name for name, bounds, is_configured in configured_limits if is_configured and bounds[0] != -bounds[1]
+    ]
+    if asymmetric_limits:
+        logger.warning(
+            "GPU augmentation (Kornia) ShiftScaleRotate approximates asymmetric %s with a symmetric range using "
+            "the greatest absolute limit. CPU augmentation (Albumentations) preserves the requested distribution.",
+            ", ".join(repr(name) for name in asymmetric_limits),
+        )
     translate = (
         max(abs(shift_x[0]), abs(shift_x[1])),
         max(abs(shift_y[0]), abs(shift_y[1])),

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -1431,10 +1431,9 @@ def _affine_ranges(transform) -> dict:
 class TestShiftScaleRotateFactory:
     """`ShiftScaleRotate` on the Kornia backend (issue #1252).
 
-    Albumentations deprecates this name in favour of `Affine`, but the CPU path still accepts it,
-    so a config using it trained on a CPU box and raised on a GPU box. It maps onto the same
-    `RandomAffine` that `Affine` uses, which is what makes it safe: no resolution change, so the
-    padding-mask constraint that keeps the crops unsupported does not apply.
+    Albumentations deprecates this name in favour of `Affine`, but the CPU path still accepts it, so a config using it
+    trained on a CPU box and raised on a GPU box. It maps onto the same `RandomAffine` that `Affine` uses, which is what
+    makes it safe: no resolution change, so the padding-mask constraint that keeps the crops unsupported does not apply.
 
     The limits are *not* pass-through, which is why this needs its own builder rather than an alias.
     """
@@ -1456,10 +1455,9 @@ class TestShiftScaleRotateFactory:
     def test_scale_limit_is_a_delta_biased_by_one(self) -> None:
         """The mapping that a plain alias to Affine would get wrong.
 
-        Albumentations documents `scale_limit` as "biased by 1": it samples from
-        `(1 + low, 1 + high)`, so `0.1` means a scale between 0.9 and 1.1. Kornia's `scale` is the
-        absolute multiplier, so forwarding `0.1` unchanged would ask it to shrink the image to
-        between a tenth of its size and nothing at all.
+        Albumentations documents `scale_limit` as "biased by 1": it samples from `(1 + low, 1 + high)`, so `0.1` means a
+        scale between 0.9 and 1.1. Kornia's `scale` is the absolute multiplier, so forwarding `0.1` unchanged would ask
+        it to shrink the image to between a tenth of its size and nothing at all.
         """
         ranges = _affine_ranges(self._only_affine({"ShiftScaleRotate": {"scale_limit": 0.1, "p": 1.0}}))
         assert ranges["scale"] == pytest.approx((0.9, 1.1), abs=1e-4)

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -1392,3 +1392,158 @@ class TestGaussianDefaultsMatchAlbumentations:
             kornia_transforms._make_gauss_noise({"p": 0.3})
 
         mock_warning.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# TestShiftScaleRotateFactory - validates the ShiftScaleRotate mapping, whose
+# limits are deltas rather than absolute ranges (issue #1252).
+# ---------------------------------------------------------------------------
+
+
+def _affine_ranges(transform) -> dict:
+    """Read the resolved degrees/translate/scale off a Kornia ``RandomAffine``.
+
+    Like :func:`_sharpness_sampler_range`, this reads a private Kornia detail because no public
+    equivalent exists: ``RandomAffine(...).flags`` carries only the resampling options (verified
+    against the installed Kornia version), so the geometric ranges are reachable only through the
+    parameter generator. A future Kornia release renaming ``_param_generator`` fails here with an
+    actionable message rather than a raw ``AttributeError`` inside a test body.
+    """
+    generator = getattr(transform, "_param_generator", None)
+    if generator is None:
+        pytest.fail(
+            "Kornia's RandomAffine no longer exposes `_param_generator` (no public alternative "
+            "exists for the resolved degrees/translate/scale). Update this helper to match "
+            "Kornia's new internal parameter-generator shape."
+        )
+    resolved = {}
+    for key in ("degrees", "translate", "scale"):
+        value = getattr(generator, key, None)
+        if value is None:
+            pytest.fail(
+                f"Kornia's RandomAffine parameter generator no longer carries {key!r}. "
+                "Update this helper to match Kornia's new internal shape."
+            )
+        resolved[key] = tuple(float(v) for v in value)
+    return resolved
+
+
+class TestShiftScaleRotateFactory:
+    """`ShiftScaleRotate` on the Kornia backend (issue #1252).
+
+    Albumentations deprecates this name in favour of `Affine`, but the CPU path still accepts it,
+    so a config using it trained on a CPU box and raised on a GPU box. It maps onto the same
+    `RandomAffine` that `Affine` uses, which is what makes it safe: no resolution change, so the
+    padding-mask constraint that keeps the crops unsupported does not apply.
+
+    The limits are *not* pass-through, which is why this needs its own builder rather than an alias.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _require_kornia(self):
+        pytest.importorskip("kornia")
+
+    def _only_affine(self, aug_config):
+        import kornia.augmentation as kornia_augmentation
+
+        from rfdetr.datasets.kornia_transforms import build_kornia_pipeline
+
+        pipeline = build_kornia_pipeline(aug_config, 560)
+        affines = [c for c in pipeline.children() if isinstance(c, kornia_augmentation.RandomAffine)]
+        assert len(affines) == 1, f"Expected exactly 1 RandomAffine, found {len(affines)}"
+        return affines[0]
+
+    def test_scale_limit_is_a_delta_biased_by_one(self) -> None:
+        """The mapping that a plain alias to Affine would get wrong.
+
+        Albumentations documents `scale_limit` as "biased by 1": it samples from
+        `(1 + low, 1 + high)`, so `0.1` means a scale between 0.9 and 1.1. Kornia's `scale` is the
+        absolute multiplier, so forwarding `0.1` unchanged would ask it to shrink the image to
+        between a tenth of its size and nothing at all.
+        """
+        ranges = _affine_ranges(self._only_affine({"ShiftScaleRotate": {"scale_limit": 0.1, "p": 1.0}}))
+        assert ranges["scale"] == pytest.approx((0.9, 1.1), abs=1e-4)
+
+    def test_scale_limit_as_asymmetric_pair(self) -> None:
+        """A pair is also a delta, so it pivots the same way rather than passing through."""
+        ranges = _affine_ranges(self._only_affine({"ShiftScaleRotate": {"scale_limit": (-0.2, 0.5), "p": 1.0}}))
+        assert ranges["scale"] == pytest.approx((0.8, 1.5), abs=1e-4)
+
+    def test_scalar_limits_expand_symmetrically(self) -> None:
+        """`rotate_limit=30` means (-30, 30), not the degenerate (30, 30) `_as_range` would give."""
+        ranges = _affine_ranges(self._only_affine({"ShiftScaleRotate": {"rotate_limit": 30, "p": 1.0}}))
+        assert ranges["degrees"] == pytest.approx((-30.0, 30.0), abs=1e-4)
+
+    def test_defaults_match_albumentations(self) -> None:
+        """An empty config resolves to Albumentations' own documented defaults."""
+        ranges = _affine_ranges(self._only_affine({"ShiftScaleRotate": {"p": 1.0}}))
+        assert ranges["degrees"] == pytest.approx((-45.0, 45.0), abs=1e-4)
+        assert ranges["translate"] == pytest.approx((0.0625, 0.0625), abs=1e-4)
+        assert ranges["scale"] == pytest.approx((0.9, 1.1), abs=1e-4)
+
+    def test_per_axis_shift_limits(self) -> None:
+        """`shift_limit_x`/`shift_limit_y` override the shared limit; Kornia takes them as (tx, ty)."""
+        ranges = _affine_ranges(
+            self._only_affine({"ShiftScaleRotate": {"shift_limit_x": 0.2, "shift_limit_y": 0.05, "p": 1.0}})
+        )
+        assert ranges["translate"] == pytest.approx((0.2, 0.05), abs=1e-4)
+
+    @pytest.mark.parametrize(
+        "key,value",
+        [
+            ("interpolation", 1),
+            ("border_mode", 0),
+            ("mask_interpolation", 0),
+            ("fill", 0),
+            ("fill_mask", 0),
+            ("rotate_method", "ellipse"),
+        ],
+    )
+    def test_unmappable_options_are_reported_not_silently_dropped(self, key, value) -> None:
+        """Kornia's RandomAffine takes only the geometric parameters; the rest must not vanish."""
+        from unittest import mock
+
+        from rfdetr.datasets import kornia_transforms
+
+        with mock.patch.object(kornia_transforms.logger, "warning") as warn:
+            kornia_transforms.build_kornia_pipeline({"ShiftScaleRotate": {key: value}}, 560)
+
+        messages = [c[0][0] % c[0][1:] if len(c[0]) > 1 else c[0][0] for c in warn.call_args_list]
+        assert any("ignores" in m and key in m for m in messages), messages
+
+    def test_a_plain_config_does_not_warn(self) -> None:
+        """Every parameter here maps, so an ordinary config must stay quiet."""
+        from unittest import mock
+
+        from rfdetr.datasets import kornia_transforms
+
+        with mock.patch.object(kornia_transforms.logger, "warning") as warn:
+            kornia_transforms.build_kornia_pipeline(
+                {"ShiftScaleRotate": {"shift_limit": 0.1, "scale_limit": 0.2, "rotate_limit": 15, "p": 1.0}}, 560
+            )
+
+        assert not warn.called, [c[0][0] for c in warn.call_args_list]
+
+    def test_output_keeps_the_input_resolution(self) -> None:
+        """The property that makes this safe where the crops are not."""
+        from rfdetr.datasets.kornia_transforms import build_kornia_pipeline
+
+        img = torch.rand(2, 3, 64, 64)
+        boxes = torch.tensor([[[8.0, 8.0, 40.0, 40.0]], [[4.0, 4.0, 20.0, 20.0]]])
+
+        pipeline = build_kornia_pipeline({"ShiftScaleRotate": {"rotate_limit": 30, "p": 1.0}}, 560)
+        img_out, _ = pipeline(img, boxes)
+
+        assert img_out.shape[-2:] == img.shape[-2:]
+
+    def test_boxes_follow_the_transform(self) -> None:
+        """A geometric transform that left the boxes behind would mislabel every image."""
+        from rfdetr.datasets.kornia_transforms import build_kornia_pipeline
+
+        img = torch.rand(1, 3, 64, 64)
+        boxes = torch.tensor([[[8.0, 8.0, 40.0, 40.0]]])
+
+        pipeline = build_kornia_pipeline({"ShiftScaleRotate": {"rotate_limit": 45, "p": 1.0}}, 560)
+        _, boxes_out = pipeline(img, boxes)
+
+        assert not torch.allclose(boxes_out, boxes), "boxes must move with the image"

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -9,6 +9,8 @@ All tests in this module are CPU-compatible — Kornia operates on CPU tensors i
 ``@pytest.mark.gpu`` is needed.
 """
 
+from typing import Any
+
 import pytest
 import torch
 
@@ -1476,7 +1478,7 @@ class TestGaussianDefaultsMatchAlbumentations:
 # ---------------------------------------------------------------------------
 
 
-def _affine_ranges(transform) -> dict:
+def _affine_ranges(transform: Any) -> dict[str, tuple[float, float]]:
     """Read the resolved degrees/translate/scale off a Kornia ``RandomAffine``.
 
     Like :func:`_sharpness_sampler_range`, this reads a private Kornia detail because no public
@@ -1484,6 +1486,11 @@ def _affine_ranges(transform) -> dict:
     against the installed Kornia version), so the geometric ranges are reachable only through the
     parameter generator. A future Kornia release renaming ``_param_generator`` fails here with an
     actionable message rather than a raw ``AttributeError`` inside a test body.
+
+    Examples:
+        >>> transform = TestShiftScaleRotateFactory()._only_affine({"ShiftScaleRotate": {"p": 1.0}})
+        >>> len(_affine_ranges(transform))
+        3
     """
     generator = getattr(transform, "_param_generator", None)
     if generator is None:
@@ -1518,7 +1525,14 @@ class TestShiftScaleRotateFactory:
     def _require_kornia(self):
         pytest.importorskip("kornia")
 
-    def _only_affine(self, aug_config):
+    def _only_affine(self, aug_config: dict[str, dict[str, Any]]) -> Any:
+        """Build a pipeline and return its sole ``RandomAffine`` transform.
+
+        Examples:
+            >>> transform = TestShiftScaleRotateFactory()._only_affine({"ShiftScaleRotate": {"p": 1.0}})
+            >>> transform.__class__.__name__
+            'RandomAffine'
+        """
         import kornia.augmentation as kornia_augmentation
 
         from rfdetr.datasets.kornia_transforms import build_kornia_pipeline
@@ -1561,6 +1575,27 @@ class TestShiftScaleRotateFactory:
             self._only_affine({"ShiftScaleRotate": {"shift_limit_x": 0.2, "shift_limit_y": 0.05, "p": 1.0}})
         )
         assert ranges["translate"] == pytest.approx((0.2, 0.05), abs=1e-4)
+
+    @pytest.mark.parametrize("key", ["shift_limit_x", "shift_limit_y"])
+    def test_none_per_axis_shift_limit_uses_the_shared_limit(self, key: str) -> None:
+        """Albumentations accepts ``None`` as an axis-level fallback to ``shift_limit``."""
+        ranges = _affine_ranges(self._only_affine({"ShiftScaleRotate": {"shift_limit": 0.2, key: None, "p": 1.0}}))
+        assert ranges["translate"] == pytest.approx((0.2, 0.2), abs=1e-4)
+
+    def test_asymmetric_shift_limit_warns_about_the_symmetric_kornia_approximation(self) -> None:
+        """A one-sided CPU range must not silently become a different GPU distribution."""
+        from unittest import mock
+
+        from rfdetr.datasets import kornia_transforms
+
+        with mock.patch.object(kornia_transforms.logger, "warning") as warn:
+            ranges = _affine_ranges(self._only_affine({"ShiftScaleRotate": {"shift_limit_x": (0.1, 0.2), "p": 1.0}}))
+
+        assert ranges["translate"] == pytest.approx((0.2, 0.0625), abs=1e-4)
+        messages = [
+            call.args[0] % call.args[1:] if len(call.args) > 1 else call.args[0] for call in warn.call_args_list
+        ]
+        assert any("asymmetric" in message and "shift_limit_x" in message for message in messages), messages
 
     @pytest.mark.parametrize(
         "key,value",


### PR DESCRIPTION
## What

Adds `ShiftScaleRotate` to the Kornia GPU augmentation backend. Follow-up to #1330 and #1277, same issue (#1252).

## Why

`ShiftScaleRotate` is one of the names `aug_configs` documents and `transforms.py` accepts on the CPU path, while the Kornia registry rejects it. Backend selection is automatic, so the same `aug_config` trains on a CPU box and raises on a GPU box:

```text
kornia ShiftScaleRotate -> ValueError: Unknown augmentation key 'ShiftScaleRotate' for Kornia GPU backend
albu   ShiftScaleRotate -> OK
```

It is safe to add for the same reason `Perspective` was: **it preserves the output resolution.** The GPU path rebuilds each batch as `NestedTensor(img_aug, samples.mask)`, reusing the pre-augmentation padding mask, so a transform that resizes leaves the mask describing a different shape. That is why the crops stay unsupported, and it does not apply here.

I should correct something I wrote in #1330 while I am here. The doc block excluded this name along with the crops, on the grounds that the group "move boxes and masks". That reason does not hold for this one: `Affine` moves boxes too and has always been supported. Resolution change is the real constraint, and `ShiftScaleRotate` does not change resolution.

## The part that is not a pass-through

Albumentations calls this "a special case of Affine transform", so an alias to `_make_affine` looks obvious. It would be wrong, because the limits are **deltas rather than absolute ranges**.

`scale_limit` is biased by 1 — from the Albumentations docstring:

> Note that the scale_limit will be biased by 1. If scale_limit is a tuple, like (low, high), sampling will be done from the range (1 + low, 1 + high).

So the documented default `(-0.1, 0.1)` means a scale between `0.9` and `1.1`. Kornia's `scale` is the absolute multiplier, so forwarding the raw value would ask it to scale the image to between a tenth of its size and nothing at all. Confirmed against the installed Albumentations rather than trusting the docstring:

```python
>>> A.ShiftScaleRotate(scale_limit=0.1).scale_limit
(0.9, 1.1)
```

The pivot is applied here, the same way `_make_sharpen` already pivots `alpha` at `1.0`.

Two smaller differences in the same vein:

| param | Albumentations | mapped as |
|---|---|---|
| `scale_limit` | delta biased by 1 | `scale=(1 + low, 1 + high)` |
| `shift_limit` | signed fraction range | `translate`, Kornia's non-negative per-axis maximum, as `_make_affine` already does for `translate_percent` |
| `shift_limit_x` / `shift_limit_y` | per-axis override | Kornia's `translate=(tx, ty)` expresses this directly |
| `rotate_limit` | degrees | `degrees` |

All three limits also read a scalar `v` as the symmetric `(-v, v)`, not the degenerate `(v, v)` that `_as_range` gives, so they go through a small `_as_symmetric_range` helper instead.

`interpolation`, `border_mode`, `mask_interpolation`, `fill`, `fill_mask` and `rotate_method` have no `RandomAffine` equivalent and are ignored **with a warning**, matching how `ToGray` and `Sharpen` already report their dropped parameters.

## One thing worth your call

**Albumentations deprecates this name.** Constructing it emits:

```
UserWarning: ShiftScaleRotate is a special case of Affine transform. Please use Affine transform instead.
```

I mapped it anyway because the CPU path in this repo still accepts it, so the parity gap is real for any config already using it, and `albumentations<3.0.0` is pinned. But if you would rather close this name out of `aug_configs` and point users at `Affine` — which this backend already supports — that is a reasonable call and I am happy to send that PR instead. The docs note added here says new configs should prefer `Affine`.

## Tests

14 cases in `TestShiftScaleRotateFactory`, covering the delta semantics (scalar and asymmetric pair), symmetric scalar expansion, the Albumentations defaults, per-axis shifts, each ignored option warning, no spurious warning on an ordinary config, resolution preservation, and boxes moving with the image.

Reading the resolved ranges needs `RandomAffine._param_generator` — `flags` carries only the resampling options — so there is a helper that fails with an actionable message if a future Kornia release changes that shape, mirroring the existing `_sharpness_sampler_range`.

```
121 passed
```
