### PR TITLE
fix(training): let compile=True reach the CUDA path with multi-scale training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Fixed XLA-marked tests on real TPU hardware: the Trainer-refusal assertion runs only where `XLAAccelerator.is_available()` is false, and the multi-process collective runs only on TPU/NEURON with an uninitialized runtime. CPU-PJRT skips the collective because it has no multi-process path. ([#1058](https://github.com/roboflow/rf-detr/issues/1058))
 
+- `compile=True` now takes effect on CUDA with the default `multi_scale=True`. The gate excluded multi-scale training to avoid one XLA graph trace per scale, but it sits behind checks that already require a CUDA device and a CUDA accelerator, so an XLA or TPU run never reached it; the exclusion only ever disabled the CUDA path, where `dynamic=True` is what handles the varying input size. Setting `compile=True` previously logged a notice and trained eagerly. ([#1411](https://github.com/roboflow/rf-detr/pull/1411) made compilation reachable in the first place.)
+
 ### Breaking Changes
 
 ---

--- a/docs/cookbooks/train-coco2017.ipynb
+++ b/docs/cookbooks/train-coco2017.ipynb
@@ -303,14 +303,13 @@
     "\n",
     "### Levers deliberately not pulled\n",
     "\n",
-    "Two further speedups exist but change the recipe rather than the schedule, so this notebook leaves them alone.\n",
+    "One further speedup exists but changes the recipe rather than the schedule, so this notebook leaves it alone.\n",
     "With `multi_scale=True` (the default) and `do_random_resize_via_padding=False`, training runs at the largest\n",
     "scale of the multi-scale ladder — 544 px for Nano, while validation and inference stay at 384 px. Setting\n",
-    "`multi_scale=False` trains at 384 px instead (roughly half the pixels) and additionally unblocks\n",
-    "`RFDETRNano(compile=True)`, which is skipped whenever multi-scale is on because the varying input shapes\n",
-    "retrigger compilation. Separately, `augmentation_backend=\"gpu\"` moves augmentation off the CPU workers — a\n",
-    "rescue for CPU-starved runtimes (a 2-core Colab), and exactly backwards on this notebook's target: with the CPU\n",
-    "mostly idle and the GPU saturated, it would add work to the bottleneck and take it away from idle cores."
+    "`multi_scale=False` trains at 384 px instead (roughly half the pixels). Separately, `augmentation_backend=\"gpu\"`\n",
+    "moves augmentation off the CPU workers — a rescue for CPU-starved runtimes (a 2-core Colab), and exactly\n",
+    "backwards on this notebook's target: with the CPU mostly idle and the GPU saturated, it would add work to the\n",
+    "bottleneck and take it away from idle cores."
    ]
   },
   {

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -419,14 +419,18 @@ class RFDETRModelModule(LightningModule):
 
         accelerator = str(train_config.accelerator).lower()
         uses_cuda_accelerator = accelerator in {"auto", "gpu", "cuda"}
-        compile_enabled = (
-            model_config.compile and DEVICE == "cuda" and uses_cuda_accelerator and not train_config.multi_scale
-        )
-        if model_config.compile and train_config.multi_scale:
+        # multi_scale is deliberately not part of this gate. The XLA concern it used to carry
+        # (one graph trace per scale) cannot arise here: DEVICE == "cuda" and an accelerator of
+        # auto/gpu/cuda are both required first, so an XLA or TPU run has already disabled
+        # compilation before multi-scale is even considered. Excluding it only ever disabled the
+        # CUDA path, where dynamic=True below is precisely what handles the varying (H, W).
+        compile_enabled = model_config.compile and DEVICE == "cuda" and uses_cuda_accelerator
+        if model_config.compile and not compile_enabled:
             logger.info(
-                "Disabling torch.compile: multi_scale=True causes dynamic shapes "
-                "(incompatible with XLA -- each scale = separate graph trace). "
-                "Use do_random_resize_via_padding=True on TPU to avoid recompilation overhead."
+                "Disabling torch.compile: requires DEVICE == 'cuda' and a CUDA-family accelerator "
+                "(got DEVICE=%r, accelerator=%r). torch.compile is not supported on XLA/TPU or CPU.",
+                DEVICE,
+                accelerator,
             )
         if compile_enabled:
             # dynamic=True: one compiled graph handles all multi-scale input sizes instead

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -427,8 +427,9 @@ class RFDETRModelModule(LightningModule):
         compile_enabled = model_config.compile and DEVICE == "cuda" and uses_cuda_accelerator
         if model_config.compile and not compile_enabled:
             logger.info(
-                "Disabling torch.compile: requires DEVICE == 'cuda' and a CUDA-family accelerator "
-                "(got DEVICE=%r, accelerator=%r). torch.compile is not supported on XLA/TPU or CPU.",
+                "Disabling torch.compile: RF-DETR enables it only on a CUDA device with a "
+                "CUDA-family accelerator (got DEVICE=%r, accelerator=%r). CPU and MPS are not "
+                "expected to benefit; on XLA/TPU the graph is compiled by the XLA runtime instead.",
                 DEVICE,
                 accelerator,
             )

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -5,6 +5,7 @@
 # ------------------------------------------------------------------------
 """Comprehensive unit tests for RFDETRModelModule (LightningModule wrapper)."""
 
+import logging
 import random
 import warnings
 from types import SimpleNamespace
@@ -402,16 +403,57 @@ class TestInit:
         assert module.model_config is mc
         assert module.train_config is tc
 
-    def test_compile_disabled_when_multi_scale_enabled(self, tmp_path):
-        """torch.compile is skipped when multi_scale=True (dynamic shapes)."""
+    def test_compile_runs_when_multi_scale_enabled(self, tmp_path):
+        """torch.compile still runs with multi_scale=True, which is the shipped default.
+
+        ``dynamic=True`` is passed precisely so one graph covers every (H, W) the multi-scale pipeline produces, so
+        multi-scale is not a reason to skip compilation on CUDA.
+        """
         mc = _base_model_config(compile=True)
         tc = _base_train_config(tmp_path, multi_scale=True)
         with (
-            patch("torch.cuda.is_available", return_value=True),
+            patch("rfdetr.config.DEVICE", "cuda"),
+            patch("rfdetr.training.module_model.torch.compile", side_effect=lambda m, **_: m) as mock_compile,
+        ):
+            _build_module(model_config=mc, train_config=tc, tmp_path=tmp_path)
+        mock_compile.assert_called_once()
+        assert mock_compile.call_args.kwargs["dynamic"] is True
+
+    @pytest.mark.parametrize("accelerator", ["xla", "tpu"])
+    def test_compile_disabled_on_xla_accelerator_even_with_static_shapes(self, accelerator, tmp_path):
+        """XLA/TPU never compiles, and that no longer depends on multi_scale being set.
+
+        This is the invariant the removed ``not multi_scale`` clause was documented as protecting; the accelerator check
+        is what actually enforces it.
+        """
+        mc = _base_model_config(compile=True)
+        tc = _base_train_config(tmp_path, multi_scale=False, accelerator=accelerator)
+        with (
+            patch("rfdetr.config.DEVICE", "cuda"),
             patch("rfdetr.training.module_model.torch.compile") as mock_compile,
         ):
             _build_module(model_config=mc, train_config=tc, tmp_path=tmp_path)
         mock_compile.assert_not_called()
+
+    def test_compile_disabled_when_device_is_not_cuda(self, tmp_path, caplog, monkeypatch):
+        """A non-CUDA accelerator disables compilation regardless of multi_scale, with an explanatory notice.
+
+        A caller who sets ``compile=True`` on CPU/XLA/TPU must still learn why nothing was compiled, the same way the
+        old multi_scale-only notice used to inform CUDA callers.
+        """
+        mc = _base_model_config(compile=True)
+        tc = _base_train_config(tmp_path, multi_scale=True)
+        # get_logger() sets propagate=False on the "rf-detr" logger, so caplog's root-level
+        # handler only sees its records while propagation is re-enabled.
+        monkeypatch.setattr(logging.getLogger("rf-detr"), "propagate", True)
+        with (
+            patch("rfdetr.config.DEVICE", "cpu"),
+            patch("rfdetr.training.module_model.torch.compile") as mock_compile,
+            caplog.at_level(logging.INFO, logger="rf-detr"),
+        ):
+            _build_module(model_config=mc, train_config=tc, tmp_path=tmp_path)
+        mock_compile.assert_not_called()
+        assert any("Disabling torch.compile" in record.getMessage() for record in caplog.records)
 
     def test_compile_runs_when_enabled_and_static_shapes(self, tmp_path):
         """torch.compile runs when compile=True and multi_scale=False on CUDA."""

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -314,6 +314,26 @@ class _ScalarLossModel(nn.Module):
         return {"loss_scale": self.value}
 
 
+class _DynamicShapeModel(nn.Module):
+    """Tiny model whose loss path depends on the multi-scale batch tensor."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(()))
+
+    def forward(self, samples, targets=None):
+        return {"dummy": samples.tensors.mean() * self.weight}
+
+    def update_drop_path(self, *args, **kwargs) -> None:
+        pass
+
+    def update_dropout(self, *args, **kwargs) -> None:
+        pass
+
+    def reinitialize_detection_head(self, *args, **kwargs) -> None:
+        pass
+
+
 class _BoxNormalizedCriterion:
     """Criterion with controllable per-target loss numerators and box counts."""
 
@@ -418,6 +438,45 @@ class TestInit:
             _build_module(model_config=mc, train_config=tc, tmp_path=tmp_path)
         mock_compile.assert_called_once()
         assert mock_compile.call_args.kwargs["dynamic"] is True
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="compiled multi-scale regression requires CUDA")
+    def test_compiled_multi_scale_forward_backward_across_resolutions(self, tmp_path):
+        """The real compiled CUDA module must backpropagate finite losses at two resized multi-scale resolutions."""
+        torch.manual_seed(0)
+        model_config = _base_model_config(compile=True, resolution=128)
+        train_config = _base_train_config(tmp_path, multi_scale=True)
+        model = _DynamicShapeModel().cuda()
+        criterion = _FakeCriterion()
+
+        with (
+            patch("rfdetr.config.DEVICE", "cuda"),
+            patch("rfdetr.training.module_model.build_model_from_config", return_value=model),
+            patch(
+                "rfdetr.training.module_model.build_criterion_from_config",
+                return_value=(criterion, _fake_postprocess()),
+            ),
+        ):
+            module = RFDETRModelModule(model_config, train_config)
+
+        resized_shapes = set()
+        for global_step in (0, 1):
+            module.trainer = SimpleNamespace(global_step=global_step)
+            samples, targets = _make_batch(h=128, w=128)
+            samples.tensors = samples.tensors.cuda()
+            samples.mask = samples.mask.cuda()
+
+            module.on_train_batch_start((samples, targets), batch_idx=global_step)
+            resized_shapes.add(tuple(samples.tensors.shape[-2:]))
+            loss = criterion(module.model(samples, targets), targets)["loss_ce"]
+            loss.backward()
+
+            assert torch.isfinite(loss)
+            assert model.weight.grad is not None
+            assert torch.isfinite(model.weight.grad)
+            model.zero_grad(set_to_none=True)
+
+        assert len(resized_shapes) == 2
 
     @pytest.mark.parametrize("accelerator", ["xla", "tpu"])
     def test_compile_disabled_on_xla_accelerator_even_with_static_shapes(self, accelerator, tmp_path):


### PR DESCRIPTION
`compile=True` gets accepted and reported as enabled, but on a default run it never compiles anything.

## The bug

`ModelConfig.compile` is documented as "Compile the model with `torch.compile` for faster throughput" (`config.py:467`), but `module_model.py` excluded multi-scale training from the gate:

```python
compile_enabled = (
    model_config.compile and DEVICE == "cuda" and uses_cuda_accelerator and not train_config.multi_scale
)
```

`TrainConfig.multi_scale` defaults to `True` (`config.py:1066`), so on a default run the flag is accepted, reported as set, and does nothing:

```python
model = RFDETRNano(compile=True)          # model_config.compile is True
model.train(dataset_dir=ds, epochs=1)     # everything else default
# dynamo frames ok/total = 0/0, inductor compilations = 0
```

The exclusion does not do what its comment describes. It sits behind two checks that already require a CUDA device (`DEVICE == "cuda"`) and a CUDA accelerator (`auto`/`gpu`/`cuda`). An XLA or TPU run fails both checks, so compilation is already disabled before `multi_scale` is even read — the clause only ever disabled the CUDA path. And that's the path where `dynamic=True`, three lines below, exists specifically so "one compiled graph handles all multi-scale input sizes instead of recompiling per (H, W) pair".

So the fix in #1411, which made compilation reachable at all and shipped in 1.10.0, is unreachable on a default configuration.

## The change

Drop the `multi_scale` term from the CUDA gate. The notice used to fire only when `compile=True and multi_scale=True`; now it fires whenever `compile=True` is requested but the device/accelerator checks fail. So a CPU/XLA/TPU caller still gets an explanation, instead of the silence the old condition would have left once its `multi_scale` half was gone. The COCO cookbook (`docs/cookbooks/train-coco2017.ipynb`) drops its now-false claim that `multi_scale=False` is required to unblock `compile=True`.

## Measurements

L4 `g2-standard-8`, torch 2.9.1+cu129, `rfdetr-nano` bs=4, bf16 autocast, `group_detr=13`. Steps timed with `torch.cuda.synchronize()` on both ends, warm-up discarded, median of 24, validation and dataloader excluded. Inputs cycle the real multi-scale set for this resolution from `compute_multi_scale_scales`: `[224, 256, 288, 320, 352, 384, 416, 448, 480, 512, 544]`.

| | eager | compiled | change | dynamo frames ok/total |
|---|---:|---:|---:|---:|
| multi-scale, run 1 | 141.65 ms | 122.66 ms | **−13.4%** | 24/32 |
| multi-scale, run 2 | 137.94 ms | 120.16 ms | **−12.9%** | 24/32 |
| single scale 384, for reference | 136.51 ms | 108.05 ms | −20.8% | 2/2 |

Both the speedup and the frame count reproduce across runs. The eager arm itself moves 2.7% between runs, which is that machine's spread.

Two limits on these numbers, so they are not read for more than they are worth. **The timing harness feeds synthetic batches** — `torch.randn` images and randomly generated boxes at the real resolutions and batch shape — through the repo's own `build_model_from_config` / `build_criterion_from_config`. That exercises the real model, criterion and optimizer, but not JPEG decode, augmentation or real target statistics, so it measures the step and not a full epoch. The functional claims are the ones checked on real data: the silent no-op and the compile/no-compile routing were both verified through `RFDETRNano(...).train()` on a real COCO dataset. And **run 1's eager leg is the one number here without an archived log** — run 2 and the single-scale pair each have both legs saved from the same process; run 1's compiled leg is archived and its eager leg is not.

The timed loop cycles the 11 scales round-robin; production instead draws `random.Random(step).choice(scales)` per step (`on_train_batch_start`), which can repeat or skip scales inside a short window. `dynamic=True` marks the shape dimensions dynamic from the first compile rather than after repeated guard failures, so one graph is expected to serve every scale regardless of visitation order — but I haven't re-measured the step-by-step latency distribution under the real per-step draw.

Compile cost: 1074 s on an empty inductor cache, **315 s on a warm one**.

## What this exposes

Enabling the path also exposes multi-scale users to two things I measured and could not fix here.

Eight of 32 frames do not compile. `suppress_errors=True` (already set on this path) hides the failure; only the dynamo counters reveal it. The cause is a PyTorch internal assert reached through the bicubic upsample backward, not anything in this diff:

```
Error detected in UpsampleBicubic2DAaBackward0
RuntimeError: isIntList() INTERNAL ASSERT FAILED at ".../ATen/core/ivalue_inl.h":1979,
  please report a bug to PyTorch. Expected IntList but got GenericList
```

It shows up as a bimodal steady state, p25 120.76 ms, p75 141.16 ms — the p75 sitting right on the eager median.

On some torch builds Inductor fails outright, and late. `RFDETRNano(compile=True).train(multi_scale=False)` on torch 2.9.1+**cu128** raises `InductorError: SubprocException` on `triton_red_fused__to_copy_add_native_layer_norm_backward_view_191` after 439 s, while 2.9.1+**cu129** compiles cleanly. That failure already reaches anyone using `compile=True` with `multi_scale=False` today, so this diff widens the exposure rather than creating it. One run per build though, so that's a correlation, not a demonstrated cause.

`compile` defaults to `False`, so only a caller who explicitly asked for compilation is affected, and today that caller gets a silent no-op — they believe they are compiling and they are not. A measured speedup or a loud failure are both better than that. That said, if you'd rather keep multi-scale users out until the two issues above are resolved, gating on something explicit (an env var, or a `compile="auto"|"force"` tri-state) would keep the flag honest without widening exposure — happy to do that instead.

This came out of #1410, which asks exactly this: steady-state ms/step for `compile=True` and whether compilation succeeds at all under the shipped configs, and scopes itself to measurement, with a fix following once the numbers say something concrete. These numbers are it.

## Tests

`test_compile_runs_when_multi_scale_enabled` fails on `develop` (`AssertionError: Expected 'compile' to have been called once. Called 0 times`, with the `Disabling torch.compile` notice captured) and passes with the fix. It also asserts `dynamic=True` is still passed.

The removed clause was documented as protecting an invariant, so two tests now cover that invariant directly: `test_compile_disabled_on_xla_accelerator_even_with_static_shapes` (parametrized over `xla` and `tpu`) and `test_compile_disabled_when_device_is_not_cuda`. The latter also asserts the `Disabling torch.compile` notice still fires for a non-CUDA caller, so dropping the `multi_scale` half of the old condition doesn't leave that caller silent. Both pass before and after.

`pytest tests/training` — 1184 passed before, 1187 after, same 13 pre-existing failures on both trees (all `ModuleNotFoundError: No module named 'roboflow'`, an optional extra absent from my environment). `pre-commit run --all-files` clean over all 19 hooks, including `mypy --strict`.

Rebased onto `develop@06852a6` (#1426 merged a `CHANGELOG.md` entry after this branch was cut) to keep the `[Unreleased]/### Fixed` section conflict-free.
