### PR TITLE
docs: add PR template grounded in real merged-PR patterns

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Your contributions can be in many forms—whether it’s enhancing existing feat
     git commit -m "A brief description of your changes"
     git push -u origin your-descriptive-name
     ```
-6. [Open a Pull Request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request): Submit your pull request against the main development branch. Please detail your changes and link any related issues.
+6. [Open a Pull Request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request): Submit your pull request against the main development branch. Fill in the [PR template](PULL_REQUEST_TEMPLATE.md) — summary, verification commands and their results, and any related issues.
 
 Before merging, check that all tests pass and that your changes adhere to our development and documentation standards.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+<!--
+Thanks for contributing to RF-DETR! Delete any section that doesn't apply — a one-line
+docs or CI fix doesn't need a Performance section, and a pure refactor doesn't need one either.
+Full guidelines: .github/CONTRIBUTING.md
+-->
+
+## Summary
+
+<!--
+What breaks/is missing today, and what does this change do about it?
+For a bug fix: include a minimal repro or the exact error/traceback.
+For a feature: what it enables and why it belongs here.
+-->
+
+## Changes
+
+<!-- Bullet list of what changed, if it's not already obvious from the summary. -->
+
+## Verification
+
+<!--
+Test commands you ran and their result, e.g.:
+  uv run --no-sync pytest tests/datasets/ -n 1: 184 passed
+  pre-commit run --all-files: passed
+The final commit must have the full CPU suite and pre-commit passing — see AGENTS.md.
+Note anything you could NOT verify (no GPU/TPU available, CI not yet rerun, etc.).
+-->
+
+## Performance
+
+<!--
+Only for perf-sensitive changes. Include: hardware, measurement method (what you ran,
+how many repetitions), and a before/after table or numbers. Delete this section otherwise.
+-->
+
+## Related issues
+
+<!-- Fixes #, Closes #, Part of #, or a link to the discussion that prompted this. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,9 +20,9 @@ For a feature: what it enables and why it belongs here.
 
 <!--
 Test commands you ran and their result, e.g.:
-  uv run --no-sync pytest tests/datasets/ -n 1: 184 passed
-  pre-commit run --all-files: passed
-The final commit must have the full CPU suite and pre-commit passing — see AGENTS.md.
+  uv run --no-sync pytest tests/datasets/ -n 1  # 184 passed
+  pre-commit run --all-files  # passed
+The final commit must have the full CPU suite and pre-commit passing — see .github/CONTRIBUTING.md.
 Note anything you could NOT verify (no GPU/TPU available, CI not yet rerun, etc.).
 -->
 


### PR DESCRIPTION
No PR template existed in this repo. Recent merged PRs converge on Summary/Changes/Verification/Performance/Related-issues sections with concrete test commands and before/after numbers; add a template that reflects that instead of generic checkbox boilerplate, and point CONTRIBUTING.md's PR step at it.
