### PR TITLE
perf(export): partition NumPy top-k selection

### DIFF
--- a/src/rfdetr/export/_topk.py
+++ b/src/rfdetr/export/_topk.py
@@ -72,7 +72,34 @@ def _select_topk_multiclass(
     # so the subsequent ``> threshold`` filter drops the same malformed scores rather than
     # allowing a lower finite score to occupy the cap.
     sort_scores = np.where(np.isnan(flat_scores), np.inf, flat_scores)
-    top_idx = np.lexsort((flat_idx, -sort_scores))[:num_to_select]
+    # Composite-key construction only pays off for sparse selections; dense custom-class
+    # grids retain the direct lexsort path.
+    if (
+        flat_scores.dtype == np.float32
+        and num_to_select < flat_scores.shape[0]
+        and num_to_select * 4 <= flat_scores.shape[0]
+        and flat_scores.shape[0] <= np.iinfo(np.uint32).max
+    ):
+        # Map native IEEE float32 bits to ascending unsigned integers, then invert them for
+        # descending score order. Canonicalising signed zero preserves lexsort's numeric tie,
+        # while replacing NaNs above makes them tie with +inf exactly as the established path.
+        score_bits = sort_scores.view(np.uint32)
+        sign_bit = np.uint32(0x80000000)
+        ordered_scores = score_bits ^ np.where(
+            (score_bits & sign_bit) != 0,
+            np.uint32(0xFFFFFFFF),
+            sign_bit,
+        )
+        ordered_scores[(score_bits & np.uint32(0x7FFFFFFF)) == 0] = sign_bit
+
+        # The low 32 bits make every key unique and encode the ascending flattened-index
+        # tiebreak. Partitioning these composite keys therefore selects the exact same cutoff
+        # set as lexsort, after which only the small selected set needs ordering.
+        selection_keys = ((~ordered_scores).astype(np.uint64) << np.uint64(32)) | flat_idx.astype(np.uint64)
+        partition_idx = np.argpartition(selection_keys, num_to_select - 1)[:num_to_select]
+        top_idx = partition_idx[np.argsort(selection_keys[partition_idx], kind="stable")]
+    else:
+        top_idx = np.lexsort((flat_idx, -sort_scores))[:num_to_select]
 
     topk_scores = flat_scores[top_idx]
     topk_query = top_idx // num_classes

--- a/tests/export/test_topk_selection_parity.py
+++ b/tests/export/test_topk_selection_parity.py
@@ -21,6 +21,8 @@ backend.
 
 from __future__ import annotations
 
+from unittest import mock
+
 import numpy as np
 import pytest
 import torch
@@ -45,6 +47,86 @@ def _reference_select_topk(
 
 
 class TestTopkSelectionParity:
+    def test_float32_partial_selection_uses_partition_without_full_sort(self) -> None:
+        """The common float32 partial-selection path partitions instead of sorting the complete score grid."""
+        rng = np.random.default_rng(12)
+        scores_all = rng.random((300, 91), dtype=np.float32)
+        num_select = 300
+        flat_scores = scores_all.reshape(-1)
+        flat_idx = np.arange(flat_scores.size, dtype=np.int64)
+        expected_idx = np.lexsort((flat_idx, -flat_scores))[:num_select]
+
+        with (
+            mock.patch("rfdetr.export._topk.np.argpartition", wraps=np.argpartition) as partition,
+            mock.patch("rfdetr.export._topk.np.lexsort", wraps=np.lexsort) as lexsort,
+        ):
+            scores, labels, queries = _select_topk_multiclass(scores_all, threshold=-1.0, num_select=num_select)
+
+        partition.assert_called_once()
+        lexsort.assert_not_called()
+        np.testing.assert_array_equal(scores.view(np.uint32), flat_scores[expected_idx].view(np.uint32))
+        np.testing.assert_array_equal(queries * scores_all.shape[1] + labels, expected_idx)
+
+    def test_dense_float32_selection_retains_full_sort(self) -> None:
+        """Selecting more than one quarter of the grid avoids partition overhead."""
+        rng = np.random.default_rng(13)
+        scores_all = rng.random((300, 2), dtype=np.float32)
+        num_select = 300
+        flat_scores = scores_all.reshape(-1)
+        flat_idx = np.arange(flat_scores.size, dtype=np.int64)
+        expected_idx = np.lexsort((flat_idx, -flat_scores))[:num_select]
+
+        with (
+            mock.patch("rfdetr.export._topk.np.argpartition", wraps=np.argpartition) as partition,
+            mock.patch("rfdetr.export._topk.np.lexsort", wraps=np.lexsort) as lexsort,
+        ):
+            scores, labels, queries = _select_topk_multiclass(scores_all, threshold=-1.0, num_select=num_select)
+
+        partition.assert_not_called()
+        lexsort.assert_called_once()
+        np.testing.assert_array_equal(scores.view(np.uint32), flat_scores[expected_idx].view(np.uint32))
+        np.testing.assert_array_equal(queries * scores_all.shape[1] + labels, expected_idx)
+
+    def test_float32_partition_preserves_special_value_and_tie_order(self) -> None:
+        """NaN, infinity, signed zero, and tied cutoff scores retain the established lexicographic order."""
+        scores_all = np.full((8, 4), -np.inf, dtype=np.float32)
+        scores_all.reshape(-1)[:8] = np.array(
+            [np.nan, np.inf, 1.0, 1.0, 0.0, -0.0, -1.0, -np.inf],
+            dtype=np.float32,
+        )
+        flat_scores = scores_all.reshape(-1)
+        flat_idx = np.arange(flat_scores.size, dtype=np.int64)
+        sort_scores = np.where(np.isnan(flat_scores), np.inf, flat_scores)
+        expected_idx = np.lexsort((flat_idx, -sort_scores))[:8]
+        expected_scores = flat_scores[expected_idx]
+        expected_keep = expected_scores > -np.inf
+
+        with mock.patch("rfdetr.export._topk.np.argpartition", wraps=np.argpartition) as partition:
+            scores, labels, queries = _select_topk_multiclass(scores_all, threshold=-np.inf, num_select=8)
+
+        partition.assert_called_once()
+        np.testing.assert_array_equal(scores.view(np.uint32), expected_scores[expected_keep].view(np.uint32))
+        np.testing.assert_array_equal(
+            queries * scores_all.shape[1] + labels,
+            expected_idx[expected_keep],
+        )
+
+    @pytest.mark.parametrize("dtype", [np.float16, np.float64], ids=["float16", "float64"])
+    def test_non_float32_fallback_preserves_exact_order(self, dtype: type[np.floating]) -> None:
+        """Other floating dtypes retain the complete lexicographic fallback."""
+        scores_all = np.array([[0.5, 0.5, 0.25], [0.75, np.nan, -0.0]], dtype=dtype)
+        flat_scores = scores_all.reshape(-1)
+        flat_idx = np.arange(flat_scores.size, dtype=np.int64)
+        sort_scores = np.where(np.isnan(flat_scores), np.inf, flat_scores)
+        expected_idx = np.lexsort((flat_idx, -sort_scores))[:4]
+        expected_scores = flat_scores[expected_idx]
+        expected_keep = expected_scores > -1.0
+
+        scores, labels, queries = _select_topk_multiclass(scores_all, threshold=-1.0, num_select=4)
+
+        np.testing.assert_array_equal(scores.view(np.uint8), expected_scores[expected_keep].view(np.uint8))
+        np.testing.assert_array_equal(queries * scores_all.shape[1] + labels, expected_idx[expected_keep])
+
     @pytest.mark.parametrize("seed", [0, 1, 2, 7, 42])
     def test_matches_postprocess_select_topk(self, seed: int) -> None:
         """Random logits: the (query, class, score) set our NumPy helper keeps above threshold must equal what


### PR DESCRIPTION
The NumPy export decoder currently applies `np.lexsort` to the complete query/class score grid before retaining `num_select` entries. With 300 queries and 91 label slots, that's a full sort of 27,300 values to keep just 300.

**Changes**

- Encode native float32 score order and the flattened-index tie break into a uint64 key, partition sparse selections, then sort only that set.
- Keep lexsort when more than one quarter of the grid is selected, as well as for other dtypes, full selection, and inputs beyond the 32-bit index range.
- Add regression coverage for sparse and dense path selection, ties, NaN/Inf, signed zero, cutoff behavior, and fallback dtypes.

**Performance**

The retained helper benchmark alternates AB/BA order for nine paired CPU rounds on a `300x91`, `k=300` score grid:

| NumPy | Before, median (range) | After, median (range) | Reduction |
|---|---:|---:|---:|
| 1.26.4 | 2664.662 us (2659.094-2665.750) | 644.571 us (642.767-648.185) | 75.81% |
| 2.2.6 | 2812.472 us (2811.518-2819.535) | 327.971 us (327.195-332.129) | 88.34% |

An adversarial class-count sweep found the first version slower for dense two-class selection. With the one-quarter guard, `300x2`, `k=300` stays on lexsort and is within +1.35% / +1.39% of the old helper on NumPy 1.26.4 / 2.2.6. The partition path is faster from `300x4`, `k=300` in both environments.

The complete batch-1 path was also measured with a real RFDETRNano ONNX model and 12 real COCO images. Each timing includes image open, NumPy preprocessing, ONNX Runtime, sigmoid/top-k, and `Detections` construction:

| Provider | Before | After | Paired median change | Faster pairs |
|---|---:|---:|---:|---:|
| CPU, one core/thread | 389.670 ms/image | 386.858 ms/image | -2.100 ms (-0.540%) | 14/15 |
| NVIDIA L4 CUDA, run 1 | 48.898 ms/image | 46.516 ms/image | -2.520 ms (-5.161%) | 21/21 |
| NVIDIA L4 CUDA, run 2 | 48.744 ms/image | 46.319 ms/image | -2.365 ms (-4.858%) | 21/21 |

The CPU paired range crosses zero (-1.822% to +0.425%). Both CUDA ranges exclude zero (-5.806% to -3.325% and -6.436% to -4.267%), and 42/42 CUDA pairs improved. An ONNX Runtime profile placed 722/722 model node events on CUDA. Final boxes, confidence bytes, and class IDs were exact between baseline and candidate for each of the 12 inputs.

**Validation**

- 20,000 varied cases matched the existing score bytes and flattened indices exactly, including ties, NaN/Inf, signed zero, non-contiguous inputs, and cutoff sizes.
- Raw pretrained Nano outputs matched the existing selector exactly on the 5,000 COCO val2017 images.
- Sparse path-selection test: red on unmodified `develop` because `argpartition` is not called, green after the change.
- Dense two-class regression test: red on the first candidate because `argpartition` is called, green with the routing guard.
- Focused selection tests: 20 passed.
- Full CPU suite: 4251 passed, 80 skipped.
- Strict precommit passed, including mypy.
- The patch is two related files and no open PR touches either one.

I did not benchmark TFLite, another accelerator architecture, or batches above one .. hope this helps!
