### PR TITLE
fix(data): keep empty COCO iscrowd/area dtypes matching populated targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Empty COCO targets now keep `iscrowd` as `int64` and `area` as `float32`, matching populated targets and allowing mixed empty/populated batches to use lossless packed-target worker transport.
+
 ---
 
 ## [1.9.4] — 2026-08-24

--- a/src/rfdetr/datasets/coco.py
+++ b/src/rfdetr/datasets/coco.py
@@ -685,8 +685,8 @@ class ConvertCoco:
         target["image_id"] = image_id
 
         # for conversion to coco api
-        area = torch.as_tensor([obj["area"] for obj in anno])
-        iscrowd = torch.as_tensor([obj["iscrowd"] if "iscrowd" in obj else 0 for obj in anno])
+        area = torch.as_tensor([obj["area"] for obj in anno], dtype=torch.float32)
+        iscrowd = torch.as_tensor([obj["iscrowd"] if "iscrowd" in obj else 0 for obj in anno], dtype=torch.int64)
         target["area"] = area[keep]
         target["iscrowd"] = iscrowd[keep]
 

--- a/tests/datasets/test_coco.py
+++ b/tests/datasets/test_coco.py
@@ -31,6 +31,7 @@ from rfdetr.datasets.coco import (
     scale_coco_annotation,
 )
 from rfdetr.detr import RFDETR
+from rfdetr.utilities import PackedTargets, pack_targets
 
 # Minimal image shared across all tests
 _IMAGE = Image.new("RGB", (100, 100))
@@ -86,6 +87,26 @@ class TestConvertCocoWithMapping:
         _, target = converter(_IMAGE, _make_target())
         # category_id 1 → 0, category_id 7 → 3
         assert target["labels"].tolist() == [0, 3]
+
+
+class TestConvertCocoPlainDetectionDtypeParity:
+    """Outside keypoint mode, integer-valued ``area`` annotations must still pack."""
+
+    def test_empty_and_populated_targets_pack_with_integer_area(self) -> None:
+        """Integer-area populated targets and float-area empty targets must keep matching dtypes."""
+        converter = ConvertCoco(cat2label=None)
+
+        _, empty_target = converter(_IMAGE, {"image_id": 1, "annotations": []})
+        _, populated_target = converter(_IMAGE, _make_target())
+
+        assert empty_target["area"].dtype == populated_target["area"].dtype
+        assert empty_target["area"].dtype == torch.float32
+        assert empty_target["iscrowd"].dtype == populated_target["iscrowd"].dtype
+        assert empty_target["iscrowd"].dtype == torch.int64
+        packed = pack_targets((empty_target, populated_target))
+        assert isinstance(packed, PackedTargets)
+        assert [target["area"].dtype for target in packed] == [torch.float32, torch.float32]
+        assert [target["iscrowd"].dtype for target in packed] == [torch.int64, torch.int64]
 
     def test_all_labels_within_num_classes(self):
         converter = ConvertCoco(cat2label=_CAT2LABEL)
@@ -1003,6 +1024,27 @@ def _make_coco_builder_args(tmp_path: Path, *, use_grouppose_keypoints: bool) ->
 
 class TestConvertCocoKeypoints:
     """ConvertCoco keypoint-mode coverage."""
+
+    def test_empty_and_populated_targets_pack_without_dtype_fallback(self) -> None:
+        """Empty and populated keypoint targets must keep matching integer dtypes for lossless packing."""
+        converter = ConvertCoco(
+            include_masks=False,
+            include_keypoints=True,
+            cat2label=None,
+            num_keypoints_per_class=[17],
+        )
+
+        _, empty_target = converter(_IMAGE, {"image_id": 1, "annotations": []})
+        _, populated_target = converter(
+            _IMAGE,
+            {"image_id": 2, "annotations": [_make_keypoint_annotation()]},
+        )
+
+        assert empty_target["iscrowd"].dtype == populated_target["iscrowd"].dtype
+        assert empty_target["iscrowd"].dtype == torch.int64
+        packed = pack_targets((empty_target, populated_target))
+        assert isinstance(packed, PackedTargets)
+        assert [target["iscrowd"].dtype for target in packed] == [torch.int64, torch.int64]
 
     def test_keypoint_target_includes_keypoints(self) -> None:
         """Keypoint-enabled conversion should emit keypoints in ``[N, K, 3]`` format."""


### PR DESCRIPTION
COCO conversion infers an empty target's `iscrowd` as `float32`, while a populated target's `iscrowd` is `int64`. The same list-to-tensor inference affects `area`: when an annotation's `area` field is serialized as an integer (a valid JSON `area` value), a populated target's `area` comes out `int64` too, while an empty target's stays `float32`. Either mismatch drops a batch out of lossless packed-target transport. The `iscrowd` case is unconditional, the `area` case depends on whether the annotation data uses integer or float area values. Empty targets are common enough on COCO's person-keypoints validation split to measure the effect directly (see below): about 2,307 of its 5,000 images carry no non-crowd person instance. This is not keypoint-visibility filtering, the converter keeps instances whose keypoints are invisible (`src/rfdetr/datasets/coco.py:723-726`). It's simply that many validation images have no person annotation left after the existing crowd/degenerate-box filtering. The same conversion path runs for plain box detection too.

## Changes

- Construct `iscrowd` explicitly as `torch.int64` and `area` explicitly as `torch.float32`, matching populated targets and the field semantics already documented on `ConvertCoco`.
- Add a regression that converts one empty and one populated keypoint target and verifies the pair uses public packed-target transport.
- Add a regression outside keypoint mode (plain box detection, using the suite's default integer-valued-`area` annotations) that verifies both `iscrowd` and `area` dtype parity and packing.

## Real-data effect

On COCO keypoint val2017, packability changes from 13 of 625 batches to 625 of 625. Pack-on versus explicit pack-off parity covers 5,000 images, 10,777 instances, and 549,627 keypoint values with zero mismatches. Boxes are matched by IoU, with minimum IoU 1.0.

Input-pipeline throughput uses batch size 8, pinned memory, 20 warmup batches, 300 timed batches, and three independent processes:

| Workers | Pack-off median images/s [range] | Pack-on median images/s [range] | Median ratio |
|---:|---:|---:|---:|
| 4 | 205.245 [179.453, 207.069] | 199.432 [170.554, 204.290] | 0.972x; ranges overlap |
| 8 | 249.491 [243.841, 254.441] | 329.780 [328.818, 400.662] | 1.322x |
| 16 | 256.592 [254.895, 260.117] | 416.613 [411.161, 419.257] | 1.624x |

No throughput improvement is claimed at four workers. A representative real batch reduces DataLoader transport from 66 tensor objects to 10 packed fields.

## Validation

- TDD: both new regressions fail on unmodified `develop` (empty `float32` vs. populated `int64` for `iscrowd`; populated `int64` vs. empty `float32` for `area`), and pass with the fix.
- Targeted dataset and packed-tensor suite: 192 passed, 2 skipped.
- CI-marker CPU suite (`pytest src/ tests/ -n 2 -m "not gpu" --ignore=tests/run_smoke_all_models.py --ignore=tests/legacy/test_checkpoint_compat.py --timeout=240`): 4,422 passed, 99 skipped, 1 pre-existing failure unrelated to this change (`tests/export/test_onnx_notes.py`'s `_export_tiny_model` doctest, reproduces identically on unmodified `develop`).
- Precommit: 19 hooks passed, including strict mypy.
- Complete COCO keypoint validation-split input and target parity: zero mismatches.
- Public full-split `evaluate()` parity: the pack-off/on dictionaries match exactly across 11 metrics. Both report keypoint mAP@50:95 0.7180646657943726, keypoint mAR 0.778636634349823, and bbox mAP@50:95 0.5067877769470215.

A bounded full-split control also reports no mismatch across the accumulated bbox states or saved keypoint prediction tensors.
