### PR TITLE
fix(ci): align mypy with Torch annotations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
       - id: mypy
         name: mypy
         # Run through the project environment, matching ci-typing.yml.
-        entry: uv run --group typing --extra train --extra cli --extra visual --no-sync mypy src/rfdetr/ --no-error-summary
+        entry: uv run --group typing --extra train --extra cli --extra visual mypy src/rfdetr/ --no-error-summary
         language: system
         pass_filenames: false
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,8 +55,8 @@ repos:
     hooks:
       - id: mypy
         name: mypy
-        # Keep the mypy requirement in pyproject.toml aligned when changing this hook.
-        entry: python -m mypy src/rfdetr/ --no-error-summary
+        # Run through the project environment, matching ci-typing.yml.
+        entry: uv run --group typing --extra train --extra cli --extra visual --no-sync mypy src/rfdetr/ --no-error-summary
         language: system
         pass_filenames: false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,6 +207,9 @@ tests = [
 typing = [
     # Keep this pin aligned with the local mypy hook in .pre-commit-config.yaml.
     "mypy==1.19.1",
+    # Match the CPU Torch annotations used by Linux ci-typing.yml.
+    "torch==2.14.0; sys_platform == 'linux'",
+    "torchvision==0.29.0; sys_platform == 'linux'",
     # mypy 1.19.x can crash while processing NumPy 2.4 symbols in strict mode.
     "numpy<2.4",
     "types-PyYAML",
@@ -268,7 +271,38 @@ conflicts = [
         { extra = "executorch" },
         { extra = "xla" },
     ],
+    # The typing group pins the CPU Torch pair used by ci-typing.yml and is
+    # therefore isolated from environments that pin older Torch releases.
+    [
+        { group = "typing" },
+        { extra = "coreml" },
+    ],
+    [
+        { group = "typing" },
+        { extra = "executorch" },
+    ],
+    [
+        { group = "typing" },
+        { extra = "xla" },
+    ],
+    [
+        { group = "typing" },
+        { group = "ci-gpu-pin" },
+    ],
+    [
+        { group = "typing" },
+        { group = "ci-executorch-pin" },
+    ],
 ]
+
+[tool.uv.sources]
+torch = [{ index = "pytorch-cpu", marker = "sys_platform == 'linux'" }]
+torchvision = [{ index = "pytorch-cpu", marker = "sys_platform == 'linux'" }]
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
 
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,9 +207,9 @@ tests = [
 typing = [
     # Keep this pin aligned with the local mypy hook in .pre-commit-config.yaml.
     "mypy==1.19.1",
-    # Match the CPU Torch annotations used by Linux ci-typing.yml.
-    "torch==2.14.0; sys_platform == 'linux'",
-    "torchvision==0.29.0; sys_platform == 'linux'",
+    # Match the Torch annotations checked by the typing pre-commit hook and CI.
+    "torch==2.14.0",
+    "torchvision==0.29.0",
     # mypy 1.19.x can crash while processing NumPy 2.4 symbols in strict mode.
     "numpy<2.4",
     "types-PyYAML",
@@ -271,8 +271,8 @@ conflicts = [
         { extra = "executorch" },
         { extra = "xla" },
     ],
-    # The typing group pins the CPU Torch pair used by ci-typing.yml and is
-    # therefore isolated from environments that pin older Torch releases.
+    # The typing group pins the Torch annotations checked by mypy and cannot
+    # share an environment with configurations that require older Torch releases.
     [
         { group = "typing" },
         { extra = "coreml" },
@@ -296,8 +296,8 @@ conflicts = [
 ]
 
 [tool.uv.sources]
-torch = [{ index = "pytorch-cpu", marker = "sys_platform == 'linux'" }]
-torchvision = [{ index = "pytorch-cpu", marker = "sys_platform == 'linux'" }]
+torch = [{ index = "pytorch-cpu", group = "typing" }]
+torchvision = [{ index = "pytorch-cpu", group = "typing" }]
 
 [[tool.uv.index]]
 name = "pytorch-cpu"

--- a/src/rfdetr/models/heads/segmentation.py
+++ b/src/rfdetr/models/heads/segmentation.py
@@ -160,17 +160,15 @@ class DepthwiseConvBlock(nn.Module):
         # backward.  A plain context-manager only covers forward; the backward
         # for nn.Conv2d runs outside that scope and re-enables cuDNN,
         # triggering RuntimeError on T4/P100 GPUs (issue #731).
-        return cast(
-            Tensor,
-            _DepthwiseConvWithoutCuDNN.apply(  # type: ignore[no-untyped-call]
-                x,
-                self.dwconv.weight,
-                self.dwconv.bias,
-                self.dwconv.stride,
-                self.dwconv.padding,
-                self.dwconv.dilation,
-                self.dwconv.groups,
-            ),
+        depthwise_conv = cast(Callable[..., Tensor], _DepthwiseConvWithoutCuDNN.apply)
+        return depthwise_conv(
+            x,
+            self.dwconv.weight,
+            self.dwconv.bias,
+            self.dwconv.stride,
+            self.dwconv.padding,
+            self.dwconv.dilation,
+            self.dwconv.groups,
         )
 
     def forward(self, x: Tensor) -> Tensor:

--- a/src/rfdetr/models/ops/modules/ms_deform_attn.py
+++ b/src/rfdetr/models/ops/modules/ms_deform_attn.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import math
 import warnings
+from collections.abc import Callable
 from typing import cast
 
 import torch
@@ -166,7 +167,8 @@ class MSDeformAttn(nn.Module):
             expected_len_in = (input_spatial_shapes[:, 0] * input_spatial_shapes[:, 1]).sum()
         error_msg = "input_spatial_shapes must match the flattened input length"
         if self._export:
-            torch._assert(expected_len_in == len_input, error_msg)  # type: ignore[no-untyped-call]
+            torch_assert = cast(Callable[[bool | Tensor, str], None], torch._assert)
+            torch_assert(expected_len_in == len_input, error_msg)
         else:
             assert expected_len_in == len_input, error_msg
 


### PR DESCRIPTION
Changes:
- Replace two version-sensitive no-untyped-call ignores with explicit callable casts for the custom autograd and export assertion paths.
- Run the pre-commit mypy hook through the typing group with CI's extras, and pin the Linux typing environment to the PyTorch CPU index versions used in CI.

Impact:
- Keeps mypy strict across Torch releases whose annotations differ without suppressing unused-ignore diagnostics.
- Makes local pre-commit type checks use the same dependency surface as the CI typing job.

Verification:
- pre-commit run --all-files: passed.
- uv run --group typing --extra train --extra cli --extra visual --no-sync mypy src/rfdetr/ --no-error-summary: passed.
- uv lock --check and git diff --check: passed.

Residual limits:
- GitHub Actions has not rerun this commit.
