### PR TITLE
perf(export): make NumPy bilinear resize separable

### DIFF
--- a/src/rfdetr/export/_resize.py
+++ b/src/rfdetr/export/_resize.py
@@ -49,9 +49,19 @@ def _bilinear_resize_half_pixel(src: NDArray[np.float32], out_h: int, out_w: int
     x1 = np.minimum(x0 + 1, src_w - 1)
     dy = (src_y - y0)[:, None]
     dx = (src_x - x0)[None, :]
-    a = src[..., y0[:, None], x0[None, :]]
-    b = src[..., y0[:, None], x1[None, :]]
-    c = src[..., y1[:, None], x0[None, :]]
-    d = src[..., y1[:, None], x1[None, :]]
-    out = (1 - dy) * ((1 - dx) * a + dx * b) + dy * ((1 - dx) * c + dx * d)
+    if 3 * src_h < 4 * out_h:
+        # Interpolate each source row horizontally once, then gather the two rows needed for
+        # each output pixel. This preserves the existing arithmetic order while avoiding four
+        # full output-grid gathers. Keep the three source-height work grids below the size of
+        # those four output-height gathers; otherwise retain the bounded formulation below.
+        left = np.take(src, x0, axis=-1)
+        right = np.take(src, x1, axis=-1)
+        horizontal = (1 - dx) * left + dx * right
+        out = (1 - dy) * horizontal[..., y0, :] + dy * horizontal[..., y1, :]
+    else:
+        a = src[..., y0[:, None], x0[None, :]]
+        b = src[..., y0[:, None], x1[None, :]]
+        c = src[..., y1[:, None], x0[None, :]]
+        d = src[..., y1[:, None], x1[None, :]]
+        out = (1 - dy) * ((1 - dx) * a + dx * b) + dy * ((1 - dx) * c + dx * d)
     return np.asarray(out, dtype=np.float32)

--- a/tests/export/test_tflite_inference.py
+++ b/tests/export/test_tflite_inference.py
@@ -812,6 +812,36 @@ class TestMaskDecoding:
 class TestBilinearResizeHalfPixel:
     """Tests for ``_bilinear_resize_half_pixel()``."""
 
+    def test_near_scale_ratio_uses_separable_horizontal_pass(self) -> None:
+        """Near-scale resizes interpolate source rows once before gathering output rows."""
+        src = np.arange(2 * 7 * 8, dtype=np.float32).reshape(2, 7, 8)
+
+        with mock.patch("rfdetr.export._resize.np.take", wraps=np.take) as take:
+            out = _bilinear_resize_half_pixel(src, 6, 5)
+
+        assert out.shape == (2, 6, 5)
+        assert take.call_count == 2
+
+    def test_large_downscale_retains_bounded_output_grid(self) -> None:
+        """Large height reductions avoid a separable intermediate proportional to the source height."""
+        src = np.arange(25 * 9, dtype=np.float32).reshape(1, 25, 9)
+
+        with mock.patch("rfdetr.export._resize.np.take", wraps=np.take) as take:
+            out = _bilinear_resize_half_pixel(src, 6, 5)
+
+        assert out.shape == (1, 6, 5)
+        take.assert_not_called()
+
+    def test_four_thirds_boundary_retains_output_grid(self) -> None:
+        """The exact 4:3 height boundary avoids the larger three-source-grid intermediate."""
+        src = np.arange(2 * 8 * 9, dtype=np.float32).reshape(2, 8, 9)
+
+        with mock.patch("rfdetr.export._resize.np.take", wraps=np.take) as take:
+            out = _bilinear_resize_half_pixel(src, 6, 5)
+
+        assert out.shape == (2, 6, 5)
+        take.assert_not_called()
+
     def test_output_shape(self) -> None:
         """Output shape is (K, out_h, out_w)."""
         src = np.ones((3, 8, 8), dtype=np.float32)


### PR DESCRIPTION
The torch-free bilinear resize gathers four complete output grids before combining them. For near-scale inputs, the horizontal interpolation can be computed once per source row and reused by the two vertical gathers.

**Changes**

- Use a separable horizontal pass when `3 * src_h < 4 * out_h`, preserving the existing arithmetic order and float32 output.
- Retain the four-output-grid path at and above the exact 4:3 boundary, which bounds the candidate's three source-height work grids.
- Add regression tests for the selected path, the exact boundary, and a large downscale.

**Performance**

I also exported a real RFDETRNano ONNX model and timed the complete torch-free reference path: image open, NumPy preprocessing, ONNX Runtime CPU inference, sigmoid/top-k, and `Detections` construction. The session used one CPU thread; each row is seven alternating rounds over six real COCO images, repeated in two fresh runs.

| Route | Run | Before, median (range) | After, median (range) | Change |
|---|---:|---:|---:|---:|
| separable selected | 1 | 389.663 ms (383.850-392.842) | 375.517 ms (367.685-379.759) | -3.63% |
| separable selected | 2 | 395.074 ms (389.847-395.626) | 380.403 ms (374.988-383.649) | -3.71% |
| fallback | 1 | 389.275 ms (385.072-390.499) | 390.475 ms (388.192-390.784) | +0.31% |
| fallback | 2 | 392.955 ms (388.238-394.505) | 392.639 ms (385.549-394.882) | -0.08% |

The pre-timing A/B parity check was bit-identical for each of the 12 images. This is the end-to-end gain for the CPU reference decoder on selected images; it is much smaller than the isolated resize gain because ONNX model execution dominates the roughly 390 ms call.

Nine alternating CPU rounds, ten calls per round, on real COCO images resized to 384:

| Input shape | Route | Before, median (range) | After, median (range) | Change |
|---|---|---:|---:|---:|
| `3x424x640` | separable | 26.411 ms (25.477-26.802) | 14.277 ms (13.320-14.859) | -45.94% |
| `3x640x427` | fallback | 25.970 ms (25.410-26.352) | 25.977 ms (25.354-27.117) | +0.03% |
| `3x640x640` | fallback | 27.155 ms (26.983-27.483) | 27.007 ms (26.698-28.340) | -0.54% |

A synthetic `100x28x28 -> 100x384x384` mask tensor improved from 473.544 ms (467.343-475.607) to 206.412 ms (203.208-213.534), while traced peak allocation fell from 562.65 to 353.99 MiB.

The guard is intentionally narrow. An unguarded `1x1504x640 -> 1x384x384` separable pass regressed 16.67% and increased traced peak allocation from 5.77 to 13.37 MiB. The selected RGB path can use slightly more temporary memory (17.02 to 17.66 MiB in the measured example), so this is not a universal memory-reduction claim.

**Validation**

The 5,000-image COCO val2017 sweep matched the baseline bit-for-bit for both resized and normalized float32 outputs; 3,720 used the separable route and 1,280 used the fallback. A retained 20,000-case fuzz run was also bit-exact across both routes and 400 exact-boundary cases.

The complete TFLite inference test file passed 59 tests, the CPU repository suite passed 4,249 tests with 80 skipped, and strict precommit completed with each hook passing. The patch touches two related files, and a read-only audit of 23 open PRs found no overlap.

I did not benchmark a complete exported TFLite segmentation model or another CPU architecture. The ONNX measurement covers the real serialized Nano detection path; the mask measurement still isolates a realistically shaped synthetic tensor at the shared helper boundary.
