### PR TITLE
fix(augment): align Kornia GaussianBlur/GaussNoise defaults with albumentations

### DIFF
--- a/src/rfdetr/datasets/aug_configs.py
+++ b/src/rfdetr/datasets/aug_configs.py
@@ -84,7 +84,7 @@ or torchvision defaults. Install it with ``pip install 'rfdetr[augment]'``.
 | ``ColorJitter`` | ``K.ColorJiggle`` | Same multiplicative semantics |
 | ``ToGray`` | ``K.RandomGrayscale`` | Grayscale, 3 channels; only ``p`` honored, method/num_output_channels ignored |
 | ``RandomBrightnessContrast`` | ``K.ColorJiggle`` | ``brightness_limit`` / ``contrast_limit`` direct |
-| ``GaussianBlur`` | ``K.RandomGaussianBlur`` | ``blur_limit`` rounded up to odd; ``sigma`` default to alb. (0.5, 3.0) |
+| ``GaussianBlur`` | ``K.RandomGaussianBlur`` | ``blur_limit`` rounded up to odd; ``sigma`` mirrors Albumentations |
 | ``GaussNoise`` | ``K.RandomGaussianNoise`` | Upper bound of ``std_range`` used as fixed std |
 | ``Blur`` | ``K.RandomBoxBlur`` | Box blur; ``blur_limit`` rounded up to odd, pair collapses to its upper bound |
 | ``Sharpen`` | ``K.RandomSharpness`` | ``sharpness = 1.0 + alpha`` (1.0-pivoted); ``lightness``/``method`` ignored |

--- a/src/rfdetr/datasets/aug_configs.py
+++ b/src/rfdetr/datasets/aug_configs.py
@@ -84,7 +84,7 @@ or torchvision defaults. Install it with ``pip install 'rfdetr[augment]'``.
 | ``ColorJitter`` | ``K.ColorJiggle`` | Same multiplicative semantics |
 | ``ToGray`` | ``K.RandomGrayscale`` | Grayscale, 3 channels; only ``p`` honored, method/num_output_channels ignored |
 | ``RandomBrightnessContrast`` | ``K.ColorJiggle`` | ``brightness_limit`` / ``contrast_limit`` direct |
-| ``GaussianBlur`` | ``K.RandomGaussianBlur`` | ``blur_limit`` rounded up to odd; ``sigma=(0.1, 2.0)`` |
+| ``GaussianBlur`` | ``K.RandomGaussianBlur`` | ``blur_limit`` rounded up to odd; ``sigma`` defaults to the albumentations (0.5, 3.0) |
 | ``GaussNoise`` | ``K.RandomGaussianNoise`` | Upper bound of ``std_range`` used as fixed std |
 | ``Blur`` | ``K.RandomBoxBlur`` | Box blur; ``blur_limit`` rounded up to odd, pair collapses to its upper bound |
 | ``Sharpen`` | ``K.RandomSharpness`` | ``sharpness = 1.0 + alpha`` (1.0-pivoted); ``lightness``/``method`` ignored |

--- a/src/rfdetr/datasets/aug_configs.py
+++ b/src/rfdetr/datasets/aug_configs.py
@@ -84,7 +84,7 @@ or torchvision defaults. Install it with ``pip install 'rfdetr[augment]'``.
 | ``ColorJitter`` | ``K.ColorJiggle`` | Same multiplicative semantics |
 | ``ToGray`` | ``K.RandomGrayscale`` | Grayscale, 3 channels; only ``p`` honored, method/num_output_channels ignored |
 | ``RandomBrightnessContrast`` | ``K.ColorJiggle`` | ``brightness_limit`` / ``contrast_limit`` direct |
-| ``GaussianBlur`` | ``K.RandomGaussianBlur`` | ``blur_limit`` rounded up to odd; ``sigma`` defaults to the albumentations (0.5, 3.0) |
+| ``GaussianBlur`` | ``K.RandomGaussianBlur`` | ``blur_limit`` rounded up to odd; ``sigma`` default to alb. (0.5, 3.0) |
 | ``GaussNoise`` | ``K.RandomGaussianNoise`` | Upper bound of ``std_range`` used as fixed std |
 | ``Blur`` | ``K.RandomBoxBlur`` | Box blur; ``blur_limit`` rounded up to odd, pair collapses to its upper bound |
 | ``Sharpen`` | ``K.RandomSharpness`` | ``sharpness = 1.0 + alpha`` (1.0-pivoted); ``lightness``/``method`` ignored |

--- a/src/rfdetr/datasets/kornia_transforms.py
+++ b/src/rfdetr/datasets/kornia_transforms.py
@@ -481,8 +481,11 @@ def _make_gaussian_blur(params: dict[str, Any]) -> Any:
 
     # Shared with Blur: a (min, max) pair collapses to its upper bound, forced odd and >= 3.
     blur_limit = _as_odd_kernel(params.get("blur_limit", 3), "GaussianBlur")
-    # Match the CPU albumentations default sigma range while allowing an explicit override via config.
-    sigma_range = params.get("sigma", (0.1, 2.0))
+    # Default to the CPU (albumentations) GaussianBlur sigma_limit default, (0.5, 3.0), so the same
+    # aug_config blurs by the same amount on either backend. The previous default (0.1, 2.0) was Kornia's
+    # own convention, so an unspecified sigma blurred noticeably less on the GPU path; AUG_INDUSTRIAL
+    # reaches this default (it sets blur_limit but no sigma). An explicit sigma still wins.
+    sigma_range = params.get("sigma", (0.5, 3.0))
     blur_sigma = _as_range(sigma_range)
     return RandomGaussianBlur(
         kernel_size=(blur_limit, blur_limit),
@@ -500,7 +503,10 @@ def _make_gauss_noise(params: dict[str, Any]) -> Any:
     """
     from kornia.augmentation import RandomGaussianNoise
 
-    std_range = _as_range(params.get("std_range", (0.01, 0.05)))
+    # Default to the CPU (albumentations) GaussNoise std_range default, (0.2, 0.44), on the 0-1 image
+    # scale both backends use, so an unspecified std_range adds the same noise on either path. The
+    # previous default (0.01, 0.05) was rf-detr's own, 4-9x weaker than the CPU backend.
+    std_range = _as_range(params.get("std_range", (0.2, 0.44)))
     if std_range[0] != std_range[1]:
         logger.warning(
             "GPU augmentation (Kornia) uses fixed std=%.3f for GaussianNoise "

--- a/src/rfdetr/datasets/kornia_transforms.py
+++ b/src/rfdetr/datasets/kornia_transforms.py
@@ -481,11 +481,20 @@ def _make_gaussian_blur(params: dict[str, Any]) -> Any:
 
     # Shared with Blur: a (min, max) pair collapses to its upper bound, forced odd and >= 3.
     blur_limit = _as_odd_kernel(params.get("blur_limit", 3), "GaussianBlur")
-    # Default to the CPU (albumentations) GaussianBlur sigma_limit default, (0.5, 3.0), so the same
-    # aug_config blurs by the same amount on either backend. The previous default (0.1, 2.0) was Kornia's
-    # own convention, so an unspecified sigma blurred noticeably less on the GPU path; AUG_INDUSTRIAL
-    # reaches this default (it sets blur_limit but no sigma). An explicit sigma still wins.
-    sigma_range = params.get("sigma", (0.5, 3.0))
+    if "sigma" in params:
+        sigma_range = params["sigma"]
+    else:
+        # The supported Albumentations range has version-dependent defaults. Read the installed CPU transform so a
+        # shared config stays aligned whenever both optional augmentation backends are available; otherwise retain
+        # Kornia's original default for GPU-only installations. AUG_INDUSTRIAL reaches this branch.
+        try:
+            import albumentations
+        except ModuleNotFoundError as error:
+            if error.name != "albumentations":
+                raise
+            sigma_range = (0.1, 2.0)
+        else:
+            sigma_range = albumentations.GaussianBlur().sigma_limit
     blur_sigma = _as_range(sigma_range)
     return RandomGaussianBlur(
         kernel_size=(blur_limit, blur_limit),
@@ -504,8 +513,8 @@ def _make_gauss_noise(params: dict[str, Any]) -> Any:
     from kornia.augmentation import RandomGaussianNoise
 
     # Default to the CPU (albumentations) GaussNoise std_range default, (0.2, 0.44), on the 0-1 image
-    # scale both backends use, so an unspecified std_range adds the same noise on either path. The
-    # previous default (0.01, 0.05) was rf-detr's own, 4-9x weaker than the CPU backend.
+    # scale both backends use. Kornia still fixes its std at the upper bound, while the CPU path samples
+    # the range; the warning below makes that unavoidable distribution difference visible.
     std_range = _as_range(params.get("std_range", (0.2, 0.44)))
     if std_range[0] != std_range[1]:
         logger.warning(

--- a/src/rfdetr/datasets/kornia_transforms.py
+++ b/src/rfdetr/datasets/kornia_transforms.py
@@ -487,14 +487,12 @@ def _make_gaussian_blur(params: dict[str, Any]) -> Any:
         # The supported Albumentations range has version-dependent defaults. Read the installed CPU transform so a
         # shared config stays aligned whenever both optional augmentation backends are available; otherwise retain
         # Kornia's original default for GPU-only installations. AUG_INDUSTRIAL reaches this branch.
-        try:
+        if AugmentationBackend.ALBU._is_available():
             import albumentations
-        except ModuleNotFoundError as error:
-            if error.name != "albumentations":
-                raise
-            sigma_range = (0.1, 2.0)
-        else:
+
             sigma_range = albumentations.GaussianBlur().sigma_limit
+        else:
+            sigma_range = (0.1, 2.0)
     blur_sigma = _as_range(sigma_range)
     return RandomGaussianBlur(
         kernel_size=(blur_limit, blur_limit),

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -9,8 +9,6 @@ All tests in this module are CPU-compatible — Kornia operates on CPU tensors i
 ``@pytest.mark.gpu`` is needed.
 """
 
-import builtins
-
 import pytest
 import torch
 
@@ -1343,51 +1341,24 @@ class TestGaussianDefaultsMatchAlbumentations:
             f"{cpu_default} on the CPU path, so the same config uses different default sigma bounds"
         )
 
-    def test_gaussian_blur_propagates_nested_albumentations_import_error(self, monkeypatch):
-        """A broken Albumentations dependency must not be mistaken for the package being absent."""
-        from rfdetr.datasets import kornia_transforms
-
-        original_import = builtins.__import__
-
-        def import_with_broken_albumentations(name, *args, **kwargs):
-            if name == "albumentations":
-                raise ModuleNotFoundError("No module named 'albumentations.core'", name="albumentations.core")
-            return original_import(name, *args, **kwargs)
-
-        monkeypatch.setattr(builtins, "__import__", import_with_broken_albumentations)
-
-        with pytest.raises(ModuleNotFoundError, match=r"albumentations\.core"):
-            kornia_transforms._make_gaussian_blur({"blur_limit": 3, "p": 0.3})
-
-    def test_gaussian_blur_uses_kornia_default_without_albumentations(self, monkeypatch):
+    def test_gaussian_blur_uses_kornia_default_when_albu_backend_is_unavailable(self, monkeypatch):
         """A GPU-only install keeps Kornia's historic GaussianBlur default."""
+        from rfdetr.config import AugmentationBackend
         from rfdetr.datasets import kornia_transforms
 
-        original_import = builtins.__import__
-
-        def import_without_albumentations(name, *args, **kwargs):
-            if name == "albumentations":
-                raise ModuleNotFoundError("No module named 'albumentations'", name="albumentations")
-            return original_import(name, *args, **kwargs)
-
-        monkeypatch.setattr(builtins, "__import__", import_without_albumentations)
+        monkeypatch.setattr(
+            AugmentationBackend,
+            "_is_available",
+            lambda self: self is not AugmentationBackend.ALBU,
+        )
 
         transform = kornia_transforms._make_gaussian_blur({"blur_limit": 3, "p": 0.3})
 
         assert tuple(float(value) for value in transform._param_generator.sigma) == pytest.approx((0.1, 2.0))
 
-    def test_gaussian_blur_keeps_explicit_sigma_when_albumentations_is_unavailable(self, monkeypatch):
-        """An explicit sigma remains authoritative when the optional CPU backend is absent."""
+    def test_gaussian_blur_keeps_explicit_sigma(self):
+        """An explicit sigma remains authoritative over backend availability."""
         from rfdetr.datasets import kornia_transforms
-
-        original_import = builtins.__import__
-
-        def import_without_albumentations(name, *args, **kwargs):
-            if name == "albumentations":
-                raise ModuleNotFoundError("No module named 'albumentations'", name="albumentations")
-            return original_import(name, *args, **kwargs)
-
-        monkeypatch.setattr(builtins, "__import__", import_without_albumentations)
 
         transform = kornia_transforms._make_gaussian_blur({"blur_limit": 3, "sigma": (1.25, 1.5), "p": 0.3})
 

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -1320,9 +1320,9 @@ class TestPerspectiveFactory:
 
 
 class TestGaussianDefaultsMatchAlbumentations:
-    """The unspecified GaussianBlur sigma and GaussNoise std defaults must match the
-    Albumentations defaults they stand in for (issue #1351): the same aug_config with no
-    explicit value should augment by the same amount on either backend."""
+    """The unspecified GaussianBlur sigma and GaussNoise std defaults must match the Albumentations defaults they stand
+    in for (issue #1351): the same aug_config with no explicit value should augment by the same amount on either
+    backend."""
 
     @pytest.fixture(autouse=True)
     def _require_kornia(self):
@@ -1361,8 +1361,8 @@ class TestGaussianDefaultsMatchAlbumentations:
         )
 
     def test_default_gauss_noise_warns_because_the_default_range_is_non_degenerate(self):
-        """The albumentations default range is non-degenerate, so building with no std_range
-        still emits the fixed-std divergence warning rather than going silent."""
+        """The albumentations default range is non-degenerate, so building with no std_range still emits the fixed-std
+        divergence warning rather than going silent."""
         from unittest import mock
 
         from rfdetr.datasets import kornia_transforms

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -1317,3 +1317,57 @@ class TestPerspectiveFactory:
 
         with pytest.raises(ValueError, match="Unknown augmentation key"):
             build_kornia_pipeline({name: {"height": 32, "width": 32}}, 560)
+
+
+class TestGaussianDefaultsMatchAlbumentations:
+    """The unspecified GaussianBlur sigma and GaussNoise std defaults must match the
+    Albumentations defaults they stand in for (issue #1351): the same aug_config with no
+    explicit value should augment by the same amount on either backend."""
+
+    @pytest.fixture(autouse=True)
+    def _require_kornia(self):
+        pytest.importorskip("kornia")
+
+    def test_gaussian_blur_sigma_default_matches_albumentations(self):
+        """An unspecified sigma must equal albumentations' GaussianBlur sigma_limit default."""
+        albumentations = pytest.importorskip("albumentations")
+
+        from rfdetr.datasets import kornia_transforms
+
+        cpu_default = tuple(albumentations.GaussianBlur().sigma_limit)
+        transform = kornia_transforms._make_gaussian_blur({"blur_limit": 3, "p": 0.3})
+        gpu_default = tuple(float(v) for v in transform._param_generator.sigma)
+
+        assert gpu_default == pytest.approx(cpu_default), (
+            f"unspecified GaussianBlur sigma is {gpu_default} on the GPU path but "
+            f"{cpu_default} on the CPU path, so the same config blurs by different amounts"
+        )
+
+    def test_gauss_noise_std_default_matches_albumentations(self):
+        """An unspecified std_range must equal albumentations' GaussNoise std_range default."""
+        albumentations = pytest.importorskip("albumentations")
+
+        from rfdetr.datasets import kornia_transforms
+
+        cpu_default = tuple(albumentations.GaussNoise().std_range)
+        # Kornia takes a single std (the range's upper bound); the DEFAULT range must still
+        # be the albumentations one, so an unspecified config lands on the same upper bound.
+        transform = kornia_transforms._make_gauss_noise({"p": 0.3})
+        gpu_std = float(transform.flags["std"])
+
+        assert gpu_std == pytest.approx(cpu_default[1]), (
+            f"unspecified GaussNoise std is {gpu_std} on the GPU path but the CPU path "
+            f"samples up to {cpu_default[1]}, so the same config adds different noise"
+        )
+
+    def test_default_gauss_noise_warns_because_the_default_range_is_non_degenerate(self):
+        """The albumentations default range is non-degenerate, so building with no std_range
+        still emits the fixed-std divergence warning rather than going silent."""
+        from unittest import mock
+
+        from rfdetr.datasets import kornia_transforms
+
+        with mock.patch.object(kornia_transforms.logger, "warning") as mock_warning:
+            kornia_transforms._make_gauss_noise({"p": 0.3})
+
+        mock_warning.assert_called_once()

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -9,6 +9,8 @@ All tests in this module are CPU-compatible — Kornia operates on CPU tensors i
 ``@pytest.mark.gpu`` is needed.
 """
 
+import builtins
+
 import pytest
 import torch
 
@@ -1320,9 +1322,8 @@ class TestPerspectiveFactory:
 
 
 class TestGaussianDefaultsMatchAlbumentations:
-    """The unspecified GaussianBlur sigma and GaussNoise std defaults must match the Albumentations defaults they stand
-    in for (issue #1351): the same aug_config with no explicit value should augment by the same amount on either
-    backend."""
+    """Unspecified Gaussian defaults must align to Albumentations bounds while documenting known sampling
+    differences."""
 
     @pytest.fixture(autouse=True)
     def _require_kornia(self):
@@ -1340,8 +1341,58 @@ class TestGaussianDefaultsMatchAlbumentations:
 
         assert gpu_default == pytest.approx(cpu_default), (
             f"unspecified GaussianBlur sigma is {gpu_default} on the GPU path but "
-            f"{cpu_default} on the CPU path, so the same config blurs by different amounts"
+            f"{cpu_default} on the CPU path, so the same config uses different default sigma bounds"
         )
+
+    def test_gaussian_blur_propagates_nested_albumentations_import_error(self, monkeypatch):
+        """A broken Albumentations dependency must not be mistaken for the package being absent."""
+        from rfdetr.datasets import kornia_transforms
+
+        original_import = builtins.__import__
+
+        def import_with_broken_albumentations(name, *args, **kwargs):
+            if name == "albumentations":
+                raise ModuleNotFoundError("No module named 'albumentations.core'", name="albumentations.core")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", import_with_broken_albumentations)
+
+        with pytest.raises(ModuleNotFoundError, match=r"albumentations\.core"):
+            kornia_transforms._make_gaussian_blur({"blur_limit": 3, "p": 0.3})
+
+    def test_gaussian_blur_uses_kornia_default_without_albumentations(self, monkeypatch):
+        """A GPU-only install keeps Kornia's historic GaussianBlur default."""
+        from rfdetr.datasets import kornia_transforms
+
+        original_import = builtins.__import__
+
+        def import_without_albumentations(name, *args, **kwargs):
+            if name == "albumentations":
+                raise ModuleNotFoundError("No module named 'albumentations'", name="albumentations")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", import_without_albumentations)
+
+        transform = kornia_transforms._make_gaussian_blur({"blur_limit": 3, "p": 0.3})
+
+        assert tuple(float(value) for value in transform._param_generator.sigma) == pytest.approx((0.1, 2.0))
+
+    def test_gaussian_blur_keeps_explicit_sigma_when_albumentations_is_unavailable(self, monkeypatch):
+        """An explicit sigma remains authoritative when the optional CPU backend is absent."""
+        from rfdetr.datasets import kornia_transforms
+
+        original_import = builtins.__import__
+
+        def import_without_albumentations(name, *args, **kwargs):
+            if name == "albumentations":
+                raise ModuleNotFoundError("No module named 'albumentations'", name="albumentations")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", import_without_albumentations)
+
+        transform = kornia_transforms._make_gaussian_blur({"blur_limit": 3, "sigma": (1.25, 1.5), "p": 0.3})
+
+        assert tuple(float(value) for value in transform._param_generator.sigma) == pytest.approx((1.25, 1.5))
 
     def test_gauss_noise_std_default_matches_albumentations(self):
         """An unspecified std_range must equal albumentations' GaussNoise std_range default."""
@@ -1357,7 +1408,7 @@ class TestGaussianDefaultsMatchAlbumentations:
 
         assert gpu_std == pytest.approx(cpu_default[1]), (
             f"unspecified GaussNoise std is {gpu_std} on the GPU path but the CPU path "
-            f"samples up to {cpu_default[1]}, so the same config adds different noise"
+            f"samples up to {cpu_default[1]}, so the default upper bound is not aligned"
         )
 
     def test_default_gauss_noise_warns_because_the_default_range_is_non_degenerate(self):


### PR DESCRIPTION
## What

Aligns two Kornia augmentation-factory defaults with the Albumentations defaults they stand in for. Closes #1351.

## Why

For the same `aug_config`, switching `augmentation_backend` silently changed augmentation strength, because two Kornia defaults did not match Albumentations':

**GaussianBlur sigma.** `AUG_INDUSTRIAL` sets `{"GaussianBlur": {"blur_limit": 3, "p": 0.3}}` with no `sigma`, so both backends fall back to their own default:

```
GPU (kornia)         sigma = (0.1, 2.0)   <- Kornia's convention
CPU (albumentations) sigma = (0.5, 3.0)   <- what the config actually means
```

The call-site comment claimed it "Match[es] the CPU albumentations default", which was the opposite of what it did.

**GaussNoise std_range.** Defaulted to rf-detr's own `(0.01, 0.05)` against the Albumentations default `(0.2, 0.44)` on the same 0-1 image scale, 4-9x weaker. The divergence warning also reported rf-detr's own `[0.01, 0.05]` as if it were Albumentations', hiding the gap.

Verified against the pinned `albumentations==2.0.8`:

```python
>>> A.GaussianBlur().sigma_limit
(0.5, 3.0)
>>> A.GaussNoise().std_range
(0.2, 0.44)
```

## Changes

- `_make_gaussian_blur` default sigma `(0.1, 2.0)` -> `(0.5, 3.0)`, comment corrected.
- `_make_gauss_noise` default std_range `(0.01, 0.05)` -> `(0.2, 0.44)`. An explicit range still wins, and the warning text is unchanged since it is still correct for a non-degenerate explicit range.
- Doc table in `aug_configs.py` updated.

This changes only the *default* used when a config omits the value; any config that sets `sigma`/`std_range` explicitly is unaffected. It follows the same "align to Albumentations" direction accepted for the sibling scalar-`clip_limit` fix (#1350).

## Testing

Three regression tests pin both defaults to the live Albumentations values. The two that assert the defaults fail on `develop` and pass here:

```
develop:     unspecified GaussianBlur sigma is (0.1, 2.0) ... FAILED
             unspecified GaussNoise std is 0.05 ...          FAILED
this branch: 8 passed (Gauss* subset)
```

Full augmentation suite: `55 passed`. `ruff check` and `ruff format --check` clean.
