### PR TITLE
fix(training): avoid duplicate packed mask transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Packed targets are now materialized directly into independent per-sample tensors on the destination device instead of first moving every concatenated field and then cloning it. This removes a transient CUDA allocation equal to the mask field's size, present whenever segmentation transfer held both the packed and the materialized masks at once; DataLoader worker transport remains packed. This is a mechanism-level fix, not the representative detection/segmentation host-device memory benchmark suite noted as a follow-up boundary above.
+
 ---
 
 ## [1.9.4] — 2026-08-24

--- a/docs/learn/train/training-parameters.md
+++ b/docs/learn/train/training-parameters.md
@@ -301,7 +301,7 @@ The parameters below are available for fine-grained control over training behavi
 | `prefetch_factor`    | `int`  | `None`  | Number of batches to prefetch per DataLoader worker. `None` uses PyTorch's built-in default.                             |
 | `pack_targets`       | `bool` | `True`  | Concatenate target dicts before crossing the DataLoader worker boundary. See the contract below; set `False` to opt out. |
 
-With `pack_targets=True`, train, validation, test, and predict loaders yield batches whose target element is `PackedTargets` whenever packing is lossless. The Lightning `transfer_batch_to_device` hook accepts those batches or an unpacked tuple of target dicts. It moves packed fields to the target device, then materializes them into the same plain per-sample dict list that training, validation, test, and prediction hooks receive on the unpacked path. Batches that cannot be packed losslessly retain their original tuple of dicts.
+With `pack_targets=True`, train, validation, test, and predict loaders yield batches whose target element is `PackedTargets` whenever packing is lossless. The Lightning `transfer_batch_to_device` hook accepts those batches or an unpacked tuple of target dicts. It materializes each packed field directly into its own independently owned per-sample tensor on the target device, producing the same plain per-sample dict list that training, validation, test, and prediction hooks receive on the unpacked path. Batches that cannot be packed losslessly retain their original tuple of dicts.
 
 ## Complete Parameter Reference
 

--- a/src/rfdetr/training/module_data.py
+++ b/src/rfdetr/training/module_data.py
@@ -814,9 +814,9 @@ class RFDETRDataModule(LightningDataModule):
         non_blocking = device.type == "cuda"
         samples = samples.to(device, non_blocking=non_blocking)
         if isinstance(targets, PackedTargets):
-            # One transfer per field instead of one per field per sample, then materialised so that callers can
-            # mutate the dicts exactly as they do on the unpacked path.
-            targets = targets.to(device, non_blocking=non_blocking).as_list()
+            # Materialise directly on the destination so the packed and per-sample copies of a large field such as
+            # segmentation masks never coexist there. Each returned tensor owns its storage, matching the unpacked path.
+            targets = targets.to_list(device, non_blocking=non_blocking)
         else:
             targets = [{k: v.to(device, non_blocking=non_blocking) for k, v in t.items()} for t in targets]
         return samples, targets

--- a/src/rfdetr/utilities/tensors.py
+++ b/src/rfdetr/utilities/tensors.py
@@ -389,8 +389,9 @@ class PackedTargets:
     Sequence subclass would be taken apart and pinned tensor by tensor, rebuilding in the main process exactly
     what the packing avoided. Indexing rebuilds a dict of views: reassigning a key on the returned dict does not
     write back into the packed storage, but an in-place write into one of its tensors does, since the view shares
-    the packed field's storage. Call :meth:`as_list` for a materialised copy that is safe to mutate in place, the
-    way the unpacked batch already is.
+    the packed field's storage. Call :meth:`as_list` for a same-device materialised copy, or :meth:`to_list` to
+    materialise directly on another device; both return independent tensors that are safe to mutate in place, the way
+    the unpacked batch already is.
 
     Args:
         values: One flat tensor per field, holding that field concatenated across the batch.
@@ -450,8 +451,8 @@ class PackedTargets:
         """Pin every packed field, keeping the batch packed.
 
         Called by PyTorch's pin-memory worker. Pinning the concatenated fields costs one pinned allocation
-        per field rather than one per field per sample, and leaves the batch in the packed form that
-        ``transfer_batch_to_device`` moves in a single copy per field.
+        per field rather than one per field per sample, and leaves the batch packed until
+        ``transfer_batch_to_device`` materialises its independent destination tensors.
 
         Returns:
             A packed batch whose fields are in pinned memory.
@@ -482,6 +483,35 @@ class PackedTargets:
             One dict per sample, ordered as packed, holding independent tensors.
         """
         return [{key: value.clone() for key, value in self[position].items()} for position in range(self._batch)]
+
+    def to_list(self, device: torch.device | str, non_blocking: bool = False) -> list[dict[str, Tensor]]:
+        """Materialise independent per-sample tensors directly on *device*.
+
+        Moving the packed object and then calling :meth:`as_list` makes the concatenated destination fields coexist
+        with all of their per-sample clones. That transient duplicate is negligible for boxes and labels but can be
+        large for segmentation masks. Transferring each packed view directly into its final independently-owned tensor
+        avoids the full-field destination copy while preserving the unpacked path's mutation semantics.
+
+        Args:
+            device: Destination device.
+            non_blocking: Whether to request asynchronous copies.
+
+        Returns:
+            One dict per sample, ordered as packed, with independent tensors on *device*.
+        """
+        materialised: list[dict[str, Tensor]] = [{} for _ in range(self._batch)]
+        for key, flat in self._values.items():
+            offset = 0
+            for target, shape in zip(materialised, self._shapes[key], strict=True):
+                elements = _numel(shape)
+                value = flat[offset : offset + elements].reshape(shape)
+                target[key] = value.to(
+                    device=device,
+                    non_blocking=non_blocking,
+                    copy=True,
+                )
+                offset += elements
+        return materialised
 
     def to(self, device: torch.device | str, non_blocking: bool = False) -> PackedTargets:
         """Move every packed field to *device* in one transfer per field.

--- a/tests/training/test_module_data.py
+++ b/tests/training/test_module_data.py
@@ -1325,6 +1325,24 @@ class TestTransferBatchToDevice:
             for key, value in original.items():
                 assert torch.equal(rebuilt[key], value)
 
+    def test_packed_targets_are_materialised_without_a_whole_batch_device_copy(self, fixture_training_setup) -> None:
+        """Packed transfer must not create a device copy of every field before constructing per-sample tensors."""
+        _, _, dm = fixture_training_setup
+        samples, plain_targets = _make_batch()
+        packed_targets = pack_targets(plain_targets)
+        assert isinstance(packed_targets, PackedTargets)
+
+        with patch.object(
+            PackedTargets,
+            "to",
+            side_effect=AssertionError("whole packed batch copied to the target device"),
+        ):
+            _, result_targets = dm.transfer_batch_to_device(
+                (samples, packed_targets), torch.device("cpu"), dataloader_idx=0
+            )
+
+        assert isinstance(result_targets, list)
+
 
 # ---------------------------------------------------------------------------
 # TestBackendResolution — validates augmentation_backend logic in setup("fit")

--- a/tests/utilities/test_tensors.py
+++ b/tests/utilities/test_tensors.py
@@ -909,7 +909,17 @@ class TestPackedTargets:
         ).pin_memory()
         mask_bytes = pinned.fields["masks"].numel()
 
-        def peak_extra(materialise):
+        def peak_extra(
+            materialise: collections.abc.Callable[[], list[dict[str, torch.Tensor]]],
+        ) -> int:
+            """Return transient CUDA bytes beyond memory retained by the result.
+
+            Examples:
+                This helper requires CUDA and state from the enclosing test.
+
+                >>> peak_extra(lambda: pinned.to_list("cuda"))  # doctest: +SKIP
+                0
+            """
             torch.cuda.synchronize()
             torch.cuda.reset_peak_memory_stats()
             out = materialise()

--- a/tests/utilities/test_tensors.py
+++ b/tests/utilities/test_tensors.py
@@ -868,6 +868,27 @@ class TestPackedTargets:
         assert packed.fields["boxes"][0].item() == 1.0
         assert torch.equal(packed.as_list()[0]["labels"], torch.tensor([3, 7]))
 
+    def test_to_list_matches_the_unpacked_batch_for_every_sample(self) -> None:
+        """Direct materialisation preserves every sample's complete tensor contract.
+
+        This catches a reconstruction that drops the empty sample, skips a field, reshapes scalar metadata, or silently
+        changes a dtype while still passing the ownership-only regression below.
+        """
+        batch = self._batch()
+        packed = pack_targets(batch)
+        assert isinstance(packed, PackedTargets)
+
+        materialised = packed.to_list(torch.device("cpu"))
+
+        assert len(materialised) == len(batch)
+        for original, rebuilt in zip(batch, materialised, strict=True):
+            assert rebuilt.keys() == original.keys()
+            for key, value in original.items():
+                assert rebuilt[key].device.type == "cpu"
+                assert rebuilt[key].dtype == value.dtype
+                assert rebuilt[key].shape == value.shape
+                assert torch.equal(rebuilt[key], value)
+
     def test_to_list_same_device_does_not_alias_packed_storage(self) -> None:
         """Direct materialisation must preserve the unpacked path's independent tensor ownership on CPU."""
         packed = pack_targets(self._batch())

--- a/tests/utilities/test_tensors.py
+++ b/tests/utilities/test_tensors.py
@@ -868,6 +868,90 @@ class TestPackedTargets:
         assert packed.fields["boxes"][0].item() == 1.0
         assert torch.equal(packed.as_list()[0]["labels"], torch.tensor([3, 7]))
 
+    def test_to_list_same_device_does_not_alias_packed_storage(self) -> None:
+        """Direct materialisation must preserve the unpacked path's independent tensor ownership on CPU."""
+        packed = pack_targets(self._batch())
+        assert isinstance(packed, PackedTargets)
+
+        materialised = packed.to_list(torch.device("cpu"))
+        materialised[0]["labels"][0] = 999
+        materialised[0]["boxes"][0, 0] = 999.0
+
+        assert torch.equal(packed.fields["labels"], torch.tensor([3, 7, 5]))
+        assert packed.fields["boxes"][0].item() == 1.0
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_to_list_transfers_pinned_views_directly_to_cuda(self) -> None:
+        """Direct materialisation must preserve values and ownership across a non-blocking CUDA transfer."""
+        packed = pack_targets(self._batch())
+        assert isinstance(packed, PackedTargets)
+        pinned = packed.pin_memory()
+
+        materialised = pinned.to_list(torch.device("cuda"), non_blocking=True)
+        torch.cuda.synchronize()
+
+        assert materialised[0]["labels"].device.type == "cuda"
+        assert torch.equal(materialised[0]["labels"].cpu(), torch.tensor([3, 7]))
+        materialised[0]["labels"][0] = 999
+        assert torch.equal(pinned.fields["labels"], torch.tensor([3, 7, 5]))
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_to_list_bounds_the_transient_cuda_peak_for_a_mask_field(self) -> None:
+        """``to_list``'s docstring claims the avoided duplicate "can be large for segmentation masks" -- pin that claim
+        on the actual CUDA peak with a mask field, not just on values or ownership."""
+        pinned = pack_targets(
+            [
+                {"labels": torch.tensor([3, 7]), "masks": torch.ones((2, 256, 256), dtype=torch.bool)},
+                {"labels": torch.tensor([5]), "masks": torch.ones((1, 256, 256), dtype=torch.bool)},
+            ]
+        ).pin_memory()
+        mask_bytes = pinned.fields["masks"].numel()
+
+        def peak_extra(materialise):
+            torch.cuda.synchronize()
+            torch.cuda.reset_peak_memory_stats()
+            out = materialise()
+            torch.cuda.synchronize()
+            extra = torch.cuda.max_memory_allocated() - torch.cuda.memory_allocated()
+            del out
+            return extra
+
+        old_extra = peak_extra(lambda: pinned.to(torch.device("cuda"), non_blocking=True).as_list())
+        new_extra = peak_extra(lambda: pinned.to_list(torch.device("cuda"), non_blocking=True))
+
+        assert old_extra >= mask_bytes
+        assert new_extra < mask_bytes // 2
+
+    def test_to_returns_self_when_already_on_the_target_device(self) -> None:
+        """``to()`` keeps the batch packed instead of materialising it, unlike ``to_list()``.
+
+        Losing its only caller in ``transfer_batch_to_device`` (replaced by ``to_list()``) must not leave it untested: a
+        no-op device request has to return the same instance, matching every no-op ``Tensor.to()`` call underneath it.
+        """
+        packed = pack_targets(self._batch())
+        assert isinstance(packed, PackedTargets)
+
+        same_device = packed.to(torch.device("cpu"))
+
+        assert same_device is packed
+        assert torch.equal(same_device.fields["labels"], torch.tensor([3, 7, 5]))
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_to_moves_every_field_and_keeps_the_batch_packed_on_cuda(self) -> None:
+        """A genuine device change must move every field and return a new packed batch, not a materialised list."""
+        packed = pack_targets(self._batch())
+        assert isinstance(packed, PackedTargets)
+
+        moved = packed.to(torch.device("cuda"))
+
+        assert isinstance(moved, PackedTargets)
+        assert moved is not packed
+        assert all(tensor.device.type == "cuda" for tensor in moved.fields.values())
+        assert torch.equal(moved.fields["labels"].cpu(), torch.tensor([3, 7, 5]))
+
     def test_collate_packs_only_when_asked(self) -> None:
         """The collate contract only changes for callers that opt in."""
         images = [torch.zeros(3, 8, 8), torch.zeros(3, 8, 8)]


### PR DESCRIPTION
Packed segmentation targets are currently copied to CUDA as complete concatenated fields and then cloned per sample. For masks, that temporarily keeps both the packed CUDA field and the materialised tensors alive.

## Changes

- Materialise packed sample views directly into independently owned tensors on the destination device.
- Preserve the list-of-dicts mutation contract used by the unpacked path.
- Add CPU ownership, pinned/non-blocking CUDA, transfer-hook, and CUDA peak-memory regression coverage (the last one uses an actual mask field and asserts on `torch.cuda.max_memory_allocated()`, not just values).
- `transfer_batch_to_device` was `PackedTargets.to()`'s only caller; add direct coverage for it (same-device identity return, and a CUDA device change that keeps the batch packed) so it doesn't go untested now that it's unused internally.

## Memory and throughput

Synthetic mask batches (not COCO-sourced; `repro/cuda_peak_memory.py`), pinned, three instance-count/resolution sizes. CUDA peak statistics are reset for each synchronized repetition; "extra" is peak minus the memory retained by the returned tensors.

| Batch | Mask bytes | Previous extra CUDA peak | Fixed extra CUDA peak | Previous time, median [range] ms | Fixed time, median [range] ms |
|---|---:|---:|---:|---:|---:|
| small | 393,216 | 393,728 bytes | 0 bytes | 0.1289 [0.1245, 0.1359] | 0.0973 [0.0965, 0.0994] |
| medium | 3,145,728 | 3,146,240 bytes | 0 bytes | 0.3061 [0.3014, 0.3216] | 0.3141 [0.3092, 0.3513] |
| large | 10,616,832 | 10,617,856 bytes | 0 bytes | 0.9153 [0.9019, 0.9547] | 0.9183 [0.9053, 1.7515] |

The previous path's extra CUDA peak tracks the mask field size almost exactly (ratio 1.000-1.001 across the three sizes). That matches the described mechanism — the packed CUDA field and the materialised per-sample clones stay alive at the same time, until the packed object goes out of scope. The fixed path's extra peak is zero at each size. Timings are noisy at this scale and are not sold as a speedup either way.

A real COCO segmentation val2017 check repeated the complete 5,000-image traversal in three independent processes (577 packed batches per run). The three summaries were identical: the previous temporary allocation was 18,915,328 bytes at the median, 32,188,416 at p95, and 44,048,384 maximum; the fixed path measured 0 bytes at each point. The previous peak follows the complete packed-field size (18,913,604 median, 43,467,692 maximum).

A `PackedTargets` batch routes through the same `to_list()` call for each field it carries. Detection- and keypoint-only batches were not profiled separately here — their fields are boxes, labels, and small metadata tensors, so the previous duplicate was already negligible for them.

Real COCO segmentation input-pipeline throughput, using batch size 8, 16 workers, 20 warmup batches, 200 timed batches, and three independent processes:

| Path | Median images/s | Three-process range |
|---|---:|---:|
| Previous packed transfer | 273.562 | 265.225-273.761 |
| Direct packed materialisation | 269.562 | 263.249-274.531 |
| Explicitly unpacked | 178.512 | 177.507-179.127 |

The two packed ranges overlap, so no speed difference is claimed between them. Direct materialisation retains a 1.51x median advantage over unpacked loading.

## Validation

- COCO segmentation val2017 target parity: 625 batches, 5,000 images, 36,335 instances, and 3,536,994,240 mask bytes; zero mismatches. Boxes are matched by IoU, with minimum IoU 1.0.
- Touched CPU/CUDA battery: 226 passed, 2 skipped.
- CI-marker CPU suite (`AGENTS.md`'s command plus the marker exclusions CI itself adds): 4,421 passed, 77 skipped, 100 deselected. 3 pre-existing failures, unrelated to this diff and present on unmodified `develop`: stale doctests in `docs/hooks/package_version.py` and `tests/export/test_onnx_notes.py`.
- Precommit: 19 hooks passed, including strict mypy.
- TDD: the new tests fail on unmodified `develop` and pass with this change.
- Full COCO segmentation val2017 metric parity: 5,000 images with RFDETRSegNano, resolution 312, batch size 16, 16 workers, and BF16. With identical bounded chunks, accumulated prediction/ground-truth states match exactly and the reported bbox/segmentation metrics are equal. Both arms report bbox mAP 0.48922181129455566 and segmentation mAP 0.40316349267959595.

An initial control with unequal chunk boundaries produced small metric deltas (about 2e-6). Matching the chunk boundaries removed the mismatches, so the cause was batch composition, not the packed transfer itself.
