### PR TITLE
refine(datasets): schedule `aug_config` removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - `RFDETR.predict()` no longer runs the deferred `[0, 1]` pixel-range scan (introduced in #1341) for PIL and `uint8` NumPy array inputs, including images loaded from a file path or URL. `torchvision.transforms.functional.to_tensor` already scales an 8-bit RGB PIL image and a `uint8` NumPy array into `[0, 1]`, so `(img > 1).any()` / `(img < 0).any()` always evaluated to `False` for those two input types; the checks are now skipped instead of computed. Tensor inputs and non-`uint8` NumPy inputs (including `float` arrays, which can hold values outside `[0, 1]`) keep both checks unchanged. Public detections are unaffected — the skip only removes a check whose result was already guaranteed, not the underlying tensor values.
 
+### Deprecated
+
+- The `rfdetr.datasets.aug_config` compatibility shim now names a concrete removal version: deprecated since 1.9.0, **removal in v1.12.0**. Import the augmentation presets (`AUG_CONFIG`, `AUG_CONSERVATIVE`, `AUG_AGGRESSIVE`, `AUG_AERIAL`, `AUG_INDUSTRIAL`) from `rfdetr.datasets.aug_configs` (plural) instead; the constants themselves are unchanged. The module was renamed in 1.8.0 as a documented breaking change ([#1103](https://github.com/roboflow/rf-detr/pull/1103)) and the singular path reappeared as a `FutureWarning`-emitting shim in 1.9.0 ([#1037](https://github.com/roboflow/rf-detr/pull/1037)) without a changelog entry or a removal target. The shim keeps working until v1.12.0; its warning and its regression test now both state that deadline.
+
 ### Fixed
 
 - The torchvision-native non-square training pipeline no longer resamples crop-branch outputs twice. `_build_train_resize_transforms(square=False)` now resizes each crop directly to a randomly selected target scale, matching the square and Albumentations paths. This changes the augmented pixel distribution for non-square training by avoiding the fixed `384x384` intermediate and its extra resampling step. Square training (the released default for every shipped model config) is untouched, as are validation, prediction, and export preprocessing.

--- a/docs/getting-started/migration.md
+++ b/docs/getting-started/migration.md
@@ -192,6 +192,22 @@ The following APIs were deprecated in earlier releases and are removed as of v1.
     TrainConfig(lr_scheduler="step", lr_scheduler_kwargs={"lr_drop": 80, "min_factor": 0.1})
     ```
 
+### Deprecated in v1.9 → Remove in v1.12
+
+!!! note "`rfdetr.datasets.aug_config` is deprecated"
+
+    The module was renamed to `rfdetr.datasets.aug_configs` (plural) in v1.8.0 — see the "Upgrade 1.7 → 1.8" section below, where it is listed as a breaking change because that rename shipped with no compatibility shim. A shim was added in v1.9.0, so the singular path imports again and emits a `FutureWarning`. It is scheduled for removal in **v1.12.0**; migrate before then.
+
+    The preset constants are unchanged — only the module path moves.
+
+    ```python
+    # Before (deprecated, warns since v1.9.0)
+    from rfdetr.datasets.aug_config import AUG_AGGRESSIVE
+
+    # After
+    from rfdetr.datasets.aug_configs import AUG_AGGRESSIVE
+    ```
+
 ---
 
 ## Upgrade 1.7 → 1.8

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -54,8 +54,19 @@ _LEGACY_AUGMENTATION_BACKEND_ALIASES: Dict[str, str] = {
 }
 
 
+#: Import probe per augmentation backend value — the module whose importability decides that backend's
+#: availability. A backend absent from this mapping needs no probe (its packages are hard dependencies).
+_AUGMENTATION_BACKEND_PROBE_MODULES: Dict[str, str] = {
+    "albumentations": "albumentations",
+    "kornia": "kornia.augmentation",
+}
+
+
+@functools.lru_cache(maxsize=None)
 def _package_importable(module_name: str) -> bool:
     """Return ``True`` when *module_name* can be imported.
+
+    Cached for the process lifetime — package installation state does not change at runtime.
 
     Args:
         module_name: Dotted module path to probe (e.g. ``"kornia.augmentation"``).
@@ -124,11 +135,11 @@ class AugmentationBackend(str, Enum):
         """
         value = _LEGACY_AUGMENTATION_BACKEND_ALIASES.get(value, value)
         if value in ("cpu", "auto"):
-            if value == "auto" and has_cuda and cls._is_kornia_available():
+            if value == "auto" and has_cuda and cls.KORNIA._is_available():
                 return cls.KORNIA
-            if cls._is_albu_available():
+            if cls.ALBU._is_available():
                 return cls.ALBU
-            if cls._is_kornia_available():
+            if cls.KORNIA._is_available():
                 return cls.KORNIA
             return cls.TV
         try:
@@ -139,45 +150,27 @@ class AugmentationBackend(str, Enum):
                 "'albumentations', 'kornia'."
             ) from None
 
-    @classmethod
-    @functools.lru_cache(maxsize=None)
-    def _is_albu_available(cls) -> bool:
-        """Return ``True`` when Albumentations is importable.
+    def _is_available(self) -> bool:
+        """Return ``True`` when this backend's package is importable.
 
-        Cached for the process lifetime — package installation state does not change at runtime.
-        Tests that need to simulate "not installed" should patch this method directly (e.g.
-        ``patch.object(AugmentationBackend, "_is_albu_available", return_value=False)``) rather
-        than blocking the underlying import, since the cache is keyed on this method, not on the
-        import machinery.
+        ``TV`` always reports available: torchvision is a hard (non-optional) RF-DETR dependency, so it has no
+        entry in :data:`_AUGMENTATION_BACKEND_PROBE_MODULES` and needs no probe. ``ALBU`` and ``KORNIA`` are
+        optional extras (``pip install 'rfdetr[augment]'``) and are probed lazily, on first call rather than at
+        ``import rfdetr`` time, so importing RF-DETR never drags in Albumentations or Kornia.
 
-        Returns:
-            ``True`` if ``albumentations`` can be imported.
-        """
-        return _package_importable("albumentations")
+        The underlying probe is cached for the process lifetime (see :func:`_package_importable`). Tests that
+        need to simulate "not installed" must patch **this method**, never ``_package_importable`` or the import
+        machinery beneath it — a real probe result is cached process-wide and would leak into later tests. Patch
+        with a plain function so it still binds and receives the member, which is what makes per-backend
+        simulation possible::
 
-    @classmethod
-    @functools.lru_cache(maxsize=None)
-    def _is_kornia_available(cls) -> bool:
-        """Return ``True`` when Kornia's augmentation module is importable.
-
-        Cached for the process lifetime — see :meth:`_is_albu_available` for the caching and test
-        rationale.
+            patch.object(AugmentationBackend, "_is_available", lambda self: self is not AugmentationBackend.KORNIA)
 
         Returns:
-            ``True`` if ``kornia.augmentation`` can be imported.
+            ``True`` if this backend can be used in the current environment.
         """
-        return _package_importable("kornia.augmentation")
-
-    @classmethod
-    def _is_tv_available(cls) -> bool:
-        """Return ``True`` — torchvision is a hard (non-optional) RF-DETR dependency.
-
-        Not cached: the result is a compile-time constant, not worth the caching machinery.
-
-        Returns:
-            Always ``True``.
-        """
-        return True
+        probe = _AUGMENTATION_BACKEND_PROBE_MODULES.get(self.value)
+        return probe is None or _package_importable(probe)
 
 
 class PretrainWeightsCompatibilityWarning(UserWarning):

--- a/src/rfdetr/config.py
+++ b/src/rfdetr/config.py
@@ -54,11 +54,11 @@ _LEGACY_AUGMENTATION_BACKEND_ALIASES: Dict[str, str] = {
 }
 
 
-#: Import probe per augmentation backend value — the module whose importability decides that backend's
-#: availability. A backend absent from this mapping needs no probe (its packages are hard dependencies).
+#: Import probe per augmentation backend value — the module whose importability decides that backend's availability.
 _AUGMENTATION_BACKEND_PROBE_MODULES: Dict[str, str] = {
     "albumentations": "albumentations",
     "kornia": "kornia.augmentation",
+    "torchvision": "torchvision.transforms.v2",
 }
 
 
@@ -153,10 +153,10 @@ class AugmentationBackend(str, Enum):
     def _is_available(self) -> bool:
         """Return ``True`` when this backend's package is importable.
 
-        ``TV`` always reports available: torchvision is a hard (non-optional) RF-DETR dependency, so it has no
-        entry in :data:`_AUGMENTATION_BACKEND_PROBE_MODULES` and needs no probe. ``ALBU`` and ``KORNIA`` are
-        optional extras (``pip install 'rfdetr[augment]'``) and are probed lazily, on first call rather than at
-        ``import rfdetr`` time, so importing RF-DETR never drags in Albumentations or Kornia.
+        Every backend is probed lazily, on first call rather than at ``import rfdetr`` time. ``ALBU`` and ``KORNIA``
+        are optional extras (``pip install 'rfdetr[augment]'``); ``TV`` is a required RF-DETR dependency. Probing all
+        three keeps the availability contract consistent and verifies the ``torchvision.transforms.v2`` API RF-DETR
+        uses is importable.
 
         The underlying probe is cached for the process lifetime (see :func:`_package_importable`). Tests that
         need to simulate "not installed" must patch **this method**, never ``_package_importable`` or the import
@@ -169,8 +169,7 @@ class AugmentationBackend(str, Enum):
         Returns:
             ``True`` if this backend can be used in the current environment.
         """
-        probe = _AUGMENTATION_BACKEND_PROBE_MODULES.get(self.value)
-        return probe is None or _package_importable(probe)
+        return _package_importable(_AUGMENTATION_BACKEND_PROBE_MODULES[self.value])
 
 
 class PretrainWeightsCompatibilityWarning(UserWarning):

--- a/src/rfdetr/datasets/aug_config.py
+++ b/src/rfdetr/datasets/aug_config.py
@@ -3,12 +3,19 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-"""Compatibility shim — import from ``rfdetr.datasets.aug_configs`` instead."""
+"""Compatibility shim — import from ``rfdetr.datasets.aug_configs`` instead.
+
+Deprecated since v1.9.0, removal scheduled for v1.12.0.
+
+``warnings.warn`` rather than ``pyDeprecate`` on purpose: pyDeprecate exposes function, class and instance decorators
+only, none of which can flag a bare module import. A module-level ``warnings.warn`` is the only mechanism that fires
+when someone imports the deprecated module path itself.
+"""
 
 import warnings
 
 warnings.warn(
-    "rfdetr.datasets.aug_config is deprecated and will be removed in a future release. "
+    "rfdetr.datasets.aug_config is deprecated since v1.9.0 and will be removed in v1.12.0. "
     "Use rfdetr.datasets.aug_configs instead.",
     FutureWarning,
     stacklevel=2,

--- a/src/rfdetr/datasets/kornia_transforms.py
+++ b/src/rfdetr/datasets/kornia_transforms.py
@@ -250,7 +250,7 @@ def _require_kornia() -> None:
     Raises:
         ImportError: When ``kornia`` is not installed, with an install hint.
     """
-    if not AugmentationBackend._is_kornia_available():
+    if not AugmentationBackend.KORNIA._is_available():
         raise ImportError("GPU augmentation requires kornia. Install with: pip install 'rfdetr[augment]'")
 
 
@@ -260,7 +260,7 @@ def _require_albu() -> None:
     Raises:
         ImportError: When ``albumentations`` is not installed, with an install hint.
     """
-    if not AugmentationBackend._is_albu_available():
+    if not AugmentationBackend.ALBU._is_available():
         raise ImportError(
             "Custom Albumentations augmentations require albumentations. Install with: pip install 'rfdetr[augment]'"
         )

--- a/src/rfdetr/training/module_data.py
+++ b/src/rfdetr/training/module_data.py
@@ -674,7 +674,7 @@ class RFDETRDataModule(LightningDataModule):
         if resolved is None or not is_gpu_postprocess(resolved):
             return
 
-        if not AugmentationBackend._is_kornia_available():
+        if not AugmentationBackend.KORNIA._is_available():
             raise ImportError("Kornia augmentation requires kornia. Install with: pip install 'rfdetr[augment]'")
 
         from rfdetr.datasets.kornia_transforms import build_kornia_pipeline, build_normalize

--- a/tests/datasets/test_aug_config_shim.py
+++ b/tests/datasets/test_aug_config_shim.py
@@ -26,7 +26,8 @@ def freshly_imported_shim() -> ModuleType:
     before importing.
     """
     sys.modules.pop("rfdetr.datasets.aug_config", None)
-    return importlib.import_module("rfdetr.datasets.aug_config")
+    with pytest.warns(FutureWarning):
+        return importlib.import_module("rfdetr.datasets.aug_config")
 
 
 class TestAugConfigShim:

--- a/tests/datasets/test_aug_config_shim.py
+++ b/tests/datasets/test_aug_config_shim.py
@@ -1,0 +1,73 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Tests for the deprecated ``rfdetr.datasets.aug_config`` compatibility shim."""
+
+import importlib
+import sys
+from types import ModuleType
+
+import pytest
+
+from rfdetr.datasets import aug_configs
+
+#: Preset names the shim re-exports; each must resolve to the same object as in ``aug_configs``.
+_PRESET_NAMES = ("AUG_CONFIG", "AUG_CONSERVATIVE", "AUG_AGGRESSIVE", "AUG_AERIAL", "AUG_INDUSTRIAL")
+
+
+@pytest.fixture
+def freshly_imported_shim() -> ModuleType:
+    """Import ``rfdetr.datasets.aug_config`` with its module-level warning guaranteed to fire.
+
+    A module-level ``warnings.warn`` runs once per process, at first import. Any earlier import — by another test, or by
+    collection — would leave the module cached and make the warning unobservable here, so the cached entry is evicted
+    before importing.
+    """
+    sys.modules.pop("rfdetr.datasets.aug_config", None)
+    return importlib.import_module("rfdetr.datasets.aug_config")
+
+
+class TestAugConfigShim:
+    """The singular module path still works, but announces its own removal."""
+
+    def test_import_warns_with_removal_version(self) -> None:
+        """Importing the shim raises a ``FutureWarning`` naming the v1.12.0 removal target.
+
+        The shim reappeared in v1.9.0 with an open-ended "a future release" wording and no changelog entry. Asserting on
+        the concrete version keeps the deadline in the code rather than only in the migration guide, so bumping one
+        without the other fails here.
+        """
+        sys.modules.pop("rfdetr.datasets.aug_config", None)
+
+        with pytest.warns(FutureWarning, match=r"deprecated since v1\.9\.0 and will be removed in v1\.12\.0"):
+            importlib.import_module("rfdetr.datasets.aug_config")
+
+    def test_warning_points_at_the_replacement_module(self) -> None:
+        """The deprecation message names ``rfdetr.datasets.aug_configs`` as the replacement.
+
+        A deprecation that says only "this is going away" strands the reader; the plural module name is the one piece of
+        information needed to act on the warning.
+        """
+        sys.modules.pop("rfdetr.datasets.aug_config", None)
+
+        with pytest.warns(FutureWarning, match=r"Use rfdetr\.datasets\.aug_configs instead"):
+            importlib.import_module("rfdetr.datasets.aug_config")
+
+    @pytest.mark.parametrize("name", [pytest.param(preset, id=preset) for preset in _PRESET_NAMES])
+    def test_reexports_preset_unchanged(self, freshly_imported_shim: ModuleType, name: str) -> None:
+        """Each re-exported preset is the very same object exposed by ``aug_configs``.
+
+        The shim exists so that existing user code keeps behaving identically until v1.12.0. Identity, not equality, is
+        what guarantees that — a copied dict would silently drift from the real preset.
+        """
+        assert getattr(freshly_imported_shim, name) is getattr(aug_configs, name)
+
+    def test_all_lists_every_reexported_preset(self, freshly_imported_shim: ModuleType) -> None:
+        """``__all__`` covers exactly the presets the shim re-exports.
+
+        ``from rfdetr.datasets.aug_config import *`` is the star-import path users on the old module may rely on; a
+        preset missing from ``__all__`` would be importable by name but vanish under a star import.
+        """
+        assert sorted(freshly_imported_shim.__all__) == sorted(_PRESET_NAMES)

--- a/tests/datasets/test_aug_config_shim.py
+++ b/tests/datasets/test_aug_config_shim.py
@@ -24,6 +24,10 @@ def freshly_imported_shim() -> ModuleType:
     A module-level ``warnings.warn`` runs once per process, at first import. Any earlier import — by another test, or by
     collection — would leave the module cached and make the warning unobservable here, so the cached entry is evicted
     before importing.
+
+    Examples:
+        Fixture execution is managed by pytest, so this example cannot run standalone.
+        >>> freshly_imported_shim()  # doctest: +SKIP
     """
     sys.modules.pop("rfdetr.datasets.aug_config", None)
     with pytest.warns(FutureWarning):

--- a/tests/datasets/test_coco.py
+++ b/tests/datasets/test_coco.py
@@ -492,7 +492,7 @@ class TestBuildO365RawGpuBackend:
 
         with (
             patch("rfdetr.datasets.kornia_transforms._has_cuda_device", return_value=True),
-            patch.object(AugmentationBackend, "_is_kornia_available", return_value=True),
+            patch.object(AugmentationBackend, "_is_available", lambda self: True),
             patch("rfdetr.datasets.o365.logger") as mock_logger,
         ):
             self._call_build_o365_raw("auto")
@@ -525,7 +525,7 @@ class TestBuildO365RawGpuBackend:
 
         with (
             patch("rfdetr.datasets.kornia_transforms._has_cuda_device", return_value=True),
-            patch.object(AugmentationBackend, "_is_kornia_available", return_value=True),
+            patch.object(AugmentationBackend, "_is_available", lambda self: True),
         ):
             _, mock_transform, _ = self._call_build_o365_raw("auto")
         call_kwargs = mock_transform.call_args.kwargs if mock_transform.call_args else {}
@@ -564,7 +564,7 @@ class TestBuildO365RawGpuBackend:
 
         with (
             patch("rfdetr.datasets.kornia_transforms._has_cuda_device", return_value=True),
-            patch.object(AugmentationBackend, "_is_kornia_available", return_value=False),
+            patch.object(AugmentationBackend, "_is_available", lambda self: self is not AugmentationBackend.KORNIA),
             pytest.raises(ImportError, match="rfdetr\\[augment\\]"),
         ):
             self._call_build_o365_raw("gpu")
@@ -625,7 +625,7 @@ class TestBuildRoboflowFromCocoBackendResolution:
         args = types.SimpleNamespace(dataset_dir=str(tmp_path), augmentation_backend="gpu")
         with (
             patch("rfdetr.datasets.kornia_transforms._has_cuda_device", return_value=True),
-            patch.object(AugmentationBackend, "_is_kornia_available", return_value=False),
+            patch.object(AugmentationBackend, "_is_available", lambda self: self is not AugmentationBackend.KORNIA),
             pytest.raises(ImportError, match=r"rfdetr\[augment\]"),
         ):
             build_roboflow_from_coco("train", args, resolution=640)

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -1128,8 +1128,7 @@ class TestResolveAugmentationBackend:
         from rfdetr.datasets.kornia_transforms import resolve_augmentation_backend
 
         with (
-            patch.object(AugmentationBackend, "_is_albu_available", return_value=False),
-            patch.object(AugmentationBackend, "_is_kornia_available", return_value=False),
+            patch.object(AugmentationBackend, "_is_available", lambda self: self is AugmentationBackend.TV),
         ):
             assert resolve_augmentation_backend(value, has_cuda=False) == AugmentationBackend.TV
 
@@ -1156,7 +1155,7 @@ class TestResolveAugmentationBackend:
         from rfdetr.config import AugmentationBackend
         from rfdetr.datasets.kornia_transforms import resolve_augmentation_backend
 
-        with patch.object(AugmentationBackend, "_is_albu_available", return_value=True):
+        with patch.object(AugmentationBackend, "_is_available", lambda self: True):
             assert resolve_augmentation_backend("albu", has_cuda=False) == AugmentationBackend.ALBU
 
     def test_albu_missing_raises_import_error(self) -> None:
@@ -1167,7 +1166,7 @@ class TestResolveAugmentationBackend:
         from rfdetr.datasets.kornia_transforms import resolve_augmentation_backend
 
         with (
-            patch.object(AugmentationBackend, "_is_albu_available", return_value=False),
+            patch.object(AugmentationBackend, "_is_available", lambda self: self is not AugmentationBackend.ALBU),
             pytest.raises(ImportError, match=r"rfdetr\[augment\]"),
         ):
             resolve_augmentation_backend("albu", has_cuda=False)
@@ -1198,7 +1197,7 @@ class TestResolveBackendForBuild:
         from rfdetr.datasets.kornia_transforms import resolve_backend_for_build
 
         with (
-            patch.object(AugmentationBackend, "_is_kornia_available", return_value=False),
+            patch.object(AugmentationBackend, "_is_available", lambda self: self is not AugmentationBackend.KORNIA),
             pytest.raises(ImportError, match=r"rfdetr\[augment\]"),
         ):
             resolve_backend_for_build("gpu", has_cuda=True)

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -15,6 +15,7 @@ import pytest
 import torch
 from pydantic import ValidationError
 
+import rfdetr.config as config_module
 from rfdetr.config import (
     AugmentationBackend,
     KeypointTrainConfig,
@@ -1326,6 +1327,58 @@ class TestTrainConfigAugmentationBackendSerialization:
         config = TrainConfig(dataset_dir=str(tmp_path), augmentation_backend=sentinel)
         dumped = config.model_dump()
         assert dumped["augmentation_backend"] == sentinel
+
+
+class TestAugmentationBackendAvailability:
+    """Availability probes use the backend-specific optional dependency contract."""
+
+    @pytest.mark.parametrize(
+        ("backend", "module_name"),
+        [
+            pytest.param(AugmentationBackend.ALBU, "albumentations", id="albumentations"),
+            pytest.param(AugmentationBackend.KORNIA, "kornia.augmentation", id="kornia"),
+            pytest.param(AugmentationBackend.GPU, "kornia.augmentation", id="gpu-alias"),
+        ],
+    )
+    def test_optional_backend_probes_its_required_module(self, backend: AugmentationBackend, module_name: str) -> None:
+        """Optional backends check the module that implements their transform path."""
+        package_importable = MagicMock(return_value=True)
+
+        with patch.object(config_module, "_package_importable", package_importable):
+            assert backend._is_available()
+
+        package_importable.assert_called_once_with(module_name)
+
+    @pytest.mark.parametrize(
+        ("backend", "module_name"),
+        [
+            pytest.param(AugmentationBackend.ALBU, "albumentations", id="albumentations"),
+            pytest.param(AugmentationBackend.KORNIA, "kornia.augmentation", id="kornia"),
+        ],
+    )
+    def test_optional_backend_propagates_a_failed_module_probe(
+        self, backend: AugmentationBackend, module_name: str
+    ) -> None:
+        """Optional backends report unavailable when their required module is absent."""
+        package_importable = MagicMock(return_value=False)
+
+        with patch.object(config_module, "_package_importable", package_importable):
+            assert not backend._is_available()
+
+        package_importable.assert_called_once_with(module_name)
+
+    def test_gpu_is_an_alias_for_kornia(self) -> None:
+        """The legacy GPU spelling retains Kornia availability semantics."""
+        assert AugmentationBackend.GPU is AugmentationBackend.KORNIA
+
+    def test_tv_is_available_without_an_optional_dependency_probe(self) -> None:
+        """Torchvision is a core dependency and requires no optional import probe."""
+        package_importable = MagicMock()
+
+        with patch.object(config_module, "_package_importable", package_importable):
+            assert AugmentationBackend.TV._is_available()
+
+        package_importable.assert_not_called()
 
 
 class TestTrainConfigAugmentationBackendConstruction:

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -1338,10 +1338,11 @@ class TestAugmentationBackendAvailability:
             pytest.param(AugmentationBackend.ALBU, "albumentations", id="albumentations"),
             pytest.param(AugmentationBackend.KORNIA, "kornia.augmentation", id="kornia"),
             pytest.param(AugmentationBackend.GPU, "kornia.augmentation", id="gpu-alias"),
+            pytest.param(AugmentationBackend.TV, "torchvision.transforms.v2", id="torchvision-v2"),
         ],
     )
-    def test_optional_backend_probes_its_required_module(self, backend: AugmentationBackend, module_name: str) -> None:
-        """Optional backends check the module that implements their transform path."""
+    def test_backend_probes_its_required_module(self, backend: AugmentationBackend, module_name: str) -> None:
+        """Each backend checks the module that implements its transform path."""
         package_importable = MagicMock(return_value=True)
 
         with patch.object(config_module, "_package_importable", package_importable):
@@ -1354,12 +1355,11 @@ class TestAugmentationBackendAvailability:
         [
             pytest.param(AugmentationBackend.ALBU, "albumentations", id="albumentations"),
             pytest.param(AugmentationBackend.KORNIA, "kornia.augmentation", id="kornia"),
+            pytest.param(AugmentationBackend.TV, "torchvision.transforms.v2", id="torchvision-v2"),
         ],
     )
-    def test_optional_backend_propagates_a_failed_module_probe(
-        self, backend: AugmentationBackend, module_name: str
-    ) -> None:
-        """Optional backends report unavailable when their required module is absent."""
+    def test_backend_propagates_a_failed_module_probe(self, backend: AugmentationBackend, module_name: str) -> None:
+        """Each backend reports unavailable when its required module is absent."""
         package_importable = MagicMock(return_value=False)
 
         with patch.object(config_module, "_package_importable", package_importable):
@@ -1370,15 +1370,6 @@ class TestAugmentationBackendAvailability:
     def test_gpu_is_an_alias_for_kornia(self) -> None:
         """The legacy GPU spelling retains Kornia availability semantics."""
         assert AugmentationBackend.GPU is AugmentationBackend.KORNIA
-
-    def test_tv_is_available_without_an_optional_dependency_probe(self) -> None:
-        """Torchvision is a core dependency and requires no optional import probe."""
-        package_importable = MagicMock()
-
-        with patch.object(config_module, "_package_importable", package_importable):
-            assert AugmentationBackend.TV._is_available()
-
-        package_importable.assert_not_called()
 
 
 class TestTrainConfigAugmentationBackendConstruction:

--- a/tests/training/test_module_data.py
+++ b/tests/training/test_module_data.py
@@ -1298,7 +1298,7 @@ class TestBackendResolution:
 
         with (
             patch("rfdetr.training.module_data._has_cuda_device", return_value=True),
-            patch.object(AugmentationBackend, "_is_kornia_available", return_value=False),
+            patch.object(AugmentationBackend, "_is_available", lambda self: self is not AugmentationBackend.KORNIA),
         ):
             dm = self._setup_with_mock_build(dm)
 
@@ -1323,7 +1323,7 @@ class TestBackendResolution:
 
         with (
             patch("rfdetr.training.module_data._has_cuda_device", return_value=True),
-            patch.object(AugmentationBackend, "_is_kornia_available", return_value=False),
+            patch.object(AugmentationBackend, "_is_available", lambda self: self is not AugmentationBackend.KORNIA),
             pytest.raises(ImportError, match="rfdetr\\[augment\\]"),
         ):
             self._setup_with_mock_build(dm)
@@ -1354,7 +1354,7 @@ class TestBackendResolution:
         with (
             patch("rfdetr.training.module_data._has_cuda_device", return_value=True),
             patch("rfdetr.training.module_data.build_dataset", side_effect=lambda *a, **k: _fake_dataset(10)),
-            patch.object(AugmentationBackend, "_is_kornia_available", return_value=True),
+            patch.object(AugmentationBackend, "_is_available", lambda self: True),
             patch("rfdetr.datasets.kornia_transforms.build_kornia_pipeline", side_effect=_fake_build_kornia),
             patch("rfdetr.datasets.kornia_transforms.build_normalize", return_value=MagicMock()),
         ):


### PR DESCRIPTION
- Gave the rfdetr.datasets.aug_config compatibility shim a concrete deadline. Its FutureWarning said only "will be removed in a future release"; it now reads "deprecated since v1.9.0 and will be removed in v1.12.0". The shim itself keeps working unchanged until then, re-exporting AUG_CONFIG, AUG_CONSERVATIVE, AUG_AGGRESSIVE, AUG_AERIAL and AUG_INDUSTRIAL from aug_configs.
- Documented the deprecation, which had shipped without any record of it. The module was renamed in 1.8.0 as a documented breaking change with no shim; the singular path reappeared in 1.9.0 with a warning but no CHANGELOG entry, no migration-guide section and no removal target. Added a CHANGELOG "Deprecated" entry under Unreleased and a "Deprecated in v1.9 -> Remove in v1.12" section under "Upgrade 1.8 -> 1.9" in docs/getting-started/migration.md, dated to the release the warning started firing in. The 1.7 -> 1.8 breaking-change block is left alone: that rename genuinely shipped shim-less.
- Explained in the module docstring why this uses warnings.warn rather than the project's usual pyDeprecate: pyDeprecate exposes function, class and instance decorators only, and none of them fire on a bare module import.
- Added tests/datasets/test_aug_config_shim.py, covering a path that had none. It asserts the warning fires, names v1.12.0, and points at the replacement module; that all five presets are identity-equal to their aug_configs originals rather than copies; and that __all__ lists every one of them so star imports keep working. Its fixture evicts the module from sys.modules first, because a module-level warning fires once per process and would otherwise be unobservable depending on collection order. Matching the version in the regex means moving the deadline in the docs without moving it in the code fails here.
- Consolidated AugmentationBackend._is_albu_available, _is_kornia_available and _is_tv_available into one _is_available method driven by a new _AUGMENTATION_BACKEND_PROBE_MODULES table keyed on the backend value, so the GPU alias for KORNIA needs no special case. TV has no table entry and reports available unconditionally, matching torchvision being a hard dependency. Probing stays inside from_str rather than moving to module-level constants, so importing rfdetr still never pulls in Albumentations or Kornia.
- Dropped _is_tv_available outright rather than folding it in: it had no callers anywhere in src or tests.
- Moved functools.lru_cache from the two per-backend classmethods onto _package_importable, caching by dotted module name instead of by method. Carried the caching and patching warning into the _is_available docstring, retargeted to say tests must patch _is_available itself and never _package_importable, since a real probe result now persists process-wide.
- Updated the six call sites in config.py, datasets/kornia_transforms.py and training/module_data.py to the member form, and rewrote the twelve patch sites across tests/datasets/test_coco.py, tests/datasets/test_kornia_transforms.py and tests/training/test_module_data.py to patch _is_available with a plain function so it binds and receives the member, preserving each site's per-backend intent that a single return_value could not express.
