### PR TITLE
docs(export): link a community RF-DETR Nano Android (LiteRT GPU) example

### DIFF
--- a/docs/learn/export.md
+++ b/docs/learn/export.md
@@ -404,6 +404,10 @@ boxes = interpreter.get_tensor(boxes_detail["index"])
 labels = interpreter.get_tensor(labels_detail["index"])
 ```
 
+### Community example: RF-DETR Nano on an Android GPU (LiteRT)
+
+[LiteRT-Models › RF-DETR Nano](https://github.com/john-rocky/LiteRT-Models#rf-detr-nano) is a community conversion of RF-DETR Nano to LiteRT (`.tflite`) with a Kotlin camera app. It was converted with `litert-torch` rather than the `onnx2tf` route above, and split into two graphs (the two-stage query selection runs on the host between them) so both graphs run fully on the phone GPU through the LiteRT CompiledModel API; on a Pixel 8a it runs live camera at ~9 fps (~110 ms/frame) with detections at IoU 0.98–0.99 against PyTorch.
+
 ## OpenVINO IR Export
 
 OpenVINO IR (Intermediate Representation) is a proprietary model format used by the OpenVINO Toolkit to optimize and deploy deep learning models.


### PR DESCRIPTION
Thanks for the TFLite export section and its honest experimental note. This adds a short community-example subsection at the end of it: RF-DETR Nano converted to LiteRT (.tflite) and running fully on an Android GPU through the LiteRT CompiledModel API, with a Kotlin camera app.

- The conversion did not go through the `onnx2tf` route above; it used `litert-torch` plus a two-graph split (query selection on the host) so both graphs stay on the GPU. The subsection says so, to keep it apart from `model.export(format="tflite")`.
- Pixel 8a: live camera at about 9 fps (~110 ms per frame); detections match PyTorch at IoU 0.98–0.99.
- Apache-2.0 weights only (Nano); the zoo section links back to this repo.
- The paragraph is on one line for the mdformat no-wrap check.

Zoo section: https://github.com/john-rocky/LiteRT-Models#rf-detr-nano — weights: https://huggingface.co/litert-community/RF-DETR-Nano-LiteRT

Happy to move it (README, FAQ) or drop it if it does not fit the docs. Thanks again.
