### PR TITLE
test(tests): simplify parametrized case IDs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -214,6 +214,8 @@ class TestModelInference:
 
 **Use `pytest.mark.parametrize` to extend test cases:**
 
+Put a semantic `id` on each `pytest.param(...)` instead of maintaining a separate `ids` list. Keeping a case and its name together avoids IDs silently drifting from the tested values.
+
 ```python
 import pytest
 
@@ -247,7 +249,10 @@ def test_all_models_have_valid_urls():
 
 
 # GOOD: Parametrized - each model is a separate test case
-@pytest.mark.parametrize("model", list(ModelWeights), ids=[m.filename for m in ModelWeights])
+@pytest.mark.parametrize(
+    "model",
+    [pytest.param(model, id=model.filename) for model in ModelWeights],
+)
 def test_all_models_have_valid_urls(model):
     assert model.url.startswith("http")  # Clear which model failed
 ```

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -214,7 +214,7 @@ class TestModelInference:
 
 **Use `pytest.mark.parametrize` to extend test cases:**
 
-Use `pytest.param(..., id="name")` instead of a separate `ids` list only when a case passes a function, object, or compound setup as one parameterized item, or when it needs a per-case pytest mark. Use bare string, number, boolean, and `None` values otherwise. Keeping each non-default case and its metadata together avoids IDs silently drifting from the tested values.
+Use `pytest.param(..., id="name")` (instead of a separate `ids` list) when a case passes a function, object, or compound setup as one parameterized item, when it needs a per-case pytest mark, or when the raw value would produce an unclear/empty ID (e.g., `""`). Use bare string, number, boolean, and `None` values otherwise; avoid parallel `ids` lists for simple types.
 
 ```python
 import pytest

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -214,7 +214,7 @@ class TestModelInference:
 
 **Use `pytest.mark.parametrize` to extend test cases:**
 
-Put a semantic `id` on each `pytest.param(...)` instead of maintaining a separate `ids` list. Keeping a case and its name together avoids IDs silently drifting from the tested values.
+Use `pytest.param(..., id="name")` instead of a separate `ids` list only when a case passes a function, object, or compound setup as one parameterized item, or when it needs a per-case pytest mark. Use bare string, number, boolean, and `None` values otherwise. Keeping each non-default case and its metadata together avoids IDs silently drifting from the tested values.
 
 ```python
 import pytest
@@ -222,11 +222,7 @@ import pytest
 
 @pytest.mark.parametrize(
     "model_variant",
-    [
-        pytest.param("nano", id="nano"),
-        pytest.param("small", id="small"),
-        pytest.param("medium", id="medium"),
-    ],
+    ["nano", "small", "medium"],
 )
 def test_model_loading(model_variant):
     # Test code that runs for each model variant

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,7 @@ pre-commit run --all-files
 **Test Organization:**
 
 - Group related tests in classes
-- Use `@pytest.mark.parametrize` with `pytest.param(..., id="name")`
+- Use `@pytest.mark.parametrize` with `pytest.param(..., id="name")`; do not maintain a parallel `ids` list
 - Mark GPU/heavy tests with `@pytest.mark.gpu`
 - Avoid multiple validation cases in a single test - see [CONTRIBUTING.md](.github/CONTRIBUTING.md#avoid-multiple-validation-cases-in-a-single-test) for details
 - Fixtures return ready-to-use concrete state or a cohesive tuple of related state. Do not return a callable factory unless fixture-managed lifecycle is required; use an ordinary helper function for configurable construction.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,7 @@ pre-commit run --all-files
 **Test Organization:**
 
 - Group related tests in classes
-- Use `@pytest.mark.parametrize` with `pytest.param(..., id="name")`; do not maintain a parallel `ids` list
+- Use `pytest.param(..., id="name")` only for a function, object, compound setup passed as one case, or a per-case mark; use bare string/number/boolean/`None` values otherwise, and do not maintain a parallel `ids` list
 - Mark GPU/heavy tests with `@pytest.mark.gpu`
 - Avoid multiple validation cases in a single test - see [CONTRIBUTING.md](.github/CONTRIBUTING.md#avoid-multiple-validation-cases-in-a-single-test) for details
 - Fixtures return ready-to-use concrete state or a cohesive tuple of related state. Do not return a callable factory unless fixture-managed lifecycle is required; use an ordinary helper function for configurable construction.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,7 @@ pre-commit run --all-files
 **Test Organization:**
 
 - Group related tests in classes
-- Use `pytest.param(..., id="name")` only for a function, object, compound setup passed as one case, or a per-case mark; use bare string/number/boolean/`None` values otherwise, and do not maintain a parallel `ids` list
+- Use `pytest.param(..., id="name")` only for a function, object, compound setup passed as one case, a per-case mark, or when the raw value would produce an unclear/empty ID (e.g., `""`); use bare string/number/boolean/`None` values otherwise, and do not maintain a parallel `ids` list
 - Mark GPU/heavy tests with `@pytest.mark.gpu`
 - Avoid multiple validation cases in a single test - see [CONTRIBUTING.md](.github/CONTRIBUTING.md#avoid-multiple-validation-cases-in-a-single-test) for details
 - Fixtures return ready-to-use concrete state or a cohesive tuple of related state. Do not return a callable factory unless fixture-managed lifecycle is required; use an ordinary helper function for configurable construction.

--- a/tests/datasets/test__torchvision.py
+++ b/tests/datasets/test__torchvision.py
@@ -383,8 +383,10 @@ class TestEdgeCaseCoverage:
 
     @pytest.mark.parametrize(
         "builder",
-        [make_coco_transforms, make_coco_transforms_square_div_64],
-        ids=["standard", "square"],
+        [
+            pytest.param(make_coco_transforms, id="standard"),
+            pytest.param(make_coco_transforms_square_div_64, id="square"),
+        ],
     )
     def test_unknown_image_set_raises(self, builder) -> None:
         """Unknown image_set raises ValueError."""

--- a/tests/datasets/test_kornia_transforms.py
+++ b/tests/datasets/test_kornia_transforms.py
@@ -1210,7 +1210,10 @@ class TestPerspectiveFactory:
     sequence. Transforms that resize output remain unsupported because this path only transports fixed-size batches.
     """
 
-    @pytest.mark.parametrize("scale", [(0.05, 0.2), 0.2], ids=["range", "scalar"])
+    @pytest.mark.parametrize(
+        "scale",
+        [pytest.param((0.05, 0.2), id="range"), 0.2],
+    )
     def test_distribution_divergence_is_always_reported(self, scale) -> None:
         """The GPU path draws uniformly where the CPU path draws a half-normal, so every config diverges.
 

--- a/tests/evaluation/test_f1_sweep.py
+++ b/tests/evaluation/test_f1_sweep.py
@@ -139,7 +139,7 @@ class TestSweepConfidenceThresholdsMatchesReference:
     """sweep_confidence_thresholds must return numerically identical results to the O(T*N) reference it replaced, across
     random data, empty classes, all-ignored classes, and threshold/score ties."""
 
-    @pytest.mark.parametrize("seed", [0, 1, 2, 3, 4], ids=lambda s: f"seed={s}")
+    @pytest.mark.parametrize("seed", [0, 1, 2, 3, 4])
     def test_matches_reference_on_random_data(self, seed: int) -> None:
         per_class_data = _random_per_class_data(seed=seed, num_classes=5, max_detections=40)
         classes_with_gt = [k for k, d in enumerate(per_class_data) if d["total_gt"] > 0]

--- a/tests/export/test_class_layout.py
+++ b/tests/export/test_class_layout.py
@@ -44,7 +44,7 @@ def test_background_exclusion_preserves_original_class_ids(
     assert class_ids.tolist() == expected_class_ids
 
 
-@pytest.mark.parametrize("background_class_id", [2, -3], ids=["positive", "negative"])
+@pytest.mark.parametrize("background_class_id", [2, -3])
 def test_out_of_range_background_class_is_rejected(background_class_id: int) -> None:
     """Background IDs outside the exported class axis fail with a clear error."""
     with pytest.raises(ValueError, match="background_class_id"):

--- a/tests/export/test_tflite_export.py
+++ b/tests/export/test_tflite_export.py
@@ -1467,8 +1467,11 @@ class TestInterpreterScriptsOnPath:
 
     @pytest.mark.parametrize(
         ("original_path", "expected_path"),
-        [("/usr/bin", "/usr/bin"), ("", ""), (None, None)],
-        ids=["nonempty", "explicit-empty", "unset"],
+        [
+            pytest.param("/usr/bin", "/usr/bin", id="nonempty"),
+            pytest.param("", "", id="explicit-empty"),
+            pytest.param(None, None, id="unset"),
+        ],
     )
     def test_restores_path_on_exception(
         self,
@@ -1513,7 +1516,10 @@ class TestInterpreterScriptsOnPath:
         assert entries[: len(preferred)] == preferred
         assert entries[len(preferred) :] == [unrelated, unrelated]
 
-    @pytest.mark.parametrize("executable", ["", "python"], ids=["empty", "relative"])
+    @pytest.mark.parametrize(
+        "executable",
+        [pytest.param("", id="empty"), pytest.param("python", id="relative")],
+    )
     def test_skips_empty_or_relative_executable(self, monkeypatch: pytest.MonkeyPatch, executable: str) -> None:
         """Invalid executable paths do not add the current directory to PATH."""
         monkeypatch.setattr("rfdetr.export._tflite.converter.sys.executable", executable)

--- a/tests/export/test_topk_selection_parity.py
+++ b/tests/export/test_topk_selection_parity.py
@@ -111,7 +111,10 @@ class TestTopkSelectionParity:
             expected_idx[expected_keep],
         )
 
-    @pytest.mark.parametrize("dtype", [np.float16, np.float64], ids=["float16", "float64"])
+    @pytest.mark.parametrize(
+        "dtype",
+        [pytest.param(np.float16, id="float16"), pytest.param(np.float64, id="float64")],
+    )
     def test_non_float32_fallback_preserves_exact_order(self, dtype: type[np.floating]) -> None:
         """Other floating dtypes retain the complete lexicographic fallback."""
         scores_all = np.array([[0.5, 0.5, 0.25], [0.75, np.nan, -0.0]], dtype=dtype)
@@ -202,7 +205,7 @@ class TestTopkSelectionParity:
         assert got_scores.shape[0] == num_select
         assert list(got_scores) == sorted(got_scores, reverse=True)
 
-    @pytest.mark.parametrize("num_select", [100, 200], ids=["seg-nano-small", "seg-medium-large"])
+    @pytest.mark.parametrize("num_select", [100, 200])
     def test_model_selection_caps_are_preserved(self, num_select: int) -> None:
         """Export decoding retains the configured cap used by shipped segmentation variants."""
         scores_all = np.full((250, 1), 0.9, dtype=np.float32)

--- a/tests/models/test_transformer.py
+++ b/tests/models/test_transformer.py
@@ -165,7 +165,7 @@ def test_gen_encoder_output_proposals_passes_ij_indexing_to_meshgrid(monkeypatch
     assert call_count == 1
 
 
-@pytest.mark.parametrize("position_layout", ["real", "strided"], ids=["real-layout", "strided-fallback"])
+@pytest.mark.parametrize("position_layout", ["real", "strided"])
 def test_transformer_packs_single_level_position_without_redundant_copy(position_layout: str) -> None:
     """Reuse real contiguous position storage while preserving contiguous output for custom strided input."""
     torch.manual_seed(0)
@@ -223,7 +223,7 @@ def test_transformer_packs_single_level_position_without_redundant_copy(position
     assert position.grad is not None
 
 
-@pytest.mark.parametrize("mask_layout", ["real", "strided"], ids=["real-layout", "strided-fallback"])
+@pytest.mark.parametrize("mask_layout", ["real", "strided"])
 def test_transformer_packs_single_level_mask_without_redundant_copy(mask_layout: str) -> None:
     """Reuse real padding-mask storage while preserving contiguous output for custom strided input."""
     torch.manual_seed(0)
@@ -276,7 +276,7 @@ def test_transformer_packs_single_level_mask_without_redundant_copy(mask_layout:
         assert seen_decoder_masks[0].data_ptr() == flattened_mask.data_ptr()
 
 
-@pytest.mark.parametrize("memory_layout", ["real", "strided"], ids=["real-layout", "strided-fallback"])
+@pytest.mark.parametrize("memory_layout", ["real", "strided"])
 def test_transformer_packs_single_level_memory_without_redundant_copy(memory_layout: str) -> None:
     """Reuse real contiguous projector-feature storage while preserving contiguous output for custom strided input."""
     torch.manual_seed(0)
@@ -335,7 +335,7 @@ def test_transformer_packs_single_level_memory_without_redundant_copy(memory_lay
     assert src.grad is not None
 
 
-@pytest.mark.parametrize("memory_layout", ["real", "strided"], ids=["real-layout", "strided-fallback"])
+@pytest.mark.parametrize("memory_layout", ["real", "strided"])
 def test_transformer_packs_single_level_cross_attn_memory_without_redundant_copy(memory_layout: str) -> None:
     """Reuse real contiguous dual-projector storage while preserving contiguous output for custom strided input."""
     torch.manual_seed(0)
@@ -1414,7 +1414,7 @@ def _make_out_of_order_scores(total_hw: int, picks: list[int]) -> torch.Tensor:
     return scores
 
 
-@pytest.mark.parametrize("bbox_reparam", [False, True], ids=["bbox_reparam=False", "bbox_reparam=True"])
+@pytest.mark.parametrize("bbox_reparam", [False, True])
 def test_two_stage_topk_gather_broadcasts_correctly_across_groups_in_training_mode(
     monkeypatch, bbox_reparam: bool
 ) -> None:
@@ -1730,7 +1730,7 @@ def _bbox_from_delta(delta: torch.Tensor, proposals: torch.Tensor, bbox_reparam:
     return delta + proposals
 
 
-@pytest.mark.parametrize("bbox_reparam", [False, True], ids=["bbox_reparam=False", "bbox_reparam=True"])
+@pytest.mark.parametrize("bbox_reparam", [False, True])
 def test_two_stage_bbox_mlp_gather_order_matches_forward_and_gradient_for_real_three_layer_mlp(
     bbox_reparam: bool,
 ) -> None:
@@ -1779,7 +1779,7 @@ def test_two_stage_bbox_mlp_gather_order_matches_forward_and_gradient_for_real_t
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("bbox_reparam", [False, True], ids=["bbox_reparam=False", "bbox_reparam=True"])
+@pytest.mark.parametrize("bbox_reparam", [False, True])
 def test_two_stage_bbox_mlp_gather_order_matches_on_cuda_for_real_three_layer_mlp(bbox_reparam: bool) -> None:
     """CUDA twin of test_two_stage_bbox_mlp_gather_order_matches_forward_and_gradient_for_real_three_layer_mlp:
     the same gather-before-vs-after-MLP comparison, but running the real bbox MLP itself on CUDA (not
@@ -1842,9 +1842,9 @@ class _ShapeRecordingLinear(nn.Module):
         return self.inner(x)
 
 
-@pytest.mark.parametrize("group_detr", [1, 3], ids=["group_detr=1", "group_detr=3"])
-@pytest.mark.parametrize("bbox_reparam", [False, True], ids=["bbox_reparam=False", "bbox_reparam=True"])
-@pytest.mark.parametrize("num_queries", [3, 20], ids=["topk_smaller_than_encoder_memory", "topk_equals_encoder_memory"])
+@pytest.mark.parametrize("group_detr", [1, 3])
+@pytest.mark.parametrize("bbox_reparam", [False, True])
+@pytest.mark.parametrize("num_queries", [3, 20])
 def test_two_stage_bbox_embed_only_runs_on_selected_rows_not_full_encoder_memory(
     group_detr: int, bbox_reparam: bool, num_queries: int
 ) -> None:

--- a/tests/training/test_build_trainer.py
+++ b/tests/training/test_build_trainer.py
@@ -575,7 +575,7 @@ class TestBuildTrainerPrecision:
             build_trainer(_tc(tmp_path, use_ema=False), _mc(amp=True))
         assert captured["precision"] == "bf16-mixed"
 
-    @pytest.mark.parametrize("accelerator", ["xla", "tpu"], ids=["xla", "tpu"])
+    @pytest.mark.parametrize("accelerator", ["xla", "tpu"])
     def test_xla_accelerator_uses_xla_precision_plugin_not_precision_string(self, tmp_path, accelerator):
         """Accelerator='xla'/'tpu' sets an XLAPrecision('bf16-true') plugin, never precision=.
 
@@ -1713,12 +1713,13 @@ class TestEvalIntervalValidationGating:
 
         assert trainer.check_val_every_n_epoch == 3
 
-    @pytest.mark.parametrize("max_epochs", [None, -1], ids=["none", "unlimited"])
+    @pytest.mark.parametrize("max_epochs", [None, -1])
     def test_force_last_epoch_callback_noops_when_max_epochs_not_a_positive_int(self, max_epochs):
         """max_epochs=None/-1 (PTL's not-yet-known / unlimited sentinels) must not force validation.
 
-        The guard is isinstance(max_epochs, int) and max_epochs > 0 — only the finite max_epochs=10 case was previously
-        tested; -1 (unlimited) and None are both PTL-permitted values with no well-defined "final epoch" to force.
+        The guard is isinstance(max_epochs, int) and max_epochs > 0 — only the finite max_epochs=10 case was
+        previously tested; -1 (unlimited) and None are both PTL-permitted values with no well-defined "final epoch" to
+        force.
         """
         cb = _ForceLastEpochValidationCallback()
         trainer = MagicMock()


### PR DESCRIPTION

This pull request standardizes and clarifies the use of `pytest.mark.parametrize` and `pytest.param(..., id=...)` throughout the codebase and documentation. The main goal is to ensure that test case IDs stay in sync with their values, avoid silent mismatches, and improve code readability. The changes update both code and documentation to reflect these best practices, removing unnecessary parallel `ids` lists and using `pytest.param` with `id` only when needed.

**Testing and Parametrization Consistency:**

* Updated all test files to use `pytest.param(..., id=...)` only when passing functions, objects, compound setups, or needing per-case marks; for simple types (strings, numbers, bools, None), bare values are used without a separate `ids` list. This prevents IDs from silently drifting from tested values and keeps metadata with each test case. [[1]](diffhunk://#diff-4f29521b408857690e84ff338317fba8d25a8341d55875ea34af4b3d5fa8290cL386-R389) [[2]](diffhunk://#diff-9909aaa7843aa633214c8c60b271545e17f8e033b47c10d84da5e87a5652d355L1213-R1216) [[3]](diffhunk://#diff-4f10e2d4ad668749f60be3bd3e53c9a8f309915bccde22a7d5f482d9eeacdbc9L1470-R1474) [[4]](diffhunk://#diff-4f10e2d4ad668749f60be3bd3e53c9a8f309915bccde22a7d5f482d9eeacdbc9L1516-R1522) [[5]](diffhunk://#diff-952e4a03db3b666bb2ec5d1f7fe990026a84bfdae05c9db5e27ed324f26070c5L114-R117) [[6]](diffhunk://#diff-952e4a03db3b666bb2ec5d1f7fe990026a84bfdae05c9db5e27ed324f26070c5L205-R208) [[7]](diffhunk://#diff-cdbe94fef3f9e2b22beb245f957bcf42e329735fe262e8bcf92cf4154d925b25L168-R168) [[8]](diffhunk://#diff-cdbe94fef3f9e2b22beb245f957bcf42e329735fe262e8bcf92cf4154d925b25L226-R226) [[9]](diffhunk://#diff-cdbe94fef3f9e2b22beb245f957bcf42e329735fe262e8bcf92cf4154d925b25L279-R279) [[10]](diffhunk://#diff-cdbe94fef3f9e2b22beb245f957bcf42e329735fe262e8bcf92cf4154d925b25L338-R338) [[11]](diffhunk://#diff-cdbe94fef3f9e2b22beb245f957bcf42e329735fe262e8bcf92cf4154d925b25L1417-R1417) [[12]](diffhunk://#diff-cdbe94fef3f9e2b22beb245f957bcf42e329735fe262e8bcf92cf4154d925b25L1733-R1733) [[13]](diffhunk://#diff-cdbe94fef3f9e2b22beb245f957bcf42e329735fe262e8bcf92cf4154d925b25L1782-R1782) [[14]](diffhunk://#diff-cdbe94fef3f9e2b22beb245f957bcf42e329735fe262e8bcf92cf4154d925b25L1845-R1847) [[15]](diffhunk://#diff-71879b9073730f28f0cfba75f843fb4f0e78a0f52350ab7c05c87a738a4fe11cL578-R578) [[16]](diffhunk://#diff-71879b9073730f28f0cfba75f843fb4f0e78a0f52350ab7c05c87a738a4fe11cL1716-R1722) [[17]](diffhunk://#diff-073a72e05994947d59c90f2f31319882603694ba800d65d26af52ab71c35b7b8L142-R142) [[18]](diffhunk://#diff-061f105169296dfd3f0499dfca6ac8fe36bf3731135935c524cd522774ed0710L47-R47)

**Documentation Updates:**

* Revised documentation in `.github/CONTRIBUTING.md` and `AGENTS.md` to explain the new recommended usage of `pytest.param(..., id=...)` and when to use bare values, removing examples that maintained separate `ids` lists for simple types. [[1]](diffhunk://#diff-98e64bc1cd2db9333c6effe87bbe0d6dfe8714aba4c6bde45aa037fe0796e44cR217-R225) [[2]](diffhunk://#diff-98e64bc1cd2db9333c6effe87bbe0d6dfe8714aba4c6bde45aa037fe0796e44cL250-R251) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L121-R121)

These changes make test code more robust and maintainable by reducing the risk of mismatches between test values and their IDs, and by aligning documentation with actual best practices.