### PR TITLE
perf(training): synchronize keypoint DDP once per optimizer step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Multi-GPU keypoint training with `grad_accum_steps > 1` now synchronizes gradients once per optimizer step instead of once per microbatch, avoiding redundant DDP reductions.
+
 ### Deprecated
 
 ### Fixed

--- a/docs/learn/train/advanced.md
+++ b/docs/learn/train/advanced.md
@@ -249,7 +249,7 @@ model.train(
     dataset_dir="path/to/keypoint-dataset",
     epochs=100,
     batch_size=2,  # per-GPU batch size
-    grad_accum_steps=1,  # recommended on multi-GPU — see note below
+    grad_accum_steps=1,  # see note below for multi-GPU accumulation behavior
     lr=1e-4,
     output_dir="output",
     devices="auto",  # or devices=8
@@ -260,9 +260,9 @@ model.train(
 torchrun --nproc_per_node=8 train_pose.py
 ```
 
-!!! note "Prefer `grad_accum_steps=1` on multi-GPU for keypoints"
+!!! note "Gradient accumulation on multi-GPU keypoint training"
 
-    Keypoint models use **manual optimization** so the per-step box-count loss normalization is computed over the full accumulated batch. As a result, gradients synchronize on **every** microbatch rather than only at the end of an accumulation window. Training with `grad_accum_steps > 1` on multiple GPUs is still numerically correct, but performs one `all_reduce` per microbatch (i.e. `grad_accum_steps`× the necessary communication). For best throughput, scale with more GPUs / a larger per-GPU `batch_size` and keep `grad_accum_steps=1`.
+    Keypoint models use **manual optimization** so the per-step box-count loss normalization is computed over the full accumulated batch. Intermediate microbatches accumulate gradients locally on each rank. The backward pass that closes the accumulation window synchronizes the full accumulated gradient before the optimizer step, avoiding redundant DDP reductions while preserving full-effective-batch normalization.
 
     Sharded strategies (FSDP / DeepSpeed) are **not** supported for keypoint models — use `ddp` (or `strategy="auto"` with `devices > 1`).
 

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -12,6 +12,7 @@ import inspect
 import math
 import random
 import warnings
+from contextlib import nullcontext
 from typing import Any, Callable, cast
 
 import torch
@@ -622,8 +623,17 @@ class RFDETRModelModule(LightningModule):
             # loss_for_backward is only None in the automatic-optimization branch above,
             # which is mutually exclusive with _use_manual_optimization.
             assert loss_for_backward is not None
-            self.manual_backward(loss_for_backward)
-            if self._should_step_optimizer(batch_idx):
+            should_step = self._should_step_optimizer(batch_idx)
+            # LightningOptimizer maps sync_grad=False to DDP's no_sync context. Intermediate
+            # microbatches accumulate locally; the closing backward reduces the whole window.
+            sync_context = (
+                optimizer.toggle_model(sync_grad=should_step)
+                if isinstance(optimizer, LightningOptimizer)
+                else nullcontext()
+            )
+            with sync_context:
+                self.manual_backward(loss_for_backward)
+            if should_step:
                 self._step_optimizer(optimizer)
         if self.train_config.compute_train_metrics:
             with torch.no_grad():

--- a/src/rfdetr/training/trainer.py
+++ b/src/rfdetr/training/trainer.py
@@ -680,9 +680,7 @@ def build_trainer(
                 )
         _logger.info(
             "Keypoint model + distributed execution (strategy=%r, devices=%r, num_nodes=%r) → "
-            "DDP with manual optimization. For best throughput on multi-GPU keep grad_accum_steps=1: "
-            "the manual-optimization path synchronizes gradients on every microbatch, so "
-            "grad_accum_steps>1 is correct but performs redundant all-reduces.",
+            "DDP with manual optimization. Accumulated gradients synchronize only when the optimizer steps.",
             strategy,
             devices,
             num_nodes,

--- a/tests/training/test_keypoint_ddp.py
+++ b/tests/training/test_keypoint_ddp.py
@@ -1,0 +1,191 @@
+# ------------------------------------------------------------------------
+# RF-DETR
+# Copyright (c) 2025 Roboflow. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+"""Exercise keypoint accumulation through real Lightning CPU/Gloo DDP."""
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+import torch
+from pytorch_lightning import Callback, Trainer
+from pytorch_lightning.strategies import DDPStrategy
+from torch import Tensor, nn
+from torch.distributed.algorithms.ddp_comm_hooks.default_hooks import allreduce_hook
+from torch.nn.parallel import DistributedDataParallel
+from torch.utils.data import DataLoader
+
+from rfdetr.config import RFDETRSmallConfig, TrainConfig
+from rfdetr.models.criterion import SetCriterion
+from rfdetr.models.matcher import HungarianMatcher
+from rfdetr.training.module_model import RFDETRModelModule
+
+
+class _RankLossModel(nn.Module):
+    """Supply rank-distinct linear gradients and one permanently unused parameter."""
+
+    def __init__(self) -> None:
+        """Initialize deterministic float64 parameters without model downloads."""
+        super().__init__()
+        self.weight = nn.Parameter(torch.zeros((), dtype=torch.float64))
+        self.unused = nn.Parameter(torch.zeros((), dtype=torch.float64))
+
+    def forward(self, samples: Tensor, targets: list[dict[str, Tensor]]) -> dict[str, Tensor]:
+        """Return a linear loss with a distinct coefficient on each rank.
+
+        Examples:
+            >>> model = _RankLossModel()
+            >>> model(torch.tensor(2), [])['pred_logits'].item()
+            0.0
+        """
+        rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+        return {"pred_logits": self.weight * (rank + 1) * samples.square()}
+
+
+class _LinearCriterion(SetCriterion):
+    """Keep production distributed box normalization with a simple linear numerator."""
+
+    def __init__(self) -> None:
+        """Configure a one-group criterion whose loss needs no matching."""
+        super().__init__(1, HungarianMatcher(), {"loss_ce": 1.0}, 0.25, [])
+
+    def forward(
+        self, outputs: dict[str, Tensor], targets: list[dict[str, Tensor]], num_boxes: Tensor
+    ) -> dict[str, Tensor]:
+        """Normalize the supplied numerator with the production caller's denominator.
+
+        Examples:
+            >>> criterion = _LinearCriterion()
+            >>> criterion({'pred_logits': torch.tensor(6.)}, [], torch.tensor(2.))
+            {'loss_ce': tensor(3.)}
+        """
+        return {"loss_ce": outputs["pred_logits"] / num_boxes}
+
+
+class _SGDModule(RFDETRModelModule):
+    """Use plain SGD to make each real RF-DETR training-step update independently calculable."""
+
+    def configure_optimizers(self) -> torch.optim.Optimizer:
+        """Use unit learning rate and no scheduler for the analytic update oracle.
+
+        Examples:
+            Requires a constructed Lightning training module.
+            >>> callable(_SGDModule.configure_optimizers)  # doctest: +SKIP
+            True
+        """
+        return torch.optim.SGD(self.parameters(), lr=1.0)
+
+
+def _count_reduction(state: dict[str, int], bucket: torch.distributed.GradBucket) -> torch.futures.Future[Tensor]:
+    """Count actual gradient buckets while preserving DDP's mean reduction.
+
+    Examples:
+        Requires a live distributed process group and reducer-owned bucket.
+        >>> callable(_count_reduction)  # doctest: +SKIP
+        True
+    """
+    state["reductions"] += 1
+    return allreduce_hook(None, bucket)
+
+
+class _CheckWindows(Callback):
+    """Assert reduction timing and effective-batch updates on both ranks after every batch."""
+
+    def __init__(self, output_dir: Path, accumulation: int) -> None:
+        """Keep per-process observations and the independent scalar reference state."""
+        self.output_dir = output_dir
+        self.accumulation = accumulation
+        self.state = {"reductions": 0}
+        self.expected = 0.0
+        self.window: list[int] = []
+        self.steps = 0
+        self.observations: list[dict[str, Any]] = []
+
+    def on_train_start(self, trainer: Trainer, pl_module: RFDETRModelModule) -> None:
+        """Register directly on CPU DDP, which Lightning's CUDA-only hook option skips.
+
+        Examples:
+            Requires a Trainer with its real two-rank DDP wrapper initialized.
+            >>> callable(_CheckWindows.on_train_start)  # doctest: +SKIP
+            True
+        """
+        assert isinstance(trainer.strategy.model, DistributedDataParallel)
+        trainer.strategy.model.register_comm_hook(self.state, _count_reduction)
+
+    def on_train_batch_end(
+        self, trainer: Trainer, pl_module: RFDETRModelModule, outputs: Any, batch: Any, batch_idx: int
+    ) -> None:
+        """Check intermediate silence and full/partial-window updates against global sums.
+
+        Examples:
+            Requires a completed distributed training batch on each rank.
+            >>> callable(_CheckWindows.on_train_batch_end)  # doctest: +SKIP
+            True
+        """
+        self.window.append(batch_idx + 1)
+        closes_window = len(self.window) == self.accumulation or batch_idx == 2
+        if closes_window:
+            # Two ranks have coefficients 1 and 2; both see n boxes and numerator n**2.
+            self.expected -= 3 * sum(n * n for n in self.window) / (2 * sum(self.window))
+            self.window.clear()
+            self.steps += 1
+        assert self.state["reductions"] == self.steps, (batch_idx, self.state, self.steps)
+        assert trainer.global_step == self.steps
+        torch.testing.assert_close(
+            pl_module.model.weight.detach(), torch.tensor(self.expected, dtype=torch.float64), rtol=1e-4, atol=1e-6
+        )
+        assert pl_module.model.unused.item() == 0.0
+        self.observations.append({"batch": batch_idx, "reductions": self.state["reductions"], "weight": self.expected})
+        if batch_idx == 2:
+            (self.output_dir / f"rank-{trainer.global_rank}.json").write_text(json.dumps(self.observations))
+
+
+@pytest.mark.parametrize("accumulation", [1, 2, 4])
+def test_keypoint_ddp_reduces_only_at_window_boundaries(tmp_path: Path, accumulation: int) -> None:
+    """Real Lightning backward must suppress intermediate reductions and flush a final partial window."""
+    if not torch.distributed.is_available() or not torch.distributed.is_gloo_available():
+        pytest.skip("PyTorch build lacks the Gloo backend")
+    model_config = RFDETRSmallConfig(
+        pretrain_weights=None, device="cpu", use_grouppose_keypoints=True, num_keypoints_per_class=[17]
+    )
+    train_config = TrainConfig(
+        dataset_dir=str(tmp_path),
+        output_dir=str(tmp_path),
+        accelerator="cpu",
+        grad_accum_steps=accumulation,
+        multi_scale=False,
+        compute_train_metrics=False,
+        clip_max_norm=0.0,
+        seed=42,
+    )
+    # Substitute expensive architecture construction only; the optimization and distributed paths stay real.
+    with (
+        patch("rfdetr.training.module_model.build_model_from_config", return_value=_RankLossModel()),
+        patch("rfdetr.training.module_model.build_criterion_from_config", return_value=(_LinearCriterion(), None)),
+    ):
+        module = _SGDModule(model_config, train_config)
+    batches = [(torch.tensor(n), [{"labels": torch.zeros(n, dtype=torch.long)}]) for n in (1, 2, 3)]
+    trainer = Trainer(
+        accelerator="cpu",
+        devices=2,
+        precision="64-true",
+        strategy=DDPStrategy(start_method="spawn", process_group_backend="gloo", find_unused_parameters=True),
+        max_epochs=1,
+        limit_val_batches=0,
+        num_sanity_val_steps=0,
+        use_distributed_sampler=False,
+        enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
+        callbacks=[_CheckWindows(tmp_path, accumulation)],
+        default_root_dir=str(tmp_path),
+    )
+    trainer.fit(module, train_dataloaders=DataLoader(batches, batch_size=None, num_workers=0))
+    rank_results = [json.loads((tmp_path / f"rank-{rank}.json").read_text()) for rank in range(2)]
+    assert len(rank_results[0]) == 3
+    assert rank_results[0] == rank_results[1]

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -8,12 +8,14 @@
 import logging
 import random
 import warnings
+from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 import torch
 from pytorch_lightning import Callback, Trainer
+from pytorch_lightning.core.optimizer import LightningOptimizer
 from torch import nn
 
 from rfdetr.config import RFDETRBaseConfig, RFDETRSmallConfig, TrainConfig
@@ -1022,6 +1024,32 @@ class TestTrainingStep:
         assert loss.item() == pytest.approx(1.0)
         backward_loss = module.manual_backward.call_args.args[0]
         assert backward_loss.item() == pytest.approx(1.0)
+
+    @pytest.mark.parametrize(
+        "grad_accum_steps,num_training_batches,batch_idx,sync_grad",
+        [(2, 2, 0, False), (2, 4, 1, True), (4, 2, 1, True)],
+    )
+    def test_keypoint_accumulation_syncs_only_when_optimizer_steps(
+        self, tmp_path, grad_accum_steps, num_training_batches, batch_idx, sync_grad
+    ):
+        """Keypoint DDP must skip gradient synchronization until an accumulation window closes."""
+        keypoint_config = _base_model_config(use_grouppose_keypoints=True, num_keypoints_per_class=[17])
+        module, samples, targets, _, _ = self._run_step(
+            tmp_path,
+            accumulate_grad_batches=grad_accum_steps,
+            model_config=keypoint_config,
+        )
+        optimizer = MagicMock(spec=LightningOptimizer)
+        optimizer.param_groups = [{"lr": 1e-3}]
+        optimizer.toggle_model.return_value = nullcontext()
+        optimizer.zero_grad = MagicMock()
+        module.optimizers.return_value = optimizer
+        module._trainer.num_training_batches = num_training_batches
+
+        module.training_step((samples, targets), batch_idx=batch_idx)
+
+        optimizer.toggle_model.assert_called_once_with(sync_grad=sync_grad)
+        module.manual_backward.assert_called_once()
 
     def test_detection_loss_uses_lightning_grad_accum_scaling(self, tmp_path):
         """Detection (automatic optimization) divides loss by ``trainer.accumulate_grad_batches`` so the returned loss


### PR DESCRIPTION
## What is wrong

Keypoint training uses manual optimization to normalise the loss over the full accumulated box count. Under DDP, `manual_backward()` currently runs with gradient synchronisation enabled on every microbatch, then `_should_step_optimizer()` decides if the optimizer can step. So with `grad_accum_steps=4`, each accumulation window performs four gradient reductions when one is enough.

This is also the limitation documented when keypoint DDP support landed in #1232, and it is the DDP training question left open in #1410.

## What changes

The backward pass now uses Lightning's own `LightningOptimizer.toggle_model(sync_grad=...)` context. Intermediate microbatches run under DDP `no_sync()`, while the backward that closes a full or partial accumulation window synchronises the accumulated gradient before the optimizer step.

There is no new option or fallback. Detection and segmentation keep the automatic-optimization path, and `grad_accum_steps=1` still synchronises every backward. The warning in `build_trainer()` and the multi-GPU training note are updated to match the new behaviour.

## Two-L4 result

Measured with `RFDETRKeypointPreview` on real COCO 2017 person-keypoint images, two NVIDIA L4 GPUs, BF16, batch size 1 per rank, two-rank NCCL DDP, `grad_accum_steps=4`, torch 2.10.0+cu130 / CUDA 13.0 / driver 580.173.02. Each trial ran 64 microbatches per rank, discarded the first 8 and timed the remaining 56 with `torch.cuda.synchronize()` at both boundaries. The arms were counterbalanced.

| | develop median [range], n=5 | this PR median [range], n=5 | change |
|---|---:|---:|---:|
| steady-state seconds / 56 microbatches | 20.4620 [20.2320, 20.5213] | 19.4276 [19.2765, 19.7102] | **-5.06%** |
| seconds / optimizer step | 1.46157 [1.44514, 1.46581] | 1.38769 [1.37689, 1.40787] | **-5.06%** |
| full `Trainer.fit` seconds | 26.2290 [25.8738, 26.3033] | 25.0748 [24.7415, 25.2746] | **-4.40%** |
| peak CUDA allocation | 3,446,091,264 bytes | 3,446,091,264 bytes | unchanged |

All ten performance trials completed and the steady-state ranges do not overlap.

## Correctness and validation

The new parametrised test covers the three synchronisation decisions: an intermediate microbatch, a complete accumulation window, and the partial final-window flush. It failed on `develop` because `toggle_model()` was never called, then passed with the change. The existing large-effective-batch tests continue to check the accumulated gradient against one large batch across six box-count/accumulation cases.

A deterministic two-device `Trainer.fit` check also ran two optimizer steps with exactly representable float64 gradients. Two baseline and two candidate runs produced the same parameter bytes (`bfaed4915cfeef3f`). The real model's full state was not bitwise repeatable even baseline against itself, so I am not using that noisy comparison as a parity claim ..

- `pytest tests/training/test_module_model.py -q`: **197 passed, 1 skipped**
- affected training shards on the L4 VM: **350 passed, 6 skipped**
- `pre-commit run --all-files`: **all hooks passed**

This does not include training to convergence or an mAP claim. It also does not generalise the 5.06% number beyond two L4 GPUs and `grad_accum_steps=4`; more GPUs, multi-node DDP and other interconnects were not measured.
