### PR TITLE
fix(datasets): require pipeline options instead of substituting wrong defaults

### DIFF
--- a/src/rfdetr/datasets/coco.py
+++ b/src/rfdetr/datasets/coco.py
@@ -1293,6 +1293,27 @@ def make_coco_transforms_square_div_64(
 
 
 def build_coco(image_set: str, args: Any, resolution: int) -> CocoDetection:
+    """Build a COCO dataset from an explicit configuration namespace.
+
+    Direct callers must provide either ``dataset_dir`` or ``coco_path``, plus
+    ``square_resize_div_64``, ``segmentation_head``, ``multi_scale``,
+    ``expanded_scales``, ``do_random_resize_via_padding``, ``patch_size``, and
+    ``num_windows`` on ``args``. Keypoint, custom augmentation, scale-jitter,
+    and augmentation-backend fields are optional.
+
+    Args:
+        image_set: COCO split identifier.
+        args: Dataset, model, and transform configuration namespace.
+        resolution: Target image resolution in pixels.
+
+    Returns:
+        The configured COCO dataset.
+
+    Raises:
+        AttributeError: If a required dataset or transform option is absent.
+        FileNotFoundError: If the configured COCO root does not exist.
+        KeyError: If ``image_set`` does not map to a supported COCO split.
+    """
     root = Path(getattr(args, "dataset_dir", None) or args.coco_path)
     if not root.exists():
         logger.error(f"COCO path {root} does not exist")
@@ -1309,8 +1330,7 @@ def build_coco(image_set: str, args: Any, resolution: int) -> CocoDetection:
 
     img_folder, ann_file = PATHS[image_set.split("_", maxsplit=1)[0]]
 
-    # Pipeline options are read directly, never via getattr with a literal default;
-    # see build_roboflow_from_coco in rfdetr/datasets/coco.py for why.
+    # Model-dependent pipeline options are mandatory for direct builder calls.
     square_resize_div_64 = args.square_resize_div_64
     include_masks = args.segmentation_head
     include_keypoints = has_keypoints
@@ -1407,6 +1427,25 @@ def build_roboflow_from_coco(image_set: str, args: Any, resolution: int) -> Coco
     Each split is built by its own call, so label indices are taken from the train split for every non-train split (see
     :func:`_train_split_cat2label`). Letting a split derive its own mapping would shift its label indices whenever its
     annotation coverage of a grouping category differs from the train split's.
+
+    Direct callers must provide ``dataset_dir``, ``square_resize_div_64``,
+    ``segmentation_head``, ``multi_scale``, ``expanded_scales``,
+    ``do_random_resize_via_padding``, ``patch_size``, and ``num_windows`` on
+    ``args``. Keypoint, custom augmentation, scale-jitter, and
+    augmentation-backend fields are optional.
+
+    Args:
+        image_set: Roboflow split identifier.
+        args: Dataset, model, and transform configuration namespace.
+        resolution: Target image resolution in pixels.
+
+    Returns:
+        The configured Roboflow COCO-format dataset.
+
+    Raises:
+        AttributeError: If a required dataset or transform option is absent.
+        FileNotFoundError: If the configured dataset root does not exist.
+        KeyError: If ``image_set`` does not map to a supported Roboflow split.
     """
     root = Path(args.dataset_dir)
     if not root.exists():
@@ -1421,11 +1460,8 @@ def build_roboflow_from_coco(image_set: str, args: Any, resolution: int) -> Coco
 
     split = image_set.split("_", maxsplit=1)[0]
     img_folder, ann_file = PATHS[split]
-    # Read directly rather than via getattr with a literal default: these options have no safe constant.
-    # patch_size, num_windows and segmentation_head are variant-dependent, and square_resize_div_64,
-    # multi_scale and expanded_scales all default to True on TrainConfig. An incomplete namespace must fail
-    # here instead of silently building a different pipeline (GitHub #N). The optional fields below keep getattr on
-    # purpose: their absence means "detection, no custom augmentation", which is a real and safe default.
+    # Model-dependent pipeline options are mandatory for direct builder calls;
+    # optional task/augmentation fields below retain documented safe defaults.
     square_resize_div_64 = args.square_resize_div_64
     include_masks = args.segmentation_head
     multi_scale = args.multi_scale

--- a/src/rfdetr/datasets/coco.py
+++ b/src/rfdetr/datasets/coco.py
@@ -1309,8 +1309,10 @@ def build_coco(image_set: str, args: Any, resolution: int) -> CocoDetection:
 
     img_folder, ann_file = PATHS[image_set.split("_", maxsplit=1)[0]]
 
-    square_resize_div_64 = getattr(args, "square_resize_div_64", False)
-    include_masks = getattr(args, "segmentation_head", False)
+    # Pipeline options are read directly, never via getattr with a literal default;
+    # see build_roboflow_from_coco in rfdetr/datasets/coco.py for why.
+    square_resize_div_64 = args.square_resize_div_64
+    include_masks = args.segmentation_head
     include_keypoints = has_keypoints
     num_keypoints_per_class = getattr(args, "num_keypoints_per_class", [])
     aug_config = getattr(args, "aug_config", None)
@@ -1419,13 +1421,18 @@ def build_roboflow_from_coco(image_set: str, args: Any, resolution: int) -> Coco
 
     split = image_set.split("_", maxsplit=1)[0]
     img_folder, ann_file = PATHS[split]
-    square_resize_div_64 = getattr(args, "square_resize_div_64", False)
-    include_masks = getattr(args, "segmentation_head", False)
-    multi_scale = getattr(args, "multi_scale", False)
-    expanded_scales = getattr(args, "expanded_scales", False)
-    do_random_resize_via_padding = getattr(args, "do_random_resize_via_padding", False)
-    patch_size = getattr(args, "patch_size", 16)
-    num_windows = getattr(args, "num_windows", 4)
+    # Read directly rather than via getattr with a literal default: these options have no safe constant.
+    # patch_size, num_windows and segmentation_head are variant-dependent, and square_resize_div_64,
+    # multi_scale and expanded_scales all default to True on TrainConfig. An incomplete namespace must fail
+    # here instead of silently building a different pipeline (GitHub #N). The optional fields below keep getattr on
+    # purpose: their absence means "detection, no custom augmentation", which is a real and safe default.
+    square_resize_div_64 = args.square_resize_div_64
+    include_masks = args.segmentation_head
+    multi_scale = args.multi_scale
+    expanded_scales = args.expanded_scales
+    do_random_resize_via_padding = args.do_random_resize_via_padding
+    patch_size = args.patch_size
+    num_windows = args.num_windows
     # Roboflow detection exports omit keypoint schema/flip-pair fields; missing values mean detection-only.
     include_keypoints = getattr(args, "use_grouppose_keypoints", False)
     num_keypoints_per_class = getattr(args, "num_keypoints_per_class", [])

--- a/src/rfdetr/datasets/o365.py
+++ b/src/rfdetr/datasets/o365.py
@@ -25,6 +25,27 @@ logger = get_logger()
 
 
 def build_o365_raw(image_set: str, args: Any, resolution: int) -> CocoDetection:
+    """Build one Object365 detection split.
+
+    Object365 currently uses detection annotations only and does not consume
+    ``segmentation_head``. Direct callers must provide either ``dataset_dir``
+    or ``coco_path``, plus ``square_resize_div_64``, ``multi_scale``,
+    ``expanded_scales``, ``do_random_resize_via_padding``, ``patch_size``, and
+    ``num_windows`` on ``args``. Optional ``scale_jitter`` and
+    ``augmentation_backend`` values retain safe defaults.
+
+    Args:
+        image_set: Object365 split, either ``"train"`` or ``"val"``.
+        args: Dataset and transform configuration namespace.
+        resolution: Target square resolution in pixels.
+
+    Returns:
+        The configured Object365 detection dataset.
+
+    Raises:
+        AttributeError: If a required dataset or transform option is absent.
+        KeyError: If ``image_set`` is not a supported Object365 split.
+    """
     root = Path(getattr(args, "dataset_dir", None) or args.coco_path)
     PATHS = {  # noqa: N806
         "train": (root, root / "zhiyuan_objv2_train_val_wo_5k.json"),
@@ -34,9 +55,14 @@ def build_o365_raw(image_set: str, args: Any, resolution: int) -> CocoDetection:
 
     from rfdetr.datasets.kornia_transforms import is_gpu_postprocess, resolve_backend_for_build
 
-    # Pipeline options are read directly, never via getattr with a literal default;
-    # see build_roboflow_from_coco in rfdetr/datasets/coco.py for why.
+    # These geometry values are model/config dependent, so direct calls must fail
+    # instead of silently falling back to the transform factories' generic defaults.
     square_resize_div_64 = args.square_resize_div_64
+    multi_scale = args.multi_scale
+    expanded_scales = args.expanded_scales
+    do_random_resize_via_padding = args.do_random_resize_via_padding
+    patch_size = args.patch_size
+    num_windows = args.num_windows
     scale_jitter = getattr(args, "scale_jitter", True)
     augmentation_backend = getattr(args, "augmentation_backend", "cpu")
     resolved_backend = resolve_backend_for_build(augmentation_backend)
@@ -56,8 +82,11 @@ def build_o365_raw(image_set: str, args: Any, resolution: int) -> CocoDetection:
             transforms=make_coco_transforms_square_div_64(
                 image_set,
                 resolution,
-                multi_scale=args.multi_scale,
-                expanded_scales=args.expanded_scales,
+                multi_scale=multi_scale,
+                expanded_scales=expanded_scales,
+                skip_random_resize=not do_random_resize_via_padding,
+                patch_size=patch_size,
+                num_windows=num_windows,
                 scale_jitter=scale_jitter,
                 gpu_postprocess=gpu_postprocess,
             ),
@@ -69,8 +98,11 @@ def build_o365_raw(image_set: str, args: Any, resolution: int) -> CocoDetection:
             transforms=make_coco_transforms(
                 image_set,
                 resolution,
-                multi_scale=args.multi_scale,
-                expanded_scales=args.expanded_scales,
+                multi_scale=multi_scale,
+                expanded_scales=expanded_scales,
+                skip_random_resize=not do_random_resize_via_padding,
+                patch_size=patch_size,
+                num_windows=num_windows,
                 scale_jitter=scale_jitter,
                 gpu_postprocess=gpu_postprocess,
             ),
@@ -79,6 +111,21 @@ def build_o365_raw(image_set: str, args: Any, resolution: int) -> CocoDetection:
 
 
 def build_o365(image_set: str, args: Any, resolution: int) -> CocoDetection:
+    """Build a supported Object365 detection split.
+
+    Args:
+        image_set: Object365 split, either ``"train"`` or ``"val"``.
+        args: Dataset and transform configuration namespace accepted by
+            :func:`build_o365_raw`.
+        resolution: Target square resolution in pixels.
+
+    Returns:
+        The configured Object365 detection dataset.
+
+    Raises:
+        AttributeError: If a required dataset or transform option is absent.
+        ValueError: If ``image_set`` is not ``"train"`` or ``"val"``.
+    """
     if image_set == "train":
         train_ds = build_o365_raw("train", args, resolution=resolution)
         return train_ds

--- a/src/rfdetr/datasets/o365.py
+++ b/src/rfdetr/datasets/o365.py
@@ -34,7 +34,9 @@ def build_o365_raw(image_set: str, args: Any, resolution: int) -> CocoDetection:
 
     from rfdetr.datasets.kornia_transforms import is_gpu_postprocess, resolve_backend_for_build
 
-    square_resize_div_64 = getattr(args, "square_resize_div_64", False)
+    # Pipeline options are read directly, never via getattr with a literal default;
+    # see build_roboflow_from_coco in rfdetr/datasets/coco.py for why.
+    square_resize_div_64 = args.square_resize_div_64
     scale_jitter = getattr(args, "scale_jitter", True)
     augmentation_backend = getattr(args, "augmentation_backend", "cpu")
     resolved_backend = resolve_backend_for_build(augmentation_backend)

--- a/src/rfdetr/datasets/yolo.py
+++ b/src/rfdetr/datasets/yolo.py
@@ -1051,13 +1051,15 @@ def build_roboflow_from_yolo(image_set: str, args: Any, resolution: int) -> Yolo
     img_folder, lb_folder = _resolve_yolo_split_dirs(root, data_file, split_key)
     if split_key == "test":
         _validate_yolo_test_split(img_folder, lb_folder)
-    square_resize_div_64 = getattr(args, "square_resize_div_64", False)
-    include_masks = getattr(args, "segmentation_head", False)
-    multi_scale = getattr(args, "multi_scale", False)
-    expanded_scales = getattr(args, "expanded_scales", False)
-    do_random_resize_via_padding = getattr(args, "do_random_resize_via_padding", False)
-    patch_size = getattr(args, "patch_size", 16)
-    num_windows = getattr(args, "num_windows", 4)
+    # Pipeline options are read directly, never via getattr with a literal default;
+    # see build_roboflow_from_coco in rfdetr/datasets/coco.py for why.
+    square_resize_div_64 = args.square_resize_div_64
+    include_masks = args.segmentation_head
+    multi_scale = args.multi_scale
+    expanded_scales = args.expanded_scales
+    do_random_resize_via_padding = args.do_random_resize_via_padding
+    patch_size = args.patch_size
+    num_windows = args.num_windows
     aug_config = getattr(args, "aug_config", None)
     scale_jitter = getattr(args, "scale_jitter", True)
     include_keypoints = getattr(args, "use_grouppose_keypoints", False)

--- a/src/rfdetr/datasets/yolo.py
+++ b/src/rfdetr/datasets/yolo.py
@@ -1031,15 +1031,20 @@ def build_roboflow_from_yolo(image_set: str, args: Any, resolution: int) -> Yolo
         image_set: Dataset split to load. One of ``"train"``, ``"val"``, or
             ``"test"``.
         args: Argument namespace. The following attributes are consumed:
-            ``dataset_dir``, ``square_resize_div_64``, ``aug_config``, ``scale_jitter``, ``segmentation_head``,
-            ``multi_scale``, ``expanded_scales``, ``do_random_resize_via_padding``, ``patch_size``, ``num_windows``.
-            ``aug_config`` is forwarded to the transform builder; when ``None`` the builder uses torchvision-native
-            defaults. ``scale_jitter`` independently controls the resize-crop branch (Option B) and defaults to
-            ``True`` when absent.
+            ``dataset_dir``, ``square_resize_div_64``, ``segmentation_head``,
+            ``multi_scale``, ``expanded_scales``, ``do_random_resize_via_padding``,
+            ``patch_size``, and ``num_windows`` are required. ``aug_config``,
+            ``scale_jitter``, keypoint fields, and ``augmentation_backend`` are
+            optional and retain documented safe defaults.
         resolution: Target square resolution in pixels.
 
     Returns:
         A :class:`YoloDetection` dataset instance ready for use with a DataLoader.
+
+    Raises:
+        AttributeError: If a required dataset or transform option is absent.
+        FileNotFoundError: If the configured dataset root does not exist.
+        ValueError: If keypoint training lacks a valid keypoint schema.
     """
     root = Path(args.dataset_dir)
     if not root.exists():
@@ -1051,8 +1056,7 @@ def build_roboflow_from_yolo(image_set: str, args: Any, resolution: int) -> Yolo
     img_folder, lb_folder = _resolve_yolo_split_dirs(root, data_file, split_key)
     if split_key == "test":
         _validate_yolo_test_split(img_folder, lb_folder)
-    # Pipeline options are read directly, never via getattr with a literal default;
-    # see build_roboflow_from_coco in rfdetr/datasets/coco.py for why.
+    # Model-dependent pipeline options are mandatory for direct builder calls.
     square_resize_div_64 = args.square_resize_div_64
     include_masks = args.segmentation_head
     multi_scale = args.multi_scale

--- a/tests/datasets/test_builder_options.py
+++ b/tests/datasets/test_builder_options.py
@@ -33,7 +33,7 @@ O365_REQUIRED_PIPELINE_OPTIONS = tuple(
 )
 
 
-def training_namespace(model_config: ModelConfig, dataset_dir: str = "/fake/dataset") -> types.SimpleNamespace:
+def _training_namespace(model_config: ModelConfig, dataset_dir: str = "/fake/dataset") -> types.SimpleNamespace:
     """Build the merged model/train namespace passed to dataset builders.
 
     Args:
@@ -44,14 +44,28 @@ def training_namespace(model_config: ModelConfig, dataset_dir: str = "/fake/data
         Namespace carrying the fields consumed by dataset builders.
 
     Examples:
-        >>> namespace = training_namespace(RFDETRSmallConfig())
+        >>> namespace = _training_namespace(RFDETRSmallConfig())
         >>> (namespace.multi_scale, namespace.num_windows, namespace.square_resize_div_64)
         (True, 2, True)
     """
     return _namespace_from_configs(model_config, TrainConfig(dataset_dir=dataset_dir))
 
 
-def call_coco_builder(args: Any, resolution: int = 512) -> dict[str, Any]:
+@patch("rfdetr.datasets.coco.CocoDetection", return_value=MagicMock())
+@patch("rfdetr.datasets.coco.make_coco_transforms")
+@patch("rfdetr.datasets.coco.make_coco_transforms_square_div_64")
+@patch("rfdetr.datasets.coco.logger")
+@patch("rfdetr.datasets.coco.Path")
+def _call_coco_builder(
+    args: Any,
+    mock_path: MagicMock,
+    _mock_logger: MagicMock,
+    mock_square: MagicMock,
+    mock_plain: MagicMock,
+    mock_dataset: MagicMock,
+    *,
+    resolution: int = 512,
+) -> dict[str, Any]:
     """Run the standard COCO builder with external dataset operations mocked.
 
     Args:
@@ -62,20 +76,13 @@ def call_coco_builder(args: Any, resolution: int = 512) -> dict[str, Any]:
         Captured transform and dataset arguments.
 
     Examples:
-        >>> captured = call_coco_builder(training_namespace(RFDETRSmallConfig()))
+        >>> captured = _call_coco_builder(_training_namespace(RFDETRSmallConfig()))
         >>> captured["transform_kwargs"]["num_windows"]
         2
     """
-    with (
-        patch("rfdetr.datasets.coco.Path") as mock_path,
-        patch("rfdetr.datasets.coco.logger"),
-        patch("rfdetr.datasets.coco.make_coco_transforms_square_div_64") as mock_square,
-        patch("rfdetr.datasets.coco.make_coco_transforms") as mock_plain,
-        patch("rfdetr.datasets.coco.CocoDetection", return_value=MagicMock()) as mock_dataset,
-    ):
-        mock_path.return_value.exists.return_value = True
-        mock_square.return_value = mock_plain.return_value = MagicMock()
-        build_coco("train", args, resolution=resolution)
+    mock_path.return_value.exists.return_value = True
+    mock_square.return_value = mock_plain.return_value = MagicMock()
+    build_coco("train", args, resolution=resolution)
 
     used = mock_square if mock_square.called else mock_plain
     return {
@@ -85,7 +92,21 @@ def call_coco_builder(args: Any, resolution: int = 512) -> dict[str, Any]:
     }
 
 
-def call_roboflow_coco_builder(args: Any, resolution: int = 512) -> dict[str, Any]:
+@patch("rfdetr.datasets.coco.CocoDetection", return_value=MagicMock())
+@patch("rfdetr.datasets.coco.make_coco_transforms")
+@patch("rfdetr.datasets.coco.make_coco_transforms_square_div_64")
+@patch("rfdetr.datasets.coco.logger")
+@patch("rfdetr.datasets.coco.Path")
+def _call_roboflow_coco_builder(
+    args: Any,
+    mock_path: MagicMock,
+    _mock_logger: MagicMock,
+    mock_square: MagicMock,
+    mock_plain: MagicMock,
+    mock_dataset: MagicMock,
+    *,
+    resolution: int = 512,
+) -> dict[str, Any]:
     """Run the Roboflow COCO builder with external dataset operations mocked.
 
     Args:
@@ -96,20 +117,13 @@ def call_roboflow_coco_builder(args: Any, resolution: int = 512) -> dict[str, An
         Captured transform and dataset arguments.
 
     Examples:
-        >>> captured = call_roboflow_coco_builder(training_namespace(RFDETRSmallConfig()))
+        >>> captured = _call_roboflow_coco_builder(_training_namespace(RFDETRSmallConfig()))
         >>> captured["transform_kwargs"]["multi_scale"]
         True
     """
-    with (
-        patch("rfdetr.datasets.coco.Path") as mock_path,
-        patch("rfdetr.datasets.coco.logger"),
-        patch("rfdetr.datasets.coco.make_coco_transforms_square_div_64") as mock_square,
-        patch("rfdetr.datasets.coco.make_coco_transforms") as mock_plain,
-        patch("rfdetr.datasets.coco.CocoDetection", return_value=MagicMock()) as mock_dataset,
-    ):
-        mock_path.return_value.exists.return_value = True
-        mock_square.return_value = mock_plain.return_value = MagicMock()
-        build_roboflow_from_coco("train", args, resolution=resolution)
+    mock_path.return_value.exists.return_value = True
+    mock_square.return_value = mock_plain.return_value = MagicMock()
+    build_roboflow_from_coco("train", args, resolution=resolution)
 
     used = mock_square if mock_square.called else mock_plain
     return {
@@ -119,7 +133,21 @@ def call_roboflow_coco_builder(args: Any, resolution: int = 512) -> dict[str, An
     }
 
 
-def call_yolo_builder(args: Any, resolution: int = 512) -> dict[str, Any]:
+@patch("rfdetr.datasets.yolo.YoloDetection", return_value=MagicMock())
+@patch("rfdetr.datasets.yolo.make_coco_transforms")
+@patch("rfdetr.datasets.yolo.make_coco_transforms_square_div_64")
+@patch("rfdetr.datasets.yolo._resolve_yolo_split_dirs")
+@patch("rfdetr.datasets.yolo.Path")
+def _call_yolo_builder(
+    args: Any,
+    mock_path: MagicMock,
+    mock_resolve_split_dirs: MagicMock,
+    mock_square: MagicMock,
+    mock_plain: MagicMock,
+    mock_dataset: MagicMock,
+    *,
+    resolution: int = 512,
+) -> dict[str, Any]:
     """Run the YOLO builder with filesystem and dataset operations mocked.
 
     Args:
@@ -130,21 +158,14 @@ def call_yolo_builder(args: Any, resolution: int = 512) -> dict[str, Any]:
         Captured transform and dataset arguments.
 
     Examples:
-        >>> captured = call_yolo_builder(training_namespace(RFDETRSmallConfig()))
+        >>> captured = _call_yolo_builder(_training_namespace(RFDETRSmallConfig()))
         >>> captured["transform_kwargs"]["expanded_scales"]
         True
     """
-    fake_dirs = (MagicMock(), MagicMock())
-    with (
-        patch("rfdetr.datasets.yolo.Path") as mock_path,
-        patch("rfdetr.datasets.yolo._resolve_yolo_split_dirs", return_value=fake_dirs),
-        patch("rfdetr.datasets.yolo.make_coco_transforms_square_div_64") as mock_square,
-        patch("rfdetr.datasets.yolo.make_coco_transforms") as mock_plain,
-        patch("rfdetr.datasets.yolo.YoloDetection", return_value=MagicMock()) as mock_dataset,
-    ):
-        mock_path.return_value.exists.return_value = True
-        mock_square.return_value = mock_plain.return_value = MagicMock()
-        build_roboflow_from_yolo("train", args, resolution=resolution)
+    mock_path.return_value.exists.return_value = True
+    mock_resolve_split_dirs.return_value = (MagicMock(), MagicMock())
+    mock_square.return_value = mock_plain.return_value = MagicMock()
+    build_roboflow_from_yolo("train", args, resolution=resolution)
 
     used = mock_square if mock_square.called else mock_plain
     return {
@@ -154,7 +175,17 @@ def call_yolo_builder(args: Any, resolution: int = 512) -> dict[str, Any]:
     }
 
 
-def call_o365_builder(args: Any, resolution: int = 512) -> dict[str, Any]:
+@patch("rfdetr.datasets.o365.CocoDetection", return_value=MagicMock())
+@patch("rfdetr.datasets.o365.make_coco_transforms")
+@patch("rfdetr.datasets.o365.make_coco_transforms_square_div_64")
+def _call_o365_builder(
+    args: Any,
+    mock_square: MagicMock,
+    mock_plain: MagicMock,
+    mock_dataset: MagicMock,
+    *,
+    resolution: int = 512,
+) -> dict[str, Any]:
     """Run the Object365 builder with dataset and transform operations mocked.
 
     Args:
@@ -165,17 +196,12 @@ def call_o365_builder(args: Any, resolution: int = 512) -> dict[str, Any]:
         Captured transform and dataset arguments.
 
     Examples:
-        >>> captured = call_o365_builder(training_namespace(RFDETRSmallConfig()))
+        >>> captured = _call_o365_builder(_training_namespace(RFDETRSmallConfig()))
         >>> captured["transform_kwargs"]["multi_scale"]
         True
     """
-    with (
-        patch("rfdetr.datasets.o365.make_coco_transforms_square_div_64") as mock_square,
-        patch("rfdetr.datasets.o365.make_coco_transforms") as mock_plain,
-        patch("rfdetr.datasets.o365.CocoDetection", return_value=MagicMock()) as mock_dataset,
-    ):
-        mock_square.return_value = mock_plain.return_value = MagicMock()
-        build_o365_raw("train", args, resolution=resolution)
+    mock_square.return_value = mock_plain.return_value = MagicMock()
+    build_o365_raw("train", args, resolution=resolution)
 
     used = mock_square if mock_square.called else mock_plain
     return {
@@ -185,12 +211,12 @@ def call_o365_builder(args: Any, resolution: int = 512) -> dict[str, Any]:
     }
 
 
-BuilderCall = Callable[[Any, int], dict[str, Any]]
+BuilderCall = Callable[..., dict[str, Any]]
 BUILDER_CONTRACTS: tuple[tuple[str, BuilderCall, tuple[str, ...]], ...] = (
-    ("coco", call_coco_builder, ALL_REQUIRED_PIPELINE_OPTIONS),
-    ("roboflow-coco", call_roboflow_coco_builder, ALL_REQUIRED_PIPELINE_OPTIONS),
-    ("yolo", call_yolo_builder, ALL_REQUIRED_PIPELINE_OPTIONS),
-    ("o365", call_o365_builder, O365_REQUIRED_PIPELINE_OPTIONS),
+    ("coco", _call_coco_builder, ALL_REQUIRED_PIPELINE_OPTIONS),
+    ("roboflow-coco", _call_roboflow_coco_builder, ALL_REQUIRED_PIPELINE_OPTIONS),
+    ("yolo", _call_yolo_builder, ALL_REQUIRED_PIPELINE_OPTIONS),
+    ("o365", _call_o365_builder, O365_REQUIRED_PIPELINE_OPTIONS),
 )
 MISSING_OPTION_CASES = tuple(
     pytest.param(builder, option, id=f"{name}-{option}")
@@ -210,7 +236,7 @@ class TestPipelineOptionsHaveNoSilentFallback:
             Pytest fixture functions cannot be called directly outside fixture injection.
             >>> TestPipelineOptionsHaveNoSilentFallback().complete_namespace(Path("."))  # doctest: +SKIP
         """
-        return training_namespace(RFDETRSmallConfig(), dataset_dir=str(tmp_path))
+        return _training_namespace(RFDETRSmallConfig(), dataset_dir=str(tmp_path))
 
     @pytest.mark.parametrize("builder,missing_option", MISSING_OPTION_CASES)
     def test_builder_raises_for_each_missing_required_option(
@@ -223,7 +249,7 @@ class TestPipelineOptionsHaveNoSilentFallback:
         delattr(complete_namespace, missing_option)
 
         with pytest.raises(AttributeError, match=missing_option):
-            builder(complete_namespace, 512)
+            builder(complete_namespace, resolution=512)
 
 
 class TestConfigValuesReachTheTransformPipeline:
@@ -232,10 +258,10 @@ class TestConfigValuesReachTheTransformPipeline:
     @pytest.mark.parametrize(
         "builder",
         [
-            pytest.param(call_coco_builder, id="coco"),
-            pytest.param(call_roboflow_coco_builder, id="roboflow-coco"),
-            pytest.param(call_yolo_builder, id="yolo"),
-            pytest.param(call_o365_builder, id="o365"),
+            pytest.param(_call_coco_builder, id="coco"),
+            pytest.param(_call_roboflow_coco_builder, id="roboflow-coco"),
+            pytest.param(_call_yolo_builder, id="yolo"),
+            pytest.param(_call_o365_builder, id="o365"),
         ],
     )
     @pytest.mark.parametrize("square_resize_div_64", [True, False])
@@ -245,20 +271,20 @@ class TestConfigValuesReachTheTransformPipeline:
         square_resize_div_64: bool,
     ) -> None:
         """The configured square-resize flag must select the matching branch."""
-        namespace = training_namespace(RFDETRSmallConfig())
+        namespace = _training_namespace(RFDETRSmallConfig())
         namespace.square_resize_div_64 = square_resize_div_64
 
-        captured = builder(namespace, 512)
+        captured = builder(namespace, resolution=512)
 
         assert captured["square_resize_used"] is square_resize_div_64
 
     @pytest.mark.parametrize(
         "builder",
         [
-            pytest.param(call_coco_builder, id="coco"),
-            pytest.param(call_roboflow_coco_builder, id="roboflow-coco"),
-            pytest.param(call_yolo_builder, id="yolo"),
-            pytest.param(call_o365_builder, id="o365"),
+            pytest.param(_call_coco_builder, id="coco"),
+            pytest.param(_call_roboflow_coco_builder, id="roboflow-coco"),
+            pytest.param(_call_yolo_builder, id="yolo"),
+            pytest.param(_call_o365_builder, id="o365"),
         ],
     )
     @pytest.mark.parametrize(
@@ -285,32 +311,32 @@ class TestConfigValuesReachTheTransformPipeline:
         square_resize_div_64: bool,
     ) -> None:
         """Each configured geometry value must reach the transform unchanged or intentionally inverted."""
-        namespace = training_namespace(RFDETRSmallConfig())
+        namespace = _training_namespace(RFDETRSmallConfig())
         namespace.square_resize_div_64 = square_resize_div_64
         setattr(namespace, namespace_option, configured_value)
 
-        captured = builder(namespace, 512)
+        captured = builder(namespace, resolution=512)
 
         assert captured["transform_kwargs"][transform_option] == expected_value
 
     def test_o365_does_not_consume_segmentation_option(self) -> None:
         """Object365's documented detection-only builder must not require or forward mask configuration."""
-        namespace = training_namespace(RFDETRSegSmallConfig())
+        namespace = _training_namespace(RFDETRSegSmallConfig())
         del namespace.segmentation_head
 
-        captured = call_o365_builder(namespace)
+        captured = _call_o365_builder(namespace)
 
         assert "include_masks" not in captured["dataset_kwargs"]
 
     @pytest.mark.parametrize(
         "builder",
         [
-            pytest.param(call_coco_builder, id="coco"),
-            pytest.param(call_roboflow_coco_builder, id="roboflow-coco"),
-            pytest.param(call_yolo_builder, id="yolo"),
+            pytest.param(_call_coco_builder, id="coco"),
+            pytest.param(_call_roboflow_coco_builder, id="roboflow-coco"),
+            pytest.param(_call_yolo_builder, id="yolo"),
         ],
     )
     def test_segmentation_builders_forward_masks(self, builder: BuilderCall) -> None:
         """Every segmentation-capable builder must enable masks for a segmentation model."""
-        captured = builder(training_namespace(RFDETRSegSmallConfig()), 512)
+        captured = builder(_training_namespace(RFDETRSegSmallConfig()), resolution=512)
         assert captured["dataset_kwargs"]["include_masks"] is True

--- a/tests/datasets/test_builder_options.py
+++ b/tests/datasets/test_builder_options.py
@@ -1,0 +1,203 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Cross-builder contract for the image-pipeline options every dataset builder reads from ``args``.
+
+``build_coco``, ``build_roboflow_from_coco``, ``build_roboflow_from_yolo`` and ``build_o365_raw`` all derive the same
+resize/geometry options from the namespace the DataModule hands them.  These options have no safe constant fallback:
+``patch_size``, ``num_windows`` and ``segmentation_head`` are variant-dependent, and ``square_resize_div_64``,
+``multi_scale`` and ``expanded_scales`` default to ``True`` on ``TrainConfig``.  Substituting a literal for a missing
+attribute silently trains a different pipeline, so every builder must read them directly and fail loudly instead.
+"""
+
+import types
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rfdetr._namespace import _namespace_from_configs
+from rfdetr.config import ModelConfig, RFDETRSegSmallConfig, RFDETRSmallConfig, TrainConfig
+from rfdetr.datasets.coco import build_coco, build_roboflow_from_coco
+from rfdetr.datasets.o365 import build_o365_raw
+from rfdetr.datasets.yolo import build_roboflow_from_yolo
+
+# The options that must come from args, with no literal fallback. Ordered as the builders read them.
+REQUIRED_PIPELINE_OPTIONS = (
+    "square_resize_div_64",
+    "segmentation_head",
+    "multi_scale",
+    "expanded_scales",
+    "do_random_resize_via_padding",
+    "patch_size",
+    "num_windows",
+)
+
+
+def training_namespace(model_config: ModelConfig, dataset_dir: str = "/fake/dataset") -> types.SimpleNamespace:
+    """Build the merged model/train namespace that ``RFDETRDataModule`` hands to a dataset builder.
+
+    Uses the real :func:`~rfdetr._namespace._namespace_from_configs` rather than a hand-rolled stub so the
+    test asserts against the values a builder actually receives during training.
+
+    Args:
+        model_config: Architecture config supplying ``patch_size``, ``num_windows`` and ``segmentation_head``.
+        dataset_dir: Dataset root recorded on the namespace.
+
+    Returns:
+        Namespace carrying every field the dataset builders read.
+
+    Examples:
+        >>> namespace = training_namespace(RFDETRSmallConfig())
+        >>> (namespace.multi_scale, namespace.num_windows, namespace.square_resize_div_64)
+        (True, 2, True)
+    """
+    return _namespace_from_configs(model_config, TrainConfig(dataset_dir=dataset_dir))
+
+
+def build_roboflow_coco_with_mocks(args: Any, resolution: int = 512) -> dict[str, Any]:
+    """Run ``build_roboflow_from_coco`` with the filesystem and transform builders mocked out.
+
+    Args:
+        args: Namespace forwarded to the builder.
+        resolution: Base square resolution.
+
+    Returns:
+        ``{"square_resize_used": bool, "transform_kwargs": dict, "dataset_kwargs": dict}`` describing which
+        transform branch ran, the kwargs it received, and the kwargs ``CocoDetection`` received.
+
+    Examples:
+        >>> captured = build_roboflow_coco_with_mocks(training_namespace(RFDETRSmallConfig()))
+        >>> captured["transform_kwargs"]["multi_scale"]
+        True
+    """
+    with (
+        patch("rfdetr.datasets.coco.Path") as mock_path,
+        patch("rfdetr.datasets.coco.logger"),  # the builder logs to stdout, which would break the doctest
+        patch("rfdetr.datasets.coco.make_coco_transforms_square_div_64") as mock_square,
+        patch("rfdetr.datasets.coco.make_coco_transforms") as mock_plain,
+        patch("rfdetr.datasets.coco.CocoDetection", return_value=MagicMock()) as mock_dataset,
+    ):
+        mock_path.return_value.exists.return_value = True
+        mock_square.return_value = mock_plain.return_value = MagicMock()
+        build_roboflow_from_coco("train", args, resolution=resolution)
+
+    used = mock_square if mock_square.called else mock_plain
+    return {
+        "square_resize_used": mock_square.called,
+        "transform_kwargs": used.call_args.kwargs,
+        "dataset_kwargs": mock_dataset.call_args.kwargs,
+    }
+
+
+def call_yolo_builder(args: Any, resolution: int = 512) -> None:
+    """Run ``build_roboflow_from_yolo`` with the filesystem and split resolution mocked out.
+
+    Args:
+        args: Namespace forwarded to the builder.
+        resolution: Base square resolution.
+
+    Examples:
+        >>> call_yolo_builder(training_namespace(RFDETRSmallConfig()))
+    """
+    fake_dirs = (MagicMock(), MagicMock())
+    with (
+        patch("rfdetr.datasets.yolo.Path") as mock_path,
+        patch("rfdetr.datasets.yolo._resolve_yolo_split_dirs", return_value=fake_dirs),
+        patch("rfdetr.datasets.yolo.make_coco_transforms_square_div_64", return_value=MagicMock()),
+        patch("rfdetr.datasets.yolo.make_coco_transforms", return_value=MagicMock()),
+        patch("rfdetr.datasets.yolo.YoloDetection", return_value=MagicMock()),
+    ):
+        mock_path.return_value.exists.return_value = True
+        build_roboflow_from_yolo("train", args, resolution=resolution)
+
+
+def call_o365_builder(args: Any, resolution: int = 512) -> None:
+    """Run ``build_o365_raw`` with the dataset class and transform builders mocked out.
+
+    Args:
+        args: Namespace forwarded to the builder.
+        resolution: Base square resolution.
+
+    Examples:
+        >>> call_o365_builder(training_namespace(RFDETRSmallConfig()))
+    """
+    with (
+        patch("rfdetr.datasets.o365.CocoDetection", return_value=MagicMock()),
+        patch("rfdetr.datasets.o365.make_coco_transforms_square_div_64", return_value=MagicMock()),
+        patch("rfdetr.datasets.o365.make_coco_transforms", return_value=MagicMock()),
+    ):
+        build_o365_raw("train", args, resolution=resolution)
+
+
+class TestPipelineOptionsHaveNoSilentFallback:
+    """A namespace missing a pipeline option must raise, not train a silently different pipeline."""
+
+    @pytest.fixture
+    def partial_namespace(self, tmp_path) -> types.SimpleNamespace:
+        """Namespace carrying only the fields unrelated to the image pipeline."""
+        return types.SimpleNamespace(
+            dataset_dir=str(tmp_path),
+            coco_path=str(tmp_path),
+            augmentation_backend="cpu",
+        )
+
+    def test_roboflow_coco_builder_raises(self, partial_namespace: types.SimpleNamespace) -> None:
+        """build_roboflow_from_coco must not substitute a literal for a missing pipeline option."""
+        with pytest.raises(AttributeError, match="square_resize_div_64"):
+            build_roboflow_coco_with_mocks(partial_namespace)
+
+    def test_roboflow_yolo_builder_raises(self, partial_namespace: types.SimpleNamespace) -> None:
+        """build_roboflow_from_yolo must not substitute a literal for a missing pipeline option."""
+        with pytest.raises(AttributeError, match="square_resize_div_64"):
+            call_yolo_builder(partial_namespace)
+
+    def test_o365_builder_raises(self, partial_namespace: types.SimpleNamespace) -> None:
+        """build_o365_raw must not substitute a literal for a missing pipeline option."""
+        with pytest.raises(AttributeError, match="square_resize_div_64"):
+            call_o365_builder(partial_namespace)
+
+    def test_coco_builder_raises(self, partial_namespace: types.SimpleNamespace) -> None:
+        """build_coco must not substitute a literal for a missing pipeline option."""
+        with (
+            patch("rfdetr.datasets.coco.Path") as mock_path,
+            patch("rfdetr.datasets.coco.CocoDetection", return_value=MagicMock()),
+        ):
+            mock_path.return_value.exists.return_value = True
+            with pytest.raises(AttributeError, match="square_resize_div_64"):
+                build_coco("train", partial_namespace, resolution=512)
+
+
+class TestConfigValuesReachTheTransformPipeline:
+    """The values the builders forward must be the configured ones, not the old literal fallbacks."""
+
+    @pytest.mark.parametrize(
+        "option,expected",
+        [
+            pytest.param("multi_scale", True, id="multi_scale_stays_enabled"),
+            pytest.param("expanded_scales", True, id="expanded_scales_stays_enabled"),
+            pytest.param("num_windows", 2, id="num_windows_from_variant_not_4"),
+            pytest.param("patch_size", 16, id="patch_size_from_variant"),
+        ],
+    )
+    def test_small_variant_option_is_forwarded(self, option: str, expected: Any) -> None:
+        """RFDETRSmall's real option values must reach the transform builder unchanged."""
+        captured = build_roboflow_coco_with_mocks(training_namespace(RFDETRSmallConfig()))
+        assert captured["transform_kwargs"][option] == expected
+
+    def test_square_resize_default_selects_the_square_branch(self) -> None:
+        """TrainConfig.square_resize_div_64 defaults to True, so the square-resize builder must run."""
+        captured = build_roboflow_coco_with_mocks(training_namespace(RFDETRSmallConfig()))
+        assert captured["square_resize_used"] is True
+
+    def test_segmentation_variant_enables_masks(self) -> None:
+        """A segmentation variant must reach CocoDetection with include_masks=True."""
+        captured = build_roboflow_coco_with_mocks(training_namespace(RFDETRSegSmallConfig()))
+        assert captured["dataset_kwargs"]["include_masks"] is True
+
+    def test_seg_variant_patch_size_is_not_the_old_literal(self) -> None:
+        """Segmentation variants use patch_size=12; the removed fallback would have forced 16."""
+        captured = build_roboflow_coco_with_mocks(training_namespace(RFDETRSegSmallConfig()))
+        assert captured["transform_kwargs"]["patch_size"] == 12

--- a/tests/datasets/test_builder_options.py
+++ b/tests/datasets/test_builder_options.py
@@ -3,16 +3,11 @@
 # Copyright (c) 2025 Roboflow. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # ------------------------------------------------------------------------
-"""Cross-builder contract for the image-pipeline options every dataset builder reads from ``args``.
-
-``build_coco``, ``build_roboflow_from_coco``, ``build_roboflow_from_yolo`` and ``build_o365_raw`` all derive the same
-resize/geometry options from the namespace the DataModule hands them.  These options have no safe constant fallback:
-``patch_size``, ``num_windows`` and ``segmentation_head`` are variant-dependent, and ``square_resize_div_64``,
-``multi_scale`` and ``expanded_scales`` default to ``True`` on ``TrainConfig``.  Substituting a literal for a missing
-attribute silently trains a different pipeline, so every builder must read them directly and fail loudly instead.
-"""
+"""Regression tests for required dataset-builder pipeline options and forwarding."""
 
 import types
+from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -24,8 +19,7 @@ from rfdetr.datasets.coco import build_coco, build_roboflow_from_coco
 from rfdetr.datasets.o365 import build_o365_raw
 from rfdetr.datasets.yolo import build_roboflow_from_yolo
 
-# The options that must come from args, with no literal fallback. Ordered as the builders read them.
-REQUIRED_PIPELINE_OPTIONS = (
+ALL_REQUIRED_PIPELINE_OPTIONS = (
     "square_resize_div_64",
     "segmentation_head",
     "multi_scale",
@@ -34,20 +28,20 @@ REQUIRED_PIPELINE_OPTIONS = (
     "patch_size",
     "num_windows",
 )
+O365_REQUIRED_PIPELINE_OPTIONS = tuple(
+    option for option in ALL_REQUIRED_PIPELINE_OPTIONS if option != "segmentation_head"
+)
 
 
 def training_namespace(model_config: ModelConfig, dataset_dir: str = "/fake/dataset") -> types.SimpleNamespace:
-    """Build the merged model/train namespace that ``RFDETRDataModule`` hands to a dataset builder.
-
-    Uses the real :func:`~rfdetr._namespace._namespace_from_configs` rather than a hand-rolled stub so the
-    test asserts against the values a builder actually receives during training.
+    """Build the merged model/train namespace passed to dataset builders.
 
     Args:
-        model_config: Architecture config supplying ``patch_size``, ``num_windows`` and ``segmentation_head``.
+        model_config: Architecture config supplying model-dependent options.
         dataset_dir: Dataset root recorded on the namespace.
 
     Returns:
-        Namespace carrying every field the dataset builders read.
+        Namespace carrying the fields consumed by dataset builders.
 
     Examples:
         >>> namespace = training_namespace(RFDETRSmallConfig())
@@ -57,25 +51,58 @@ def training_namespace(model_config: ModelConfig, dataset_dir: str = "/fake/data
     return _namespace_from_configs(model_config, TrainConfig(dataset_dir=dataset_dir))
 
 
-def build_roboflow_coco_with_mocks(args: Any, resolution: int = 512) -> dict[str, Any]:
-    """Run ``build_roboflow_from_coco`` with the filesystem and transform builders mocked out.
+def call_coco_builder(args: Any, resolution: int = 512) -> dict[str, Any]:
+    """Run the standard COCO builder with external dataset operations mocked.
 
     Args:
         args: Namespace forwarded to the builder.
         resolution: Base square resolution.
 
     Returns:
-        ``{"square_resize_used": bool, "transform_kwargs": dict, "dataset_kwargs": dict}`` describing which
-        transform branch ran, the kwargs it received, and the kwargs ``CocoDetection`` received.
+        Captured transform and dataset arguments.
 
     Examples:
-        >>> captured = build_roboflow_coco_with_mocks(training_namespace(RFDETRSmallConfig()))
+        >>> captured = call_coco_builder(training_namespace(RFDETRSmallConfig()))
+        >>> captured["transform_kwargs"]["num_windows"]
+        2
+    """
+    with (
+        patch("rfdetr.datasets.coco.Path") as mock_path,
+        patch("rfdetr.datasets.coco.logger"),
+        patch("rfdetr.datasets.coco.make_coco_transforms_square_div_64") as mock_square,
+        patch("rfdetr.datasets.coco.make_coco_transforms") as mock_plain,
+        patch("rfdetr.datasets.coco.CocoDetection", return_value=MagicMock()) as mock_dataset,
+    ):
+        mock_path.return_value.exists.return_value = True
+        mock_square.return_value = mock_plain.return_value = MagicMock()
+        build_coco("train", args, resolution=resolution)
+
+    used = mock_square if mock_square.called else mock_plain
+    return {
+        "square_resize_used": mock_square.called,
+        "transform_kwargs": used.call_args.kwargs,
+        "dataset_kwargs": mock_dataset.call_args.kwargs,
+    }
+
+
+def call_roboflow_coco_builder(args: Any, resolution: int = 512) -> dict[str, Any]:
+    """Run the Roboflow COCO builder with external dataset operations mocked.
+
+    Args:
+        args: Namespace forwarded to the builder.
+        resolution: Base square resolution.
+
+    Returns:
+        Captured transform and dataset arguments.
+
+    Examples:
+        >>> captured = call_roboflow_coco_builder(training_namespace(RFDETRSmallConfig()))
         >>> captured["transform_kwargs"]["multi_scale"]
         True
     """
     with (
         patch("rfdetr.datasets.coco.Path") as mock_path,
-        patch("rfdetr.datasets.coco.logger"),  # the builder logs to stdout, which would break the doctest
+        patch("rfdetr.datasets.coco.logger"),
         patch("rfdetr.datasets.coco.make_coco_transforms_square_div_64") as mock_square,
         patch("rfdetr.datasets.coco.make_coco_transforms") as mock_plain,
         patch("rfdetr.datasets.coco.CocoDetection", return_value=MagicMock()) as mock_dataset,
@@ -92,112 +119,198 @@ def build_roboflow_coco_with_mocks(args: Any, resolution: int = 512) -> dict[str
     }
 
 
-def call_yolo_builder(args: Any, resolution: int = 512) -> None:
-    """Run ``build_roboflow_from_yolo`` with the filesystem and split resolution mocked out.
+def call_yolo_builder(args: Any, resolution: int = 512) -> dict[str, Any]:
+    """Run the YOLO builder with filesystem and dataset operations mocked.
 
     Args:
         args: Namespace forwarded to the builder.
         resolution: Base square resolution.
 
+    Returns:
+        Captured transform and dataset arguments.
+
     Examples:
-        >>> call_yolo_builder(training_namespace(RFDETRSmallConfig()))
+        >>> captured = call_yolo_builder(training_namespace(RFDETRSmallConfig()))
+        >>> captured["transform_kwargs"]["expanded_scales"]
+        True
     """
     fake_dirs = (MagicMock(), MagicMock())
     with (
         patch("rfdetr.datasets.yolo.Path") as mock_path,
         patch("rfdetr.datasets.yolo._resolve_yolo_split_dirs", return_value=fake_dirs),
-        patch("rfdetr.datasets.yolo.make_coco_transforms_square_div_64", return_value=MagicMock()),
-        patch("rfdetr.datasets.yolo.make_coco_transforms", return_value=MagicMock()),
-        patch("rfdetr.datasets.yolo.YoloDetection", return_value=MagicMock()),
+        patch("rfdetr.datasets.yolo.make_coco_transforms_square_div_64") as mock_square,
+        patch("rfdetr.datasets.yolo.make_coco_transforms") as mock_plain,
+        patch("rfdetr.datasets.yolo.YoloDetection", return_value=MagicMock()) as mock_dataset,
     ):
         mock_path.return_value.exists.return_value = True
+        mock_square.return_value = mock_plain.return_value = MagicMock()
         build_roboflow_from_yolo("train", args, resolution=resolution)
 
+    used = mock_square if mock_square.called else mock_plain
+    return {
+        "square_resize_used": mock_square.called,
+        "transform_kwargs": used.call_args.kwargs,
+        "dataset_kwargs": mock_dataset.call_args.kwargs,
+    }
 
-def call_o365_builder(args: Any, resolution: int = 512) -> None:
-    """Run ``build_o365_raw`` with the dataset class and transform builders mocked out.
+
+def call_o365_builder(args: Any, resolution: int = 512) -> dict[str, Any]:
+    """Run the Object365 builder with dataset and transform operations mocked.
 
     Args:
         args: Namespace forwarded to the builder.
         resolution: Base square resolution.
 
+    Returns:
+        Captured transform and dataset arguments.
+
     Examples:
-        >>> call_o365_builder(training_namespace(RFDETRSmallConfig()))
+        >>> captured = call_o365_builder(training_namespace(RFDETRSmallConfig()))
+        >>> captured["transform_kwargs"]["multi_scale"]
+        True
     """
     with (
-        patch("rfdetr.datasets.o365.CocoDetection", return_value=MagicMock()),
-        patch("rfdetr.datasets.o365.make_coco_transforms_square_div_64", return_value=MagicMock()),
-        patch("rfdetr.datasets.o365.make_coco_transforms", return_value=MagicMock()),
+        patch("rfdetr.datasets.o365.make_coco_transforms_square_div_64") as mock_square,
+        patch("rfdetr.datasets.o365.make_coco_transforms") as mock_plain,
+        patch("rfdetr.datasets.o365.CocoDetection", return_value=MagicMock()) as mock_dataset,
     ):
+        mock_square.return_value = mock_plain.return_value = MagicMock()
         build_o365_raw("train", args, resolution=resolution)
+
+    used = mock_square if mock_square.called else mock_plain
+    return {
+        "square_resize_used": mock_square.called,
+        "transform_kwargs": used.call_args.kwargs,
+        "dataset_kwargs": mock_dataset.call_args.kwargs,
+    }
+
+
+BuilderCall = Callable[[Any, int], dict[str, Any]]
+BUILDER_CONTRACTS: tuple[tuple[str, BuilderCall, tuple[str, ...]], ...] = (
+    ("coco", call_coco_builder, ALL_REQUIRED_PIPELINE_OPTIONS),
+    ("roboflow-coco", call_roboflow_coco_builder, ALL_REQUIRED_PIPELINE_OPTIONS),
+    ("yolo", call_yolo_builder, ALL_REQUIRED_PIPELINE_OPTIONS),
+    ("o365", call_o365_builder, O365_REQUIRED_PIPELINE_OPTIONS),
+)
+MISSING_OPTION_CASES = tuple(
+    pytest.param(builder, option, id=f"{name}-{option}")
+    for name, builder, required_options in BUILDER_CONTRACTS
+    for option in required_options
+)
 
 
 class TestPipelineOptionsHaveNoSilentFallback:
-    """A namespace missing a pipeline option must raise, not train a silently different pipeline."""
+    """Every builder-consumed pipeline option must be present on its namespace."""
 
     @pytest.fixture
-    def partial_namespace(self, tmp_path) -> types.SimpleNamespace:
-        """Namespace carrying only the fields unrelated to the image pipeline."""
-        return types.SimpleNamespace(
-            dataset_dir=str(tmp_path),
-            coco_path=str(tmp_path),
-            augmentation_backend="cpu",
-        )
+    def complete_namespace(self, tmp_path: Path) -> types.SimpleNamespace:
+        """Provide a complete training namespace rooted in a temporary directory.
 
-    def test_roboflow_coco_builder_raises(self, partial_namespace: types.SimpleNamespace) -> None:
-        """build_roboflow_from_coco must not substitute a literal for a missing pipeline option."""
-        with pytest.raises(AttributeError, match="square_resize_div_64"):
-            build_roboflow_coco_with_mocks(partial_namespace)
+        Examples:
+            Pytest fixture functions cannot be called directly outside fixture injection.
+            >>> TestPipelineOptionsHaveNoSilentFallback().complete_namespace(Path("."))  # doctest: +SKIP
+        """
+        return training_namespace(RFDETRSmallConfig(), dataset_dir=str(tmp_path))
 
-    def test_roboflow_yolo_builder_raises(self, partial_namespace: types.SimpleNamespace) -> None:
-        """build_roboflow_from_yolo must not substitute a literal for a missing pipeline option."""
-        with pytest.raises(AttributeError, match="square_resize_div_64"):
-            call_yolo_builder(partial_namespace)
+    @pytest.mark.parametrize("builder,missing_option", MISSING_OPTION_CASES)
+    def test_builder_raises_for_each_missing_required_option(
+        self,
+        complete_namespace: types.SimpleNamespace,
+        builder: BuilderCall,
+        missing_option: str,
+    ) -> None:
+        """Removing any consumed option must raise for that exact field."""
+        delattr(complete_namespace, missing_option)
 
-    def test_o365_builder_raises(self, partial_namespace: types.SimpleNamespace) -> None:
-        """build_o365_raw must not substitute a literal for a missing pipeline option."""
-        with pytest.raises(AttributeError, match="square_resize_div_64"):
-            call_o365_builder(partial_namespace)
-
-    def test_coco_builder_raises(self, partial_namespace: types.SimpleNamespace) -> None:
-        """build_coco must not substitute a literal for a missing pipeline option."""
-        with (
-            patch("rfdetr.datasets.coco.Path") as mock_path,
-            patch("rfdetr.datasets.coco.CocoDetection", return_value=MagicMock()),
-        ):
-            mock_path.return_value.exists.return_value = True
-            with pytest.raises(AttributeError, match="square_resize_div_64"):
-                build_coco("train", partial_namespace, resolution=512)
+        with pytest.raises(AttributeError, match=missing_option):
+            builder(complete_namespace, 512)
 
 
 class TestConfigValuesReachTheTransformPipeline:
-    """The values the builders forward must be the configured ones, not the old literal fallbacks."""
+    """Builders must forward configured values instead of transform defaults."""
 
     @pytest.mark.parametrize(
-        "option,expected",
+        "builder",
         [
-            pytest.param("multi_scale", True, id="multi_scale_stays_enabled"),
-            pytest.param("expanded_scales", True, id="expanded_scales_stays_enabled"),
-            pytest.param("num_windows", 2, id="num_windows_from_variant_not_4"),
-            pytest.param("patch_size", 16, id="patch_size_from_variant"),
+            pytest.param(call_coco_builder, id="coco"),
+            pytest.param(call_roboflow_coco_builder, id="roboflow-coco"),
+            pytest.param(call_yolo_builder, id="yolo"),
+            pytest.param(call_o365_builder, id="o365"),
         ],
     )
-    def test_small_variant_option_is_forwarded(self, option: str, expected: Any) -> None:
-        """RFDETRSmall's real option values must reach the transform builder unchanged."""
-        captured = build_roboflow_coco_with_mocks(training_namespace(RFDETRSmallConfig()))
-        assert captured["transform_kwargs"][option] == expected
+    @pytest.mark.parametrize("square_resize_div_64", [True, False])
+    def test_builder_selects_configured_resize_branch(
+        self,
+        builder: BuilderCall,
+        square_resize_div_64: bool,
+    ) -> None:
+        """The configured square-resize flag must select the matching branch."""
+        namespace = training_namespace(RFDETRSmallConfig())
+        namespace.square_resize_div_64 = square_resize_div_64
 
-    def test_square_resize_default_selects_the_square_branch(self) -> None:
-        """TrainConfig.square_resize_div_64 defaults to True, so the square-resize builder must run."""
-        captured = build_roboflow_coco_with_mocks(training_namespace(RFDETRSmallConfig()))
-        assert captured["square_resize_used"] is True
+        captured = builder(namespace, 512)
 
-    def test_segmentation_variant_enables_masks(self) -> None:
-        """A segmentation variant must reach CocoDetection with include_masks=True."""
-        captured = build_roboflow_coco_with_mocks(training_namespace(RFDETRSegSmallConfig()))
+        assert captured["square_resize_used"] is square_resize_div_64
+
+    @pytest.mark.parametrize(
+        "builder",
+        [
+            pytest.param(call_coco_builder, id="coco"),
+            pytest.param(call_roboflow_coco_builder, id="roboflow-coco"),
+            pytest.param(call_yolo_builder, id="yolo"),
+            pytest.param(call_o365_builder, id="o365"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "namespace_option,configured_value,transform_option,expected_value",
+        [
+            ("multi_scale", True, "multi_scale", True),
+            ("multi_scale", False, "multi_scale", False),
+            ("expanded_scales", True, "expanded_scales", True),
+            ("expanded_scales", False, "expanded_scales", False),
+            ("do_random_resize_via_padding", True, "skip_random_resize", False),
+            ("do_random_resize_via_padding", False, "skip_random_resize", True),
+            ("patch_size", 12, "patch_size", 12),
+            ("num_windows", 3, "num_windows", 3),
+        ],
+    )
+    @pytest.mark.parametrize("square_resize_div_64", [True, False])
+    def test_builder_forwards_each_geometry_option(
+        self,
+        builder: BuilderCall,
+        namespace_option: str,
+        configured_value: bool | int,
+        transform_option: str,
+        expected_value: bool | int,
+        square_resize_div_64: bool,
+    ) -> None:
+        """Each configured geometry value must reach the transform unchanged or intentionally inverted."""
+        namespace = training_namespace(RFDETRSmallConfig())
+        namespace.square_resize_div_64 = square_resize_div_64
+        setattr(namespace, namespace_option, configured_value)
+
+        captured = builder(namespace, 512)
+
+        assert captured["transform_kwargs"][transform_option] == expected_value
+
+    def test_o365_does_not_consume_segmentation_option(self) -> None:
+        """Object365's documented detection-only builder must not require or forward mask configuration."""
+        namespace = training_namespace(RFDETRSegSmallConfig())
+        del namespace.segmentation_head
+
+        captured = call_o365_builder(namespace)
+
+        assert "include_masks" not in captured["dataset_kwargs"]
+
+    @pytest.mark.parametrize(
+        "builder",
+        [
+            pytest.param(call_coco_builder, id="coco"),
+            pytest.param(call_roboflow_coco_builder, id="roboflow-coco"),
+            pytest.param(call_yolo_builder, id="yolo"),
+        ],
+    )
+    def test_segmentation_builders_forward_masks(self, builder: BuilderCall) -> None:
+        """Every segmentation-capable builder must enable masks for a segmentation model."""
+        captured = builder(training_namespace(RFDETRSegSmallConfig()), 512)
         assert captured["dataset_kwargs"]["include_masks"] is True
-
-    def test_seg_variant_patch_size_is_not_the_old_literal(self) -> None:
-        """Segmentation variants use patch_size=12; the removed fallback would have forced 16."""
-        captured = build_roboflow_coco_with_mocks(training_namespace(RFDETRSegSmallConfig()))
-        assert captured["transform_kwargs"]["patch_size"] == 12

--- a/tests/datasets/test_coco.py
+++ b/tests/datasets/test_coco.py
@@ -507,6 +507,9 @@ class TestBuildO365RawGpuBackend:
             self.square_resize_div_64 = square_resize_div_64
             self.multi_scale = False
             self.expanded_scales = False
+            self.do_random_resize_via_padding = False
+            self.patch_size = 16
+            self.num_windows = 4
             self.dataset_dir = "/nonexistent/o365"
             self.coco_path = "/nonexistent/o365"
 

--- a/tests/datasets/test_coco.py
+++ b/tests/datasets/test_coco.py
@@ -246,6 +246,39 @@ def _write_roboflow_keypoint_coco(path: Path, *, category_id: int = 0) -> None:
     path.write_text(json.dumps(data), encoding="utf-8")
 
 
+def _pipeline_args(dataset_dir: object, **overrides: object) -> types.SimpleNamespace:
+    """Build a builder namespace carrying the image-pipeline options the dataset builders require.
+
+    The builders read these options directly, with no literal fallback, so a namespace handed to one must spell
+    them out. The values here reproduce the pipeline the removed ``getattr`` fallbacks used to produce, which
+    keeps tests that only care about label space or backend resolution behaviourally unchanged. Tests asserting
+    that the *configured* values reach the pipeline live in ``tests/datasets/test_builder_options.py``.
+
+    Args:
+        dataset_dir: Dataset root recorded on the namespace.
+        **overrides: Extra fields to add, or pipeline options to replace.
+
+    Returns:
+        Namespace accepted by the Roboflow COCO and YOLO builders.
+
+    Examples:
+        >>> _pipeline_args("/tmp/ds", augmentation_backend="gpu").multi_scale
+        False
+    """
+    options = {
+        "dataset_dir": str(dataset_dir),
+        "square_resize_div_64": False,
+        "segmentation_head": False,
+        "multi_scale": False,
+        "expanded_scales": False,
+        "do_random_resize_via_padding": False,
+        "patch_size": 16,
+        "num_windows": 4,
+    }
+    options.update(overrides)
+    return types.SimpleNamespace(**options)
+
+
 class TestLoadClassesHierarchy:
     """Regression tests for ``_load_classes`` supercategory filtering (#609).
 
@@ -629,7 +662,7 @@ class TestBuildRoboflowFromCocoBackendResolution:
 
         from rfdetr.datasets.coco import build_roboflow_from_coco
 
-        args = types.SimpleNamespace(dataset_dir=str(tmp_path), augmentation_backend="gpu")
+        args = _pipeline_args(tmp_path, augmentation_backend="gpu")
         with (
             patch("rfdetr.datasets.kornia_transforms._has_cuda_device", return_value=False),
             pytest.raises(RuntimeError, match="CUDA"),
@@ -643,7 +676,7 @@ class TestBuildRoboflowFromCocoBackendResolution:
         from rfdetr.config import AugmentationBackend
         from rfdetr.datasets.coco import build_roboflow_from_coco
 
-        args = types.SimpleNamespace(dataset_dir=str(tmp_path), augmentation_backend="gpu")
+        args = _pipeline_args(tmp_path, augmentation_backend="gpu")
         with (
             patch("rfdetr.datasets.kornia_transforms._has_cuda_device", return_value=True),
             patch.object(AugmentationBackend, "_is_available", lambda self: self is not AugmentationBackend.KORNIA),
@@ -1768,7 +1801,7 @@ class TestCrossSplitLabelSpace:
         """A grouping category annotated in train only keeps its train label slot in val instead of shifting it."""
         _write_roboflow_hierarchy_split(tmp_path / "train", [0, 1])
         _write_roboflow_hierarchy_split(tmp_path / "valid", [1])
-        args = types.SimpleNamespace(dataset_dir=str(tmp_path))
+        args = _pipeline_args(tmp_path)
 
         train_dataset = build_roboflow_from_coco("train", args, resolution=64)
         val_dataset = build_roboflow_from_coco("val", args, resolution=64)
@@ -1779,7 +1812,7 @@ class TestCrossSplitLabelSpace:
         """Val targets carry the label index training assigned, not the one val's own coverage would produce."""
         _write_roboflow_hierarchy_split(tmp_path / "train", [0, 1])
         _write_roboflow_hierarchy_split(tmp_path / "valid", [1])
-        args = types.SimpleNamespace(dataset_dir=str(tmp_path))
+        args = _pipeline_args(tmp_path)
 
         val_dataset = build_roboflow_from_coco("val", args, resolution=64)
         _, target = val_dataset[0]


### PR DESCRIPTION
Closes #1412
The four dataset builders derive the same image-pipeline options from `args`, but disagree on how. `build_coco` reads most of them directly; `build_roboflow_from_coco`, `build_roboflow_from_yolo` and `build_o365_raw` use `getattr` with literal fallbacks — five of which contradict the real config default:

| option | old fallback | actual default |
|---|---|---|
| `square_resize_div_64` | `False` | `True` (`TrainConfig`) |
| `segmentation_head` | `False` | `True` on every seg variant |
| `multi_scale` | `False` | `True` (`TrainConfig`) |
| `expanded_scales` | `False` | `True` (`TrainConfig`) |
| `patch_size` | `16` | variant-dependent — `12` seg/keypoint, `14` base |
| `num_windows` | `4` | `2` on every released variant |

`patch_size` and `num_windows` have no default on `ModelConfig`, so no constant is correct — and `(16, 4)` matches no shipped variant.

### Change

All four builders now read these seven options directly, so an incomplete namespace raises `AttributeError` instead of silently building a different pipeline. `do_random_resize_via_padding` is included for cluster parity; its fallback already matched the default, so that one is a no-op.

The remaining `getattr` fallbacks are deliberately untouched — `aug_config`, `scale_jitter` and `augmentation_backend` match their config default, and the keypoint fields' absence is meaningful ("detection-only", per the existing comment at `coco.py:1301`).

### Scope

Latent on the `RFDETRDataModule` path: `_namespace_from_configs` populates every field, so normal `model.train(...)` is unaffected. The exposure is the direct-call path, which the builders' re-export from `rfdetr.datasets` and the comment at `coco.py:1318-1322` both document as supported.

### Tests

New `tests/datasets/test_builder_options.py` covers the cross-builder contract:

- each of the four builders raises on a namespace missing a pipeline option (fails on `develop`)
- the configured values reach the transform builder — `num_windows=2` not `4`, `multi_scale=True`, seg variants at `patch_size=12` with `include_masks=True`

Four tests in `test_coco.py` passed partial namespaces and relied on the old fallbacks. They now use a `_pipeline_args` helper that spells out the values those fallbacks used to produce, so their behavior is unchanged and what they depend on is visible.

`674 passed` across `tests/datasets/` and `src/rfdetr/datasets/`. `ruff`, `ruff format`, `docformatter` and `codespell` pass on the changed files; `mypy` reports nothing in them.
