### PR TITLE
fix(docs): consolidate search index on /latest/

### DIFF
--- a/.github/workflows/docs-noindex-sweep.yml
+++ b/.github/workflows/docs-noindex-sweep.yml
@@ -1,0 +1,92 @@
+# Patch already-published doc versions on gh-pages with `<meta name="robots" content="noindex, follow">`.
+#
+# Why this exists: /latest/ is the only indexable version, enforced at build time in
+# docs/theme/main.html. Version directories published before that change are frozen HTML
+# that no future build touches, so ~25 archives keep a self-canonical and keep competing
+# with /latest/ in search results. This job rewrites them in place.
+#
+# Manual, idempotent, and safe to re-run: files that already carry a robots meta tag are
+# skipped, and `latest/` is never touched.
+
+name: Docs noindex Sweep
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Report the files that would change without committing"
+        type: boolean
+        required: false
+        default: true
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write # Required for committing to gh-pages
+
+jobs:
+  sweep:
+    name: Inject noindex into archived doc versions
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: 📥 Checkout gh-pages
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: gh-pages
+          fetch-depth: 1
+
+      - name: ⚙️ Configure git for github-actions
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: 🏷️ Inject noindex
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          META='<meta name="robots" content="noindex, follow">'
+          PATCHED=0
+          SKIPPED=0
+          # Every version directory except latest/: mike keeps one directory per deployed
+          # version at the gh-pages root, so anything holding an index.html qualifies.
+          for dir in */; do
+            VERSION="${dir%/}"
+            # `[ ... ] && continue` would abort the whole step under `set -e` whenever the
+            # test is false, so both guards are written as explicit conditionals.
+            if [ "$VERSION" = "latest" ]; then
+              continue
+            fi
+            if [ ! -f "$VERSION/index.html" ]; then
+              continue
+            fi
+            while IFS= read -r -d '' page; do
+              if grep -qi 'name="robots"' "$page"; then
+                SKIPPED=$((SKIPPED + 1))
+                continue
+              fi
+              # Only the first `<head>` is rewritten, so a docs page quoting `<head>`
+              # inside a code sample keeps its visible content untouched.
+              awk -v meta="    $META" \
+                'done_ins == 0 && /<head>/ { sub(/<head>/, "<head>\n" meta); done_ins = 1 } { print }' \
+                "$page" > "$page.tmp"
+              mv "$page.tmp" "$page"
+              PATCHED=$((PATCHED + 1))
+            done < <(find "$VERSION" -name '*.html' -print0)
+          done
+          echo "patched=$PATCHED skipped=$SKIPPED"
+          if [ "$PATCHED" -eq 0 ]; then
+            echo "Nothing to do."
+            exit 0
+          fi
+          if [ "$DRY_RUN" = "true" ]; then
+            git diff --stat
+            echo "::notice::Dry run - $PATCHED files would be patched. Re-run with dry_run=false to commit."
+            exit 0
+          fi
+          git add -u
+          git commit -m "chore(docs): noindex archived doc versions ($PATCHED pages)"
+          git push origin gh-pages || (git pull --rebase origin gh-pages && git push origin gh-pages)

--- a/.github/workflows/docs-noindex-sweep.yml
+++ b/.github/workflows/docs-noindex-sweep.yml
@@ -50,7 +50,6 @@ jobs:
           fetch-depth: 1
 
       - name: 🏷️ Inject noindex
-        id: sweep
         run: |
           set -euo pipefail
           META='<meta name="robots" content="noindex, follow">'
@@ -83,28 +82,19 @@ jobs:
             done < <(find "$VERSION" -name '*.html' -print0)
           done
           echo "patched=$PATCHED skipped=$SKIPPED"
-          echo "patched=$PATCHED" >> "$GITHUB_OUTPUT"
-          if [ "$PATCHED" -gt 0 ]; then
-            git diff --stat
-          fi
+          git diff --stat
 
-      # Only a dispatched run with dry_run=false mutates gh-pages; a pull_request run has no
-      # matching condition and therefore stops after reporting the diff above.
       - name: 📤 Commit and push
-        if: >-
-          github.event_name == 'workflow_dispatch' &&
-          inputs.dry_run == false &&
-          steps.sweep.outputs.patched != '0'
+        # A pull_request run never matches, so it stops after the report above.
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run == false
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -u
-          git commit -m "chore(docs): noindex archived doc versions (${{ steps.sweep.outputs.patched }} pages)"
+          if git diff --cached --quiet; then
+            echo "Nothing to commit."
+            exit 0
+          fi
+          git commit -m "chore(docs): noindex archived doc versions"
           git push origin gh-pages || (git pull --rebase origin gh-pages && git push origin gh-pages)
-
-      - name: 📝 Report dry run
-        if: >-
-          !(github.event_name == 'workflow_dispatch' && inputs.dry_run == false) &&
-          steps.sweep.outputs.patched != '0'
-        run: echo "::notice::Dry run - ${{ steps.sweep.outputs.patched }} files would be patched. Dispatch this workflow with dry_run=false to commit."

--- a/.github/workflows/docs-noindex-sweep.yml
+++ b/.github/workflows/docs-noindex-sweep.yml
@@ -11,7 +11,7 @@
 # The event decides whether anything is written:
 #   pull_request touching the indexing rules → dry run, reporting how many archived pages
 #     the sweep would rewrite without mutating gh-pages
-#   workflow_dispatch                        → patches gh-pages and pushes
+#   workflow_dispatch with confirm=BACKFILL  → patches gh-pages and pushes
 
 name: Docs noindex Sweep
 
@@ -23,6 +23,11 @@ on:
       - "docs/root-static/robots.txt"
       - "docs/root-static/mike-redirect.html"
   workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type BACKFILL to rewrite archived pages on gh-pages"
+        required: true
+        default: ""
 
 concurrency:
   # This sweep and Build and Publish Docs both write gh-pages. Keep one writer at a
@@ -40,6 +45,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      # A dispatched run rewrites hundreds of published pages, so it takes a typed
+      # confirmation. Failing here keeps a mistyped dispatch from reaching the checkout.
+      - name: 🔍 Validate confirmation
+        if: github.event_name == 'workflow_dispatch' && inputs.confirm != 'BACKFILL'
+        run: |
+          echo "::error::Dispatch requires confirm=BACKFILL; got '${{ inputs.confirm }}'."
+          exit 1
+
       - name: 📥 Checkout gh-pages
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:

--- a/.github/workflows/docs-noindex-sweep.yml
+++ b/.github/workflows/docs-noindex-sweep.yml
@@ -8,10 +8,10 @@
 # Idempotent and safe to re-run: files that already carry a robots meta tag are skipped,
 # and `latest/` is never touched.
 #
-# Triggers:
-#   pull_request touching the indexing rules → always a dry run, so a PR shows how many
-#     archived pages the sweep would rewrite without mutating gh-pages
-#   workflow_dispatch                       → dry run by default; only dry_run=false commits
+# The event decides whether anything is written:
+#   pull_request touching the indexing rules → dry run, reporting how many archived pages
+#     the sweep would rewrite without mutating gh-pages
+#   workflow_dispatch                        → patches gh-pages and pushes
 
 name: Docs noindex Sweep
 
@@ -23,19 +23,13 @@ on:
       - "docs/root-static/robots.txt"
       - "docs/root-static/mike-redirect.html"
   workflow_dispatch:
-    inputs:
-      dry_run:
-        description: "Report the files that would change without committing"
-        type: boolean
-        required: false
-        default: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
-  contents: write # Required for committing to gh-pages on a dispatched non-dry run
+  contents: write # Required for committing to gh-pages on a dispatched run
 
 jobs:
   sweep:
@@ -86,7 +80,7 @@ jobs:
 
       - name: 📤 Commit and push
         # A pull_request run never matches, so it stops after the report above.
-        if: github.event_name == 'workflow_dispatch' && inputs.dry_run == false
+        if: github.event_name == 'workflow_dispatch'
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"

--- a/.github/workflows/docs-noindex-sweep.yml
+++ b/.github/workflows/docs-noindex-sweep.yml
@@ -25,8 +25,11 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # This sweep and Build and Publish Docs both write gh-pages. Keep one writer at a
+  # time: a retry cannot safely rebase generated pages that another deployment replaced.
+  group: gh-pages-writer
+  queue: max
+  cancel-in-progress: false
 
 permissions:
   contents: write # Required for committing to gh-pages on a dispatched run

--- a/.github/workflows/docs-noindex-sweep.yml
+++ b/.github/workflows/docs-noindex-sweep.yml
@@ -49,16 +49,8 @@ jobs:
           ref: gh-pages
           fetch-depth: 1
 
-      - name: ⚙️ Configure git for github-actions
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
       - name: 🏷️ Inject noindex
-        env:
-          # Anything other than an explicit dispatched dry_run=false stays a dry run, so a
-          # pull_request run can never commit to gh-pages.
-          DRY_RUN: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run == false) }}
+        id: sweep
         run: |
           set -euo pipefail
           META='<meta name="robots" content="noindex, follow">'
@@ -91,15 +83,28 @@ jobs:
             done < <(find "$VERSION" -name '*.html' -print0)
           done
           echo "patched=$PATCHED skipped=$SKIPPED"
-          if [ "$PATCHED" -eq 0 ]; then
-            echo "Nothing to do."
-            exit 0
-          fi
-          if [ "$DRY_RUN" != "false" ]; then
+          echo "patched=$PATCHED" >> "$GITHUB_OUTPUT"
+          if [ "$PATCHED" -gt 0 ]; then
             git diff --stat
-            echo "::notice::Dry run - $PATCHED files would be patched. Dispatch this workflow with dry_run=false to commit."
-            exit 0
           fi
+
+      # Only a dispatched run with dry_run=false mutates gh-pages; a pull_request run has no
+      # matching condition and therefore stops after reporting the diff above.
+      - name: 📤 Commit and push
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          inputs.dry_run == false &&
+          steps.sweep.outputs.patched != '0'
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -u
-          git commit -m "chore(docs): noindex archived doc versions ($PATCHED pages)"
+          git commit -m "chore(docs): noindex archived doc versions (${{ steps.sweep.outputs.patched }} pages)"
           git push origin gh-pages || (git pull --rebase origin gh-pages && git push origin gh-pages)
+
+      - name: 📝 Report dry run
+        if: >-
+          !(github.event_name == 'workflow_dispatch' && inputs.dry_run == false) &&
+          steps.sweep.outputs.patched != '0'
+        run: echo "::notice::Dry run - ${{ steps.sweep.outputs.patched }} files would be patched. Dispatch this workflow with dry_run=false to commit."

--- a/.github/workflows/docs-noindex-sweep.yml
+++ b/.github/workflows/docs-noindex-sweep.yml
@@ -5,12 +5,23 @@
 # that no future build touches, so ~25 archives keep a self-canonical and keep competing
 # with /latest/ in search results. This job rewrites them in place.
 #
-# Manual, idempotent, and safe to re-run: files that already carry a robots meta tag are
-# skipped, and `latest/` is never touched.
+# Idempotent and safe to re-run: files that already carry a robots meta tag are skipped,
+# and `latest/` is never touched.
+#
+# Triggers:
+#   pull_request touching the indexing rules → always a dry run, so a PR shows how many
+#     archived pages the sweep would rewrite without mutating gh-pages
+#   workflow_dispatch                       → dry run by default; only dry_run=false commits
 
 name: Docs noindex Sweep
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/docs-noindex-sweep.yml"
+      - "docs/theme/main.html"
+      - "docs/root-static/robots.txt"
+      - "docs/root-static/mike-redirect.html"
   workflow_dispatch:
     inputs:
       dry_run:
@@ -20,11 +31,11 @@ on:
         default: true
 
 concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
-  contents: write # Required for committing to gh-pages
+  contents: write # Required for committing to gh-pages on a dispatched non-dry run
 
 jobs:
   sweep:
@@ -45,7 +56,9 @@ jobs:
 
       - name: 🏷️ Inject noindex
         env:
-          DRY_RUN: ${{ inputs.dry_run }}
+          # Anything other than an explicit dispatched dry_run=false stays a dry run, so a
+          # pull_request run can never commit to gh-pages.
+          DRY_RUN: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run == false) }}
         run: |
           set -euo pipefail
           META='<meta name="robots" content="noindex, follow">'
@@ -82,9 +95,9 @@ jobs:
             echo "Nothing to do."
             exit 0
           fi
-          if [ "$DRY_RUN" = "true" ]; then
+          if [ "$DRY_RUN" != "false" ]; then
             git diff --stat
-            echo "::notice::Dry run - $PATCHED files would be patched. Re-run with dry_run=false to commit."
+            echo "::notice::Dry run - $PATCHED files would be patched. Dispatch this workflow with dry_run=false to commit."
             exit 0
           fi
           git add -u

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -13,6 +13,11 @@
 #   - Copies robots.txt, llms.txt, llms-full.txt to gh-pages root
 #   - Regenerates sitemap.xml normalising versioned paths to /latest/
 #   - Pings IndexNow (Bing) with canonical /latest/ URLs
+#
+# Search-index consolidation: /latest/ is the only indexable version. Non-latest builds
+# carry `noindex, follow` (docs/theme/main.html), and a latest deploy re-points the site
+# root at /latest/ through a redirect template carrying a canonical link. Version dirs
+# published before that theme change are patched by .github/workflows/docs-noindex-sweep.yml.
 
 name: Build and Publish Docs
 
@@ -118,6 +123,15 @@ jobs:
             DOC_VERSION="${TARGET%.post*}"
             uv run --no-sync mike deploy --push "$DOC_VERSION"
           fi
+
+      # GitHub Pages cannot serve a 301, so the root is a client-side redirect. mike's stock
+      # template carries no canonical, which leaves the root a thin page passing nothing to
+      # /latest/; the template below adds one.
+      - name: 🔗 Point site root at /latest/
+        if: >-
+          (github.event_name == 'push' && github.ref == 'refs/heads/release/latest') ||
+          (github.event_name == 'workflow_dispatch' && inputs.target == 'release/latest')
+        run: uv run --no-sync mike set-default --push --template docs/root-static/mike-redirect.html latest
 
       - name: 🏗️ Build docs for artifact
         run: uv run --no-sync mkdocs build

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -33,10 +33,12 @@ on:
         required: true
         default: "release/latest"
 
-# Ensure only one concurrent deployment
+# Every deployment and Docs noindex Sweep can write gh-pages. They must share one
+# non-cancelling queue, because generated-page retries cannot safely rebase each other.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref_name || github.event_name == 'workflow_dispatch' && inputs.target || github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}
-  cancel-in-progress: true
+  group: gh-pages-writer
+  queue: max
+  cancel-in-progress: false
 
 # Restrict permissions by default
 permissions:
@@ -66,11 +68,39 @@ jobs:
             exit 1
           fi
 
+      # Numeric tag dispatches intentionally build historical docs, but their old theme
+      # and robots.txt would undo the current site's noindex policy. Keep the policy from
+      # develop, the canonical source branch, and restore it before mike deploys the archive.
+      - name: 📥 Checkout current indexing policy
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          inputs.target != 'develop' &&
+          inputs.target != 'release/latest'
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: develop
+          path: .docs-index-policy
+          sparse-checkout: |
+            docs/theme/main.html
+            docs/root-static/robots.txt
+          sparse-checkout-cone-mode: false
+
       - name: 📥 Checkout the repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
+          # Preserve the separately checked-out current policy files below.
+          clean: false
           fetch-depth: 0
           ref: ${{ inputs.target || github.ref }}
+
+      - name: ♻️ Restore current indexing policy
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          inputs.target != 'develop' &&
+          inputs.target != 'release/latest'
+        run: |
+          cp .docs-index-policy/docs/theme/main.html docs/theme/main.html
+          cp .docs-index-policy/docs/root-static/robots.txt docs/root-static/robots.txt
 
       - name: 🐍 Install uv and set Python
         uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0

--- a/docs/root-static/mike-redirect.html
+++ b/docs/root-static/mike-redirect.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<!--
+  Root redirect template for `mike set-default latest --template ...`.
+
+  GitHub Pages cannot serve a 301, so the site root is a client-side redirect to the
+  default version. mike's stock template carries no canonical, which leaves the root
+  as a thin page passing nothing to the version it points at. The canonical below
+  consolidates the root onto /latest/.
+
+  Deliberately no `noindex` here: noindex plus canonical on the same URL is a
+  conflicting signal that search engines discard.
+-->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting</title>
+  <link rel="canonical" href="https://rfdetr.roboflow.com/latest/">
+  <noscript>
+    <meta http-equiv="refresh" content="1; url={{href}}" />
+  </noscript>
+  <script>
+    window.location.replace(
+      "{{href}}" + window.location.search + window.location.hash
+    );
+  </script>
+</head>
+<body>
+  Redirecting to <a href="{{href}}">{{href}}</a>...
+</body>
+</html>

--- a/docs/root-static/robots.txt
+++ b/docs/root-static/robots.txt
@@ -1,17 +1,9 @@
 User-agent: *
 Allow: /
-# Block numeric-versioned paths (/0.x/, /1.x/, etc.) — canonical URL is /latest/
-# robots.txt has no character classes, so one Disallow per leading digit is required.
-Disallow: /0.*/
-Disallow: /1.*/
-Disallow: /2.*/
-Disallow: /3.*/
-Disallow: /4.*/
-Disallow: /5.*/
-Disallow: /6.*/
-Disallow: /7.*/
-Disallow: /8.*/
-Disallow: /9.*/
+# Versioned paths (/develop/, /1.2.3/, ...) are deliberately crawlable: they carry
+# `<meta name="robots" content="noindex, follow">`, and a Disallow rule would keep
+# crawlers from ever fetching that tag - leaving already-indexed archives in the
+# index with no way to drop out. Canonical URL stays /latest/.
 
 # AI crawlers — explicitly allow all paths including numeric-versioned ones.
 # Named groups are independent of User-agent: * — they do NOT inherit its Disallow rules.

--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -10,6 +10,13 @@
 
 {% block extrahead %}
   {{ super() }}
+  {# Index consolidation: only the /latest/ deploy may be indexed. mike rewrites site_url
+     per deployed version, so /develop/ and every /X.Y.Z/ archive - which mkdocs-material
+     otherwise gives a self-canonical - is marked noindex; "follow" keeps their links live.
+     Un-versioned builds (local, CI artifact) also match and stay out of any index. #}
+  {% if not (config.site_url or "").rstrip("/").endswith("/latest") %}
+  <meta name="robots" content="noindex, follow">
+  {% endif %}
   {% set ga4_measurement_id = "G-5M220DKLMB" %}
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id={{ ga4_measurement_id }}"></script>


### PR DESCRIPTION
- Mark every non-latest docs build `noindex, follow` in the theme head, branching on the `site_url` mike rewrites per deployed version, so /develop/ and each /X.Y.Z/ archive stops competing with /latest/ on identical content
- Add a manual, idempotent `Docs noindex Sweep` workflow that injects the same robots meta into version directories already frozen on gh-pages, which no future build would otherwise touch
- Drop the ten numeric `Disallow` rules from robots.txt: a blocked archive is never refetched, so it keeps its index entry with no way to drop out
- Add a mike root-redirect template carrying `rel="canonical"` to /latest/, and run `mike set-default --template` on latest deploys so the site root stops being a thin page that passes nothing on
