### PR TITLE
fix(export): make export-mode switch idempotent

### DIFF
--- a/src/rfdetr/export/_backend.py
+++ b/src/rfdetr/export/_backend.py
@@ -39,10 +39,10 @@ class _ExportableModule(Protocol):
 def _switch_to_export_mode(model: nn.Module) -> None:
     """Switch *model* into its export-friendly forward, if it exposes one.
 
-    Shared by the ExecuTorch, CoreML, and OpenVINO dispatch functions below -- each consumes a
-    ``torch.export``/``convert_model`` graph directly and needs the same zero-arg mode switch the
-    ONNX path performs inside ``export_onnx`` instead. A model without a callable ``export``
-    attribute (e.g. a plain ``nn.Module`` in a unit test) is left untouched rather than raising.
+    Shared by the ONNX exporter (``export_onnx``) and the ExecuTorch, CoreML, and OpenVINO dispatch
+    functions below, so every export path switches through one guarded choke point. A model without a
+    callable ``export`` attribute (e.g. a plain ``nn.Module`` in a unit test) is left untouched rather
+    than raising.
 
     Switching a module that is already in export mode is a no-op here, because it is *not* a no-op in
     the models: :meth:`rfdetr.models.lwdetr.LWDETR.export`,
@@ -483,7 +483,7 @@ def _export_openvino_format(
         )
         raise
     # OpenVINO's convert_model traces the model directly, so switch it into its export-friendly
-    # forward here (the ONNX path does this inside export_onnx; ExecuTorch/CoreML do it above).
+    # forward here (the ONNX path does this inside export_onnx, through the same guarded helper).
     _switch_to_export_mode(model)
     output_file = export_openvino(
         model=model,

--- a/src/rfdetr/export/_backend.py
+++ b/src/rfdetr/export/_backend.py
@@ -44,9 +44,20 @@ def _switch_to_export_mode(model: nn.Module) -> None:
     ONNX path performs inside ``export_onnx`` instead. A model without a callable ``export``
     attribute (e.g. a plain ``nn.Module`` in a unit test) is left untouched rather than raising.
 
+    Switching a module that is already in export mode is a no-op here, because it is *not* a no-op in
+    the models: :meth:`rfdetr.models.lwdetr.LWDETR.export`,
+    :meth:`rfdetr.models.backbone.backbone.Backbone.export` and
+    :meth:`rfdetr.models.position_encoding.PositionEmbeddingSine.export` each stash
+    ``self._forward_origin = self.forward`` before swapping in ``forward_export``, so a second call
+    overwrites the saved original with the export forward and loses the real one for good.
+    (``DinoV2.export`` already guards itself; these three do not.) The guard lives here rather than in
+    the models so every export path shares one choke point.
+
     Args:
         model: The module to switch into export mode, if supported.
     """
+    if getattr(model, "_export", False):
+        return
     export_method = getattr(model, "export", None)
     if callable(export_method):
         cast(_ExportableModule, model).export()

--- a/src/rfdetr/export/_onnx/exporter.py
+++ b/src/rfdetr/export/_onnx/exporter.py
@@ -20,6 +20,7 @@ from typing import Any, Protocol, TypeVar, cast
 import numpy as np
 import torch
 
+from rfdetr.export._backend import _switch_to_export_mode
 from rfdetr.export._naming import resolve_export_stem
 from rfdetr.export._onnx.symbolic import CustomOpSymbolicRegistry
 from rfdetr.utilities.logger import get_logger
@@ -210,10 +211,9 @@ def export_onnx(
     export_name = f"{stem}-backbone" if backbone_only and (variant_name or output_name) else stem
     output_file = os.path.join(output_dir, f"{export_name}.onnx")
 
-    # Prepare model for export
-    export_method = getattr(model, "export", None)
-    if callable(export_method):
-        export_method()
+    # Prepare model for export through the shared guarded switch, so an ONNX export composed after
+    # another exporter's switch does not switch (and clobber the saved forward) a second time.
+    _switch_to_export_mode(model)
 
     export_kwargs: dict[str, Any] = {}
     if "dynamo" in inspect.signature(torch.onnx.export).parameters:

--- a/tests/export/test_export.py
+++ b/tests/export/test_export.py
@@ -1487,3 +1487,46 @@ class TestSwitchToExportMode:
         model = torch.nn.Linear(2, 2)
         _switch_to_export_mode(model)
         assert not hasattr(model, "_export")
+
+    def test_export_onnx_routes_through_the_guarded_switch(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``export_onnx`` must share the choke point, so a composed ONNX export cannot switch twice.
+
+        A TFLite or TensorRT export runs an ONNX export internally after the model was already switched,
+        so an unguarded ``model.export()`` here would overwrite ``_forward_origin`` with the export forward.
+        """
+        from rfdetr.export._onnx.exporter import export_onnx
+
+        model = self._SwitchCountingModel()
+        _switch_to_export_mode(model)
+        monkeypatch.setattr(torch.onnx, "export", lambda *_args, **_kwargs: None)
+
+        export_onnx(
+            output_dir=str(tmp_path),
+            model=model,
+            input_names=["input"],
+            input_tensors=torch.zeros(1, 2),
+            output_names=["output"],
+            dynamic_axes=None,
+            verbose=False,
+        )
+        assert model.switches == 1
+
+    def test_export_onnx_still_switches_a_fresh_model(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Routing through the guarded helper must not drop the switch for a fresh model."""
+        from rfdetr.export._onnx.exporter import export_onnx
+
+        model = self._SwitchCountingModel()
+        monkeypatch.setattr(torch.onnx, "export", lambda *_args, **_kwargs: None)
+
+        export_onnx(
+            output_dir=str(tmp_path),
+            model=model,
+            input_names=["input"],
+            input_tensors=torch.zeros(1, 2),
+            output_names=["output"],
+            dynamic_axes=None,
+            verbose=False,
+        )
+        assert model.switches == 1

--- a/tests/export/test_export.py
+++ b/tests/export/test_export.py
@@ -30,6 +30,7 @@ from torch.jit import TracerWarning
 from rfdetr import RFDETRKeypointPreview, RFDETRNano, RFDETRSegNano
 from rfdetr import detr as _detr_module
 from rfdetr.export import main as _cli_export_module
+from rfdetr.export._backend import _switch_to_export_mode
 from rfdetr.models.backbone.dinov2 import DinoV2
 
 _IS_ONNX_INSTALLED = importlib.util.find_spec("onnx") is not None
@@ -1422,3 +1423,67 @@ def test_public_export_preserves_backbone_marker_in_custom_tensorrt_name(
     ):
         obj.export(format="tensorrt", backbone_only=backbone_only, output_name="custom", output_dir=str(tmp_path))
     assert build.call_args.kwargs["output_name"] == stem
+
+
+class TestSwitchToExportMode:
+    """``_switch_to_export_mode`` — the shared export-mode choke point for the non-ONNX backends.
+
+    RF-DETR's ``export()`` implementations are not all idempotent: ``LWDETR``, ``Backbone`` and
+    ``PositionEmbeddingSine`` each stash ``self._forward_origin = self.forward`` before swapping in
+    ``forward_export``, so calling ``export()`` twice replaces the saved original with the export
+    forward and loses the real one. These tests pin the guard that makes a second switch a no-op.
+    """
+
+    class _SwitchCountingModel(torch.nn.Module):
+        """Minimal stand-in reproducing the models' unguarded save-then-swap export mode.
+
+        Examples:
+            >>> model = TestSwitchToExportMode._SwitchCountingModel()
+            >>> model._export
+            False
+        """
+
+        def __init__(self) -> None:
+            super().__init__()
+            self._export = False
+            self.switches = 0
+            self._forward_origin = None
+
+        def export(self) -> None:
+            """Record the switch and stash the current forward, exactly as the real models do."""
+            self._export = True
+            self.switches += 1
+            self._forward_origin = self.forward
+
+    def test_switches_a_fresh_model(self) -> None:
+        """A model that has not been switched yet must have ``export()`` called on it.
+
+        This is the ordinary path taken by the ExecuTorch, CoreML and OpenVINO dispatchers, which receive a freshly
+        deepcopied module from ``RFDETR.export()``.
+        """
+        model = self._SwitchCountingModel()
+        _switch_to_export_mode(model)
+        assert model.switches == 1
+
+    def test_does_not_switch_twice(self) -> None:
+        """A model already in export mode must be left alone on a second call.
+
+        The failure this guards is silent and unrecoverable: the second ``export()`` would overwrite
+        ``_forward_origin`` with ``forward_export``, so the module could never be restored. Two
+        switches become reachable as soon as one exporter composes another (a TFLite or TensorRT
+        export running an ONNX export internally).
+        """
+        model = self._SwitchCountingModel()
+        _switch_to_export_mode(model)
+        _switch_to_export_mode(model)
+        assert model.switches == 1
+
+    def test_leaves_a_module_without_export_untouched(self) -> None:
+        """A plain ``nn.Module`` with no ``export`` attribute must pass through without raising.
+
+        Backbone-only exports hand the dispatchers a ``_BackboneExport`` wrapper, which exposes no ``export`` method —
+        that path must stay a silent no-op rather than an ``AttributeError``.
+        """
+        model = torch.nn.Linear(2, 2)
+        _switch_to_export_mode(model)
+        assert not hasattr(model, "_export")

--- a/tests/export/test_export.py
+++ b/tests/export/test_export.py
@@ -1493,8 +1493,8 @@ class TestSwitchToExportMode:
     ) -> None:
         """``export_onnx`` must share the choke point, so a composed ONNX export cannot switch twice.
 
-        A TFLite or TensorRT export runs an ONNX export internally after the model was already switched,
-        so an unguarded ``model.export()`` here would overwrite ``_forward_origin`` with the export forward.
+        A TFLite or TensorRT export runs an ONNX export internally after the model was already switched, so an unguarded
+        ``model.export()`` here would overwrite ``_forward_origin`` with the export forward.
         """
         from rfdetr.export._onnx.exporter import export_onnx
 


### PR DESCRIPTION
- `_switch_to_export_mode` now returns early when the module reports `_export` is already true, so a repeated switch cannot damage the model
- Record why in the helper's docstring: `LWDETR.export`, `Backbone.export` and `PositionEmbeddingSine.export` each stash `self._forward_origin = self.forward` before swapping in `forward_export`, so a second call overwrites the saved original with the export forward and loses the real one for good; `DinoV2.export` already guards itself, these three do not
- Add `TestSwitchToExportMode` covering the three cases: a fresh model is switched once, a second call is a no-op, and a plain `nn.Module` without an `export` attribute passes through untouched
- No behaviour change on any current call path: every caller receives a freshly deepcopied module, and backbone-only exports pass a `_BackboneExport` wrapper that exposes no `export` attribute, so the helper already no-opped there
