### PR TITLE
fix(docs): keep banner off current release

### DIFF
--- a/.github/_tests/test_docs_theme.py
+++ b/.github/_tests/test_docs_theme.py
@@ -141,3 +141,28 @@ def test_banner_script_reasserts_its_verdict(repo_root: Path) -> None:
     # Material unhides asides after its own async check, so the verdict has to survive that.
     script = (repo_root / "docs" / "javascripts" / "version-banner.js").read_text(encoding="utf-8")
     assert "__outdated" in script
+
+
+def test_banner_script_claims_a_verdict_before_fetching(repo_root: Path) -> None:
+    # Material's inline partial unhides from a cached `__outdated` before this script runs, and its
+    # bundled check recomputes only while that key is unset - so a verdict claimed after the fetch
+    # resolves comes too late to keep the banner off the current release.
+    script = (repo_root / "docs" / "javascripts" / "version-banner.js").read_text(encoding="utf-8")
+    assert script.index("applyVerdict(versionBase, false)") < script.index("fetch(new URL")
+
+
+def test_backfilled_trees_are_flagged_for_the_banner_script(injector: ModuleType, repo_root: Path) -> None:
+    # The backfill reveals the banner itself, and the flag tells the script that reveal is settled -
+    # without it a patched archived tree would blink the banner off for the length of a fetch. Both
+    # halves of that handshake live in different files and must not drift apart.
+    script = (repo_root / "docs" / "javascripts" / "version-banner.js").read_text(encoding="utf-8")
+    assert 'dataset.rfOutdated="true"' in injector._UNHIDE_SCRIPT
+    assert 'banner.dataset.rfOutdated === "true"' in script
+
+
+def test_banner_script_restores_the_cached_verdict_when_versions_json_fails(repo_root: Path) -> None:
+    # The provisional verdict overwrites what Material cached; an unreachable versions.json leaves
+    # this script with nothing to say, so that value has to go back rather than stay overwritten.
+    script = (repo_root / "docs" / "javascripts" / "version-banner.js").read_text(encoding="utf-8")
+    rejection_path = script[script.index(".catch(") :]
+    assert "cacheVerdict(versionBase, cached)" in rejection_path

--- a/.github/_tests/test_docs_theme.py
+++ b/.github/_tests/test_docs_theme.py
@@ -128,3 +128,16 @@ def test_banner_script_is_registered(repo_root: Path) -> None:
 def test_banner_stylesheet_defines_the_height_variable(repo_root: Path) -> None:
     stylesheet = (repo_root / "docs" / "stylesheets" / "rf.css").read_text(encoding="utf-8")
     assert "--rf-banner-height" in stylesheet
+
+
+def test_banner_script_decides_visibility_from_versions_json(repo_root: Path) -> None:
+    # Material's own check tests the `latest` alias, which this site's versions.json never
+    # carries, so it flags the current release as outdated; the script decides instead.
+    script = (repo_root / "docs" / "javascripts" / "version-banner.js").read_text(encoding="utf-8")
+    assert "versions.json" in script
+
+
+def test_banner_script_reasserts_its_verdict(repo_root: Path) -> None:
+    # Material unhides asides after its own async check, so the verdict has to survive that.
+    script = (repo_root / "docs" / "javascripts" / "version-banner.js").read_text(encoding="utf-8")
+    assert "__outdated" in script

--- a/.github/_tests/test_inject_outdated_banner.py
+++ b/.github/_tests/test_inject_outdated_banner.py
@@ -183,6 +183,20 @@ def test_current_release_is_not_warned_about(injector: ModuleType, gh_pages: Pat
     assert (gh_pages / "1.9.4" / "index.html").read_text(encoding="utf-8") == EMPTY_PAGE
 
 
+def test_current_release_gets_the_banner_script(injector: ModuleType, gh_pages: Path) -> None:
+    # The script is what keeps a natively built banner hidden on the newest release, so that
+    # tree needs it even though it is never banner-ed or styled.
+    injector.patch_scripts(gh_pages)
+    script = gh_pages / "1.9.4" / "javascripts" / "version-banner.js"
+    assert script.read_text(encoding="utf-8") == injector.VERSION_BANNER_JS
+
+
+def test_current_release_page_references_the_banner_script(injector: ModuleType, gh_pages: Path) -> None:
+    injector.patch_scripts(gh_pages)
+    page = (gh_pages / "1.9.4" / "index.html").read_text(encoding="utf-8")
+    assert '<script src="javascripts/version-banner.js"></script>' in page
+
+
 def test_current_release_stylesheet_is_not_patched(injector: ModuleType, gh_pages: Path) -> None:
     injector.patch_stylesheets(gh_pages)
     stylesheet = (gh_pages / "1.9.4" / "stylesheets" / "rf.css").read_text(encoding="utf-8")

--- a/.github/scripts/inject_outdated_banner.py
+++ b/.github/scripts/inject_outdated_banner.py
@@ -80,8 +80,14 @@ ARCHIVED_TEXT = (
 
 # The backfill only patches develop and archived numeric trees, both of which need the
 # warning visible. Reveal the injected wrapper directly; a relative URL has no base in
-# `new URL()` and would abort this inline script before it reaches the banner.
-_UNHIDE_SCRIPT = '<script>var el=document.querySelector("[data-md-component=outdated]");el&&(el.hidden=!1)</script>'
+# `new URL()` and would abort this inline script before it reaches the banner. The flag
+# it sets alongside says the reveal is settled rather than guessed: `version-banner.js`
+# hides a numbered tree while it checks versions.json, and would otherwise blink the
+# banner back off on every page this script patched.
+_UNHIDE_SCRIPT = (
+    '<script>var el=document.querySelector("[data-md-component=outdated]");'
+    'el&&(el.dataset.rfOutdated="true",el.hidden=!1)</script>'
+)
 
 
 def _aside(text: str) -> str:

--- a/.github/scripts/inject_outdated_banner.py
+++ b/.github/scripts/inject_outdated_banner.py
@@ -26,7 +26,8 @@ Scope:
     ``latest`` is never touched, and neither is the newest release directory: ``mike``
     publishes each release both under its own number and under ``latest``, so a reader there
     is on the current release. An earlier run that did banner it is undone by
-    ``strip_from_current_release``.
+    ``strip_from_current_release``. The newest release does get ``version-banner.js``, which
+    is what keeps its natively built banner markup hidden.
 Usage:
     Run ``python .github/scripts/inject_outdated_banner.py <gh-pages checkout root>``.
     Safe to re-run: previously injected content is replaced in place (so wording or style
@@ -153,12 +154,12 @@ BANNER_CSS = """[data-md-component="outdated"] .md-banner,
   text-decoration: underline;
 }"""
 
-# docs/javascripts/version-banner.js publishes the banner's height as a CSS variable and
-# nudges the sticky header/sidebars below it. Archived trees never got it, so a copy is
-# written into each one: without it the banner still sticks (pure CSS), but the header
-# can briefly overlap it before a reader scrolls. Read from the source tree rather than
-# duplicated here, so the two never drift; the sweep workflow's sparse checkout carries
-# both this script and that file.
+# docs/javascripts/version-banner.js decides whether the banner is revealed - comparing this
+# tree against the highest version in versions.json, which Material's own alias-based check
+# gets wrong here - and publishes the banner's height so the sticky header clears it. Trees
+# published before it existed get a copy. Read from the source tree rather than duplicated
+# here, so the two never drift; the sweep workflow's sparse checkout carries both this script
+# and that file.
 VERSION_BANNER_JS = (Path(__file__).resolve().parents[2] / "docs" / "javascripts" / "version-banner.js").read_text(
     encoding="utf-8"
 )
@@ -249,6 +250,35 @@ def _version_dirs(root: Path) -> list[Path]:
     develop = root / "develop"
     if develop.is_dir():
         dirs = [*dirs, develop]
+    return dirs
+
+
+def _script_dirs(root: Path) -> list[Path]:
+    """Return every directory that needs the banner script, current release included.
+
+    The script decides whether the banner is revealed, so the current release needs it as much
+    as the superseded trees do: its pages carry banner markup built before that decision moved
+    out of Material, and without the script Material's own check - which never sees a `latest`
+    alias in versions.json - warns readers of the newest docs that they are reading old ones.
+
+    Args:
+        root: Root of the gh-pages checkout.
+
+    Returns:
+        Directories that should carry the script.
+
+    Examples:
+        >>> import tempfile
+        >>> with tempfile.TemporaryDirectory() as tmp:
+        ...     (Path(tmp) / "1.2.3").mkdir()
+        ...     (Path(tmp) / "1.3.0").mkdir()
+        ...     [d.name for d in _script_dirs(Path(tmp))]
+        ['1.2.3', '1.3.0']
+    """
+    dirs = _version_dirs(root)
+    current = current_release_dir(root)
+    if current is not None and current not in dirs:
+        dirs = [*dirs, current]
     return dirs
 
 
@@ -348,8 +378,9 @@ def _relative_prefix(html_file: Path, version_dir: Path) -> str:
 def patch_scripts(root: Path) -> list[Path]:
     """Copy version-banner.js into each version tree, referenced from every page.
 
-    Without it the banner still sticks (pure CSS), but the header can briefly overlap it
-    before a reader scrolls, since nothing offsets the header below it.
+    The script both decides whether the banner is revealed and offsets the sticky header below
+    it, so every version tree gets it - the current release included, whose pages would
+    otherwise fall back to Material's own outdated check and warn about themselves.
 
     Args:
         root: Root of the gh-pages checkout.
@@ -362,13 +393,13 @@ def patch_scripts(root: Path) -> list[Path]:
         >>> with tempfile.TemporaryDirectory() as tmp:
         ...     page = Path(tmp) / "1.2.3" / "index.html"
         ...     page.parent.mkdir(parents=True)
-        ...     (Path(tmp) / "1.3.0").mkdir()  # the current release, never scripted
+        ...     (Path(tmp) / "1.3.0").mkdir()  # the current release, scripted but never banner-ed
         ...     _ = page.write_text("<body></body>")
         ...     len(patch_scripts(Path(tmp)))
-        2
+        3
     """
     changed: list[Path] = []
-    for version_dir in _version_dirs(root):
+    for version_dir in _script_dirs(root):
         js_file = version_dir / "javascripts" / "version-banner.js"
         if not js_file.is_file() or js_file.read_text(encoding="utf-8") != VERSION_BANNER_JS:
             js_file.parent.mkdir(parents=True, exist_ok=True)
@@ -393,9 +424,9 @@ def strip_from_current_release(root: Path) -> list[Path]:
 
     An earlier backfill treated every numbered directory as superseded, so the release that
     is now current carries an "older version" warning it must not show. Only content bounded
-    by this script's own markers is removed, so a genuine build is never touched. The copied
-    `version-banner.js` and its script tag are left in place: with no banner markup left to
-    measure the script is inert, and removing the file would break the tag that references it.
+    by this script's own markers is removed, so a genuine build is never touched - a natively
+    built banner stays in the markup and is kept hidden by `version-banner.js`, which
+    `patch_scripts` also delivers here. The copied script and its tag are left in place.
 
     Args:
         root: Root of the gh-pages checkout.

--- a/docs/javascripts/version-banner.js
+++ b/docs/javascripts/version-banner.js
@@ -188,7 +188,7 @@
               (best, name) => (best === null || isNewer(name, best) ? name : best),
               null,
             );
-          applyVerdict(versionBase, newest !== null && newest !== version);
+          applyVerdict(versionBase, newest !== null && isNewer(newest, version));
         })
         .catch(() => {
           // versions.json unreachable: leave whatever verdict Material reached.

--- a/docs/javascripts/version-banner.js
+++ b/docs/javascripts/version-banner.js
@@ -1,10 +1,20 @@
 /*
- * Publishes the height of the version banner as a CSS variable.
+ * Decides whether the version banner is shown, and publishes its height as a CSS
+ * variable.
  *
  * The banner is pinned to the top of the viewport, so the sticky header and
  * sidebars have to start below it instead of scrolling underneath. Its height
  * cannot be hardcoded: the banner wraps at different viewport widths and stays
  * hidden entirely on the latest release docs.
+ *
+ * The reveal is decided here rather than left to Material. Material tests
+ * `extra.version.default` ("latest") against each versions.json entry's aliases
+ * plus its version name; this site publishes `latest` as its own mike version
+ * instead of as an alias of the current release, so no entry carries that alias
+ * and every numbered tree - the newest included - is flagged outdated. Comparing
+ * against the highest published release instead keeps the banner off the current
+ * release, and still turns it on for that same tree once a newer release ships,
+ * without rebuilding it: versions.json is read on every page load.
  */
 (() => {
   const banner = document.querySelector("[data-md-component=outdated]");
@@ -86,11 +96,25 @@
     syncSidebarLayout();
   };
 
+  // Verdict of the version check below: true when this tree is superseded, null
+  // while versions.json is still in flight or unreachable. Material runs its own
+  // check on the same file and may flip `hidden` afterwards, so once a verdict
+  // exists it is re-asserted rather than trusted to stick.
+  let outdatedVerdict = null;
+
+  const onHiddenChange = () => {
+    if (outdatedVerdict !== null && banner.hidden === outdatedVerdict) {
+      banner.hidden = !outdatedVerdict;
+      return;
+    }
+    publishHeight();
+  };
+
   publishHeight();
-  // Width changes reflow the text; Material flips `hidden` once its version
-  // check decides the build is outdated, which is after this script runs.
+  // Width changes reflow the text; `hidden` flips once a version check decides
+  // the build is outdated, which is after this script runs.
   new ResizeObserver(publishHeight).observe(banner);
-  new MutationObserver(publishHeight).observe(banner, {
+  new MutationObserver(onHiddenChange).observe(banner, {
     attributeFilter: ["hidden"],
     attributes: true,
   });
@@ -104,5 +128,71 @@
   }
   for (const breakpoint of Object.values(sidebarBreakpoints)) {
     breakpoint.addEventListener("change", syncSidebarLayout);
+  }
+
+  const isRelease = (name) => /^\d+(\.\d+)*$/.test(name);
+
+  const isNewer = (candidate, incumbent) => {
+    const left = candidate.split(".").map(Number);
+    const right = incumbent.split(".").map(Number);
+    for (let index = 0; index < Math.max(left.length, right.length); index++) {
+      const delta = (left[index] ?? 0) - (right[index] ?? 0);
+      if (delta !== 0) {
+        return delta > 0;
+      }
+    }
+    return false;
+  };
+
+  const applyVerdict = (versionBase, outdated) => {
+    outdatedVerdict = outdated;
+    // Material caches its own verdict under this key and unhides from it, so
+    // overwrite it too: a page visited before the fix carries a stale `true`, and
+    // agreeing here avoids a visible flash before `onHiddenChange` re-asserts.
+    try {
+      window.sessionStorage.setItem(
+        `${versionBase.pathname}.__outdated`,
+        JSON.stringify(outdated),
+      );
+    } catch (error) {
+      // Storage can be unavailable; the attribute is authoritative regardless.
+    }
+    if (banner.hidden === outdated) {
+      banner.hidden = !outdated;
+    }
+  };
+
+  const configElement = document.getElementById("__config");
+  if (configElement) {
+    // mkdocs writes a per-page relative base; resolved, it always ends at the
+    // version root, so its last segment names this tree and versions.json sits one
+    // level above it - the same file and the same scope Material reads.
+    const versionBase = new URL(
+      JSON.parse(configElement.textContent).base,
+      window.location.href,
+    );
+    const version = versionBase.pathname.replace(/\/$/, "").split("/").pop();
+
+    if (version === "develop") {
+      applyVerdict(versionBase, true);
+    } else if (isRelease(version)) {
+      fetch(new URL("../versions.json", versionBase))
+        .then((response) =>
+          response.ok ? response.json() : Promise.reject(response.status),
+        )
+        .then((versions) => {
+          const newest = versions
+            .map((entry) => entry.version)
+            .filter(isRelease)
+            .reduce(
+              (best, name) => (best === null || isNewer(name, best) ? name : best),
+              null,
+            );
+          applyVerdict(versionBase, newest !== null && newest !== version);
+        })
+        .catch(() => {
+          // versions.json unreachable: leave whatever verdict Material reached.
+        });
+    }
   }
 })();

--- a/docs/javascripts/version-banner.js
+++ b/docs/javascripts/version-banner.js
@@ -96,10 +96,12 @@
     syncSidebarLayout();
   };
 
-  // Verdict of the version check below: true when this tree is superseded, null
-  // while versions.json is still in flight or unreachable. Material runs its own
-  // check on the same file and may flip `hidden` afterwards, so once a verdict
-  // exists it is re-asserted rather than trusted to stick.
+  // Verdict of the version check below: true when this tree is superseded, false
+  // when it is current or provisionally assumed so while versions.json is in
+  // flight, null when this script has nothing to say - versions.json unreachable,
+  // or a tree it does not classify. Material runs its own check on the same file
+  // and may flip `hidden` afterwards, so once a verdict exists it is re-asserted
+  // rather than trusted to stick.
   let outdatedVerdict = null;
 
   const onHiddenChange = () => {
@@ -144,19 +146,40 @@
     return false;
   };
 
-  const applyVerdict = (versionBase, outdated) => {
-    outdatedVerdict = outdated;
-    // Material caches its own verdict under this key and unhides from it, so
-    // overwrite it too: a page visited before the fix carries a stale `true`, and
-    // agreeing here avoids a visible flash before `onHiddenChange` re-asserts.
+  // Material caches its own verdict under this key, and both of its reveal paths
+  // are driven by it: the inline partial next to the banner markup unhides from a
+  // cached `true` before this script runs at all, and its bundled check recomputes
+  // only when the key is unset. Writing the key is therefore how the banner is kept
+  // off the current release, not bookkeeping alongside the `hidden` attribute.
+  const storageKey = (versionBase) => `${versionBase.pathname}.__outdated`;
+
+  const readCachedVerdict = (versionBase) => {
     try {
-      window.sessionStorage.setItem(
-        `${versionBase.pathname}.__outdated`,
-        JSON.stringify(outdated),
-      );
+      return JSON.parse(window.sessionStorage.getItem(storageKey(versionBase)));
+    } catch (error) {
+      // Storage unavailable or holding something Material did not write.
+      return null;
+    }
+  };
+
+  const cacheVerdict = (versionBase, outdated) => {
+    try {
+      if (outdated === null) {
+        window.sessionStorage.removeItem(storageKey(versionBase));
+      } else {
+        window.sessionStorage.setItem(
+          storageKey(versionBase),
+          JSON.stringify(outdated),
+        );
+      }
     } catch (error) {
       // Storage can be unavailable; the attribute is authoritative regardless.
     }
+  };
+
+  const applyVerdict = (versionBase, outdated) => {
+    outdatedVerdict = outdated;
+    cacheVerdict(versionBase, outdated);
     if (banner.hidden === outdated) {
       banner.hidden = !outdated;
     }
@@ -173,9 +196,21 @@
     );
     const version = versionBase.pathname.replace(/\/$/, "").split("/").pop();
 
-    if (version === "develop") {
+    // The backfill script sets `data-rf-outdated` on the trees it banners and reveals
+    // them itself. Those are settled - mike never makes an archived tree current again
+    // - so take the flag rather than hiding the banner again until the fetch answers.
+    if (version === "develop" || banner.dataset.rfOutdated === "true") {
       applyVerdict(versionBase, true);
     } else if (isRelease(version)) {
+      // Waiting for the fetch with no verdict would leave both of Material's reveal
+      // paths free to run first: a `true` cached by a page visited before this check
+      // existed has already unhidden the banner above, and its bundled check reads
+      // the same versions.json and may resolve first. Claim "not outdated" up front
+      // so neither can warn the current release about itself, and let the fetch
+      // upgrade the verdict; a superseded tree gets its banner a fetch later.
+      const cached = readCachedVerdict(versionBase);
+      const hiddenBeforeFetch = banner.hidden;
+      applyVerdict(versionBase, false);
       fetch(new URL("../versions.json", versionBase))
         .then((response) =>
           response.ok ? response.json() : Promise.reject(response.status),
@@ -191,7 +226,13 @@
           applyVerdict(versionBase, newest !== null && isNewer(newest, version));
         })
         .catch(() => {
-          // versions.json unreachable: leave whatever verdict Material reached.
+          // versions.json unreachable: drop the provisional verdict and put back the
+          // state it overwrote, so Material stays authoritative when this check has
+          // nothing to say. Restoring the cache also lets its bundled check, which
+          // skips a key that is already set, still run if it has not yet.
+          outdatedVerdict = null;
+          cacheVerdict(versionBase, cached);
+          banner.hidden = hiddenBeforeFetch;
         });
     }
   }


### PR DESCRIPTION
- version-banner.js now decides the reveal itself: it fetches versions.json, picks the highest release, and unhides the banner only for develop and superseded releases; Material's own check tests the `latest` alias, which this site's versions.json never carries, so it flagged every numbered tree including the newest
- the verdict is written to the `__outdated` sessionStorage key Material reads and re-asserted through the hidden-attribute MutationObserver, so a late unhide or a stale cached verdict from an earlier visit cannot resurface the banner; an unreachable versions.json leaves Material's verdict untouched
- inject_outdated_banner.py gains `_script_dirs`, so patch_scripts also delivers version-banner.js to the current release directory - the one tree whose natively built banner markup needs the script to stay hidden - while banner markup and stylesheet injection keep skipping it
- tests cover the current release receiving the script and its page reference, plus theme-side guards that the script reads versions.json and re-asserts its verdict
