### PR TITLE
fix(training): disable Inductor coalesce tiling

### DIFF
--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -452,16 +452,21 @@ class RFDETRModelModule(LightningModule):
             # tiling_utils.get_pw_red_splits comparing size hints. That assert has no
             # symbolic-shape escape, unlike the CantSplit branch below it, so entire forward
             # frames fall back to eager. Turning the analysis off costs nothing under
-            # dynamic=True. The attribute is absent on older torch versions and assigning an
-            # unknown name to the inductor config raises AttributeError, hence the hasattr guard.
+            # dynamic=True. Passed as a compile option rather than assigned on the inductor
+            # config module, so the default is preserved for any other compilation in this
+            # process. The knob is absent on older torch versions, where passing it would raise
+            # RuntimeError("Unexpected optimization option ..."), hence the hasattr guard.
             # Local import: pulls in inductor, which an uncompiled run never needs.
             import torch._inductor.config as inductor_config
 
+            compile_options: dict[str, Any] = {}
             if hasattr(inductor_config.triton, "coalesce_tiling_analysis"):
-                inductor_config.triton.coalesce_tiling_analysis = False
+                compile_options["triton.coalesce_tiling_analysis"] = False
             # OptimizedModule forwards attribute access to the wrapped LWDETR via
             # __getattr__ at runtime, so self.model keeps working everywhere it's used below.
-            self.model = torch.compile(self.model, dynamic=True)  # type: ignore[assignment]
+            self.model = torch.compile(  # type: ignore[assignment]
+                self.model, dynamic=True, options=compile_options or None
+            )
 
     # ------------------------------------------------------------------
     # PTL lifecycle hooks

--- a/src/rfdetr/training/module_model.py
+++ b/src/rfdetr/training/module_model.py
@@ -446,6 +446,19 @@ class RFDETRModelModule(LightningModule):
             # would cause PendingUnbackedSymbolNotFound (which only occurs without dynamic).
             torch._dynamo.config.suppress_errors = True
             torch._dynamo.config.capture_scalar_outputs = True
+            # Inductor's coalesce tiling analysis is unsupported on the dynamic-shape path
+            # (torch/_inductor/config.py: "coalesce_tiling_analysis does not yet apply to
+            # dynamic shapes"), yet it still runs and reaches an assert in
+            # tiling_utils.get_pw_red_splits comparing size hints. That assert has no
+            # symbolic-shape escape, unlike the CantSplit branch below it, so entire forward
+            # frames fall back to eager. Turning the analysis off costs nothing under
+            # dynamic=True. The attribute is absent on older torch versions and assigning an
+            # unknown name to the inductor config raises AttributeError, hence the hasattr guard.
+            # Local import: pulls in inductor, which an uncompiled run never needs.
+            import torch._inductor.config as inductor_config
+
+            if hasattr(inductor_config.triton, "coalesce_tiling_analysis"):
+                inductor_config.triton.coalesce_tiling_analysis = False
             # OptimizedModule forwards attribute access to the wrapped LWDETR via
             # __getattr__ at runtime, so self.model keeps working everywhere it's used below.
             self.model = torch.compile(self.model, dynamic=True)  # type: ignore[assignment]

--- a/tests/training/test_module_model.py
+++ b/tests/training/test_module_model.py
@@ -527,6 +527,41 @@ class TestInit:
             _build_module(model_config=mc, train_config=tc, tmp_path=tmp_path)
         mock_compile.assert_called_once()
 
+    @pytest.mark.parametrize("knob_supported", [True, False])
+    def test_coalesce_tiling_knob_passed_only_when_torch_exposes_it(self, knob_supported, tmp_path):
+        """The Inductor workaround reaches torch.compile only on a torch whose config exposes the knob.
+
+        Older torch versions have no ``triton.coalesce_tiling_analysis``; passing it there raises
+        ``RuntimeError("Unexpected optimization option ...")`` from ``_TorchCompileInductorWrapper.apply_options``.
+        Compilation must still proceed in both cases.
+        """
+        triton_config = SimpleNamespace(coalesce_tiling_analysis=True) if knob_supported else SimpleNamespace()
+        mc = _base_model_config(compile=True)
+        tc = _base_train_config(tmp_path, multi_scale=False)
+        with (
+            patch("rfdetr.config.DEVICE", "cuda"),
+            patch("torch._inductor.config", SimpleNamespace(triton=triton_config)),
+            patch("rfdetr.training.module_model.torch.compile", side_effect=lambda m, **_: m) as mock_compile,
+        ):
+            _build_module(model_config=mc, train_config=tc, tmp_path=tmp_path)
+
+        expected = {"triton.coalesce_tiling_analysis": False} if knob_supported else None
+        assert mock_compile.call_args.kwargs["options"] == expected
+
+    def test_coalesce_tiling_knob_leaves_process_global_config_untouched(self, tmp_path):
+        """The workaround must not disable coalesce tiling for unrelated compilations in the same process."""
+        triton_config = SimpleNamespace(coalesce_tiling_analysis=True)
+        mc = _base_model_config(compile=True)
+        tc = _base_train_config(tmp_path, multi_scale=False)
+        with (
+            patch("rfdetr.config.DEVICE", "cuda"),
+            patch("torch._inductor.config", SimpleNamespace(triton=triton_config)),
+            patch("rfdetr.training.module_model.torch.compile", side_effect=lambda m, **_: m),
+        ):
+            _build_module(model_config=mc, train_config=tc, tmp_path=tmp_path)
+
+        assert triton_config.coalesce_tiling_analysis is True
+
     @patch("rfdetr.training.module_model.torch.compile")
     @patch("rfdetr.config.DEVICE", "cuda")
     def test_compile_disabled_when_train_accelerator_is_cpu(self, _mock_compile: MagicMock, tmp_path):


### PR DESCRIPTION
- Turn off `torch._inductor.config.triton.coalesce_tiling_analysis` before `torch.compile(..., dynamic=True)`. The analysis is unsupported on the dynamic-shape path but still runs, reaching a size-hint assert in `tiling_utils.get_pw_red_splits` that has no symbolic-shape escape, so whole forward frames fall back to eager.
- Guard the assignment with `hasattr`: the attribute is absent on older torch versions, and assigning an unknown name to the inductor config raises `AttributeError`.
