### PR TITLE
perf(export): disable ONNX Runtime CPU thread-pool spinning in `_create_onnx_session`

### DIFF
--- a/.github/workflows/ci-integrations.yml
+++ b/.github/workflows/ci-integrations.yml
@@ -377,27 +377,83 @@ jobs:
         continue-on-error: true
         run: uv cache prune --ci
 
+  onnxruntime-session:
+    name: ONNX Runtime session
+    # tests/export/test_onnx_inference.py builds a real onnxruntime CPU session through _create_onnx_session.
+    # Neither test workflow reaches those tests: ci-tests-cpu.yml does not install the [onnx] extra, so they
+    # skip behind pytest.importorskip, and ci-tests-gpu.yml installs it but collects only `-m gpu`. This job
+    # is the CPU path that turns a regression in the session options red. onnxruntime ships portable
+    # manylinux wheels, so ubuntu-latest is sufficient.
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pytest-onnxruntime-${{ matrix.python-version }}-${{ github.ref }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        # The [onnx] extra declares two onnxruntime resolutions (see pyproject.toml): `<1.24` on 3.10, whose
+        # last cp310 release 1.23.2 loads models up to IR 11, and unpinned on 3.11+. 3.10 and 3.13 bracket
+        # both, so a model the tests build has to load under each.
+        python-version: ["3.10", "3.13"]
+    steps:
+      - name: 📥 Checkout the repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: 🐍 Install uv and set Python version ${{ matrix.python-version }}
+        uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
+        with:
+          version: "0.9.26"
+          python-version: ${{ matrix.python-version }}
+          activate-environment: true
+
+      - name: 🚀 Install Packages (onnx extra)
+        timeout-minutes: 8
+        run: uv pip install -e ".[onnx,train,augment,cli,visual]" --group tests
+
+      - name: 🔎 Verify onnx and onnxruntime imports
+        # Guard against a silently-skipped test: the real-session tests are gated by
+        # pytest.importorskip("onnx") / pytest.importorskip("onnxruntime"), so a broken/missing wheel
+        # would skip them (false green) instead of failing red.
+        run: |
+          import onnx
+          import onnxruntime
+
+          print(f"onnx {onnx.__version__} (IR {onnx.IR_VERSION}) / onnxruntime {onnxruntime.__version__} import OK")
+        shell: python
+
+      - name: 🧪 Run ONNX Runtime session tests
+        run: |
+          uv run --no-sync pytest tests/export/test_onnx_inference.py -n 1 \
+            --timeout=300 --durations=20
+
+      - name: Minimize uv cache
+        continue-on-error: true
+        run: uv cache prune --ci
+
   export-priority-guardian:
     runs-on: ubuntu-latest
-    needs: [executorch-parity, coreml-parity, openvino-parity, tensorrt-parity]
+    needs: [executorch-parity, coreml-parity, openvino-parity, tensorrt-parity, onnxruntime-session]
     if: always()
     steps:
-      - name: 📋 Display parity job results
+      - name: 📋 Display export job results
         run: |
-          echo "executorch-parity: ${{ needs.executorch-parity.result }}"
-          echo "coreml-parity:     ${{ needs.coreml-parity.result }}"
-          echo "openvino-parity:   ${{ needs.openvino-parity.result }}"
-          echo "tensorrt-parity:   ${{ needs.tensorrt-parity.result }}"
+          echo "executorch-parity:   ${{ needs.executorch-parity.result }}"
+          echo "coreml-parity:       ${{ needs.coreml-parity.result }}"
+          echo "openvino-parity:     ${{ needs.openvino-parity.result }}"
+          echo "tensorrt-parity:     ${{ needs.tensorrt-parity.result }}"
+          echo "onnxruntime-session: ${{ needs.onnxruntime-session.result }}"
       # Fail explicitly on any non-success result (failure, cancelled, or skipped) instead of
-      # relying on timeout behavior, so a cancelled or skipped parity job still blocks the gate.
-      - name: ❌ Fail guardian unless every parity job succeeded
+      # relying on timeout behavior, so a cancelled or skipped export job still blocks the gate.
+      - name: ❌ Fail guardian unless every export job succeeded
         if: >-
           needs.executorch-parity.result != 'success' ||
           needs.coreml-parity.result != 'success' ||
           needs.openvino-parity.result != 'success' ||
-          needs.tensorrt-parity.result != 'success'
+          needs.tensorrt-parity.result != 'success' ||
+          needs.onnxruntime-session.result != 'success'
         run: |
-          echo "One or more export parity jobs did not succeed; failing explicitly."
+          echo "One or more export jobs did not succeed; failing explicitly."
           exit 1
-      - name: ✅ all parity jobs succeeded
-        run: echo "All export parity jobs (executorch, coreml, openvino, tensorrt) completed successfully."
+      - name: ✅ all export jobs succeeded
+        run: echo "All export jobs (executorch/coreml/openvino/tensorrt parity, onnxruntime session) completed successfully."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Distributed (DDP) training now preserves the minimum five optimizer steps per epoch for short datasets instead of losing the replacement sample count when Lightning injects its distributed sampler.
 
+- Installing the `[onnx]` extra from a source checkout with `uv` on Python 3.10, 3.11 or 3.13 now brings in `ml-dtypes` again; the `ml-dtypes==0.5.1` override, scoped to Python 3.12 for the TFLite stack, was dropping the requirement on every other interpreter and left `import onnx` failing with `ModuleNotFoundError`.
+
 - Kornia `Affine` now applies scalar `translate_percent` to both axes and reads scalar `scale` as a fixed range, avoiding silent horizontal-translation loss and construction failures. Scalar translation emits a warning because Kornia samples signed offsets while Albumentations applies the scalar as a fixed positive offset.
 
 - TFLite INT8 documentation and warnings now reflect that dynamic-range quantization needs no calibration data. ([#1363](https://github.com/roboflow/rf-detr/issues/1363))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Multi-GPU keypoint training with `grad_accum_steps > 1` now synchronizes gradients once per optimizer step instead of once per microbatch, avoiding redundant DDP reductions.
 
+- The ONNX Runtime CPU inference session built by `RFDETR.export(format="onnx")`'s inference helper no longer lets its intra-op thread pool busy-spin between calls. Spinning previously contended for CPU with any other work sharing the process — including this same helper's own torchvision-based preprocessing step — for as long as the session was alive.
+
 ### Deprecated
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,6 +278,13 @@ rfdetr = "rfdetr.cli:main"
 # remove the <'3.13' upper bound from the tflite deps AND from the override below.
 override-dependencies = [
     "ml-dtypes==0.5.1; python_version >= '3.12' and python_version < '3.13'",
+    # An override replaces every requirement on ml-dtypes with the entries listed here, and an entry
+    # whose marker is false contributes nothing. With the 3.12 pin alone, `uv pip install -e ".[onnx]"`
+    # on 3.10, 3.11 or 3.13 installed no ml-dtypes at all, and `import onnx` (which loads ml_dtypes at
+    # module import) failed with ModuleNotFoundError. This entry restores the unpinned requirement on
+    # every other interpreter; it adds nothing where no package asks for ml-dtypes. Keep its marker the
+    # exact complement of the pinned entry's whenever that one changes.
+    "ml-dtypes; python_version < '3.12' or python_version >= '3.13'",
 ]
 
 # ci-gpu-pin (torch<2.11, GPU-driver constraint) and the executorch extra (torch>=2.12.0a0,

--- a/src/rfdetr/export/_onnx/inference.py
+++ b/src/rfdetr/export/_onnx/inference.py
@@ -35,6 +35,13 @@ def _create_onnx_session(model_path: str | Path, providers: list[str] | None = N
     installed, otherwise CPU (with a warning).  Pass an explicit list to pin the backend — useful for benchmarking
     CPU vs CUDA side-by-side.
 
+    The session's CPU intra-op thread pool -- the one actually created under this function's default sequential
+    execution mode -- is configured to block rather than busy-spin while idle, since spinning would otherwise contend
+    for CPU with any other work sharing the process for as long as the session lives, including this module's own
+    ``preprocess_to_nchw`` step, which prefers torchvision when it is installed. The inter-op entry is set for the
+    same reason but has no effect here: ONNX Runtime only creates an inter-op thread pool under
+    ``ExecutionMode.ORT_PARALLEL``, which this function never requests.
+
     Args:
         model_path: Path to the ``.onnx`` model file.
         providers: Ordered list of ORT execution providers, e.g.
@@ -69,7 +76,20 @@ def _create_onnx_session(model_path: str | Path, providers: list[str] | None = N
                 "CUDAExecutionProvider not available — running ONNX inference on CPU. "
                 "Install onnxruntime-gpu for GPU acceleration: `pip install onnxruntime-gpu`"
             )
-    session = ort.InferenceSession(str(model_path), providers=providers)
+    session_options = ort.SessionOptions()
+    # ORT's default CPU intra-op thread pool busy-spins while idle instead of blocking, trading
+    # wake-up latency for CPU usage between calls. That spinning contends for CPU with any other
+    # work in this process -- including this module's own torchvision-based preprocessing in
+    # ``preprocess_to_nchw`` -- for as long as the session lives, and measurably slows down the
+    # session's own next call too. Disabling it only changes how idle threads wait, not computed
+    # values. This session never sets ``execution_mode``, so it stays at ORT's default
+    # ExecutionMode.ORT_SEQUENTIAL, under which ORT never creates an inter-op thread pool at all --
+    # that pool only exists under ORT_PARALLEL. The inter-op entry below is set defensively for
+    # that case; it has no effect on this function's own (sequential) behavior, applies identically
+    # regardless of the requested execution provider, and does not change computed values either way.
+    session_options.add_session_config_entry("session.intra_op.allow_spinning", "0")
+    session_options.add_session_config_entry("session.inter_op.allow_spinning", "0")
+    session = ort.InferenceSession(str(model_path), sess_options=session_options, providers=providers)
     logger.debug("ONNX Runtime providers in use: %s", session.get_providers())
     for inp in session.get_inputs():
         logger.debug("Input  : name=%s  shape=%s  type=%s", inp.name, inp.shape, inp.type)

--- a/tests/export/test_onnx_inference.py
+++ b/tests/export/test_onnx_inference.py
@@ -20,7 +20,7 @@ import numpy as np
 import pytest
 from PIL import Image as PILImage
 
-from rfdetr.export._onnx.inference import _run_inference
+from rfdetr.export._onnx.inference import _create_onnx_session, _run_inference
 
 _INPUT_SHAPE = [1, 3, 224, 224]
 
@@ -166,3 +166,73 @@ class TestMulticlassSelection:
         dets, _ = _run_inference(session, rgb_image, threshold=0.3, num_select=3)
 
         assert len(dets) == 3
+
+
+@pytest.fixture()
+def tiny_onnx_model(tmp_path: Path) -> Path:
+    """Write a minimal single-node ONNX model and return its path.
+
+    ``_create_onnx_session`` only needs a loadable graph; an ``Identity`` node avoids depending on the real RF-DETR
+    export path for a session-construction test.
+
+    Examples:
+        Pytest fixture functions cannot be called directly outside fixture injection.
+        >>> tiny_onnx_model(Path("."))  # doctest: +SKIP
+    """
+    onnx = pytest.importorskip("onnx", reason="onnx not installed")
+    tensor_proto, helper = onnx.TensorProto, onnx.helper
+
+    inp = helper.make_tensor_value_info("input", tensor_proto.FLOAT, [1, 3, 8, 8])
+    out = helper.make_tensor_value_info("output", tensor_proto.FLOAT, [1, 3, 8, 8])
+    node = helper.make_node("Identity", inputs=["input"], outputs=["output"])
+    graph = helper.make_graph([node], "test", [inp], [out])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    onnx_path = tmp_path / "identity.onnx"
+    onnx.save(model, str(onnx_path))
+    return onnx_path
+
+
+class TestCreateOnnxSession:
+    """Tests for ``_create_onnx_session``'s CPU thread-pool configuration.
+
+    ``_run_inference``'s own preprocessing (``preprocess_to_nchw``, via ``torchvision`` when installed) runs in the same
+    process as the session it feeds. ONNX Runtime's default CPU thread pool busy-spins between calls rather than
+    blocking, so those idle-but-spinning threads contend for CPU with that preprocessing step -- and with the session's
+    own next call -- for as long as the process lives. Disabling spinning only changes how idle threads wait; it does
+    not change computed values.
+    """
+
+    def test_disables_intra_op_spinning_on_cpu(self, tiny_onnx_model: Path) -> None:
+        """The constructed session must not let its CPU threads busy-spin between calls."""
+        pytest.importorskip("onnxruntime", reason="onnxruntime not installed")
+
+        session = _create_onnx_session(tiny_onnx_model, providers=["CPUExecutionProvider"])
+
+        options = session.get_session_options()
+        assert options.get_session_config_entry("session.intra_op.allow_spinning") == "0"
+        assert options.get_session_config_entry("session.inter_op.allow_spinning") == "0"
+
+    def test_still_produces_correct_output(self, tiny_onnx_model: Path) -> None:
+        """Disabling spinning must not change what the session computes."""
+        pytest.importorskip("onnxruntime", reason="onnxruntime not installed")
+
+        session = _create_onnx_session(tiny_onnx_model, providers=["CPUExecutionProvider"])
+
+        feed = np.arange(3 * 8 * 8, dtype=np.float32).reshape(1, 3, 8, 8)
+        (actual,) = session.run(None, {session.get_inputs()[0].name: feed})
+
+        np.testing.assert_array_equal(actual, feed)
+
+    def test_disables_spinning_regardless_of_requested_provider_list(self, tiny_onnx_model: Path) -> None:
+        """The spin-config entries attach before provider selection, so they apply the same way for any requested
+        provider list -- including one naming a GPU provider unavailable on the machine running the test.
+
+        ONNX Runtime falls back to an available provider with a warning rather than raising in that case.
+        """
+        pytest.importorskip("onnxruntime", reason="onnxruntime not installed")
+
+        session = _create_onnx_session(tiny_onnx_model, providers=["CUDAExecutionProvider", "CPUExecutionProvider"])
+
+        options = session.get_session_options()
+        assert options.get_session_config_entry("session.intra_op.allow_spinning") == "0"
+        assert options.get_session_config_entry("session.inter_op.allow_spinning") == "0"

--- a/tests/export/test_onnx_inference.py
+++ b/tests/export/test_onnx_inference.py
@@ -186,7 +186,12 @@ def tiny_onnx_model(tmp_path: Path) -> Path:
     out = helper.make_tensor_value_info("output", tensor_proto.FLOAT, [1, 3, 8, 8])
     node = helper.make_node("Identity", inputs=["input"], outputs=["output"])
     graph = helper.make_graph([node], "test", [inp], [out])
-    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    # Pin the IR version rather than taking ``make_model``'s default, which is the installed ``onnx`` package's own
+    # ``IR_VERSION`` (13 since onnx 1.20). The ``[onnx]`` extra resolves ``onnxruntime<1.24`` on Python 3.10, and
+    # that last cp310 release (1.23.2) refuses the file at load time with "Unsupported model IR version: 13, max
+    # supported IR version: 11" -- before any assertion runs. IR 10 is what onnx 1.16/1.17 emitted, loads across the
+    # whole onnxruntime range the extra can resolve, and is more than enough for an opset-13 ``Identity`` graph.
+    model = helper.make_model(graph, ir_version=10, opset_imports=[helper.make_opsetid("", 13)])
     onnx_path = tmp_path / "identity.onnx"
     onnx.save(model, str(onnx_path))
     return onnx_path


### PR DESCRIPTION
## Summary

`_create_onnx_session` lives in `rfdetr.export._onnx.inference` — the private module that `docs/learn/export.md` points readers to as the reference ONNX post-processing implementation, and the one `docs/cookbooks/inference-latency-benchmark.ipynb` imports `_onnx_runtime` from directly. It builds its `ort.InferenceSession` with no `SessionOptions`, so ONNX Runtime's CPU execution provider falls back to its own default: an intra-op thread pool that busy-spins while idle instead of blocking. That keeps CPU usage high between calls in exchange for a faster wake-up on the next one. The function also never sets `execution_mode`, so the session stays at ORT's default `ExecutionMode.ORT_SEQUENTIAL` — under that mode ORT doesn't even create a separate inter-op thread pool, that one (and its own spin setting) only exists under `ORT_PARALLEL`.

That spinning takes CPU away from anything else running in the same process, for as long as the session stays open. That includes `_run_inference`'s own preprocessing step, `preprocess_to_nchw`, which prefers a `torchvision`-based path when it's importable (it always is, `torch`/`torchvision` are core `rfdetr` dependencies). On a 32-thread CPU, just having a default session around turns unrelated preprocessing work from ~3.4ms into ~98ms per call, a ~29x slowdown, measured with `preprocess_to_nchw` and the session running in the same tight loop a real deployment would use. Disabling spin-waiting removes that contention and also speeds up the session's own `session.run()` calls, which were competing against each other for the same cores.

This PR sets `session.intra_op.allow_spinning` and `session.inter_op.allow_spinning` to `"0"` on the `SessionOptions` passed into `_create_onnx_session`'s `ort.InferenceSession(...)` call. The inter-op entry has no effect under this function's sequential execution mode — it's included only so the session stays correctly configured if that ever changes. Both entries get attached to `SessionOptions` before `providers` is resolved, so they apply the same way no matter which execution provider ends up active. Nothing else about session construction changes: thread *count* stays at ONNX Runtime's own default, since capping it (the other common piece of ORT tuning advice) was measured and it slowed the model's own compute down instead of helping — see below.

## Measured impact

Real, unmodified `_run_inference()`, `RFDETRNano` exported to ONNX, `CPUExecutionProvider`, a real photo as input, 5 alternating fresh-process baseline/candidate pairs (20 warmup + 60 measured calls each):

| | median (ms/call) | range |
| --- | ---: | --- |
| before | 201.561 | [191.363, 216.208] |
| after | 88.516 | [73.955, 94.350] |

**−56.08%**, ranges non-overlapping. A second pass with a synthetic 640x480 random-noise image gives a consistent −61.07% (also non-overlapping) — the mechanism depends on tensor shape and thread scheduling, not on pixel content, so this second run is a consistency check, not a separate independent result.

Isolating preprocessing and `session.run` separately (synthetic image, only relative timing matters here) shows why (5 repeats, 20 warmup + 60 measured calls each; median [range]):

| configuration | preprocess median (µs/call) | session.run median (µs/call) | total median (µs/call) |
| --- | --- | --- | --- |
| no ONNX Runtime session exists at all | 4517 [3353-4669] | 0.5 [0.5-0.7] | 4518 [3353-4670] |
| current code (default thread pool) | 115219 [103408-116513] | 75999 [67833-78405] | 191338 [171240-193624] |
| spinning disabled, thread count unchanged | 4018 [3217-4212] | 62497 [48642-66632] | 66514 [51859-70844] |
| spinning disabled + `intra_op_num_threads=4` | 3319 [3179-3429] | 97941 [91919-109202] | 101260 [95098-112630] |

Capping the thread count is not part of this fix. The last row shows why: `session.run` stays close to the current code's own median (97.9ms vs 76.0ms) instead of dropping to the 62.5ms that disabling spinning alone gives, because capping the thread count starves the model's own parallel compute.

## Correctness

This only changes how idle CPU threads wait, it doesn't change any computed value. Running the real `_run_inference()` once with the current code and once with this patch, against the same exported model and image (checked with both the photograph and the synthetic image above), gives exactly bit-identical `xyxy`/`confidence`/`class_id` arrays (300 detections each).

Added `TestCreateOnnxSession` (3 cases) to `tests/export/test_onnx_inference.py`:

- `test_disables_intra_op_spinning_on_cpu` builds a minimal single-node ONNX graph, calls the real
`_create_onnx_session`, and asserts the constructed session's own `get_session_options()` reads back `"0"` for both spinning config entries.
- `test_still_produces_correct_output` runs that session and checks the output matches the input
exactly.
- `test_disables_spinning_regardless_of_requested_provider_list` requests
`["CUDAExecutionProvider", "CPUExecutionProvider"]` (falling back to CPU with a warning on a machine without a CUDA execution provider, never raising) and asserts the same config entries, confirming the fix isn't gated on which provider ends up active.

`test_disables_intra_op_spinning_on_cpu` fails against the code before this change (`RuntimeError: SessionOptions does not have configuration with key: session.intra_op.allow_spinning`) and passes after it. `test_still_produces_correct_output` and `test_disables_spinning_regardless_of_requested_provider_list` pass either way — they check that the fix doesn't change what the session computes or depend on the requested provider, they're not there to catch a regression.

Full `tests/export/` suite (`-m "not gpu"`), with all three `TestCreateOnnxSession` cases: 510 passed, 74 skipped, 1 failed — the one failure (`test_onnx_notes.py`'s `_export_tiny_model` doctest, unrelated to this file) reproduces identically without this change too, so it's pre-existing. `pre-commit run --all-files` (ruff, docformatter, `mypy --strict`, mdformat, codespell, license header) is clean.

## Scope

`src/rfdetr/export/_onnx/inference.py`, `tests/export/test_onnx_inference.py`, `CHANGELOG.md`. `_create_onnx_session`'s signature is unchanged. The sibling TFLite and OpenVINO inference wrappers build their own runtimes with their own, different threading models and were not touched or measured here.
